### PR TITLE
feat: retrieve-then-decide clustering architecture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,7 @@ jobs:
         run: uv lock --check
 
       - name: Sync (Dev)
-        run: uv sync --dev
+        run: uv sync --dev --locked
 
       - name: Tests
-        run: uv run pytest -q
-
+        run: uv run python -m pytest -q

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -189,8 +189,9 @@ for concurrent read/write access.
 - Multi-key rotation: keys loaded from `BRAVE_SEARCH_API_KEYS` env var (or single-key `BRAVE_SEARCH_API_KEY`).
 - Key state persisted in `data/newsroom/brave_key_state.json` (tracks usage,
   rate limit events per key_id = sha256 prefix).
-- `select_brave_api_key()` picks the least-recently-rate-limited key.
-- `record_brave_rate_limit()` marks a key as rate-limited with a cooldown.
+- `select_brave_api_key()` skips keys that are temporarily cooled down or exhausted.
+- `record_brave_rate_limit()` persists the last-seen quota headers and can mark a key as exhausted until reset.
+- `record_brave_cooldown()` records a short-term cooldown after transient errors (e.g. 429/503) so callers can rotate keys.
 - Each key has a label (e.g., "free", "paid") parsed from `label:key` format.
 - URL normalization strips fragments and tracking params (`utm_*`, `fbclid`, etc.).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ uv sync --dev
 All tests must pass before submitting changes:
 
 ```bash
-uv run pytest newsroom/tests/ -v
+uv run python -m pytest newsroom/tests/ -v
 ```
 
 Tests are located in `newsroom/tests/` and cover validators, result repair, prompt registry resolution, job schemas, deduplication, tokenization, and more.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ All scripts live in the `scripts/` directory and are invoked as standalone Pytho
 ## Testing
 
 ```bash
-uv run pytest newsroom/tests/ -v
+uv run python -m pytest newsroom/tests/ -v
 ```
 
 ## Key Modules

--- a/newsroom/news_pool_db.py
+++ b/newsroom/news_pool_db.py
@@ -592,6 +592,45 @@ class NewsPoolDB:
         row = cur.execute("SELECT * FROM events WHERE id = ?", (event_id,)).fetchone()
         return dict(row) if row else None
 
+    def get_all_fresh_events(self, *, max_age_hours: int = 168) -> list[dict[str, Any]]:
+        """All events within max_age_hours, regardless of status/expiry.
+
+        Used by retrieval-based clustering to include posted events.
+        """
+        now = _utc_now_ts()
+        cutoff = now - max_age_hours * 3600
+        cur = self._conn.cursor()
+        rows = cur.execute(
+            """
+            SELECT id, parent_event_id, category, jurisdiction, summary_en,
+                   development, title, primary_url, link_count, best_published_ts,
+                   status, created_at_ts, updated_at_ts, expires_at_ts,
+                   posted_at_ts, thread_id, run_id
+            FROM events
+            WHERE created_at_ts >= ?
+            ORDER BY created_at_ts DESC
+            """,
+            (cutoff,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    def get_root_event_id(self, event_id: int) -> int:
+        """Walk parent_event_id chain to root. Returns event_id itself if already root."""
+        cur = self._conn.cursor()
+        current = event_id
+        seen: set[int] = set()
+        while True:
+            if current in seen:
+                break  # cycle guard
+            seen.add(current)
+            row = cur.execute(
+                "SELECT parent_event_id FROM events WHERE id = ?", (current,)
+            ).fetchone()
+            if not row or row["parent_event_id"] is None:
+                break
+            current = row["parent_event_id"]
+        return current
+
     def get_fresh_events(self, *, now_ts: int | None = None) -> list[dict[str, Any]]:
         """Return events where expires_at_ts > now (for clustering prompt)."""
         now = now_ts if now_ts is not None else _utc_now_ts()
@@ -889,9 +928,10 @@ class NewsPoolDB:
             # Field aliases for backward compat with newsroom_write_run_job.py.
             c["suggested_category"] = c.get("category") or "Global News"
             c["description"] = c.get("summary_en") or ""
-            c["event_key"] = f"event:{eid}"
-            c["semantic_event_key"] = f"event:{eid}"
-            c["anchor_key"] = f"event:{eid}"
+            root_eid = self.get_root_event_id(eid)
+            c["event_key"] = f"event:{root_eid}"
+            c["semantic_event_key"] = f"event:{root_eid}"
+            c["anchor_key"] = f"event:{root_eid}"
             c["cluster_size"] = c.get("link_count") or 0
             c["cluster_terms"] = []
             c["anchor_terms"] = []

--- a/newsroom/news_pool_db.py
+++ b/newsroom/news_pool_db.py
@@ -64,6 +64,8 @@ class NewsPoolDB:
         # Use WAL for concurrent readers (planner) while collector is writing.
         self._conn = sqlite3.connect(str(path), timeout=30, isolation_level=None)
         self._conn.row_factory = sqlite3.Row
+        # Ensure SQLite enforces declared foreign key constraints.
+        self._conn.execute("PRAGMA foreign_keys=ON;")
         self._conn.execute("PRAGMA journal_mode=WAL;")
         self._conn.execute("PRAGMA synchronous=NORMAL;")
 

--- a/newsroom/schemas/run_job_v1.schema.json
+++ b/newsroom/schemas/run_job_v1.schema.json
@@ -22,7 +22,7 @@
     "destination": {
       "type": "object",
       "properties": {
-        "platform": { "type": "string", "enum": ["discord", "webhook"] },
+        "platform": { "type": "string", "enum": ["discord"] },
         "default_title_channel_id": { "type": "string" }
       },
       "additionalProperties": true
@@ -42,4 +42,3 @@
   },
   "additionalProperties": true
 }
-

--- a/newsroom/schemas/story_job_v1.schema.json
+++ b/newsroom/schemas/story_job_v1.schema.json
@@ -66,9 +66,9 @@
     },
     "destination": {
       "type": "object",
-      "required": ["platform"],
+      "required": ["platform", "title_channel_id"],
       "properties": {
-        "platform": { "type": "string", "enum": ["discord", "webhook"] },
+        "platform": { "type": "string", "enum": ["discord"] },
         "title_channel_id": { "type": "string" },
         "thread_name_template": { "type": "string" },
         "webhook_url": { "type": "string", "format": "uri" }

--- a/newsroom/subprocess_json.py
+++ b/newsroom/subprocess_json.py
@@ -1,0 +1,104 @@
+"""Helpers for running JSON-emitting subprocesses safely.
+
+These inputs scripts are invoked from cron-driven LLM planners. If a child
+process hangs (network stall, deadlock, etc.), the planner turn can be
+blocked until the cron timeout. To avoid that, we always run subprocesses
+with a hard timeout and return structured error objects with truncated
+stdout/stderr for debugging.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Any
+
+
+def _as_text(v: str | bytes | None) -> str:
+    if v is None:
+        return ""
+    if isinstance(v, bytes):
+        return v.decode("utf-8", errors="replace")
+    return v
+
+
+def _truncate(s: str | bytes | None, max_chars: int) -> str:
+    text = _as_text(s)
+    if max_chars <= 0:
+        return ""
+    return text[:max_chars]
+
+
+def run_json_command(
+    cmd: list[str],
+    *,
+    timeout_seconds: float,
+    max_output_chars: int = 2000,
+) -> dict[str, Any]:
+    """Run *cmd* and parse a JSON object from stdout.
+
+    On failure, returns a structured object with `ok: false` and truncated
+    stdout/stderr to keep planner payloads bounded.
+    """
+    try:
+        proc = subprocess.run(
+            cmd,
+            text=True,
+            capture_output=True,
+            timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired as e:
+        return {
+            "ok": False,
+            "error": "timeout",
+            "timeout_seconds": float(timeout_seconds),
+            "stdout": _truncate(getattr(e, "stdout", None), max_output_chars),
+            "stderr": _truncate(getattr(e, "stderr", None), max_output_chars),
+            "cmd": cmd,
+        }
+    except Exception as e:
+        return {
+            "ok": False,
+            "error": "spawn_failed",
+            "detail": str(e),
+            "stdout": "",
+            "stderr": "",
+            "cmd": cmd,
+        }
+
+    out = proc.stdout or ""
+    err = proc.stderr or ""
+
+    if proc.returncode != 0:
+        return {
+            "ok": False,
+            "error": "cmd_failed",
+            "returncode": int(proc.returncode),
+            "stdout": _truncate(out, max_output_chars),
+            "stderr": _truncate(err, max_output_chars),
+            "cmd": cmd,
+        }
+
+    try:
+        obj = json.loads(out)
+    except Exception as e:
+        return {
+            "ok": False,
+            "error": "invalid_json",
+            "detail": str(e),
+            "stdout": _truncate(out, max_output_chars),
+            "stderr": _truncate(err, max_output_chars),
+            "cmd": cmd,
+        }
+
+    if isinstance(obj, dict):
+        return obj
+
+    return {
+        "ok": False,
+        "error": "json_not_object",
+        "stdout": _truncate(out, max_output_chars),
+        "stderr": _truncate(err, max_output_chars),
+        "cmd": cmd,
+    }
+

--- a/newsroom/tests/test_brave_rate_limit_cooldown.py
+++ b/newsroom/tests/test_brave_rate_limit_cooldown.py
@@ -1,0 +1,82 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from newsroom.brave_news import (
+    BraveApiError,
+    BraveApiKey,
+    fetch_brave_news,
+    record_brave_cooldown,
+    record_brave_rate_limit,
+    select_brave_api_key,
+)
+
+
+class TestBraveRateLimitCooldown(unittest.TestCase):
+    @patch("newsroom.brave_news.time.sleep", autospec=True)
+    @patch("newsroom.brave_news.requests.get")
+    def test_cooldown_skips_key_after_429(self, mock_get: MagicMock, mock_sleep: MagicMock) -> None:
+        mock_sleep.return_value = None
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 429
+        mock_resp.headers = {
+            "Retry-After": "10",
+            "X-RateLimit-Limit": "1,1000",
+            "X-RateLimit-Remaining": "0,500",
+            "X-RateLimit-Reset": "1,3600",
+        }
+        mock_resp.json.return_value = {"error": {"message": "Too many requests"}}
+        mock_resp.text = json.dumps(mock_resp.json.return_value)
+        mock_get.return_value = mock_resp
+
+        key1 = BraveApiKey(key="k1", label="one")
+        key2 = BraveApiKey(key="k2", label="two")
+        now_ts = 1700000000
+
+        with tempfile.TemporaryDirectory() as td:
+            openclaw_home = Path(td)
+
+            with self.assertRaises(BraveApiError) as ctx:
+                fetch_brave_news(api_key=key1.key, q="test", count=1, offset=0, freshness="day", cache_dir=None, last_request_ts=0.0)
+            err = ctx.exception
+            self.assertEqual(err.status_code, 429)
+            self.assertEqual(err.requests_made, 3)
+            self.assertIsInstance(err.rate_limit, dict)
+
+            record_brave_rate_limit(openclaw_home=openclaw_home, key=key1, rate_limit=err.rate_limit, now_ts=now_ts)
+            record_brave_cooldown(openclaw_home=openclaw_home, key=key1, cooldown_seconds=err.retry_after_s or 60, now_ts=now_ts, reason="http_429")
+
+            selected = select_brave_api_key(openclaw_home=openclaw_home, keys=[key1, key2], now_ts=now_ts)
+            self.assertEqual(selected.key_id, key2.key_id)
+
+    @patch("newsroom.brave_news.time.sleep", autospec=True)
+    @patch("newsroom.brave_news.requests.get")
+    def test_requests_made_counts_retries_on_success(self, mock_get: MagicMock, mock_sleep: MagicMock) -> None:
+        mock_sleep.return_value = None
+
+        r503 = MagicMock()
+        r503.status_code = 503
+        r503.headers = {}
+        r503.json.return_value = {"error": {"message": "Service unavailable"}}
+        r503.text = json.dumps(r503.json.return_value)
+
+        r200 = MagicMock()
+        r200.status_code = 200
+        r200.headers = {"X-RateLimit-Limit": "1,1000", "X-RateLimit-Remaining": "1,500", "X-RateLimit-Reset": "1,3600"}
+        r200.json.return_value = {"results": [{"title": "A", "url": "https://example.com/a"}]}
+        r200.text = json.dumps(r200.json.return_value)
+
+        mock_get.side_effect = [r503, r503, r200]
+
+        fetched, _ = fetch_brave_news(api_key="k", q="test", count=1, offset=0, freshness="day", cache_dir=None, last_request_ts=0.0)
+        self.assertTrue(fetched.ok)
+        self.assertEqual(fetched.requests_made, 3)
+        self.assertEqual(len(fetched.results), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/newsroom/tests/test_newsroom.py
+++ b/newsroom/tests/test_newsroom.py
@@ -17,11 +17,35 @@ class TestSchemas(unittest.TestCase):
         example = json.loads((root / "newsroom" / "examples" / "story_job_example.json").read_text(encoding="utf-8"))
         jsonschema.validate(instance=example, schema=schema)
 
+    def test_story_job_disallows_webhook_platform(self) -> None:
+        root = Path(__file__).resolve().parents[2]
+        schema = json.loads((root / "newsroom" / "schemas" / "story_job_v1.schema.json").read_text(encoding="utf-8"))
+        example = json.loads((root / "newsroom" / "examples" / "story_job_example.json").read_text(encoding="utf-8"))
+        example["destination"]["platform"] = "webhook"
+        with self.assertRaises(jsonschema.ValidationError):
+            jsonschema.validate(instance=example, schema=schema)
+
+    def test_story_job_requires_title_channel_id_for_discord(self) -> None:
+        root = Path(__file__).resolve().parents[2]
+        schema = json.loads((root / "newsroom" / "schemas" / "story_job_v1.schema.json").read_text(encoding="utf-8"))
+        example = json.loads((root / "newsroom" / "examples" / "story_job_example.json").read_text(encoding="utf-8"))
+        example["destination"].pop("title_channel_id", None)
+        with self.assertRaises(jsonschema.ValidationError):
+            jsonschema.validate(instance=example, schema=schema)
+
     def test_run_job_example_validates(self) -> None:
         root = Path(__file__).resolve().parents[2]
         schema = json.loads((root / "newsroom" / "schemas" / "run_job_v1.schema.json").read_text(encoding="utf-8"))
         example = json.loads((root / "newsroom" / "examples" / "run_job_example.json").read_text(encoding="utf-8"))
         jsonschema.validate(instance=example, schema=schema)
+
+    def test_run_job_disallows_webhook_platform(self) -> None:
+        root = Path(__file__).resolve().parents[2]
+        schema = json.loads((root / "newsroom" / "schemas" / "run_job_v1.schema.json").read_text(encoding="utf-8"))
+        example = json.loads((root / "newsroom" / "examples" / "run_job_example.json").read_text(encoding="utf-8"))
+        example["destination"]["platform"] = "webhook"
+        with self.assertRaises(jsonschema.ValidationError):
+            jsonschema.validate(instance=example, schema=schema)
 
 
 class TestPromptRegistry(unittest.TestCase):

--- a/newsroom/tests/test_pool_update_ok_semantics.py
+++ b/newsroom/tests/test_pool_update_ok_semantics.py
@@ -1,0 +1,256 @@
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+import scripts.gdelt_pool_update as gdelt_pool_update
+import scripts.rss_pool_update as rss_pool_update
+from newsroom.gdelt_news import GdeltFetch
+from newsroom.news_pool_db import NewsPoolDB
+from newsroom.rss_news import RssArticle, RssFeed, RssFetch
+
+
+class TestPoolUpdateOkSemantics(unittest.TestCase):
+    def test_gdelt_does_not_update_fetch_state_on_fetch_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "news_pool.sqlite3"
+            state_key = "gdelt_test"
+
+            def fake_fetch_gdelt_articles(**kwargs):
+                return (
+                    GdeltFetch(
+                        ok=False,
+                        cached=False,
+                        requests_made=1,
+                        query=str(kwargs.get("query") or ""),
+                        maxrecords=int(kwargs.get("maxrecords") or 75),
+                        timespan=str(kwargs.get("timespan") or "24h"),
+                        fetched_at="2026-02-10T00:00:00+00:00",
+                        results=[],
+                        error="boom",
+                    ),
+                    0.0,
+                )
+
+            buf = io.StringIO()
+            with patch.object(gdelt_pool_update, "fetch_gdelt_articles", side_effect=fake_fetch_gdelt_articles):
+                with redirect_stdout(buf):
+                    rc = gdelt_pool_update.main(
+                        [
+                            "--db",
+                            str(db_path),
+                            "--state-key",
+                            state_key,
+                            "--min-interval-seconds",
+                            "0",
+                            "--query",
+                            "test",
+                        ]
+                    )
+
+            self.assertEqual(rc, 0)
+            out = json.loads(buf.getvalue())
+            self.assertFalse(out["ok"])
+            self.assertTrue(out["fetch"]["should_fetch"])
+            self.assertFalse(out["fetch"]["ok"])
+            self.assertEqual(out["fetch"]["error"], "boom")
+
+            with NewsPoolDB(path=db_path) as db:
+                state = db.fetch_state(state_key)
+                self.assertEqual(state["run_count"], 0)
+                self.assertEqual(state["last_fetch_ts"], 0)
+
+    def test_gdelt_updates_fetch_state_on_success(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "news_pool.sqlite3"
+            state_key = "gdelt_test"
+
+            def fake_fetch_gdelt_articles(**kwargs):
+                return (
+                    GdeltFetch(
+                        ok=True,
+                        cached=False,
+                        requests_made=1,
+                        query=str(kwargs.get("query") or ""),
+                        maxrecords=int(kwargs.get("maxrecords") or 75),
+                        timespan=str(kwargs.get("timespan") or "24h"),
+                        fetched_at="2026-02-10T00:00:00+00:00",
+                        results=[
+                            {
+                                "title": "Example",
+                                "url": "https://example.com/a",
+                                "domain": "example.com",
+                                "page_age": "2026-02-10T00:00:00+00:00",
+                            }
+                        ],
+                    ),
+                    0.0,
+                )
+
+            buf = io.StringIO()
+            with patch.object(gdelt_pool_update, "fetch_gdelt_articles", side_effect=fake_fetch_gdelt_articles):
+                with redirect_stdout(buf):
+                    rc = gdelt_pool_update.main(
+                        [
+                            "--db",
+                            str(db_path),
+                            "--state-key",
+                            state_key,
+                            "--min-interval-seconds",
+                            "0",
+                            "--query",
+                            "test",
+                        ]
+                    )
+
+            self.assertEqual(rc, 0)
+            out = json.loads(buf.getvalue())
+            self.assertTrue(out["ok"])
+            self.assertTrue(out["fetch"]["should_fetch"])
+            self.assertTrue(out["fetch"]["ok"])
+
+            with NewsPoolDB(path=db_path) as db:
+                state = db.fetch_state(state_key)
+                self.assertEqual(state["run_count"], 1)
+                self.assertGreater(state["last_fetch_ts"], 0)
+
+    def test_rss_does_not_update_fetch_state_if_all_feeds_fail(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "news_pool.sqlite3"
+            state_key = "rss_test"
+
+            feeds = [
+                RssFeed(key="f1", url="https://example.com/f1.xml", label="Feed 1", region="global"),
+                RssFeed(key="f2", url="https://example.com/f2.xml", label="Feed 2", region="global"),
+            ]
+
+            def fake_load_feeds(*, config_path: Path | None = None):
+                return list(feeds)
+
+            def fake_fetch_rss_feed(feed: RssFeed, **kwargs):
+                return (
+                    RssFetch(
+                        ok=False,
+                        feed_key=feed.key,
+                        requests_made=1,
+                        fetched_at="2026-02-10T00:00:00+00:00",
+                        articles=[],
+                        error=f"fail:{feed.key}",
+                    ),
+                    0.0,
+                )
+
+            buf = io.StringIO()
+            with patch.object(rss_pool_update, "load_feeds", side_effect=fake_load_feeds):
+                with patch.object(rss_pool_update, "fetch_rss_feed", side_effect=fake_fetch_rss_feed):
+                    with redirect_stdout(buf):
+                        rc = rss_pool_update.main(
+                            [
+                                "--db",
+                                str(db_path),
+                                "--state-key",
+                                state_key,
+                                "--min-interval-seconds",
+                                "0",
+                                "--feeds-config",
+                                str(Path(td) / "rss_feeds.yaml"),
+                            ]
+                        )
+
+            self.assertEqual(rc, 0)
+            out = json.loads(buf.getvalue())
+            self.assertFalse(out["ok"])
+            self.assertTrue(out["fetch"]["should_fetch"])
+            self.assertFalse(out["fetch"]["ok"])
+            self.assertEqual(out["fetch"]["feeds_ok"], 0)
+            self.assertEqual(out["fetch"]["feeds_failed"], 2)
+            self.assertIn("errors", out["fetch"])
+
+            with NewsPoolDB(path=db_path) as db:
+                state = db.fetch_state(state_key)
+                self.assertEqual(state["run_count"], 0)
+                self.assertEqual(state["last_fetch_ts"], 0)
+
+    def test_rss_updates_fetch_state_if_any_feed_succeeds(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "news_pool.sqlite3"
+            state_key = "rss_test"
+
+            feeds = [
+                RssFeed(key="f1", url="https://example.com/f1.xml", label="Feed 1", region="global"),
+                RssFeed(key="f2", url="https://example.com/f2.xml", label="Feed 2", region="global"),
+            ]
+
+            def fake_load_feeds(*, config_path: Path | None = None):
+                return list(feeds)
+
+            def fake_fetch_rss_feed(feed: RssFeed, **kwargs):
+                if feed.key == "f1":
+                    return (
+                        RssFetch(
+                            ok=False,
+                            feed_key=feed.key,
+                            requests_made=1,
+                            fetched_at="2026-02-10T00:00:00+00:00",
+                            articles=[],
+                            error="fail:f1",
+                        ),
+                        0.0,
+                    )
+
+                return (
+                    RssFetch(
+                        ok=True,
+                        feed_key=feed.key,
+                        requests_made=1,
+                        fetched_at="2026-02-10T00:00:00+00:00",
+                        articles=[
+                            RssArticle(
+                                url="https://example.com/a",
+                                title="Example",
+                                description=None,
+                                published="2026-02-10T00:00:00+00:00",
+                                domain="example.com",
+                            )
+                        ],
+                    ),
+                    0.0,
+                )
+
+            buf = io.StringIO()
+            with patch.object(rss_pool_update, "load_feeds", side_effect=fake_load_feeds):
+                with patch.object(rss_pool_update, "fetch_rss_feed", side_effect=fake_fetch_rss_feed):
+                    with redirect_stdout(buf):
+                        rc = rss_pool_update.main(
+                            [
+                                "--db",
+                                str(db_path),
+                                "--state-key",
+                                state_key,
+                                "--min-interval-seconds",
+                                "0",
+                                "--feeds-config",
+                                str(Path(td) / "rss_feeds.yaml"),
+                            ]
+                        )
+
+            self.assertEqual(rc, 0)
+            out = json.loads(buf.getvalue())
+            self.assertTrue(out["ok"])
+            self.assertTrue(out["fetch"]["should_fetch"])
+            self.assertTrue(out["fetch"]["ok"])
+            self.assertEqual(out["fetch"]["feeds_ok"], 1)
+            self.assertEqual(out["fetch"]["feeds_failed"], 1)
+
+            with NewsPoolDB(path=db_path) as db:
+                state = db.fetch_state(state_key)
+                self.assertEqual(state["run_count"], 1)
+                self.assertGreater(state["last_fetch_ts"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/newsroom/tests/test_runner_hardening.py
+++ b/newsroom/tests/test_runner_hardening.py
@@ -1,0 +1,162 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from newsroom.brave_news import BraveApiKey
+from newsroom.runner import (
+    NewsroomRunner,
+    PromptRegistry,
+    PromptRegistryError,
+    _render_template,
+    discover_jobs_under,
+    discover_story_job_files,
+)
+
+
+class _DummyGateway:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str | None, dict[str, object]]] = []
+
+    def invoke(  # type: ignore[no-untyped-def]
+        self,
+        *,
+        tool: str,
+        action: str | None = None,
+        args: dict[str, object] | None = None,
+        **_kwargs,
+    ) -> dict[str, object]:
+        self.calls.append((tool, action, dict(args or {})))
+        return {"ok": True}
+
+
+class TestRunnerHardening(unittest.TestCase):
+    def test_render_template_does_not_replace_inside_input_json(self) -> None:
+        tpl = "header\n{{INPUT_JSON}}\nfooter\nhome={{OPENCLAW_HOME}}\n"
+        injected = json.dumps({"x": "{{OPENCLAW_HOME}}", "y": "{{MISSING_VAR}}"}, ensure_ascii=False)
+        out = _render_template(tpl, {"INPUT_JSON": injected, "OPENCLAW_HOME": "/tmp/openclaw"})
+        # Placeholders inside INPUT_JSON must remain literal.
+        self.assertIn('"x": "{{OPENCLAW_HOME}}"', out)
+        self.assertIn('"y": "{{MISSING_VAR}}"', out)
+        # Placeholders in the template itself must be rendered.
+        self.assertIn("home=/tmp/openclaw", out)
+
+    def test_render_template_rejects_mixed_case_placeholder_names(self) -> None:
+        with self.assertRaises(PromptRegistryError):
+            _render_template("{{Input_JSON}}", {"INPUT_JSON": "{}"})
+
+    def test_render_template_rejects_missing_placeholders(self) -> None:
+        with self.assertRaises(PromptRegistryError):
+            _render_template("{{MISSING_VAR}}", {"INPUT_JSON": "{}"})
+
+    def test_send_dm_summary_is_best_effort_and_continues(self) -> None:
+        root = Path(__file__).resolve().parents[2]
+
+        class FlakyGateway(_DummyGateway):
+            def invoke(self, *, tool: str, action: str | None = None, args=None, **kwargs):  # type: ignore[no-untyped-def]
+                # Fail only the first send.
+                if len(self.calls) == 0:
+                    self.calls.append((tool, action, dict(args or {})))
+                    raise RuntimeError("boom")
+                return super().invoke(tool=tool, action=action, args=args, **kwargs)
+
+        gw = FlakyGateway()
+        runner = NewsroomRunner(
+            openclaw_home=root,
+            gateway=gw,  # type: ignore[arg-type]
+            prompt_registry=PromptRegistry(openclaw_home=root),
+            dry_run=False,
+            lock_ttl_seconds=3600,
+            log_root=root / "logs" / "newsroom-test",
+        )
+
+        with self.assertLogs("newsroom.runner", level="WARNING") as cm:
+            runner.send_dm_summary(dm_targets=["discord:1", "discord:2"], summary="test\n")
+
+        self.assertGreaterEqual(len(gw.calls), 2)
+        self.assertTrue(any("DM summary send failed" in msg for msg in cm.output))
+
+    def test_discover_story_job_files_jails_unreadable_job_like_json(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            (d / "run.json").write_text("{}", encoding="utf-8")
+
+            bad = d / "story_01.json"
+            bad.write_text("{not-json", encoding="utf-8")
+
+            with self.assertLogs("newsroom.runner", level="WARNING") as cm:
+                jobs = discover_story_job_files(d)
+
+            self.assertEqual(jobs, [])
+            self.assertFalse(bad.exists())
+            self.assertTrue((d / "story_01.json.jail").exists())
+            self.assertTrue((d / "story_01.json.jail.reason").exists())
+            self.assertTrue(any("Unreadable JSON while discovering story jobs" in msg for msg in cm.output))
+
+    def test_discover_story_job_files_warns_but_does_not_jail_non_job_like_json(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            bad = d / "foo.json"
+            bad.write_text("{not-json", encoding="utf-8")
+
+            with self.assertLogs("newsroom.runner", level="WARNING") as cm:
+                jobs = discover_story_job_files(d)
+
+            self.assertEqual(jobs, [])
+            self.assertTrue(bad.exists())
+            self.assertFalse((d / "foo.json.jail").exists())
+            self.assertTrue(any("Unreadable JSON while discovering story jobs" in msg for msg in cm.output))
+
+    def test_brave_fetch_pacing_is_per_key_id(self) -> None:
+        root = Path(__file__).resolve().parents[2]
+        runner = NewsroomRunner(
+            openclaw_home=root,
+            gateway=_DummyGateway(),  # type: ignore[arg-type]
+            prompt_registry=PromptRegistry(openclaw_home=root),
+            dry_run=True,
+            lock_ttl_seconds=3600,
+            log_root=root / "logs" / "newsroom-test",
+        )
+
+        key1 = BraveApiKey(key="k1", label="a")
+        key2 = BraveApiKey(key="k2", label="b")
+
+        expected_last: dict[str, float] = {"k1": 0.0, "k2": 0.0}
+        new_ts: dict[str, float] = {"k1": 111.0, "k2": 222.0}
+
+        def _fake_fetch(  # type: ignore[no-untyped-def]
+            *,
+            api_key: str,
+            q: str,
+            last_request_ts: float = 0.0,
+            **_kwargs,
+        ):
+            self.assertEqual(q, "test")
+            self.assertAlmostEqual(float(last_request_ts), expected_last[api_key], places=6)
+            expected_last[api_key] = new_ts[api_key]
+            fetch = SimpleNamespace(results=[], rate_limit=None)
+            return fetch, new_ts[api_key]
+
+        with patch("newsroom.runner.fetch_brave_news", side_effect=_fake_fetch):
+            runner._fetch_brave_news_paced(key=key1, q="test")  # type: ignore[attr-defined]
+            runner._fetch_brave_news_paced(key=key2, q="test")  # type: ignore[attr-defined]
+            runner._fetch_brave_news_paced(key=key1, q="test")  # type: ignore[attr-defined]
+
+    def test_discover_jobs_under_jails_unreadable_job_like_json(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            jobs_root = Path(td)
+
+            # Create a corrupt job directly under jobs_root (not under a run dir).
+            bad = jobs_root / "story_01.json"
+            bad.write_text("{not-json", encoding="utf-8")
+
+            with self.assertLogs("newsroom.runner", level="WARNING") as cm:
+                jobs = discover_jobs_under(jobs_root)
+
+            self.assertEqual(jobs, [])
+            self.assertFalse(bad.exists())
+            self.assertTrue((jobs_root / "story_01.json.jail").exists())
+            self.assertTrue(any("Unreadable JSON while discovering story jobs" in msg for msg in cm.output))
+

--- a/newsroom/tests/test_subprocess_json.py
+++ b/newsroom/tests/test_subprocess_json.py
@@ -1,0 +1,35 @@
+import sys
+import unittest
+
+from newsroom.subprocess_json import run_json_command
+
+
+class TestRunJsonCommand(unittest.TestCase):
+    def test_success_parses_json_object(self) -> None:
+        cmd = [sys.executable, "-c", "print('{\"ok\": true, \"value\": 123}')"]
+        res = run_json_command(cmd, timeout_seconds=2, max_output_chars=2000)
+        self.assertTrue(res.get("ok"))
+        self.assertEqual(res.get("value"), 123)
+
+    def test_timeout_returns_structured_error_with_truncation(self) -> None:
+        # Emit a lot of output, then hang long enough to trigger the timeout.
+        cmd = [
+            sys.executable,
+            "-c",
+            (
+                "import sys, time;"
+                "sys.stdout.write('a' * 5000); sys.stdout.flush();"
+                "sys.stderr.write('b' * 5000); sys.stderr.flush();"
+                "time.sleep(5)"
+            ),
+        ]
+        res = run_json_command(cmd, timeout_seconds=0.5, max_output_chars=2000)
+        self.assertFalse(res.get("ok"))
+        self.assertEqual(res.get("error"), "timeout")
+        self.assertEqual(res.get("timeout_seconds"), 0.5)
+        self.assertEqual(res.get("cmd"), cmd)
+        self.assertEqual(len(res.get("stdout", "")), 2000)
+        self.assertEqual(len(res.get("stderr", "")), 2000)
+        self.assertEqual(res.get("stdout"), "a" * 2000)
+        self.assertEqual(res.get("stderr"), "b" * 2000)
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,10 @@ Issues = "https://github.com/fol2/openclaw-newsroom/issues"
 
 [project.optional-dependencies]
 charts = ["Pillow>=10.0"]
+dev = [
+    "pytest>=7.0",
+    "pytest-cov>=4.0",
+]
 
 [dependency-groups]
 dev = [

--- a/scripts/newsroom_daily_inputs.py
+++ b/scripts/newsroom_daily_inputs.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import subprocess
 import sys
 import time
 from datetime import UTC, datetime
@@ -24,6 +23,7 @@ sys.path.insert(0, str(OPENCLAW_HOME))
 from newsroom.event_manager import cluster_all_pending, merge_events  # noqa: E402
 from newsroom.gemini_client import GeminiClient  # noqa: E402
 from newsroom.news_pool_db import NewsPoolDB  # noqa: E402
+from newsroom.subprocess_json import run_json_command  # noqa: E402
 
 # Default queries:
 # - Global: exclude explicit UK terms (daily does a dedicated UK call).
@@ -37,27 +37,27 @@ DEFAULT_UK_QUERY = "UK (site:co.uk OR site:theguardian.com OR site:news.sky.com 
 _DB_PATH = OPENCLAW_HOME / "data" / "newsroom" / "news_pool.sqlite3"
 
 
+def _default_subprocess_timeout_seconds() -> float:
+    """Timeout for child processes spawned by the inputs scripts.
+
+    These scripts are called from cron-driven LLM planners. A hung subprocess
+    should not block the planner turn until the cron timeout.
+    """
+    raw = (os.environ.get("NEWSROOM_INPUTS_SUBPROCESS_TIMEOUT_SECONDS") or "").strip()
+    if not raw:
+        return 120.0
+    try:
+        return float(raw)
+    except ValueError:
+        return 120.0
+
+
+_SUBPROCESS_TIMEOUT_SECONDS = _default_subprocess_timeout_seconds()
+
+
 def _run_json(cmd: list[str]) -> dict[str, Any]:
-    """Run a command that prints JSON to stdout and parse it."""
-    try:
-        proc = subprocess.run(cmd, text=True, capture_output=True)
-    except Exception as e:
-        return {"ok": False, "error": "spawn_failed", "detail": str(e), "cmd": cmd}
-    out = proc.stdout or ""
-    if proc.returncode != 0:
-        return {
-            "ok": False,
-            "error": "cmd_failed",
-            "returncode": int(proc.returncode),
-            "stdout": out[:2000],
-            "stderr": (proc.stderr or "")[:2000],
-            "cmd": cmd,
-        }
-    try:
-        obj = json.loads(out)
-    except Exception:
-        return {"ok": False, "error": "invalid_json", "stdout": out[:2000]}
-    return obj if isinstance(obj, dict) else {"ok": False, "error": "json_not_object"}
+    """Run a JSON-emitting subprocess with a hard timeout."""
+    return run_json_command(cmd, timeout_seconds=_SUBPROCESS_TIMEOUT_SECONDS, max_output_chars=2000)
 
 
 def main(argv: list[str]) -> int:

--- a/scripts/recluster_events.py
+++ b/scripts/recluster_events.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""One-time re-clustering: merge fragmented events using retrieve-then-decide.
+
+Uses pairwise token/anchor retrieval to find duplicate event pairs,
+then asks the LLM to confirm merges. Multi-pass until convergence.
+
+Usage:
+    PYTHONPATH=. python scripts/recluster_events.py [--dry-run] [--max-merges 50] [--passes 3]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+OPENCLAW_HOME = Path(__file__).resolve().parents[1]
+os.environ.setdefault("OPENCLAW_HOME", str(OPENCLAW_HOME))
+sys.path.insert(0, str(OPENCLAW_HOME))
+
+from newsroom.event_manager import (  # noqa: E402
+    EventTokens,
+    _tokenize_event,
+    build_merge_prompt,
+    parse_merge_response,
+    retrieve_candidates,
+)
+from newsroom.gemini_client import GeminiClient  # noqa: E402
+from newsroom.news_pool_db import NewsPoolDB  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+_DB_PATH = OPENCLAW_HOME / "data" / "newsroom" / "news_pool.sqlite3"
+
+
+def _pairwise_scores(
+    events: list[dict[str, Any]],
+    *,
+    min_score: float = 0.25,
+    token_cache: dict[int, EventTokens],
+) -> list[tuple[int, int, float]]:
+    """Compute pairwise retrieval scores between all root events.
+
+    Returns list of (eid_a, eid_b, score) where score >= min_score,
+    sorted by score descending.
+    """
+    pairs: list[tuple[int, int, float]] = []
+
+    for i, ev_a in enumerate(events):
+        # Use retrieve_candidates to find matches for ev_a among remaining events.
+        # We treat ev_a as a "link" for retrieval purposes.
+        link_like = {
+            "title": ev_a.get("summary_en") or ev_a.get("title") or "",
+            "description": ev_a.get("title") or "",
+        }
+        others = events[i + 1:]
+        if not others:
+            continue
+
+        candidates = retrieve_candidates(
+            link_like, others,
+            top_k=10, min_score=min_score,
+            token_cache=token_cache,
+        )
+        for ev_b, score in candidates:
+            pairs.append((ev_a["id"], ev_b["id"], score))
+
+    pairs.sort(key=lambda x: x[2], reverse=True)
+    return pairs
+
+
+def recluster_pass(
+    *,
+    db: NewsPoolDB,
+    gemini: GeminiClient,
+    max_merges: int,
+    dry_run: bool,
+    delay_seconds: float = 3.0,
+) -> dict[str, int]:
+    """Run one reclustering pass. Returns stats."""
+    stats = {
+        "root_events": 0,
+        "pairs_found": 0,
+        "llm_calls": 0,
+        "merges": 0,
+        "links_moved": 0,
+        "errors": 0,
+    }
+
+    all_events = db.get_all_fresh_events(max_age_hours=168)
+    root_events = [
+        ev for ev in all_events
+        if ev.get("parent_event_id") is None
+    ]
+    stats["root_events"] = len(root_events)
+
+    if len(root_events) < 2:
+        return stats
+
+    token_cache: dict[int, EventTokens] = {}
+    pairs = _pairwise_scores(root_events, token_cache=token_cache)
+    stats["pairs_found"] = len(pairs)
+
+    if not pairs:
+        return stats
+
+    ev_lookup = {ev["id"]: ev for ev in root_events}
+    merged_this_pass: set[int] = set()
+
+    for eid_a, eid_b, score in pairs:
+        if stats["merges"] >= max_merges:
+            break
+        if eid_a in merged_this_pass or eid_b in merged_this_pass:
+            continue
+
+        ev_a = ev_lookup.get(eid_a)
+        ev_b = ev_lookup.get(eid_b)
+        if not ev_a or not ev_b:
+            continue
+
+        # Ask LLM to confirm merge.
+        prompt = build_merge_prompt(
+            [ev_a, ev_b],
+            f"recluster ({ev_a.get('category', '?')} + {ev_b.get('category', '?')})",
+        )
+
+        try:
+            raw_text = gemini.generate(prompt)
+        except Exception as e:
+            logger.warning("LLM call failed for pair (%d, %d): %s", eid_a, eid_b, e)
+            stats["errors"] += 1
+            continue
+
+        stats["llm_calls"] += 1
+
+        if not raw_text:
+            stats["errors"] += 1
+            continue
+
+        sanitized = re.sub(r'\bE(\d+)\b', r'\1', raw_text)
+        try:
+            response = json.loads(
+                sanitized[sanitized.find("{"):sanitized.rfind("}") + 1]
+            )
+        except (json.JSONDecodeError, ValueError):
+            stats["errors"] += 1
+            continue
+
+        valid_ids = {eid_a, eid_b}
+        groups = parse_merge_response(response, valid_ids)
+        if not groups:
+            continue
+
+        for group in groups:
+            group_events = [ev_lookup[eid] for eid in group if eid in ev_lookup]
+            if len(group_events) < 2:
+                continue
+
+            # Pick winner: most links, tiebreak oldest.
+            winner = max(
+                group_events,
+                key=lambda e: (e.get("link_count", 0), -(e.get("created_at_ts", 0))),
+            )
+            loser_ids = [e["id"] for e in group_events if e["id"] != winner["id"]]
+
+            if dry_run:
+                for lid in loser_ids:
+                    loser = ev_lookup.get(lid, {})
+                    logger.info(
+                        "[DRY RUN] Would merge event %d (%s) into %d (%s) | score=%.3f",
+                        lid, loser.get("summary_en", "?")[:60],
+                        winner["id"], winner.get("summary_en", "?")[:60],
+                        score,
+                    )
+                stats["merges"] += 1
+                merged_this_pass.update(loser_ids)
+            else:
+                # Handle posted status transfer.
+                winner_posted = winner.get("status") == "posted"
+                for lid in loser_ids:
+                    loser = ev_lookup.get(lid, {})
+                    if loser.get("status") == "posted" and not winner_posted:
+                        try:
+                            db.mark_event_posted(
+                                winner["id"],
+                                thread_id=loser.get("thread_id"),
+                                run_id=loser.get("run_id"),
+                            )
+                            winner_posted = True
+                        except Exception:
+                            pass
+
+                try:
+                    links_moved = db.merge_events_into(
+                        winner_id=winner["id"], loser_ids=loser_ids,
+                    )
+                    stats["merges"] += 1
+                    stats["links_moved"] += links_moved
+                    merged_this_pass.update(loser_ids)
+                    logger.info(
+                        "Merged event(s) %s into %d, %d links moved | score=%.3f",
+                        loser_ids, winner["id"], links_moved, score,
+                    )
+                except Exception as e:
+                    logger.warning("Merge failed for %s → %d: %s", loser_ids, winner["id"], e)
+                    stats["errors"] += 1
+
+        if delay_seconds > 0:
+            time.sleep(delay_seconds)
+
+    return stats
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Re-cluster fragmented events using retrieve-then-decide.")
+    parser.add_argument("--dry-run", action="store_true", help="Show proposed merges without executing.")
+    parser.add_argument("--max-merges", type=int, default=50, help="Max merges per pass (default: 50).")
+    parser.add_argument("--passes", type=int, default=3, help="Max re-clustering passes (default: 3).")
+    parser.add_argument("--delay", type=float, default=3.0, help="Delay between LLM calls in seconds (default: 3.0).")
+    parser.add_argument("--db-path", default=str(_DB_PATH), help="Path to news_pool.sqlite3.")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Verbose logging.")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    db_path = Path(args.db_path)
+    if not db_path.exists():
+        logger.error("Database not found: %s", db_path)
+        return 1
+
+    gemini = GeminiClient()
+    all_pass_stats: list[dict[str, int]] = []
+
+    for pass_num in range(1, args.passes + 1):
+        logger.info("=== Recluster pass %d/%d ===", pass_num, args.passes)
+
+        with NewsPoolDB(path=db_path) as db:
+            pass_stats = recluster_pass(
+                db=db,
+                gemini=gemini,
+                max_merges=args.max_merges,
+                dry_run=args.dry_run,
+                delay_seconds=args.delay,
+            )
+
+        all_pass_stats.append(pass_stats)
+        logger.info(
+            "Pass %d: %d root events, %d pairs, %d LLM calls, %d merges, %d links moved, %d errors",
+            pass_num,
+            pass_stats["root_events"], pass_stats["pairs_found"],
+            pass_stats["llm_calls"], pass_stats["merges"],
+            pass_stats["links_moved"], pass_stats["errors"],
+        )
+
+        # Stop if no merges happened this pass.
+        if pass_stats["merges"] == 0:
+            logger.info("No merges in pass %d — converged.", pass_num)
+            break
+
+    # Output JSON stats.
+    out = {
+        "ok": True,
+        "dry_run": args.dry_run,
+        "passes": all_pass_stats,
+        "total_merges": sum(s["merges"] for s in all_pass_stats),
+        "total_links_moved": sum(s["links_moved"] for s in all_pass_stats),
+        "total_errors": sum(s["errors"] for s in all_pass_stats),
+    }
+    print(json.dumps(out, ensure_ascii=False, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/uv.lock
+++ b/uv.lock
@@ -310,6 +310,10 @@ dependencies = [
 charts = [
     { name = "pillow" },
 ]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -322,10 +326,12 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.0" },
     { name = "lxml", specifier = ">=4.9" },
     { name = "pillow", marker = "extra == 'charts'", specifier = ">=10.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.28" },
 ]
-provides-extras = ["charts"]
+provides-extras = ["charts", "dev"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

- **Retrieve-then-decide architecture**: Split LLM clustering into deterministic token/anchor retrieval (top 5 candidates) + focused LLM prompt, replacing the old approach of dumping 50+ events into the prompt
- **Cross-category, status-agnostic matching**: Retrieval sees ALL events (including posted), eliminating blind spots that caused duplicate posts
- **Recluster script**: `scripts/recluster_events.py` for retroactive cleanup of fragmented events (tested: 51 merges, 98 links moved, 0 errors on production DB)

### Key changes

| File | What changed |
|------|-------------|
| `newsroom/event_manager.py` | `EventTokens`, `retrieve_candidates()`, `build_focused_clustering_prompt()`, modified `cluster_link()` / `cluster_all_pending()` / `merge_events()`, cross-category merge pass |
| `newsroom/news_pool_db.py` | `get_all_fresh_events()`, `get_root_event_id()`, fixed `_enrich_candidates()` dedupe keys |
| `newsroom/tests/test_event_manager.py` | 51 tests (25+ new), covering retrieval, focused prompt, merge, cross-category, dedupe keys |
| `scripts/recluster_events.py` | New multi-pass recluster script with `--dry-run` support |

### Backward compatibility

- `cluster_link()` accepts both `all_events` (new) and `fresh_events` (legacy alias)
- `build_clustering_prompt()` kept as legacy
- `merge_events()` and `cluster_all_pending()` signatures unchanged for callers

## Test plan

- [x] All 51 unit tests pass (`uv run pytest newsroom/tests/ -v`)
- [x] Dry run on production DB: 256 candidate pairs from 1010 root events
- [x] Real run on production DB: 51 merges across 3 passes, 0 errors
- [x] Jimmy Lai event consolidated from 8+ fragments to 1 root with 74 children
- [ ] Monitor Discord for duplicate reduction over 24-48h after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)