### PR TITLE
feat: store bilingual entity aliases for new events

### DIFF
--- a/newsroom/event_manager.py
+++ b/newsroom/event_manager.py
@@ -107,6 +107,8 @@ def _normalise_entity_aliases(raw: Any, *, max_entities: int = 12, max_aliases_p
 
     if isinstance(parsed, dict):
         parsed = parsed.get("entity_aliases", parsed)
+    if isinstance(parsed, dict):
+        parsed = [parsed]
 
     if not isinstance(parsed, list):
         return []

--- a/newsroom/event_manager.py
+++ b/newsroom/event_manager.py
@@ -75,6 +75,156 @@ def _normalise_category(raw: str | None) -> str:
     return "Global News"
 
 
+def _clean_alias_text(v: Any, *, max_len: int = 120) -> str | None:
+    if not isinstance(v, (str, int, float)):
+        return None
+    s = " ".join(str(v).strip().split())
+    if not s:
+        return None
+    if len(s) > max_len:
+        s = s[:max_len]
+    return s
+
+
+def _normalise_entity_aliases(raw: Any, *, max_entities: int = 12, max_aliases_per_entity: int = 8) -> list[dict[str, Any]]:
+    """Normalise model-provided entity aliases to a stable list[dict] shape.
+
+    Output shape:
+      [{"label": "<canonical>", "aliases": ["<alias1>", ...]}, ...]
+    """
+    parsed = raw
+    if isinstance(parsed, str):
+        s = parsed.strip()
+        if not s:
+            return []
+        try:
+            parsed = json.loads(s)
+        except Exception:
+            parsed = [s]
+
+    if isinstance(parsed, dict):
+        parsed = parsed.get("entity_aliases", parsed)
+
+    if not isinstance(parsed, list):
+        return []
+
+    out: list[dict[str, Any]] = []
+    by_label: dict[str, int] = {}
+
+    def _parse_item(item: Any) -> tuple[str | None, list[str]]:
+        if isinstance(item, dict):
+            label = _clean_alias_text(
+                item.get("label")
+                or item.get("entity")
+                or item.get("name")
+                or item.get("canonical")
+            )
+            aliases_raw = item.get("aliases")
+            aliases: list[Any]
+            if isinstance(aliases_raw, list):
+                aliases = aliases_raw
+            elif aliases_raw is None:
+                aliases = []
+            else:
+                aliases = [aliases_raw]
+            for k in ("zh", "zh_hant", "zh_tw", "english", "en"):
+                if k in item:
+                    aliases.append(item.get(k))
+            return label, [_clean_alias_text(v) for v in aliases if _clean_alias_text(v)]
+        label = _clean_alias_text(item)
+        return label, []
+
+    for item in parsed:
+        label, aliases_raw = _parse_item(item)
+        all_terms: list[str] = []
+        seen_terms: set[str] = set()
+
+        if label:
+            seen_terms.add(label.casefold())
+            all_terms.append(label)
+
+        for a in aliases_raw:
+            low = a.casefold()
+            if low in seen_terms:
+                continue
+            seen_terms.add(low)
+            all_terms.append(a)
+            if len(all_terms) >= max_aliases_per_entity:
+                break
+
+        if not all_terms:
+            continue
+
+        canonical = all_terms[0]
+        canonical_key = canonical.casefold()
+        aliases = all_terms[1:]
+
+        existing_idx = by_label.get(canonical_key)
+        if existing_idx is None:
+            if len(out) >= max_entities:
+                break
+            out.append({"label": canonical, "aliases": aliases})
+            by_label[canonical_key] = len(out) - 1
+            continue
+
+        existing = out[existing_idx]
+        existing_aliases = existing.get("aliases")
+        if not isinstance(existing_aliases, list):
+            existing_aliases = []
+        existing_seen = {
+            str(existing.get("label", "")).casefold(),
+            *[str(v).casefold() for v in existing_aliases if isinstance(v, str)],
+        }
+        for a in aliases:
+            low = a.casefold()
+            if low in existing_seen:
+                continue
+            existing_seen.add(low)
+            existing_aliases.append(a)
+            if len(existing_aliases) >= max_aliases_per_entity:
+                break
+        existing["aliases"] = existing_aliases
+
+    return out
+
+
+def _entity_alias_surface_forms(event: dict[str, Any], *, max_terms: int = 32) -> list[str]:
+    """Return flattened alias surface forms from an event object."""
+    aliases_obj = event.get("entity_aliases")
+    if aliases_obj is None:
+        aliases_obj = event.get("entity_aliases_json")
+
+    aliases = _normalise_entity_aliases(aliases_obj)
+    out: list[str] = []
+    seen: set[str] = set()
+    for item in aliases:
+        label = _clean_alias_text(item.get("label"))
+        if label:
+            low = label.casefold()
+            if low not in seen:
+                seen.add(low)
+                out.append(label)
+                if len(out) >= max_terms:
+                    break
+        raw_aliases = item.get("aliases")
+        if not isinstance(raw_aliases, list):
+            continue
+        for v in raw_aliases:
+            alias = _clean_alias_text(v)
+            if not alias:
+                continue
+            low = alias.casefold()
+            if low in seen:
+                continue
+            seen.add(low)
+            out.append(alias)
+            if len(out) >= max_terms:
+                break
+        if len(out) >= max_terms:
+            break
+    return out
+
+
 # ---------------------------------------------------------------------------
 # Retrieve-then-decide helpers
 # ---------------------------------------------------------------------------
@@ -128,8 +278,14 @@ def _tokenize_event(event: dict[str, Any], *, drop_high_df: set[str] | None = No
     drop_high_df = drop_high_df or set()
     summary = str(event.get("summary_en") or "").strip()
     title = str(event.get("title") or "").strip()
-    tokens = _si_tokenize_text(summary or title, title if summary else None)
-    anchors = _si_anchor_terms(summary or title, title if summary else None)
+    alias_terms = _entity_alias_surface_forms(event)
+    alias_text = " ".join(alias_terms).strip()
+    primary_text = summary or title
+    if alias_text:
+        primary_text = f"{primary_text} {alias_text}".strip() if primary_text else alias_text
+
+    tokens = _si_tokenize_text(primary_text, title if summary else None)
+    anchors = _si_anchor_terms(primary_text, title if summary else None)
     key = choose_key_tokens(tokens, drop_high_df=drop_high_df)
     return EventTokens(key_tokens=frozenset(key), anchor_tokens=frozenset(anchors))
 
@@ -444,6 +600,7 @@ Return STRICT JSON:
 {{"action":"new_event",
   "confidence":<0.0-1.0>,
   "summary_en":"<one-sentence English summary>",
+  "entity_aliases":[{{"label":"<entity>","aliases":["<alias 1>","<alias 2>"]}}],
   "category":"<category>","jurisdiction":"<jurisdiction>",
   "link_flags":[],
   "match_basis":[]}}
@@ -491,6 +648,7 @@ B) NEW DEVELOPMENT of existing event (significant escalation, verdict, arrest, r
       "confidence":<0.0-1.0>,
       "summary_en":"<one-sentence English summary>",
       "development":"<short label>",
+      "entity_aliases":[{{"label":"<entity>","aliases":["<alias 1>","<alias 2>"]}}],
       "category":"<category>","jurisdiction":"<jurisdiction>",
       "link_flags":[],
       "match_basis":["<entity|number|location|time|other>"]}}
@@ -500,6 +658,7 @@ C) NEW EVENT (completely new story, none of the candidates match)
    → {{"action":"new_event",
       "confidence":<0.0-1.0>,
       "summary_en":"<one-sentence English summary>",
+      "entity_aliases":[{{"label":"<entity>","aliases":["<alias 1>","<alias 2>"]}}],
       "category":"<category>","jurisdiction":"<jurisdiction>",
       "link_flags":[],
       "match_basis":[]}}
@@ -514,6 +673,7 @@ Rules:
 - Match across languages (Chinese headline about same event = same event)
 - Only use ASSIGN if a matching event exists in the candidates above
 - Always include: confidence (0.0-1.0), summary_en, category, jurisdiction, link_flags (list), match_basis (list; can be empty)
+- For NEW_EVENT and DEVELOPMENT, include entity_aliases with bilingual aliases when available (e.g. Chinese + English names)
 - link_flags may include: "roundup", "opinion", "live_updates", "multi_topic"
 - If you are NOT at least 70% sure for ASSIGN or DEVELOPMENT, choose NEW EVENT instead
 - If the link is a roundup/briefing, opinion, live updates, or clearly multi-topic, set link_flags accordingly and choose NEW EVENT
@@ -591,6 +751,7 @@ B) NEW DEVELOPMENT of existing event (significant escalation, result, reversal)
       "confidence":<0.0-1.0>,
       "summary_en":"<one-sentence English summary>",
       "development":"<short label>",
+      "entity_aliases":[{{"label":"<entity>","aliases":["<alias 1>","<alias 2>"]}}],
       "category":"<category>","jurisdiction":"<jurisdiction>",
       "link_flags":[],
       "match_basis":["<entity|number|location|time|other>"]}}
@@ -599,6 +760,7 @@ C) NEW EVENT (completely new story)
    → {{"action":"new_event",
       "confidence":<0.0-1.0>,
       "summary_en":"<one-sentence English summary>",
+      "entity_aliases":[{{"label":"<entity>","aliases":["<alias 1>","<alias 2>"]}}],
       "category":"<category>","jurisdiction":"<jurisdiction>",
       "link_flags":[],
       "match_basis":[]}}
@@ -614,6 +776,7 @@ Rules:
 - Only use ASSIGN if a matching event exists in the list above
 - Do NOT assign to events with status=posted unless it's truly the same event
 - Always include: confidence (0.0-1.0), summary_en, category, jurisdiction, link_flags (list), match_basis (list; can be empty)
+- For NEW_EVENT and DEVELOPMENT, include entity_aliases with bilingual aliases when available (e.g. Chinese + English names)
 - link_flags may include: "roundup", "opinion", "live_updates", "multi_topic"
 - If you are NOT at least 70% sure for ASSIGN or DEVELOPMENT, choose NEW EVENT instead
 - If the link is a roundup/briefing, opinion, live updates, or clearly multi-topic, set link_flags accordingly and choose NEW EVENT
@@ -699,6 +862,7 @@ def parse_clustering_response(
 
     match_basis = _parse_str_list(response.get("match_basis"))
     link_flags = _parse_link_flags(response.get("link_flags"))
+    entity_aliases = _normalise_entity_aliases(response.get("entity_aliases"))
 
     raw_category = str(response.get("category") or "").strip() or None
     category = _normalise_category(raw_category)
@@ -732,6 +896,7 @@ def parse_clustering_response(
             "confidence": confidence,
             "match_basis": match_basis,
             "link_flags": link_flags,
+            "entity_aliases": entity_aliases,
             "summary_en": summary_en,
             "category": category,
             "jurisdiction": jurisdiction,
@@ -758,6 +923,7 @@ def parse_clustering_response(
             "confidence": confidence,
             "match_basis": match_basis,
             "link_flags": link_flags,
+            "entity_aliases": entity_aliases,
         }
 
     elif action in ("new_event", "new"):
@@ -772,6 +938,7 @@ def parse_clustering_response(
             "confidence": confidence,
             "match_basis": match_basis,
             "link_flags": link_flags,
+            "entity_aliases": entity_aliases,
         }
 
     else:
@@ -807,6 +974,7 @@ def parse_clustering_response(
             "confidence": confidence,
             "match_basis": match_basis,
             "link_flags": link_flags,
+            "entity_aliases": entity_aliases,
             "enforcement": {
                 "original_action": str(validated.get("action") or ""),
                 "reasons": override_reasons,
@@ -1003,6 +1171,7 @@ def cluster_link(
             primary_url=link_url,
             parent_event_id=parent_id,
             development=enforced.get("development"),
+            entity_aliases=enforced.get("entity_aliases"),
             model=model_name,
         )
         db.assign_link_to_event(link_id=link_id, event_id=event_id)
@@ -1025,6 +1194,7 @@ def cluster_link(
             jurisdiction=enforced.get("jurisdiction"),
             title=link_title,
             primary_url=link_url,
+            entity_aliases=enforced.get("entity_aliases"),
             model=model_name,
         )
         db.assign_link_to_event(link_id=link_id, event_id=event_id)

--- a/newsroom/event_manager.py
+++ b/newsroom/event_manager.py
@@ -89,11 +89,27 @@ def _clean_alias_text(v: Any, *, max_len: int = 120) -> str | None:
     return s
 
 
+def _normalise_entity_type(v: Any) -> str | None:
+    """Normalise entity type labels to person/org/location."""
+    raw = _clean_alias_text(v, max_len=40)
+    if not raw:
+        return None
+    key = " ".join(raw.casefold().replace("-", " ").replace("_", " ").split())
+    if key in {"person", "people", "human", "individual"}:
+        return "person"
+    if key in {"org", "organisation", "organization", "company", "institution", "agency"}:
+        return "org"
+    if key in {"location", "place", "country", "city", "region", "state"}:
+        return "location"
+    return None
+
+
 def _normalise_entity_aliases(raw: Any, *, max_entities: int = 12, max_aliases_per_entity: int = 8) -> list[dict[str, Any]]:
     """Normalise model-provided entity aliases to a stable list[dict] shape.
 
     Output shape:
-      [{"label": "<canonical>", "aliases": ["<alias1>", ...]}, ...]
+      [{"label": "<canonical>", "type": "<person|org|location>", "aliases": ["<alias1>", ...]}, ...]
+    Type is optional and only included when recognised.
     """
     parsed = raw
     if isinstance(parsed, str):
@@ -116,13 +132,19 @@ def _normalise_entity_aliases(raw: Any, *, max_entities: int = 12, max_aliases_p
     out: list[dict[str, Any]] = []
     by_label: dict[str, int] = {}
 
-    def _parse_item(item: Any) -> tuple[str | None, list[str]]:
+    def _parse_item(item: Any) -> tuple[str | None, str | None, list[str]]:
         if isinstance(item, dict):
             label = _clean_alias_text(
                 item.get("label")
                 or item.get("entity")
                 or item.get("name")
                 or item.get("canonical")
+            )
+            entity_type = _normalise_entity_type(
+                item.get("type")
+                or item.get("entity_type")
+                or item.get("entityType")
+                or item.get("kind")
             )
             aliases_raw = item.get("aliases")
             aliases: list[Any]
@@ -135,12 +157,12 @@ def _normalise_entity_aliases(raw: Any, *, max_entities: int = 12, max_aliases_p
             for k in ("zh", "zh_hant", "zh_tw", "english", "en"):
                 if k in item:
                     aliases.append(item.get(k))
-            return label, [_clean_alias_text(v) for v in aliases if _clean_alias_text(v)]
+            return label, entity_type, [_clean_alias_text(v) for v in aliases if _clean_alias_text(v)]
         label = _clean_alias_text(item)
-        return label, []
+        return label, None, []
 
     for item in parsed:
-        label, aliases_raw = _parse_item(item)
+        label, entity_type, aliases_raw = _parse_item(item)
         all_terms: list[str] = []
         seen_terms: set[str] = set()
 
@@ -168,11 +190,16 @@ def _normalise_entity_aliases(raw: Any, *, max_entities: int = 12, max_aliases_p
         if existing_idx is None:
             if len(out) >= max_entities:
                 break
-            out.append({"label": canonical, "aliases": aliases})
+            row: dict[str, Any] = {"label": canonical, "aliases": aliases}
+            if entity_type:
+                row["type"] = entity_type
+            out.append(row)
             by_label[canonical_key] = len(out) - 1
             continue
 
         existing = out[existing_idx]
+        if entity_type and _normalise_entity_type(existing.get("type")) is None:
+            existing["type"] = entity_type
         existing_aliases = existing.get("aliases")
         if not isinstance(existing_aliases, list):
             existing_aliases = []
@@ -732,7 +759,7 @@ Return STRICT JSON:
 {{"action":"new_event",
   "confidence":<0.0-1.0>,
   "summary_en":"<one-sentence English summary>",
-  "entity_aliases":[{{"label":"<entity>","aliases":["<alias 1>","<alias 2>"]}}],
+  "entity_aliases":[{{"label":"<entity>","type":"<person|org|location>","aliases":["<alias 1>","<alias 2>"]}}],
   "category":"<category>","jurisdiction":"<jurisdiction>",
   "link_flags":[],
   "match_basis":[]}}
@@ -780,7 +807,7 @@ B) NEW DEVELOPMENT of existing event (significant escalation, verdict, arrest, r
       "confidence":<0.0-1.0>,
       "summary_en":"<one-sentence English summary>",
       "development":"<short label>",
-      "entity_aliases":[{{"label":"<entity>","aliases":["<alias 1>","<alias 2>"]}}],
+      "entity_aliases":[{{"label":"<entity>","type":"<person|org|location>","aliases":["<alias 1>","<alias 2>"]}}],
       "category":"<category>","jurisdiction":"<jurisdiction>",
       "link_flags":[],
       "match_basis":["<entity|number|location|time|other>"]}}
@@ -790,7 +817,7 @@ C) NEW EVENT (completely new story, none of the candidates match)
    → {{"action":"new_event",
       "confidence":<0.0-1.0>,
       "summary_en":"<one-sentence English summary>",
-      "entity_aliases":[{{"label":"<entity>","aliases":["<alias 1>","<alias 2>"]}}],
+      "entity_aliases":[{{"label":"<entity>","type":"<person|org|location>","aliases":["<alias 1>","<alias 2>"]}}],
       "category":"<category>","jurisdiction":"<jurisdiction>",
       "link_flags":[],
       "match_basis":[]}}
@@ -806,6 +833,7 @@ Rules:
 - Only use ASSIGN if a matching event exists in the candidates above
 - Always include: confidence (0.0-1.0), summary_en, category, jurisdiction, link_flags (list), match_basis (list; can be empty)
 - For NEW_EVENT and DEVELOPMENT, include entity_aliases with bilingual aliases when available (e.g. Chinese + English names)
+- For each entity_aliases item, include type as person/org/location when known
 - link_flags may include: "roundup", "opinion", "live_updates", "multi_topic"
 - If you are NOT at least 70% sure for ASSIGN or DEVELOPMENT, choose NEW EVENT instead
 - If the link is a roundup/briefing, opinion, live updates, or clearly multi-topic, set link_flags accordingly and choose NEW EVENT
@@ -885,7 +913,7 @@ B) NEW DEVELOPMENT of existing event (significant escalation, result, reversal)
       "confidence":<0.0-1.0>,
       "summary_en":"<one-sentence English summary>",
       "development":"<short label>",
-      "entity_aliases":[{{"label":"<entity>","aliases":["<alias 1>","<alias 2>"]}}],
+      "entity_aliases":[{{"label":"<entity>","type":"<person|org|location>","aliases":["<alias 1>","<alias 2>"]}}],
       "category":"<category>","jurisdiction":"<jurisdiction>",
       "link_flags":[],
       "match_basis":["<entity|number|location|time|other>"]}}
@@ -894,7 +922,7 @@ C) NEW EVENT (completely new story)
    → {{"action":"new_event",
       "confidence":<0.0-1.0>,
       "summary_en":"<one-sentence English summary>",
-      "entity_aliases":[{{"label":"<entity>","aliases":["<alias 1>","<alias 2>"]}}],
+      "entity_aliases":[{{"label":"<entity>","type":"<person|org|location>","aliases":["<alias 1>","<alias 2>"]}}],
       "category":"<category>","jurisdiction":"<jurisdiction>",
       "link_flags":[],
       "match_basis":[]}}
@@ -911,6 +939,7 @@ Rules:
 - Do NOT assign to events with status=posted unless it's truly the same event
 - Always include: confidence (0.0-1.0), summary_en, category, jurisdiction, link_flags (list), match_basis (list; can be empty)
 - For NEW_EVENT and DEVELOPMENT, include entity_aliases with bilingual aliases when available (e.g. Chinese + English names)
+- For each entity_aliases item, include type as person/org/location when known
 - link_flags may include: "roundup", "opinion", "live_updates", "multi_topic"
 - If you are NOT at least 70% sure for ASSIGN or DEVELOPMENT, choose NEW EVENT instead
 - If the link is a roundup/briefing, opinion, live updates, or clearly multi-topic, set link_flags accordingly and choose NEW EVENT

--- a/newsroom/event_manager.py
+++ b/newsroom/event_manager.py
@@ -78,6 +78,156 @@ def _normalise_category(raw: str | None) -> str:
     return "Global News"
 
 
+def _clean_alias_text(v: Any, *, max_len: int = 120) -> str | None:
+    if not isinstance(v, (str, int, float)):
+        return None
+    s = " ".join(str(v).strip().split())
+    if not s:
+        return None
+    if len(s) > max_len:
+        s = s[:max_len]
+    return s
+
+
+def _normalise_entity_aliases(raw: Any, *, max_entities: int = 12, max_aliases_per_entity: int = 8) -> list[dict[str, Any]]:
+    """Normalise model-provided entity aliases to a stable list[dict] shape.
+
+    Output shape:
+      [{"label": "<canonical>", "aliases": ["<alias1>", ...]}, ...]
+    """
+    parsed = raw
+    if isinstance(parsed, str):
+        s = parsed.strip()
+        if not s:
+            return []
+        try:
+            parsed = json.loads(s)
+        except Exception:
+            parsed = [s]
+
+    if isinstance(parsed, dict):
+        parsed = parsed.get("entity_aliases", parsed)
+
+    if not isinstance(parsed, list):
+        return []
+
+    out: list[dict[str, Any]] = []
+    by_label: dict[str, int] = {}
+
+    def _parse_item(item: Any) -> tuple[str | None, list[str]]:
+        if isinstance(item, dict):
+            label = _clean_alias_text(
+                item.get("label")
+                or item.get("entity")
+                or item.get("name")
+                or item.get("canonical")
+            )
+            aliases_raw = item.get("aliases")
+            aliases: list[Any]
+            if isinstance(aliases_raw, list):
+                aliases = aliases_raw
+            elif aliases_raw is None:
+                aliases = []
+            else:
+                aliases = [aliases_raw]
+            for k in ("zh", "zh_hant", "zh_tw", "english", "en"):
+                if k in item:
+                    aliases.append(item.get(k))
+            return label, [_clean_alias_text(v) for v in aliases if _clean_alias_text(v)]
+        label = _clean_alias_text(item)
+        return label, []
+
+    for item in parsed:
+        label, aliases_raw = _parse_item(item)
+        all_terms: list[str] = []
+        seen_terms: set[str] = set()
+
+        if label:
+            seen_terms.add(label.casefold())
+            all_terms.append(label)
+
+        for a in aliases_raw:
+            low = a.casefold()
+            if low in seen_terms:
+                continue
+            seen_terms.add(low)
+            all_terms.append(a)
+            if len(all_terms) >= max_aliases_per_entity:
+                break
+
+        if not all_terms:
+            continue
+
+        canonical = all_terms[0]
+        canonical_key = canonical.casefold()
+        aliases = all_terms[1:]
+
+        existing_idx = by_label.get(canonical_key)
+        if existing_idx is None:
+            if len(out) >= max_entities:
+                break
+            out.append({"label": canonical, "aliases": aliases})
+            by_label[canonical_key] = len(out) - 1
+            continue
+
+        existing = out[existing_idx]
+        existing_aliases = existing.get("aliases")
+        if not isinstance(existing_aliases, list):
+            existing_aliases = []
+        existing_seen = {
+            str(existing.get("label", "")).casefold(),
+            *[str(v).casefold() for v in existing_aliases if isinstance(v, str)],
+        }
+        for a in aliases:
+            low = a.casefold()
+            if low in existing_seen:
+                continue
+            existing_seen.add(low)
+            existing_aliases.append(a)
+            if len(existing_aliases) >= max_aliases_per_entity:
+                break
+        existing["aliases"] = existing_aliases
+
+    return out
+
+
+def _entity_alias_surface_forms(event: dict[str, Any], *, max_terms: int = 32) -> list[str]:
+    """Return flattened alias surface forms from an event object."""
+    aliases_obj = event.get("entity_aliases")
+    if aliases_obj is None:
+        aliases_obj = event.get("entity_aliases_json")
+
+    aliases = _normalise_entity_aliases(aliases_obj)
+    out: list[str] = []
+    seen: set[str] = set()
+    for item in aliases:
+        label = _clean_alias_text(item.get("label"))
+        if label:
+            low = label.casefold()
+            if low not in seen:
+                seen.add(low)
+                out.append(label)
+                if len(out) >= max_terms:
+                    break
+        raw_aliases = item.get("aliases")
+        if not isinstance(raw_aliases, list):
+            continue
+        for v in raw_aliases:
+            alias = _clean_alias_text(v)
+            if not alias:
+                continue
+            low = alias.casefold()
+            if low in seen:
+                continue
+            seen.add(low)
+            out.append(alias)
+            if len(out) >= max_terms:
+                break
+        if len(out) >= max_terms:
+            break
+    return out
+
+
 # ---------------------------------------------------------------------------
 # Retrieve-then-decide helpers
 # ---------------------------------------------------------------------------
@@ -132,8 +282,14 @@ def _tokenize_event(event: dict[str, Any], *, drop_high_df: set[str] | None = No
     drop_high_df = drop_high_df or set()
     summary = str(event.get("summary_en") or "").strip()
     title = str(event.get("title") or "").strip()
-    tokens = _si_tokenize_text(summary or title, title if summary else None)
-    anchors = _si_anchor_terms(summary or title, title if summary else None)
+    alias_terms = _entity_alias_surface_forms(event)
+    alias_text = " ".join(alias_terms).strip()
+    primary_text = summary or title
+    if alias_text:
+        primary_text = f"{primary_text} {alias_text}".strip() if primary_text else alias_text
+
+    tokens = _si_tokenize_text(primary_text, title if summary else None)
+    anchors = _si_anchor_terms(primary_text, title if summary else None)
     key = choose_key_tokens(tokens, drop_high_df=drop_high_df)
     return EventTokens(key_tokens=frozenset(key), anchor_tokens=frozenset(anchors))
 
@@ -574,6 +730,7 @@ Return STRICT JSON:
 {{"action":"new_event",
   "confidence":<0.0-1.0>,
   "summary_en":"<one-sentence English summary>",
+  "entity_aliases":[{{"label":"<entity>","aliases":["<alias 1>","<alias 2>"]}}],
   "category":"<category>","jurisdiction":"<jurisdiction>",
   "link_flags":[],
   "match_basis":[]}}
@@ -621,6 +778,7 @@ B) NEW DEVELOPMENT of existing event (significant escalation, verdict, arrest, r
       "confidence":<0.0-1.0>,
       "summary_en":"<one-sentence English summary>",
       "development":"<short label>",
+      "entity_aliases":[{{"label":"<entity>","aliases":["<alias 1>","<alias 2>"]}}],
       "category":"<category>","jurisdiction":"<jurisdiction>",
       "link_flags":[],
       "match_basis":["<entity|number|location|time|other>"]}}
@@ -630,6 +788,7 @@ C) NEW EVENT (completely new story, none of the candidates match)
    → {{"action":"new_event",
       "confidence":<0.0-1.0>,
       "summary_en":"<one-sentence English summary>",
+      "entity_aliases":[{{"label":"<entity>","aliases":["<alias 1>","<alias 2>"]}}],
       "category":"<category>","jurisdiction":"<jurisdiction>",
       "link_flags":[],
       "match_basis":[]}}
@@ -644,6 +803,7 @@ Rules:
 - Match across languages (Chinese headline about same event = same event)
 - Only use ASSIGN if a matching event exists in the candidates above
 - Always include: confidence (0.0-1.0), summary_en, category, jurisdiction, link_flags (list), match_basis (list; can be empty)
+- For NEW_EVENT and DEVELOPMENT, include entity_aliases with bilingual aliases when available (e.g. Chinese + English names)
 - link_flags may include: "roundup", "opinion", "live_updates", "multi_topic"
 - If you are NOT at least 70% sure for ASSIGN or DEVELOPMENT, choose NEW EVENT instead
 - If the link is a roundup/briefing, opinion, live updates, or clearly multi-topic, set link_flags accordingly and choose NEW EVENT
@@ -723,6 +883,7 @@ B) NEW DEVELOPMENT of existing event (significant escalation, result, reversal)
       "confidence":<0.0-1.0>,
       "summary_en":"<one-sentence English summary>",
       "development":"<short label>",
+      "entity_aliases":[{{"label":"<entity>","aliases":["<alias 1>","<alias 2>"]}}],
       "category":"<category>","jurisdiction":"<jurisdiction>",
       "link_flags":[],
       "match_basis":["<entity|number|location|time|other>"]}}
@@ -731,6 +892,7 @@ C) NEW EVENT (completely new story)
    → {{"action":"new_event",
       "confidence":<0.0-1.0>,
       "summary_en":"<one-sentence English summary>",
+      "entity_aliases":[{{"label":"<entity>","aliases":["<alias 1>","<alias 2>"]}}],
       "category":"<category>","jurisdiction":"<jurisdiction>",
       "link_flags":[],
       "match_basis":[]}}
@@ -746,6 +908,7 @@ Rules:
 - Only use ASSIGN if a matching event exists in the list above
 - Do NOT assign to events with status=posted unless it's truly the same event
 - Always include: confidence (0.0-1.0), summary_en, category, jurisdiction, link_flags (list), match_basis (list; can be empty)
+- For NEW_EVENT and DEVELOPMENT, include entity_aliases with bilingual aliases when available (e.g. Chinese + English names)
 - link_flags may include: "roundup", "opinion", "live_updates", "multi_topic"
 - If you are NOT at least 70% sure for ASSIGN or DEVELOPMENT, choose NEW EVENT instead
 - If the link is a roundup/briefing, opinion, live updates, or clearly multi-topic, set link_flags accordingly and choose NEW EVENT
@@ -831,6 +994,7 @@ def parse_clustering_response(
 
     match_basis = _parse_str_list(response.get("match_basis"))
     link_flags = _parse_link_flags(response.get("link_flags"))
+    entity_aliases = _normalise_entity_aliases(response.get("entity_aliases"))
 
     raw_category = str(response.get("category") or "").strip() or None
     category = _normalise_category(raw_category)
@@ -864,6 +1028,7 @@ def parse_clustering_response(
             "confidence": confidence,
             "match_basis": match_basis,
             "link_flags": link_flags,
+            "entity_aliases": entity_aliases,
             "summary_en": summary_en,
             "category": category,
             "jurisdiction": jurisdiction,
@@ -890,6 +1055,7 @@ def parse_clustering_response(
             "confidence": confidence,
             "match_basis": match_basis,
             "link_flags": link_flags,
+            "entity_aliases": entity_aliases,
         }
 
     elif action in ("new_event", "new"):
@@ -904,6 +1070,7 @@ def parse_clustering_response(
             "confidence": confidence,
             "match_basis": match_basis,
             "link_flags": link_flags,
+            "entity_aliases": entity_aliases,
         }
 
     else:
@@ -939,6 +1106,7 @@ def parse_clustering_response(
             "confidence": confidence,
             "match_basis": match_basis,
             "link_flags": link_flags,
+            "entity_aliases": entity_aliases,
             "enforcement": {
                 "original_action": str(validated.get("action") or ""),
                 "reasons": override_reasons,
@@ -1191,6 +1359,7 @@ def cluster_link(
             primary_url=link_url,
             parent_event_id=parent_id,
             development=enforced.get("development"),
+            entity_aliases=enforced.get("entity_aliases"),
             model=model_name,
         )
         db.assign_link_to_event(link_id=link_id, event_id=event_id)
@@ -1213,6 +1382,7 @@ def cluster_link(
             jurisdiction=enforced.get("jurisdiction"),
             title=link_title,
             primary_url=link_url,
+            entity_aliases=enforced.get("entity_aliases"),
             model=model_name,
         )
         db.assign_link_to_event(link_id=link_id, event_id=event_id)

--- a/newsroom/event_manager.py
+++ b/newsroom/event_manager.py
@@ -104,6 +104,8 @@ def _normalise_entity_aliases(raw: Any, *, max_entities: int = 12, max_aliases_p
 
     if isinstance(parsed, dict):
         parsed = parsed.get("entity_aliases", parsed)
+    if isinstance(parsed, dict):
+        parsed = [parsed]
 
     if not isinstance(parsed, list):
         return []

--- a/newsroom/lang_hint.py
+++ b/newsroom/lang_hint.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import unicodedata
+from typing import Any, Literal
+
+LangHint = Literal["en", "zh", "mixed"]
+
+_VALID_LANG_HINTS: frozenset[str] = frozenset({"en", "zh", "mixed"})
+_CJK_RANGES: tuple[tuple[int, int], ...] = (
+    (0x3400, 0x4DBF),  # CJK Unified Ideographs Extension A
+    (0x4E00, 0x9FFF),  # CJK Unified Ideographs
+    (0xF900, 0xFAFF),  # CJK Compatibility Ideographs
+)
+
+
+def _is_cjk_char(ch: str) -> bool:
+    code = ord(ch)
+    for lo, hi in _CJK_RANGES:
+        if lo <= code <= hi:
+            return True
+    return False
+
+
+def _count_cjk_chars(text: str) -> int:
+    return sum(1 for ch in (text or "") if _is_cjk_char(ch))
+
+
+def _is_latin_letter(ch: str) -> bool:
+    if not ch.isalpha():
+        return False
+    if ch.isascii():
+        return True
+    try:
+        return "LATIN" in unicodedata.name(ch)
+    except ValueError:
+        return False
+
+
+def _count_latin_letters(text: str) -> int:
+    return sum(1 for ch in (text or "") if _is_latin_letter(ch))
+
+
+def normalise_lang_hint(value: Any) -> LangHint | None:
+    if not isinstance(value, str):
+        return None
+    s = value.strip().lower()
+    if s in _VALID_LANG_HINTS:
+        return s  # type: ignore[return-value]
+    return None
+
+
+def detect_text_lang_hint(text: str | None) -> LangHint:
+    cjk = _count_cjk_chars(text or "")
+    latin = _count_latin_letters(text or "")
+
+    if cjk == 0 and latin == 0:
+        return "mixed"
+    if cjk == 0:
+        return "en"
+    if latin == 0:
+        return "zh"
+
+    total = cjk + latin
+    cjk_ratio = cjk / total
+    latin_ratio = latin / total
+
+    # "Mostly CJK" and "mostly Latin" with conservative thresholds.
+    if cjk_ratio >= 0.72:
+        return "zh"
+    if latin_ratio >= 0.72:
+        return "en"
+
+    # Tie-breaker for longer strings where one script is still clearly dominant.
+    if cjk >= 10 and cjk >= (latin * 1.2):
+        return "zh"
+    if latin >= 14 and latin >= (cjk * 1.2):
+        return "en"
+
+    return "mixed"
+
+
+def detect_link_lang_hint(
+    *,
+    title: str | None,
+    description: str | None,
+    existing_hint: Any | None = None,
+) -> LangHint:
+    norm = normalise_lang_hint(existing_hint)
+    if norm:
+        return norm
+
+    parts: list[str] = []
+    if isinstance(title, str) and title.strip():
+        parts.append(title.strip())
+    if isinstance(description, str) and description.strip():
+        parts.append(description.strip())
+    return detect_text_lang_hint(" ".join(parts))

--- a/newsroom/news_pool_db.py
+++ b/newsroom/news_pool_db.py
@@ -69,6 +69,8 @@ def _normalise_entity_aliases(raw: Any, *, max_entities: int = 12, max_aliases_p
 
     if isinstance(parsed, dict):
         parsed = parsed.get("entity_aliases", parsed)
+    if isinstance(parsed, dict):
+        parsed = [parsed]
     if not isinstance(parsed, list):
         return []
 

--- a/newsroom/news_pool_db.py
+++ b/newsroom/news_pool_db.py
@@ -67,6 +67,8 @@ def _normalise_entity_aliases(raw: Any, *, max_entities: int = 12, max_aliases_p
 
     if isinstance(parsed, dict):
         parsed = parsed.get("entity_aliases", parsed)
+    if isinstance(parsed, dict):
+        parsed = [parsed]
     if not isinstance(parsed, list):
         return []
 

--- a/newsroom/news_pool_db.py
+++ b/newsroom/news_pool_db.py
@@ -44,6 +44,157 @@ def _parse_page_age_ts(page_age: str | None) -> int | None:
     return int(dt.timestamp())
 
 
+def _clean_alias_text(v: Any, *, max_len: int = 120) -> str | None:
+    if not isinstance(v, (str, int, float)):
+        return None
+    s = " ".join(str(v).strip().split())
+    if not s:
+        return None
+    if len(s) > max_len:
+        s = s[:max_len]
+    return s
+
+
+def _normalise_entity_aliases(raw: Any, *, max_entities: int = 12, max_aliases_per_entity: int = 8) -> list[dict[str, Any]]:
+    """Normalise entity aliases into a stable list-of-dicts structure."""
+    parsed = raw
+    if isinstance(parsed, str):
+        s = parsed.strip()
+        if not s:
+            return []
+        try:
+            parsed = json.loads(s)
+        except Exception:
+            parsed = [s]
+
+    if isinstance(parsed, dict):
+        parsed = parsed.get("entity_aliases", parsed)
+    if not isinstance(parsed, list):
+        return []
+
+    out: list[dict[str, Any]] = []
+    by_label: dict[str, int] = {}
+
+    def _parse_item(item: Any) -> tuple[str | None, list[str]]:
+        if isinstance(item, dict):
+            label = _clean_alias_text(
+                item.get("label")
+                or item.get("entity")
+                or item.get("name")
+                or item.get("canonical")
+            )
+            aliases_raw = item.get("aliases")
+            aliases: list[Any]
+            if isinstance(aliases_raw, list):
+                aliases = aliases_raw
+            elif aliases_raw is None:
+                aliases = []
+            else:
+                aliases = [aliases_raw]
+            for k in ("zh", "zh_hant", "zh_tw", "english", "en"):
+                if k in item:
+                    aliases.append(item.get(k))
+            return label, [_clean_alias_text(v) for v in aliases if _clean_alias_text(v)]
+        label = _clean_alias_text(item)
+        return label, []
+
+    for item in parsed:
+        label, aliases_raw = _parse_item(item)
+        all_terms: list[str] = []
+        seen_terms: set[str] = set()
+
+        if label:
+            seen_terms.add(label.casefold())
+            all_terms.append(label)
+
+        for alias in aliases_raw:
+            low = alias.casefold()
+            if low in seen_terms:
+                continue
+            seen_terms.add(low)
+            all_terms.append(alias)
+            if len(all_terms) >= max_aliases_per_entity:
+                break
+
+        if not all_terms:
+            continue
+
+        canonical = all_terms[0]
+        canonical_key = canonical.casefold()
+        aliases = all_terms[1:]
+
+        existing_idx = by_label.get(canonical_key)
+        if existing_idx is None:
+            if len(out) >= max_entities:
+                break
+            out.append({"label": canonical, "aliases": aliases})
+            by_label[canonical_key] = len(out) - 1
+            continue
+
+        existing = out[existing_idx]
+        existing_aliases = existing.get("aliases")
+        if not isinstance(existing_aliases, list):
+            existing_aliases = []
+        existing_seen = {
+            str(existing.get("label", "")).casefold(),
+            *[str(v).casefold() for v in existing_aliases if isinstance(v, str)],
+        }
+        for alias in aliases:
+            low = alias.casefold()
+            if low in existing_seen:
+                continue
+            existing_seen.add(low)
+            existing_aliases.append(alias)
+            if len(existing_aliases) >= max_aliases_per_entity:
+                break
+        existing["aliases"] = existing_aliases
+
+    return out
+
+
+def _entity_aliases_to_json(raw: Any) -> str | None:
+    aliases = _normalise_entity_aliases(raw)
+    if not aliases:
+        return None
+    return json.dumps(aliases, ensure_ascii=False, separators=(",", ":"))
+
+
+def _entity_aliases_from_json(raw: Any) -> list[dict[str, Any]]:
+    return _normalise_entity_aliases(raw)
+
+
+def _entity_alias_terms(raw: Any, *, max_terms: int = 12) -> list[str]:
+    aliases = _normalise_entity_aliases(raw)
+    out: list[str] = []
+    seen: set[str] = set()
+    for item in aliases:
+        label = _clean_alias_text(item.get("label"))
+        if label:
+            low = label.casefold()
+            if low not in seen:
+                seen.add(low)
+                out.append(label)
+                if len(out) >= max_terms:
+                    break
+        raw_aliases = item.get("aliases")
+        if not isinstance(raw_aliases, list):
+            continue
+        for a in raw_aliases:
+            alias = _clean_alias_text(a)
+            if not alias:
+                continue
+            low = alias.casefold()
+            if low in seen:
+                continue
+            seen.add(low)
+            out.append(alias)
+            if len(out) >= max_terms:
+                break
+        if len(out) >= max_terms:
+            break
+    return out
+
+
 @dataclass(frozen=True)
 class PoolLink:
     url: str
@@ -108,6 +259,7 @@ class NewsPoolDB:
             self._create_retrieval_translation_cache_table(cur)
             self._ensure_links_skip_cluster_columns(cur)
             self._ensure_links_lang_hint_column(cur)
+            self._ensure_events_entity_aliases_column(cur)
             self.set_meta("schema_version", str(SCHEMA_VERSION))
             return
 
@@ -117,6 +269,7 @@ class NewsPoolDB:
             self._create_retrieval_translation_cache_table(cur)
             self._ensure_links_skip_cluster_columns(cur)
             self._ensure_links_lang_hint_column(cur)
+            self._ensure_events_entity_aliases_column(cur)
             return
 
         if schema <= 4:
@@ -129,6 +282,7 @@ class NewsPoolDB:
             self._create_retrieval_translation_cache_table(cur)
             self._ensure_links_skip_cluster_columns(cur)
             self._ensure_links_lang_hint_column(cur)
+            self._ensure_events_entity_aliases_column(cur)
             self.set_meta("schema_version", str(SCHEMA_VERSION))
             return
 
@@ -309,6 +463,11 @@ class NewsPoolDB:
         if not self._column_exists(cur, "links", "lang_hint"):
             cur.execute("ALTER TABLE links ADD COLUMN lang_hint TEXT;")
 
+    def _ensure_events_entity_aliases_column(self, cur: sqlite3.Cursor) -> None:
+        """Ensure events can persist entity aliases as JSON text."""
+        if not self._column_exists(cur, "events", "entity_aliases_json"):
+            cur.execute("ALTER TABLE events ADD COLUMN entity_aliases_json TEXT;")
+
     def _create_events_table_v5(self, cur: sqlite3.Cursor) -> None:
         """Create the new event-centric events table (v5+v6 columns)."""
         cur.execute(
@@ -332,6 +491,7 @@ class NewsPoolDB:
               posted_at_ts INTEGER,
               thread_id TEXT,
               run_id TEXT,
+              entity_aliases_json TEXT,
               model TEXT,
               reserved_until_ts INTEGER
             );
@@ -795,19 +955,21 @@ class NewsPoolDB:
         primary_url: str | None = None,
         parent_event_id: int | None = None,
         development: str | None = None,
+        entity_aliases: Any | None = None,
         model: str | None = None,
     ) -> int:
         """Insert a new event. Returns the event id."""
         now = _utc_now_ts()
         expires = now + _DEFAULT_TTL_SECONDS
+        aliases_json = _entity_aliases_to_json(entity_aliases)
         cur = self._conn.cursor()
         cur.execute(
             """
             INSERT INTO events (
               parent_event_id, category, jurisdiction, summary_en, development,
-              title, primary_url, link_count, best_published_ts,
+              title, primary_url, link_count, best_published_ts, entity_aliases_json,
               status, created_at_ts, updated_at_ts, expires_at_ts, model
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, 0, NULL, 'new', ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, 0, NULL, ?, 'new', ?, ?, ?, ?)
             """,
             (
                 parent_event_id,
@@ -817,6 +979,7 @@ class NewsPoolDB:
                 development,
                 title,
                 primary_url,
+                aliases_json,
                 now,
                 now,
                 expires,
@@ -838,7 +1001,11 @@ class NewsPoolDB:
         """Get a single event by id."""
         cur = self._conn.cursor()
         row = cur.execute("SELECT * FROM events WHERE id = ?", (event_id,)).fetchone()
-        return dict(row) if row else None
+        if not row:
+            return None
+        out = dict(row)
+        out["entity_aliases"] = _entity_aliases_from_json(out.get("entity_aliases_json"))
+        return out
 
     def get_all_fresh_events(
         self,
@@ -871,7 +1038,7 @@ class NewsPoolDB:
             """
             SELECT id, parent_event_id, category, jurisdiction, summary_en,
                    development, title, primary_url, link_count, best_published_ts,
-                   status, created_at_ts, updated_at_ts, expires_at_ts,
+                   status, created_at_ts, updated_at_ts, expires_at_ts, entity_aliases_json,
                    posted_at_ts, thread_id, run_id
             FROM events
             WHERE parent_event_id IS NULL
@@ -895,7 +1062,7 @@ class NewsPoolDB:
             """
             SELECT id, parent_event_id, category, jurisdiction, summary_en,
                    development, title, primary_url, link_count, best_published_ts,
-                   status, created_at_ts, updated_at_ts, expires_at_ts,
+                   status, created_at_ts, updated_at_ts, expires_at_ts, entity_aliases_json,
                    posted_at_ts, thread_id, run_id
             FROM events
             WHERE parent_event_id IS NULL
@@ -908,7 +1075,12 @@ class NewsPoolDB:
         ).fetchall()
 
         rows = list(unposted_rows) + list(posted_rows)
-        return [dict(r) for r in rows]
+        out: list[dict[str, Any]] = []
+        for r in rows:
+            item = dict(r)
+            item["entity_aliases"] = _entity_aliases_from_json(item.get("entity_aliases_json"))
+            out.append(item)
+        return out
 
     def get_root_event_id(self, event_id: int) -> int:
         """Walk parent_event_id chain to root. Returns event_id itself if already root."""
@@ -935,14 +1107,19 @@ class NewsPoolDB:
             """
             SELECT id, parent_event_id, category, jurisdiction, summary_en,
                    development, title, primary_url, link_count, best_published_ts,
-                   status, created_at_ts, updated_at_ts, expires_at_ts
+                   status, created_at_ts, updated_at_ts, expires_at_ts, entity_aliases_json
             FROM events
             WHERE expires_at_ts > ?
             ORDER BY created_at_ts DESC
             """,
             (now,),
         ).fetchall()
-        return [dict(r) for r in rows]
+        out: list[dict[str, Any]] = []
+        for r in rows:
+            item = dict(r)
+            item["entity_aliases"] = _entity_aliases_from_json(item.get("entity_aliases_json"))
+            out.append(item)
+        return out
 
     def prune_expired_events(self, *, max_age_hours: int = 72, now_ts: int | None = None) -> int:
         """Delete events that are expired AND older than max_age_hours.
@@ -1011,7 +1188,7 @@ class NewsPoolDB:
                 """
                 SELECT id, parent_event_id, category, jurisdiction, summary_en,
                        development, title, primary_url, link_count, best_published_ts,
-                       status, created_at_ts, updated_at_ts, expires_at_ts
+                       status, created_at_ts, updated_at_ts, expires_at_ts, entity_aliases_json
                 FROM events
                 WHERE status IN ('new', 'active')
                   AND expires_at_ts > ?
@@ -1129,7 +1306,7 @@ class NewsPoolDB:
                 """
                 SELECT id, parent_event_id, category, jurisdiction, summary_en,
                        development, title, primary_url, link_count, best_published_ts,
-                       status, created_at_ts, updated_at_ts, expires_at_ts
+                       status, created_at_ts, updated_at_ts, expires_at_ts, entity_aliases_json
                 FROM events
                 WHERE status IN ('new', 'active')
                   AND expires_at_ts > ?
@@ -1240,8 +1417,11 @@ class NewsPoolDB:
             c["semantic_event_key"] = f"event:{root_eid}"
             c["anchor_key"] = f"event:{root_eid}"
             c["cluster_size"] = c.get("link_count") or 0
-            c["cluster_terms"] = []
-            c["anchor_terms"] = []
+            aliases = _entity_aliases_from_json(c.get("entity_aliases_json"))
+            alias_terms = _entity_alias_terms(aliases, max_terms=12)
+            c["entity_aliases"] = aliases
+            c["cluster_terms"] = list(alias_terms)
+            c["anchor_terms"] = list(alias_terms[:8])
             c["suggest_flags"] = []
             c["event_id"] = eid
 
@@ -1312,6 +1492,14 @@ class NewsPoolDB:
             ).fetchone()
             best_pub = row["bp"] if row else None
             best_exp = row["ex"] if row else None
+            alias_rows = cur.execute(
+                f"SELECT entity_aliases_json FROM events WHERE id IN (?, {placeholders})",
+                [winner_id] + loser_ids,
+            ).fetchall()
+            merged_aliases: list[dict[str, Any]] = []
+            for arow in alias_rows:
+                merged_aliases.extend(_entity_aliases_from_json(arow["entity_aliases_json"]))
+            merged_aliases_json = _entity_aliases_to_json(merged_aliases)
 
             # 5. Update winner: link_count, timestamps, promote if multi-link.
             new_status_expr = "CASE WHEN ? > 1 AND status = 'new' THEN 'active' ELSE status END"
@@ -1321,11 +1509,20 @@ class NewsPoolDB:
                   link_count = ?,
                   best_published_ts = ?,
                   expires_at_ts = ?,
+                  entity_aliases_json = ?,
                   updated_at_ts = ?,
                   status = {new_status_expr}
                 WHERE id = ?
                 """,
-                (actual_link_count, best_pub, best_exp, now, actual_link_count, winner_id),
+                (
+                    actual_link_count,
+                    best_pub,
+                    best_exp,
+                    merged_aliases_json,
+                    now,
+                    actual_link_count,
+                    winner_id,
+                ),
             )
 
             # 6. Delete losers.

--- a/newsroom/tests/test_event_manager.py
+++ b/newsroom/tests/test_event_manager.py
@@ -29,11 +29,12 @@ from newsroom.news_pool_db import NewsPoolDB, PoolLink
 
 class TestBuildClusteringPrompt(unittest.TestCase):
     def test_builds_prompt_with_no_events(self) -> None:
-        link = {"title": "Tesla Q4 earnings beat", "description": "Revenue up 20%"}
+        link = {"title": "Tesla Q4 earnings beat", "description": "Revenue up 20%", "lang_hint": "en"}
         prompt = build_clustering_prompt(link, [])
         self.assertIn("Tesla Q4 earnings beat", prompt)
         self.assertIn("(no fresh events)", prompt)
         self.assertIn("action", prompt)
+        self.assertIn("Language hint: en", prompt)
 
     def test_builds_prompt_with_events(self) -> None:
         link = {"title": "FCA probes Mandelson", "description": "Investigation opened"}
@@ -1100,11 +1101,12 @@ class TestRetrieveCandidates(unittest.TestCase):
 
 class TestBuildFocusedClusteringPrompt(unittest.TestCase):
     def test_no_candidates_prompt(self) -> None:
-        link = {"title": "New volcano erupts", "description": ""}
+        link = {"title": "New volcano erupts", "description": "", "lang_hint": "en"}
         prompt = build_focused_clustering_prompt(link, [])
         self.assertIn("NEW EVENT", prompt)
         self.assertIn("new_event", prompt)
         self.assertNotIn("ASSIGN", prompt)
+        self.assertIn("Language hint: en", prompt)
 
     def test_with_candidates_shows_scores(self) -> None:
         ev = {"id": 42, "summary_en": "Volcano erupted", "category": "Global News",
@@ -1129,6 +1131,13 @@ class TestBuildFocusedClusteringPrompt(unittest.TestCase):
         prompt = build_focused_clustering_prompt({"title": "Test"}, candidates)
         self.assertIn("DEVELOPMENT", prompt)
         self.assertIn("new phase", prompt)
+
+    def test_prompt_derives_language_hint_when_missing(self) -> None:
+        prompt = build_focused_clustering_prompt(
+            {"title": "香港議會通過新法案", "description": "涉及公共開支及社會福利"},
+            [],
+        )
+        self.assertIn("Language hint: zh", prompt)
 
 
 class TestMergeIncludesPosted(unittest.TestCase):

--- a/newsroom/tests/test_event_manager.py
+++ b/newsroom/tests/test_event_manager.py
@@ -136,6 +136,9 @@ class TestParseClusteringResponse(unittest.TestCase):
             "action": "new_event",
             "confidence": 0.95,
             "summary_en": "Tesla Q4 earnings beat expectations",
+            "entity_aliases": [
+                {"label": "Elon Musk", "aliases": ["馬斯克"]},
+            ],
             "category": "US Stocks",
             "jurisdiction": "US",
             "link_flags": [],
@@ -146,6 +149,10 @@ class TestParseClusteringResponse(unittest.TestCase):
         assert result is not None
         self.assertEqual(result["validated"]["action"], "new_event")
         self.assertEqual(result["validated"]["summary_en"], "Tesla Q4 earnings beat expectations")
+        self.assertEqual(
+            result["validated"]["entity_aliases"],
+            [{"label": "Elon Musk", "aliases": ["馬斯克"]}],
+        )
         self.assertEqual(result["enforced"]["action"], "new_event")
 
     def test_parse_normalises_category_aliases(self) -> None:
@@ -726,6 +733,9 @@ class TestClusterLink(unittest.TestCase):
                     "action": "new_event",
                     "confidence": 0.9,
                     "summary_en": "Scientists discover new species",
+                    "entity_aliases": [
+                        {"label": "Ocean Institute", "aliases": ["海洋研究所"]},
+                    ],
                     "category": "Global News",
                     "jurisdiction": "GLOBAL",
                     "link_flags": [],
@@ -742,6 +752,10 @@ class TestClusterLink(unittest.TestCase):
                 self.assertIsNotNone(ev)
                 assert ev is not None
                 self.assertEqual(ev["summary_en"], "Scientists discover new species")
+                self.assertEqual(
+                    ev.get("entity_aliases"),
+                    [{"label": "Ocean Institute", "aliases": ["海洋研究所"]}],
+                )
 
     def test_cluster_link_normalises_category_before_db_write(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -1253,6 +1267,31 @@ class TestRetrieveCandidates(unittest.TestCase):
         candidates = retrieve_candidates(link, events, min_score=0.05)
         found_ids = {ev["id"] for ev, _ in candidates}
         self.assertIn(3, found_ids)  # Posted event should be found.
+
+    def test_retrieval_uses_entity_aliases(self) -> None:
+        events = [
+            {
+                "id": 1,
+                "summary_en": "Court confirms sentencing in high-profile case",
+                "title": "Sentencing update",
+                "category": "Hong Kong News",
+                "status": "active",
+                "entity_aliases": [
+                    {"label": "Jimmy Lai", "aliases": ["黎智英"]},
+                ],
+            },
+            {
+                "id": 2,
+                "summary_en": "New football transfer update",
+                "title": "Sports transfer",
+                "category": "Sports",
+                "status": "active",
+            },
+        ]
+        link = {"title": "黎智英被判囚 20 年", "description": "香港法院判刑"}
+        candidates = retrieve_candidates(link, events, min_score=0.05)
+        self.assertTrue(len(candidates) > 0)
+        self.assertEqual(candidates[0][0]["id"], 1)
 
     def test_respects_top_k(self) -> None:
         events = self._make_events()

--- a/newsroom/tests/test_event_manager.py
+++ b/newsroom/tests/test_event_manager.py
@@ -154,6 +154,28 @@ class TestParseClusteringResponse(unittest.TestCase):
         )
         self.assertEqual(result["enforced"]["action"], "new_event")
 
+    def test_parse_new_event_single_object_entity_aliases(self) -> None:
+        response = {
+            "action": "new_event",
+            "confidence": 0.95,
+            "summary_en": "Tesla Q4 earnings beat expectations",
+            "entity_aliases": {
+                "label": "Elon Musk",
+                "aliases": ["馬斯克"],
+            },
+            "category": "US Stocks",
+            "jurisdiction": "US",
+            "link_flags": [],
+            "match_basis": ["entity", "number"],
+        }
+        result = parse_clustering_response(response, {}, [])
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(
+            result["validated"]["entity_aliases"],
+            [{"label": "Elon Musk", "aliases": ["馬斯克"]}],
+        )
+
     def test_parse_normalises_category_aliases(self) -> None:
         response = {
             "action": "new_event",

--- a/newsroom/tests/test_event_manager.py
+++ b/newsroom/tests/test_event_manager.py
@@ -155,6 +155,28 @@ class TestParseClusteringResponse(unittest.TestCase):
         )
         self.assertEqual(result["enforced"]["action"], "new_event")
 
+    def test_parse_new_event_single_object_entity_aliases(self) -> None:
+        response = {
+            "action": "new_event",
+            "confidence": 0.95,
+            "summary_en": "Tesla Q4 earnings beat expectations",
+            "entity_aliases": {
+                "label": "Elon Musk",
+                "aliases": ["馬斯克"],
+            },
+            "category": "US Stocks",
+            "jurisdiction": "US",
+            "link_flags": [],
+            "match_basis": ["entity", "number"],
+        }
+        result = parse_clustering_response(response, {}, [])
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(
+            result["validated"]["entity_aliases"],
+            [{"label": "Elon Musk", "aliases": ["馬斯克"]}],
+        )
+
     def test_parse_normalises_category_aliases(self) -> None:
         response = {
             "action": "new_event",

--- a/newsroom/tests/test_lang_hint.py
+++ b/newsroom/tests/test_lang_hint.py
@@ -1,0 +1,46 @@
+import unittest
+
+from newsroom.lang_hint import detect_link_lang_hint, detect_text_lang_hint, normalise_lang_hint
+
+
+class TestLangHint(unittest.TestCase):
+    def test_detect_text_lang_hint_mostly_latin(self) -> None:
+        text = "Prime Minister announces housing reform and detailed fiscal updates for London councils."
+        self.assertEqual(detect_text_lang_hint(text), "en")
+
+    def test_detect_text_lang_hint_mostly_cjk(self) -> None:
+        text = "香港立法會通過新預算案，重點增加公共醫療資源同社區支援服務。"
+        self.assertEqual(detect_text_lang_hint(text), "zh")
+
+    def test_detect_text_lang_hint_mixed(self) -> None:
+        text = "港股反彈 after Fed comments, 科技股領漲但成交未見明顯放大。"
+        self.assertEqual(detect_text_lang_hint(text), "mixed")
+
+    def test_detect_link_lang_hint_uses_existing_hint(self) -> None:
+        self.assertEqual(
+            detect_link_lang_hint(
+                title="English title",
+                description="English description",
+                existing_hint="zh",
+            ),
+            "zh",
+        )
+
+    def test_detect_link_lang_hint_from_title_and_description(self) -> None:
+        self.assertEqual(
+            detect_link_lang_hint(
+                title="美股急跌",
+                description="Nasdaq drops after inflation surprise",
+            ),
+            "en",
+        )
+
+    def test_normalise_lang_hint(self) -> None:
+        self.assertEqual(normalise_lang_hint("EN"), "en")
+        self.assertEqual(normalise_lang_hint(" zh "), "zh")
+        self.assertEqual(normalise_lang_hint("mixed"), "mixed")
+        self.assertIsNone(normalise_lang_hint("fr"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/newsroom/tests/test_news_pool_db.py
+++ b/newsroom/tests/test_news_pool_db.py
@@ -287,6 +287,25 @@ class TestNewsPoolDBEvents(unittest.TestCase):
                     ],
                 )
 
+    def test_create_event_persists_single_object_entity_aliases(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "news_pool.sqlite3"
+            with NewsPoolDB(path=db_path) as db:
+                eid = db.create_event(
+                    summary_en="Jimmy Lai sentenced in Hong Kong",
+                    category="Hong Kong News",
+                    jurisdiction="HK",
+                    entity_aliases={"label": "Jimmy Lai", "aliases": ["黎智英", "Lai"]},
+                )
+                ev = db.get_event(eid)
+                self.assertIsNotNone(ev)
+                assert ev is not None
+                self.assertIsInstance(ev.get("entity_aliases_json"), str)
+                self.assertEqual(
+                    ev.get("entity_aliases"),
+                    [{"label": "Jimmy Lai", "aliases": ["黎智英", "Lai"]}],
+                )
+
     def test_create_development(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             db_path = Path(td) / "news_pool.sqlite3"

--- a/newsroom/tests/test_news_pool_db.py
+++ b/newsroom/tests/test_news_pool_db.py
@@ -55,6 +55,7 @@ class TestNewsPoolDBV5Fresh(unittest.TestCase):
                 self.assertEqual(len(links), 1)
                 self.assertIsNone(links[0]["event_id"])
                 self.assertIsNotNone(links[0]["published_at_ts"])
+                self.assertEqual(links[0]["lang_hint"], "en")
 
 
 class TestLinkSkipCluster(unittest.TestCase):
@@ -714,6 +715,7 @@ class TestCandidateEnrichment(unittest.TestCase):
                 self.assertEqual(c["event_id"], eid)
                 self.assertEqual(c["cluster_size"], 2)
                 self.assertIsInstance(c["age_minutes"], int)
+                self.assertEqual(c["lang_hint"], "en")
 
                 # supporting_urls: should have the non-primary URL.
                 self.assertIn("https://bbc.co.uk/tesla-q4", c["supporting_urls"])
@@ -737,6 +739,8 @@ class TestCandidateEnrichment(unittest.TestCase):
                 self.assertIn("event_id", c)
                 self.assertIn("supporting_urls", c)
                 self.assertIn("domains", c)
+                self.assertIn("lang_hint", c)
+                self.assertEqual(c["lang_hint"], "mixed")
 
 
 class TestMergeEventsInto(unittest.TestCase):

--- a/newsroom/tests/test_news_pool_db.py
+++ b/newsroom/tests/test_news_pool_db.py
@@ -271,8 +271,8 @@ class TestNewsPoolDBEvents(unittest.TestCase):
                     category="Hong Kong News",
                     jurisdiction="HK",
                     entity_aliases=[
-                        {"label": "Jimmy Lai", "aliases": ["黎智英", "Lai"]},
-                        {"entity": "Hong Kong Court", "zh": "香港法院"},
+                        {"label": "Jimmy Lai", "type": "person", "aliases": ["黎智英", "Lai"]},
+                        {"entity": "Hong Kong Court", "type": "organisation", "zh": "香港法院"},
                     ],
                 )
                 ev = db.get_event(eid)
@@ -282,8 +282,8 @@ class TestNewsPoolDBEvents(unittest.TestCase):
                 self.assertEqual(
                     ev.get("entity_aliases"),
                     [
-                        {"label": "Jimmy Lai", "aliases": ["黎智英", "Lai"]},
-                        {"label": "Hong Kong Court", "aliases": ["香港法院"]},
+                        {"label": "Jimmy Lai", "type": "person", "aliases": ["黎智英", "Lai"]},
+                        {"label": "Hong Kong Court", "type": "org", "aliases": ["香港法院"]},
                     ],
                 )
 
@@ -295,7 +295,7 @@ class TestNewsPoolDBEvents(unittest.TestCase):
                     summary_en="Jimmy Lai sentenced in Hong Kong",
                     category="Hong Kong News",
                     jurisdiction="HK",
-                    entity_aliases={"label": "Jimmy Lai", "aliases": ["黎智英", "Lai"]},
+                    entity_aliases={"label": "Jimmy Lai", "type": "person", "aliases": ["黎智英", "Lai"]},
                 )
                 ev = db.get_event(eid)
                 self.assertIsNotNone(ev)
@@ -303,7 +303,7 @@ class TestNewsPoolDBEvents(unittest.TestCase):
                 self.assertIsInstance(ev.get("entity_aliases_json"), str)
                 self.assertEqual(
                     ev.get("entity_aliases"),
-                    [{"label": "Jimmy Lai", "aliases": ["黎智英", "Lai"]}],
+                    [{"label": "Jimmy Lai", "type": "person", "aliases": ["黎智英", "Lai"]}],
                 )
 
     def test_create_development(self) -> None:

--- a/newsroom/tests/test_news_pool_db.py
+++ b/newsroom/tests/test_news_pool_db.py
@@ -261,6 +261,31 @@ class TestNewsPoolDBEvents(unittest.TestCase):
                 self.assertEqual(ev["link_count"], 0)
                 self.assertIsNotNone(ev["expires_at_ts"])
 
+    def test_create_event_persists_entity_aliases(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "news_pool.sqlite3"
+            with NewsPoolDB(path=db_path) as db:
+                eid = db.create_event(
+                    summary_en="Jimmy Lai sentenced in Hong Kong",
+                    category="Hong Kong News",
+                    jurisdiction="HK",
+                    entity_aliases=[
+                        {"label": "Jimmy Lai", "aliases": ["黎智英", "Lai"]},
+                        {"entity": "Hong Kong Court", "zh": "香港法院"},
+                    ],
+                )
+                ev = db.get_event(eid)
+                self.assertIsNotNone(ev)
+                assert ev is not None
+                self.assertIsInstance(ev.get("entity_aliases_json"), str)
+                self.assertEqual(
+                    ev.get("entity_aliases"),
+                    [
+                        {"label": "Jimmy Lai", "aliases": ["黎智英", "Lai"]},
+                        {"label": "Hong Kong Court", "aliases": ["香港法院"]},
+                    ],
+                )
+
     def test_create_development(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             db_path = Path(td) / "news_pool.sqlite3"
@@ -737,6 +762,49 @@ class TestCandidateEnrichment(unittest.TestCase):
                 self.assertIn("event_id", c)
                 self.assertIn("supporting_urls", c)
                 self.assertIn("domains", c)
+
+    def test_candidate_enrichment_includes_entity_aliases_terms(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "news_pool.sqlite3"
+            with NewsPoolDB(path=db_path) as db:
+                eid = db.create_event(
+                    summary_en="Sentencing update",
+                    category="Hong Kong News",
+                    jurisdiction="HK",
+                    entity_aliases=[
+                        {"label": "Jimmy Lai", "aliases": ["黎智英"]},
+                        {"label": "Hong Kong Court", "aliases": ["香港法院"]},
+                    ],
+                )
+                link = PoolLink(
+                    url="https://example.com/hk-case",
+                    norm_url="https://example.com/hk-case",
+                    domain="example.com",
+                    title="Case update",
+                    description="Sentencing update",
+                    age=None,
+                    page_age="2026-02-07T10:00:00",
+                    query="test",
+                    offset=1,
+                    fetched_at_ts=int(time.time()),
+                )
+                db.upsert_links([link])
+                unassigned = db.get_unassigned_links()
+                self.assertEqual(len(unassigned), 1)
+                db.assign_link_to_event(link_id=unassigned[0]["id"], event_id=eid)
+
+                candidates = db.get_daily_candidates(limit=5)
+                self.assertGreater(len(candidates), 0)
+                c = candidates[0]
+                self.assertEqual(
+                    c.get("entity_aliases"),
+                    [
+                        {"label": "Jimmy Lai", "aliases": ["黎智英"]},
+                        {"label": "Hong Kong Court", "aliases": ["香港法院"]},
+                    ],
+                )
+                self.assertIn("Jimmy Lai", c.get("cluster_terms", []))
+                self.assertIn("黎智英", c.get("anchor_terms", []))
 
 
 class TestMergeEventsInto(unittest.TestCase):

--- a/newsroom/tests/test_news_pool_db.py
+++ b/newsroom/tests/test_news_pool_db.py
@@ -286,6 +286,25 @@ class TestNewsPoolDBEvents(unittest.TestCase):
                     ],
                 )
 
+    def test_create_event_persists_single_object_entity_aliases(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "news_pool.sqlite3"
+            with NewsPoolDB(path=db_path) as db:
+                eid = db.create_event(
+                    summary_en="Jimmy Lai sentenced in Hong Kong",
+                    category="Hong Kong News",
+                    jurisdiction="HK",
+                    entity_aliases={"label": "Jimmy Lai", "aliases": ["黎智英", "Lai"]},
+                )
+                ev = db.get_event(eid)
+                self.assertIsNotNone(ev)
+                assert ev is not None
+                self.assertIsInstance(ev.get("entity_aliases_json"), str)
+                self.assertEqual(
+                    ev.get("entity_aliases"),
+                    [{"label": "Jimmy Lai", "aliases": ["黎智英", "Lai"]}],
+                )
+
     def test_create_development(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             db_path = Path(td) / "news_pool.sqlite3"

--- a/newsroom/tests/test_write_run_job.py
+++ b/newsroom/tests/test_write_run_job.py
@@ -30,6 +30,7 @@ class TestWriteRunJobScript(unittest.TestCase):
                         "suggested_category": "AI" if i % 2 == 0 else "Global News",
                         "title": f"Example Title {i}",
                         "description": f"Example description {i}.",
+                        "lang_hint": "en" if i % 2 == 0 else "zh",
                         "primary_url": f"https://example.com/{i}",
                         "supporting_urls": [f"https://example.org/{i}a", f"https://example.net/{i}b"],
                         "age_minutes": 30 * i,
@@ -90,6 +91,8 @@ class TestWriteRunJobScript(unittest.TestCase):
                 self.assertEqual(story["run"]["trigger"], "cron_daily")
                 self.assertEqual(story["destination"]["title_channel_id"], "1467628391082496041")
                 self.assertEqual(story["monitor"]["timeout_seconds"], 1234)
+                self.assertIn(story["story"]["lang_hint"], {"en", "zh"})
+                self.assertEqual(story["spawn"]["input_mapping"]["lang_hint"], "$.story.lang_hint")
 
 
     def test_write_run_job_timeout_seconds_has_sane_minimum(self) -> None:
@@ -111,6 +114,7 @@ class TestWriteRunJobScript(unittest.TestCase):
                     "suggested_category": "Global News",
                     "title": "Example Title 1",
                     "description": "Example description 1.",
+                    "lang_hint": "en",
                     "primary_url": "https://example.com/1",
                     "supporting_urls": ["https://example.org/1a"],
                     "age_minutes": 30,
@@ -152,6 +156,7 @@ class TestWriteRunJobScript(unittest.TestCase):
             story = json.loads(story_files[0].read_text(encoding="utf-8"))
             jsonschema.validate(instance=story, schema=story_schema)
             self.assertEqual(story["monitor"]["timeout_seconds"], 60)
+            self.assertEqual(story["story"]["lang_hint"], "en")
 
 
     def test_write_run_job_v5_top_level_candidates(self) -> None:
@@ -177,6 +182,7 @@ class TestWriteRunJobScript(unittest.TestCase):
                     "category": "Politics",
                     "title": "PM crisis deepens",
                     "description": "UK PM faces renewed pressure",
+                    "lang_hint": "en",
                     "summary_en": "UK PM faces renewed pressure",
                     "primary_url": "https://bbc.co.uk/pm-crisis",
                     "supporting_urls": ["https://guardian.com/pm-crisis"],
@@ -199,6 +205,7 @@ class TestWriteRunJobScript(unittest.TestCase):
                     "category": "AI",
                     "title": "New AI model released",
                     "description": "Company releases AI model",
+                    "lang_hint": "mixed",
                     "summary_en": "Company releases AI model",
                     "primary_url": "https://techcrunch.com/ai-model",
                     "supporting_urls": [],
@@ -245,6 +252,8 @@ class TestWriteRunJobScript(unittest.TestCase):
             # Verify category and title.
             self.assertEqual(s1["story"]["category"], "Politics")
             self.assertEqual(s2["story"]["category"], "AI")
+            self.assertEqual(s1["story"]["lang_hint"], "en")
+            self.assertEqual(s2["story"]["lang_hint"], "mixed")
 
 
 if __name__ == "__main__":

--- a/scripts/newsroom_write_run_job.py
+++ b/scripts/newsroom_write_run_job.py
@@ -17,6 +17,7 @@ sys.path.insert(0, str(OPENCLAW_HOME))
 
 from newsroom.brave_news import normalize_url  # noqa: E402
 from newsroom.job_store import atomic_write_json  # noqa: E402
+from newsroom.lang_hint import normalise_lang_hint  # noqa: E402
 from newsroom.prompt_policy import prompt_id_for_category  # noqa: E402
 
 
@@ -108,6 +109,11 @@ def _concrete_anchor_from_candidate(c: dict[str, Any]) -> str:
         if words:
             return ("Key terms: " + ", ".join(words[:8]))[:220]
     return "See linked sources for details."
+
+
+def _story_lang_hint_from_candidate(c: dict[str, Any]) -> str:
+    hint = normalise_lang_hint(c.get("lang_hint"))
+    return hint or "mixed"
 
 
 def _candidate_by_index(inputs_obj: dict[str, Any]) -> dict[int, dict[str, Any]]:
@@ -300,6 +306,7 @@ def main(argv: list[str]) -> int:
                 "content_type": "news_deep_dive",
                 "category": category,
                 "title": title,
+                "lang_hint": _story_lang_hint_from_candidate(c),
                 "primary_url": primary_url,
                 "supporting_urls": supporting_urls,
                 "concrete_anchor": _concrete_anchor_from_candidate(c),
@@ -326,6 +333,7 @@ def main(argv: list[str]) -> int:
                     "story_id": "$.story.story_id",
                     "category": "$.story.category",
                     "title": "$.story.title",
+                    "lang_hint": "$.story.lang_hint",
                     "primary_url": "$.story.primary_url",
                     "supporting_urls": "$.story.supporting_urls",
                     "concrete_anchor": "$.story.concrete_anchor",


### PR DESCRIPTION
## Summary
- capture `entity_aliases` from clustering `new_event` and `development` outputs
- persist aliases on events via `entity_aliases_json` with backwards-compatible schema upgrade logic
- expose aliases in candidate enrichment and use aliases during retrieval tokenisation for better bilingual matching
- add tests covering alias parsing, persistence, and retrieval usage

## Testing
- `PYTHONPATH=. pytest -q newsroom/tests/test_event_manager.py newsroom/tests/test_news_pool_db.py`

Closes #16