### PR TITLE
Enforce canonical categories in clustering

### DIFF
--- a/newsroom/event_manager.py
+++ b/newsroom/event_manager.py
@@ -51,7 +51,7 @@ _CATEGORY_ALIASES = {
     "world news": "Global News",
     "technology": "AI",
     "tech": "AI",
-    "technology/tech": "AI",
+    "technology / tech": "AI",
 }
 
 
@@ -63,7 +63,9 @@ def _normalise_category(raw: str | None) -> str:
     if not s:
         return "Global News"
     low = s.lower()
-    low = re.sub(r"\s*/\s*", "/", low)
+    # Normalise slash spacing so labels like "UK Parliament/Politics" match our
+    # canonical "UK Parliament / Politics" category strings.
+    low = re.sub(r"\s*/\s*", " / ", low)
     direct = _CANONICAL_CATEGORY_BY_LOWER.get(low)
     if direct:
         return direct

--- a/newsroom/event_manager.py
+++ b/newsroom/event_manager.py
@@ -45,6 +45,31 @@ _ASSIGNMENT_MIN_CONFIDENCE = 0.70
 _LINK_FLAGS_ALLOWED = {"roundup", "opinion", "live_updates", "multi_topic"}
 _LINK_FLAGS_FORCE_NEW_EVENT = {"roundup", "multi_topic"}
 
+_CANONICAL_CATEGORY_BY_LOWER = {c.lower(): c for c in CATEGORY_LIST}
+_CATEGORY_ALIASES = {
+    "us news": "Global News",
+    "world news": "Global News",
+    "technology": "AI",
+    "tech": "AI",
+}
+
+
+def _normalise_category(raw: str | None) -> str:
+    """Map a category label onto the canonical category set."""
+    if raw is None:
+        return "Global News"
+    s = str(raw).strip()
+    if not s:
+        return "Global News"
+    low = s.lower()
+    direct = _CANONICAL_CATEGORY_BY_LOWER.get(low)
+    if direct:
+        return direct
+    alias = _CATEGORY_ALIASES.get(low)
+    if alias:
+        return alias
+    return "Global News"
+
 
 # ---------------------------------------------------------------------------
 # Retrieve-then-decide helpers
@@ -671,7 +696,8 @@ def parse_clustering_response(
     match_basis = _parse_str_list(response.get("match_basis"))
     link_flags = _parse_link_flags(response.get("link_flags"))
 
-    category = str(response.get("category") or "").strip() or None
+    raw_category = str(response.get("category") or "").strip() or None
+    category = _normalise_category(raw_category)
     jurisdiction = str(response.get("jurisdiction") or "").strip() or None
 
     summary_en = str(response.get("summary_en") or "").strip()

--- a/newsroom/event_manager.py
+++ b/newsroom/event_manager.py
@@ -51,6 +51,7 @@ _CATEGORY_ALIASES = {
     "world news": "Global News",
     "technology": "AI",
     "tech": "AI",
+    "technology/tech": "AI",
 }
 
 
@@ -62,6 +63,7 @@ def _normalise_category(raw: str | None) -> str:
     if not s:
         return "Global News"
     low = s.lower()
+    low = re.sub(r"\s*/\s*", "/", low)
     direct = _CANONICAL_CATEGORY_BY_LOWER.get(low)
     if direct:
         return direct

--- a/newsroom/tests/test_event_manager.py
+++ b/newsroom/tests/test_event_manager.py
@@ -238,6 +238,8 @@ class TestParseClusteringResponse(unittest.TestCase):
             ("Technology", "AI"),
             ("Tech", "AI"),
             ("Technology/Tech", "AI"),
+            ("UK Parliament / Politics", "UK Parliament / Politics"),
+            ("UK Parliament/Politics", "UK Parliament / Politics"),
             ("global news", "Global News"),
             ("", "Global News"),
             (None, "Global News"),

--- a/newsroom/tests/test_event_manager.py
+++ b/newsroom/tests/test_event_manager.py
@@ -146,6 +146,36 @@ class TestParseClusteringResponse(unittest.TestCase):
         self.assertEqual(result["validated"]["summary_en"], "Tesla Q4 earnings beat expectations")
         self.assertEqual(result["enforced"]["action"], "new_event")
 
+    def test_parse_normalises_category_aliases(self) -> None:
+        response = {
+            "action": "new_event",
+            "confidence": 0.9,
+            "summary_en": "Tech story",
+            "category": "Technology",
+            "jurisdiction": "US",
+            "link_flags": [],
+            "match_basis": [],
+        }
+        result = parse_clustering_response(response, {}, [])
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["validated"]["category"], "AI")
+
+    def test_parse_defaults_unknown_category(self) -> None:
+        response = {
+            "action": "new_event",
+            "confidence": 0.9,
+            "summary_en": "Some story",
+            "category": "Completely Unknown",
+            "jurisdiction": "GLOBAL",
+            "link_flags": [],
+            "match_basis": [],
+        }
+        result = parse_clustering_response(response, {}, [])
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["validated"]["category"], "Global News")
+
     def test_parse_new_event_missing_summary(self) -> None:
         response = {"action": "new_event", "category": "AI"}
         result = parse_clustering_response(response, {}, [])


### PR DESCRIPTION
Normalises category labels from clustering responses so the DB never stores drifted category strings.

Key changes:
- Map aliases (US News/World News -> Global News; Technology/Tech -> AI).
- Default unknown/empty categories to Global News.
- Enforced in parse_clustering_response() so create_event() only sees canonical categories.

Tests:
- uv run pytest

Closes #10