### PR TITLE
DB backup: JSONL dump/restore sandbox tools

### DIFF
--- a/newsroom/news_pool_backup.py
+++ b/newsroom/news_pool_backup.py
@@ -1,0 +1,332 @@
+from __future__ import annotations
+
+"""JSONL dump/restore utilities for the newsroom SQLite news pool.
+
+This module exists to support reproducible clustering experiments without touching
+the production database.  It provides two operations:
+
+1) Dump a time-windowed snapshot of `links` and `events` to JSONL.
+2) Restore that JSONL into a fresh SQLite database (with the current schema).
+
+The dump uses a read-only SQLite connection and runs inside a single transaction
+to ensure the `links` and `events` exports are mutually consistent.
+"""
+
+import json
+import os
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any
+
+from newsroom.news_pool_db import NewsPoolDB
+
+
+def _jsonl_write(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, ensure_ascii=False, sort_keys=True))
+            f.write("\n")
+
+
+def _jsonl_read(path: Path) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            s = line.strip()
+            if not s:
+                continue
+            out.append(json.loads(s))
+    return out
+
+
+def _sqlite_ro_connect(path: Path) -> sqlite3.Connection:
+    # Using mode=ro ensures we never create a new DB by accident.
+    uri = path.resolve().as_uri() + "?mode=ro"
+    conn = sqlite3.connect(uri, uri=True, timeout=30)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys=ON;")
+    return conn
+
+
+def dump_news_pool_jsonl(
+    *,
+    source_db: Path,
+    out_dir: Path,
+    links_window_hours: int = 48,
+    events_max_age_hours: int = 168,
+    now_ts: int | None = None,
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    """Dump `links` and `events` to JSONL under out_dir.
+
+    Args:
+        source_db: Existing SQLite database path.
+        out_dir: Output directory. Files written: links.jsonl, events.jsonl, manifest.json.
+        links_window_hours: Export links where last_seen_ts is within this window.
+        events_max_age_hours: Export events where created_at_ts is within this window.
+            Events referenced by the exported links (and their parent chain) are always included.
+        now_ts: Override 'now' for deterministic dumps/tests.
+        overwrite: If True, allow overwriting existing output files.
+
+    Returns:
+        Manifest dict written to manifest.json.
+    """
+    source_db = Path(source_db).expanduser()
+    out_dir = Path(out_dir).expanduser()
+
+    if not source_db.exists():
+        raise FileNotFoundError(f"Source DB does not exist: {source_db}")
+
+    if links_window_hours <= 0:
+        raise ValueError("links_window_hours must be > 0")
+    if events_max_age_hours <= 0:
+        raise ValueError("events_max_age_hours must be > 0")
+
+    links_path = out_dir / "links.jsonl"
+    events_path = out_dir / "events.jsonl"
+    manifest_path = out_dir / "manifest.json"
+
+    if not overwrite:
+        for p in (links_path, events_path, manifest_path):
+            if p.exists():
+                raise FileExistsError(f"Refusing to overwrite existing dump file: {p}")
+
+    now = int(time.time()) if now_ts is None else int(now_ts)
+    link_cutoff_ts = now - int(links_window_hours) * 3600
+    event_cutoff_ts = now - int(events_max_age_hours) * 3600
+
+    with _sqlite_ro_connect(source_db) as conn:
+        # Single snapshot for consistency across tables.
+        conn.execute("BEGIN;")
+
+        schema_version = None
+        try:
+            row = conn.execute("SELECT v FROM meta WHERE k='schema_version'").fetchone()
+            schema_version = int(row["v"]) if row and row["v"] is not None else None
+        except Exception:
+            schema_version = None
+
+        # Links (time-windowed).
+        links_rows: list[dict[str, Any]] = []
+        referenced_event_ids: set[int] = set()
+        for r in conn.execute(
+            "SELECT * FROM links WHERE last_seen_ts >= ? ORDER BY id ASC",
+            (int(link_cutoff_ts),),
+        ).fetchall():
+            obj = dict(r)
+            links_rows.append(obj)
+            eid = obj.get("event_id")
+            if isinstance(eid, int):
+                referenced_event_ids.add(int(eid))
+
+        # Events within window.
+        events_by_id: dict[int, dict[str, Any]] = {}
+        for r in conn.execute(
+            "SELECT * FROM events WHERE created_at_ts >= ? ORDER BY id ASC",
+            (int(event_cutoff_ts),),
+        ).fetchall():
+            obj = dict(r)
+            eid = obj.get("id")
+            if isinstance(eid, int):
+                events_by_id[int(eid)] = obj
+
+        # Ensure referenced events (and parent chain) exist in the dump even if older.
+        missing: set[int] = {eid for eid in referenced_event_ids if eid not in events_by_id}
+        while missing:
+            eid = missing.pop()
+            row = conn.execute("SELECT * FROM events WHERE id = ?", (int(eid),)).fetchone()
+            if not row:
+                raise RuntimeError(f"links references missing event_id={eid} in {source_db}")
+            obj = dict(row)
+            events_by_id[int(eid)] = obj
+
+            pid = obj.get("parent_event_id")
+            if isinstance(pid, int) and int(pid) not in events_by_id:
+                missing.add(int(pid))
+
+        # Expand any remaining parents from window events too.
+        expanded = True
+        while expanded:
+            expanded = False
+            for ev in list(events_by_id.values()):
+                pid = ev.get("parent_event_id")
+                if not isinstance(pid, int):
+                    continue
+                pid_i = int(pid)
+                if pid_i in events_by_id:
+                    continue
+                row = conn.execute("SELECT * FROM events WHERE id = ?", (pid_i,)).fetchone()
+                if not row:
+                    raise RuntimeError(f"events references missing parent_event_id={pid_i} in {source_db}")
+                events_by_id[pid_i] = dict(row)
+                expanded = True
+
+        conn.execute("COMMIT;")
+
+    # Deterministic file order.
+    events_rows = [events_by_id[eid] for eid in sorted(events_by_id)]
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    _jsonl_write(links_path, links_rows)
+    _jsonl_write(events_path, events_rows)
+
+    manifest = {
+        "ok": True,
+        "dumped_at_ts": now,
+        "source_db": str(source_db),
+        "schema_version": schema_version,
+        "links_window_hours": int(links_window_hours),
+        "events_max_age_hours": int(events_max_age_hours),
+        "counts": {"links": len(links_rows), "events": len(events_rows)},
+        "files": {
+            "links_jsonl": str(links_path),
+            "events_jsonl": str(events_path),
+        },
+    }
+    manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return manifest
+
+
+def restore_news_pool_jsonl(
+    *,
+    dump_dir: Path,
+    target_db: Path,
+    overwrite: bool = False,
+    validate_foreign_keys: bool = True,
+) -> dict[str, Any]:
+    """Restore a dump directory produced by dump_news_pool_jsonl() into target_db.
+
+    The restore is implemented as a write to a temporary DB followed by an atomic
+    rename into place. This avoids leaving a partially-written SQLite file on disk
+    if the restore fails partway through.
+    """
+    dump_dir = Path(dump_dir).expanduser()
+    target_db = Path(target_db).expanduser()
+
+    links_path = dump_dir / "links.jsonl"
+    events_path = dump_dir / "events.jsonl"
+    manifest_path = dump_dir / "manifest.json"
+
+    if not links_path.exists():
+        raise FileNotFoundError(f"Missing dump file: {links_path}")
+    if not events_path.exists():
+        raise FileNotFoundError(f"Missing dump file: {events_path}")
+
+    if target_db.exists() and not overwrite:
+        raise FileExistsError(f"Target DB exists (pass --overwrite to replace): {target_db}")
+
+    target_db.parent.mkdir(parents=True, exist_ok=True)
+
+    # Use a temp path in the same directory so os.replace() stays atomic.
+    tmp_db = target_db.with_name(target_db.name + f".tmp.{os.getpid()}.{int(time.time())}")
+    if tmp_db.exists():
+        tmp_db.unlink()
+
+    # Best-effort cleanup of sidecar WAL/SHM files when overwriting.
+    if target_db.exists() and overwrite:
+        for sidecar in (Path(str(target_db) + "-wal"), Path(str(target_db) + "-shm")):
+            try:
+                sidecar.unlink()
+            except FileNotFoundError:
+                pass
+
+    try:
+        with NewsPoolDB(path=tmp_db) as db:
+            conn = db._conn
+            cur = conn.cursor()
+            cur.execute("BEGIN;")
+
+            # Restore events first (self-FK parent_event_id).
+            events = _jsonl_read(events_path)
+            events_by_id: dict[int, dict[str, Any]] = {}
+            for row in events:
+                eid = row.get("id")
+                if not isinstance(eid, int):
+                    raise ValueError("events.jsonl row missing integer 'id'")
+                events_by_id[int(eid)] = row
+
+            ev_cols = [r["name"] for r in cur.execute("PRAGMA table_info(events)").fetchall()]
+            ev_cols_set = set(ev_cols)
+            ev_insert_cols = [c for c in ev_cols if c in ev_cols_set]  # keep order
+            ev_sql = f"INSERT INTO events({','.join(ev_insert_cols)}) VALUES ({','.join(['?' for _ in ev_insert_cols])});"
+
+            remaining = set(events_by_id.keys())
+            inserted: set[int] = set()
+            while remaining:
+                progressed = False
+                for eid in sorted(remaining):
+                    row = events_by_id[eid]
+                    pid = row.get("parent_event_id")
+                    if pid is None:
+                        pass
+                    elif not isinstance(pid, int):
+                        raise ValueError(f"events.id={eid} has non-integer parent_event_id")
+                    elif int(pid) not in events_by_id:
+                        raise ValueError(f"events.id={eid} references missing parent_event_id={pid}")
+                    elif int(pid) not in inserted:
+                        continue  # parent not inserted yet
+
+                    values = [row.get(c) for c in ev_insert_cols]
+                    cur.execute(ev_sql, values)
+                    inserted.add(eid)
+                    remaining.remove(eid)
+                    progressed = True
+                    break
+                if not progressed:
+                    raise RuntimeError(f"Could not resolve parent_event_id order for events: {sorted(remaining)[:10]}")
+
+            # Restore links after events.
+            link_cols = [r["name"] for r in cur.execute("PRAGMA table_info(links)").fetchall()]
+            link_sql = f"INSERT INTO links({','.join(link_cols)}) VALUES ({','.join(['?' for _ in link_cols])});"
+
+            with links_path.open("r", encoding="utf-8") as f:
+                for line in f:
+                    s = line.strip()
+                    if not s:
+                        continue
+                    row = json.loads(s)
+                    if not isinstance(row, dict):
+                        raise ValueError("links.jsonl must contain JSON objects per line")
+                    values = [row.get(c) for c in link_cols]
+                    cur.execute(link_sql, values)
+
+            if validate_foreign_keys:
+                # This returns one row per violation. We only need to know if any exist.
+                bad = cur.execute("PRAGMA foreign_key_check;").fetchone()
+                if bad:
+                    raise RuntimeError(f"Foreign key check failed: {bad}")
+
+            cur.execute("COMMIT;")
+
+        # Replace into place.
+        os.replace(str(tmp_db), str(target_db))
+
+        # Best-effort remove sidecar files for the replaced DB path.
+        for sidecar in (Path(str(target_db) + "-wal"), Path(str(target_db) + "-shm")):
+            try:
+                sidecar.unlink()
+            except FileNotFoundError:
+                pass
+
+        manifest = None
+        try:
+            if manifest_path.exists():
+                manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except Exception:
+            manifest = None
+
+        return {
+            "ok": True,
+            "dump_dir": str(dump_dir),
+            "target_db": str(target_db),
+            "manifest": manifest,
+        }
+    finally:
+        try:
+            if tmp_db.exists():
+                tmp_db.unlink()
+        except Exception:
+            pass
+

--- a/newsroom/tests/test_news_pool_backup_jsonl.py
+++ b/newsroom/tests/test_news_pool_backup_jsonl.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from newsroom.news_pool_backup import dump_news_pool_jsonl, restore_news_pool_jsonl
+from newsroom.news_pool_db import NewsPoolDB, PoolLink
+
+
+def _table_rows(db_path: Path, table: str) -> list[dict]:
+    conn = sqlite3.connect(str(db_path), timeout=30)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(f"SELECT * FROM {table} ORDER BY id ASC").fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def test_dump_restore_roundtrip(tmp_path: Path) -> None:
+    src_db = tmp_path / "src.sqlite3"
+
+    now = int(time.time())
+
+    with NewsPoolDB(path=src_db) as db:
+        root_id = db.create_event(
+            summary_en="Root summary",
+            category="Global News",
+            jurisdiction="GB",
+            title="Root event",
+            primary_url="https://example.com/root",
+        )
+        child_id = db.create_event(
+            summary_en="Child summary",
+            category="Global News",
+            jurisdiction="GB",
+            title="Child event",
+            primary_url="https://example.com/child",
+            parent_event_id=root_id,
+        )
+
+        link = PoolLink(
+            url="https://example.com/a",
+            norm_url="https://example.com/a",
+            domain="example.com",
+            title="A",
+            description="desc",
+            age="1h",
+            page_age=None,
+            query="q",
+            offset=1,
+            fetched_at_ts=now,
+        )
+        db.upsert_links([link], now_ts=now)
+        link_id = int(db._conn.execute("SELECT id FROM links WHERE norm_url = ?", (link.norm_url,)).fetchone()["id"])
+        db.assign_link_to_event(link_id=link_id, event_id=child_id)
+
+    dump_dir = tmp_path / "dump"
+    manifest = dump_news_pool_jsonl(
+        source_db=src_db,
+        out_dir=dump_dir,
+        links_window_hours=48,
+        events_max_age_hours=168,
+        now_ts=now + 1,
+    )
+
+    assert manifest["ok"] is True
+    assert (dump_dir / "links.jsonl").exists()
+    assert (dump_dir / "events.jsonl").exists()
+    assert manifest["counts"]["links"] == 1
+    assert manifest["counts"]["events"] >= 2
+
+    restored_db = tmp_path / "restored.sqlite3"
+    restore_news_pool_jsonl(dump_dir=dump_dir, target_db=restored_db)
+
+    assert _table_rows(src_db, "links") == _table_rows(restored_db, "links")
+    assert _table_rows(src_db, "events") == _table_rows(restored_db, "events")
+
+
+def test_restore_refuses_existing_target_db(tmp_path: Path) -> None:
+    src_db = tmp_path / "src.sqlite3"
+    now = int(time.time())
+
+    with NewsPoolDB(path=src_db) as db:
+        eid = db.create_event(summary_en="Summary", category="Global News", jurisdiction="GB")
+        link = PoolLink(
+            url="https://example.com/a",
+            norm_url="https://example.com/a",
+            domain="example.com",
+            title="A",
+            description="desc",
+            age="1h",
+            page_age=None,
+            query="q",
+            offset=1,
+            fetched_at_ts=now,
+        )
+        db.upsert_links([link], now_ts=now)
+        link_id = int(db._conn.execute("SELECT id FROM links WHERE norm_url = ?", (link.norm_url,)).fetchone()["id"])
+        db.assign_link_to_event(link_id=link_id, event_id=eid)
+
+    dump_dir = tmp_path / "dump"
+    dump_news_pool_jsonl(source_db=src_db, out_dir=dump_dir, now_ts=now + 1)
+
+    target_db = tmp_path / "target.sqlite3"
+    restore_news_pool_jsonl(dump_dir=dump_dir, target_db=target_db)
+
+    with pytest.raises(FileExistsError):
+        restore_news_pool_jsonl(dump_dir=dump_dir, target_db=target_db, overwrite=False)
+
+    # Overwrite should succeed.
+    restore_news_pool_jsonl(dump_dir=dump_dir, target_db=target_db, overwrite=True)
+

--- a/scripts/news_pool_dump_jsonl.py
+++ b/scripts/news_pool_dump_jsonl.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""Dump the SQLite news pool (`links` + `events`) to JSONL for sandbox rebuilds.
+
+This is a lightweight safety tool for clustering experiments. It creates a
+read-only snapshot export of the production DB so you can restore it elsewhere
+and iterate without risk.
+
+By default the dump includes:
+- Links seen in the last 48 hours (by `last_seen_ts`)
+- Events created in the last 168 hours (by `created_at_ts`)
+- Any events referenced by those links, plus their parent chain
+
+Example:
+
+  # Dump into a timestamped folder
+  uv run python scripts/news_pool_dump_jsonl.py \\
+    --db data/newsroom/news_pool.sqlite3 \\
+    --out-dir data/newsroom/db_dumps/20260210T120000Z
+
+  # Restore into a separate DB for experiments
+  uv run python scripts/news_pool_restore_jsonl.py \\
+    --dump-dir data/newsroom/db_dumps/20260210T120000Z \\
+    --db data/newsroom/news_pool.sandbox.sqlite3
+"""
+
+import argparse
+import os
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+OPENCLAW_HOME = Path(__file__).resolve().parents[1]
+os.environ.setdefault("OPENCLAW_HOME", str(OPENCLAW_HOME))
+sys.path.insert(0, str(OPENCLAW_HOME))
+
+from newsroom.news_pool_backup import dump_news_pool_jsonl  # noqa: E402
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Dump newsroom news_pool.sqlite3 tables to JSONL (links + events).")
+    parser.add_argument("--db", default=str(OPENCLAW_HOME / "data" / "newsroom" / "news_pool.sqlite3"), help="Source SQLite db path.")
+    parser.add_argument("--out-dir", default="", help="Output directory (default: data/newsroom/db_dumps/<UTC timestamp>).")
+    parser.add_argument("--links-window-hours", type=int, default=48, help="Dump links seen within this window (default: 48).")
+    parser.add_argument("--events-max-age-hours", type=int, default=168, help="Dump events created within this window (default: 168).")
+    parser.add_argument("--overwrite", action="store_true", help="Overwrite existing dump files if they already exist.")
+    args = parser.parse_args(argv)
+
+    out_dir = str(args.out_dir or "").strip()
+    if not out_dir:
+        ts = datetime.now(tz=UTC).strftime("%Y%m%dT%H%M%SZ")
+        out_dir = str(OPENCLAW_HOME / "data" / "newsroom" / "db_dumps" / ts)
+
+    dump_news_pool_jsonl(
+        source_db=Path(args.db).expanduser(),
+        out_dir=Path(out_dir).expanduser(),
+        links_window_hours=int(args.links_window_hours),
+        events_max_age_hours=int(args.events_max_age_hours),
+        overwrite=bool(args.overwrite),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))
+

--- a/scripts/news_pool_restore_jsonl.py
+++ b/scripts/news_pool_restore_jsonl.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+"""Restore a JSONL dump into a fresh SQLite news pool database.
+
+This is the companion to scripts/news_pool_dump_jsonl.py.
+
+Safety:
+- If the target DB already exists, the script refuses to overwrite it unless
+  you pass --overwrite.
+- The restore writes to a temporary DB first and then atomically renames it
+  into place, so a failed restore will not leave a partially written DB.
+
+Example:
+
+  uv run python scripts/news_pool_restore_jsonl.py \\
+    --dump-dir data/newsroom/db_dumps/20260210T120000Z \\
+    --db data/newsroom/news_pool.sandbox.sqlite3
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+OPENCLAW_HOME = Path(__file__).resolve().parents[1]
+os.environ.setdefault("OPENCLAW_HOME", str(OPENCLAW_HOME))
+sys.path.insert(0, str(OPENCLAW_HOME))
+
+from newsroom.news_pool_backup import restore_news_pool_jsonl  # noqa: E402
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Restore a news pool JSONL dump into a fresh SQLite DB.")
+    parser.add_argument("--dump-dir", required=True, help="Dump directory produced by scripts/news_pool_dump_jsonl.py.")
+    parser.add_argument("--db", required=True, help="Target SQLite db path to create/replace.")
+    parser.add_argument("--overwrite", action="store_true", help="Replace target DB if it already exists.")
+    parser.add_argument("--no-foreign-key-check", action="store_true", help="Skip PRAGMA foreign_key_check after restore.")
+    args = parser.parse_args(argv)
+
+    restore_news_pool_jsonl(
+        dump_dir=Path(args.dump_dir).expanduser(),
+        target_db=Path(args.db).expanduser(),
+        overwrite=bool(args.overwrite),
+        validate_foreign_keys=not bool(args.no_foreign_key_check),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))
+


### PR DESCRIPTION
Adds JSONL dump/restore utilities for the SQLite news pool so clustering experiments can run against a sandbox DB without touching production.

- New module: newsroom/news_pool_backup.py
- New scripts: scripts/news_pool_dump_jsonl.py, scripts/news_pool_restore_jsonl.py
- README workflow documentation
- Tests for round-trip restore and overwrite safety

Restore is implemented as a write to a temporary DB followed by an atomic rename into place, and it refuses to overwrite an existing target unless --overwrite is set.

Closes #4