### PR TITLE
Implement link language hint detection and clustering/data-path integration

### DIFF
--- a/newsroom/lang_hint.py
+++ b/newsroom/lang_hint.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import unicodedata
+from typing import Any, Literal
+
+LangHint = Literal["en", "zh", "mixed"]
+
+_VALID_LANG_HINTS: frozenset[str] = frozenset({"en", "zh", "mixed"})
+_CJK_RANGES: tuple[tuple[int, int], ...] = (
+    (0x3400, 0x4DBF),  # CJK Unified Ideographs Extension A
+    (0x4E00, 0x9FFF),  # CJK Unified Ideographs
+    (0xF900, 0xFAFF),  # CJK Compatibility Ideographs
+)
+
+
+def _is_cjk_char(ch: str) -> bool:
+    code = ord(ch)
+    for lo, hi in _CJK_RANGES:
+        if lo <= code <= hi:
+            return True
+    return False
+
+
+def _count_cjk_chars(text: str) -> int:
+    return sum(1 for ch in (text or "") if _is_cjk_char(ch))
+
+
+def _is_latin_letter(ch: str) -> bool:
+    if not ch.isalpha():
+        return False
+    if ch.isascii():
+        return True
+    try:
+        return "LATIN" in unicodedata.name(ch)
+    except ValueError:
+        return False
+
+
+def _count_latin_letters(text: str) -> int:
+    return sum(1 for ch in (text or "") if _is_latin_letter(ch))
+
+
+def normalise_lang_hint(value: Any) -> LangHint | None:
+    if not isinstance(value, str):
+        return None
+    s = value.strip().lower()
+    if s in _VALID_LANG_HINTS:
+        return s  # type: ignore[return-value]
+    return None
+
+
+def detect_text_lang_hint(text: str | None) -> LangHint:
+    cjk = _count_cjk_chars(text or "")
+    latin = _count_latin_letters(text or "")
+
+    if cjk == 0 and latin == 0:
+        return "mixed"
+    if cjk == 0:
+        return "en"
+    if latin == 0:
+        return "zh"
+
+    total = cjk + latin
+    cjk_ratio = cjk / total
+    latin_ratio = latin / total
+
+    # "Mostly CJK" and "mostly Latin" with conservative thresholds.
+    if cjk_ratio >= 0.72:
+        return "zh"
+    if latin_ratio >= 0.72:
+        return "en"
+
+    # Tie-breaker for longer strings where one script is still clearly dominant.
+    if cjk >= 10 and cjk >= (latin * 1.2):
+        return "zh"
+    if latin >= 14 and latin >= (cjk * 1.2):
+        return "en"
+
+    return "mixed"
+
+
+def detect_link_lang_hint(
+    *,
+    title: str | None,
+    description: str | None,
+    existing_hint: Any | None = None,
+) -> LangHint:
+    norm = normalise_lang_hint(existing_hint)
+    if norm:
+        return norm
+
+    parts: list[str] = []
+    if isinstance(title, str) and title.strip():
+        parts.append(title.strip())
+    if isinstance(description, str) and description.strip():
+        parts.append(description.strip())
+    return detect_text_lang_hint(" ".join(parts))

--- a/newsroom/tests/test_event_manager.py
+++ b/newsroom/tests/test_event_manager.py
@@ -29,11 +29,12 @@ from newsroom.news_pool_db import NewsPoolDB, PoolLink
 
 class TestBuildClusteringPrompt(unittest.TestCase):
     def test_builds_prompt_with_no_events(self) -> None:
-        link = {"title": "Tesla Q4 earnings beat", "description": "Revenue up 20%"}
+        link = {"title": "Tesla Q4 earnings beat", "description": "Revenue up 20%", "lang_hint": "en"}
         prompt = build_clustering_prompt(link, [])
         self.assertIn("Tesla Q4 earnings beat", prompt)
         self.assertIn("(no fresh events)", prompt)
         self.assertIn("action", prompt)
+        self.assertIn("Language hint: en", prompt)
 
     def test_builds_prompt_with_events(self) -> None:
         link = {"title": "FCA probes Mandelson", "description": "Investigation opened"}
@@ -1100,11 +1101,12 @@ class TestRetrieveCandidates(unittest.TestCase):
 
 class TestBuildFocusedClusteringPrompt(unittest.TestCase):
     def test_no_candidates_prompt(self) -> None:
-        link = {"title": "New volcano erupts", "description": ""}
+        link = {"title": "New volcano erupts", "description": "", "lang_hint": "en"}
         prompt = build_focused_clustering_prompt(link, [])
         self.assertIn("NEW EVENT", prompt)
         self.assertIn("new_event", prompt)
         self.assertNotIn("ASSIGN", prompt)
+        self.assertIn("Language hint: en", prompt)
 
     def test_with_candidates_shows_scores(self) -> None:
         ev = {"id": 42, "summary_en": "Volcano erupted", "category": "Global News",
@@ -1129,6 +1131,13 @@ class TestBuildFocusedClusteringPrompt(unittest.TestCase):
         prompt = build_focused_clustering_prompt({"title": "Test"}, candidates)
         self.assertIn("DEVELOPMENT", prompt)
         self.assertIn("new phase", prompt)
+
+    def test_prompt_derives_language_hint_when_missing(self) -> None:
+        prompt = build_focused_clustering_prompt(
+            {"title": "香港議會通過新法案", "description": "涉及公共開支及社會福利"},
+            [],
+        )
+        self.assertIn("Language hint: zh", prompt)
 
 
 class TestMergeIncludesPosted(unittest.TestCase):

--- a/newsroom/tests/test_lang_hint.py
+++ b/newsroom/tests/test_lang_hint.py
@@ -1,0 +1,46 @@
+import unittest
+
+from newsroom.lang_hint import detect_link_lang_hint, detect_text_lang_hint, normalise_lang_hint
+
+
+class TestLangHint(unittest.TestCase):
+    def test_detect_text_lang_hint_mostly_latin(self) -> None:
+        text = "Prime Minister announces housing reform and detailed fiscal updates for London councils."
+        self.assertEqual(detect_text_lang_hint(text), "en")
+
+    def test_detect_text_lang_hint_mostly_cjk(self) -> None:
+        text = "香港立法會通過新預算案，重點增加公共醫療資源同社區支援服務。"
+        self.assertEqual(detect_text_lang_hint(text), "zh")
+
+    def test_detect_text_lang_hint_mixed(self) -> None:
+        text = "港股反彈 after Fed comments, 科技股領漲但成交未見明顯放大。"
+        self.assertEqual(detect_text_lang_hint(text), "mixed")
+
+    def test_detect_link_lang_hint_uses_existing_hint(self) -> None:
+        self.assertEqual(
+            detect_link_lang_hint(
+                title="English title",
+                description="English description",
+                existing_hint="zh",
+            ),
+            "zh",
+        )
+
+    def test_detect_link_lang_hint_from_title_and_description(self) -> None:
+        self.assertEqual(
+            detect_link_lang_hint(
+                title="美股急跌",
+                description="Nasdaq drops after inflation surprise",
+            ),
+            "en",
+        )
+
+    def test_normalise_lang_hint(self) -> None:
+        self.assertEqual(normalise_lang_hint("EN"), "en")
+        self.assertEqual(normalise_lang_hint(" zh "), "zh")
+        self.assertEqual(normalise_lang_hint("mixed"), "mixed")
+        self.assertIsNone(normalise_lang_hint("fr"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/newsroom/tests/test_news_pool_db.py
+++ b/newsroom/tests/test_news_pool_db.py
@@ -55,6 +55,7 @@ class TestNewsPoolDBV5Fresh(unittest.TestCase):
                 self.assertEqual(len(links), 1)
                 self.assertIsNone(links[0]["event_id"])
                 self.assertIsNotNone(links[0]["published_at_ts"])
+                self.assertEqual(links[0]["lang_hint"], "en")
 
 
 class TestLinkSkipCluster(unittest.TestCase):
@@ -714,6 +715,7 @@ class TestCandidateEnrichment(unittest.TestCase):
                 self.assertEqual(c["event_id"], eid)
                 self.assertEqual(c["cluster_size"], 2)
                 self.assertIsInstance(c["age_minutes"], int)
+                self.assertEqual(c["lang_hint"], "en")
 
                 # supporting_urls: should have the non-primary URL.
                 self.assertIn("https://bbc.co.uk/tesla-q4", c["supporting_urls"])
@@ -737,6 +739,8 @@ class TestCandidateEnrichment(unittest.TestCase):
                 self.assertIn("event_id", c)
                 self.assertIn("supporting_urls", c)
                 self.assertIn("domains", c)
+                self.assertIn("lang_hint", c)
+                self.assertEqual(c["lang_hint"], "mixed")
 
 
 class TestMergeEventsInto(unittest.TestCase):

--- a/newsroom/tests/test_write_run_job.py
+++ b/newsroom/tests/test_write_run_job.py
@@ -30,6 +30,7 @@ class TestWriteRunJobScript(unittest.TestCase):
                         "suggested_category": "AI" if i % 2 == 0 else "Global News",
                         "title": f"Example Title {i}",
                         "description": f"Example description {i}.",
+                        "lang_hint": "en" if i % 2 == 0 else "zh",
                         "primary_url": f"https://example.com/{i}",
                         "supporting_urls": [f"https://example.org/{i}a", f"https://example.net/{i}b"],
                         "age_minutes": 30 * i,
@@ -90,6 +91,8 @@ class TestWriteRunJobScript(unittest.TestCase):
                 self.assertEqual(story["run"]["trigger"], "cron_daily")
                 self.assertEqual(story["destination"]["title_channel_id"], "1467628391082496041")
                 self.assertEqual(story["monitor"]["timeout_seconds"], 1234)
+                self.assertIn(story["story"]["lang_hint"], {"en", "zh"})
+                self.assertEqual(story["spawn"]["input_mapping"]["lang_hint"], "$.story.lang_hint")
 
 
     def test_write_run_job_timeout_seconds_has_sane_minimum(self) -> None:
@@ -111,6 +114,7 @@ class TestWriteRunJobScript(unittest.TestCase):
                     "suggested_category": "Global News",
                     "title": "Example Title 1",
                     "description": "Example description 1.",
+                    "lang_hint": "en",
                     "primary_url": "https://example.com/1",
                     "supporting_urls": ["https://example.org/1a"],
                     "age_minutes": 30,
@@ -152,6 +156,7 @@ class TestWriteRunJobScript(unittest.TestCase):
             story = json.loads(story_files[0].read_text(encoding="utf-8"))
             jsonschema.validate(instance=story, schema=story_schema)
             self.assertEqual(story["monitor"]["timeout_seconds"], 60)
+            self.assertEqual(story["story"]["lang_hint"], "en")
 
 
     def test_write_run_job_v5_top_level_candidates(self) -> None:
@@ -177,6 +182,7 @@ class TestWriteRunJobScript(unittest.TestCase):
                     "category": "Politics",
                     "title": "PM crisis deepens",
                     "description": "UK PM faces renewed pressure",
+                    "lang_hint": "en",
                     "summary_en": "UK PM faces renewed pressure",
                     "primary_url": "https://bbc.co.uk/pm-crisis",
                     "supporting_urls": ["https://guardian.com/pm-crisis"],
@@ -199,6 +205,7 @@ class TestWriteRunJobScript(unittest.TestCase):
                     "category": "AI",
                     "title": "New AI model released",
                     "description": "Company releases AI model",
+                    "lang_hint": "mixed",
                     "summary_en": "Company releases AI model",
                     "primary_url": "https://techcrunch.com/ai-model",
                     "supporting_urls": [],
@@ -245,6 +252,8 @@ class TestWriteRunJobScript(unittest.TestCase):
             # Verify category and title.
             self.assertEqual(s1["story"]["category"], "Politics")
             self.assertEqual(s2["story"]["category"], "AI")
+            self.assertEqual(s1["story"]["lang_hint"], "en")
+            self.assertEqual(s2["story"]["lang_hint"], "mixed")
 
 
 if __name__ == "__main__":

--- a/scripts/newsroom_write_run_job.py
+++ b/scripts/newsroom_write_run_job.py
@@ -17,6 +17,7 @@ sys.path.insert(0, str(OPENCLAW_HOME))
 
 from newsroom.brave_news import normalize_url  # noqa: E402
 from newsroom.job_store import atomic_write_json  # noqa: E402
+from newsroom.lang_hint import normalise_lang_hint  # noqa: E402
 from newsroom.prompt_policy import prompt_id_for_category  # noqa: E402
 
 
@@ -108,6 +109,11 @@ def _concrete_anchor_from_candidate(c: dict[str, Any]) -> str:
         if words:
             return ("Key terms: " + ", ".join(words[:8]))[:220]
     return "See linked sources for details."
+
+
+def _story_lang_hint_from_candidate(c: dict[str, Any]) -> str:
+    hint = normalise_lang_hint(c.get("lang_hint"))
+    return hint or "mixed"
 
 
 def _candidate_by_index(inputs_obj: dict[str, Any]) -> dict[int, dict[str, Any]]:
@@ -300,6 +306,7 @@ def main(argv: list[str]) -> int:
                 "content_type": "news_deep_dive",
                 "category": category,
                 "title": title,
+                "lang_hint": _story_lang_hint_from_candidate(c),
                 "primary_url": primary_url,
                 "supporting_urls": supporting_urls,
                 "concrete_anchor": _concrete_anchor_from_candidate(c),
@@ -326,6 +333,7 @@ def main(argv: list[str]) -> int:
                     "story_id": "$.story.story_id",
                     "category": "$.story.category",
                     "title": "$.story.title",
+                    "lang_hint": "$.story.lang_hint",
                     "primary_url": "$.story.primary_url",
                     "supporting_urls": "$.story.supporting_urls",
                     "concrete_anchor": "$.story.concrete_anchor",


### PR DESCRIPTION
## Summary
- add a lightweight script-based language hint utility that classifies link text as `en`, `zh`, or `mixed`
- persist `lang_hint` on links in `news_pool_db`, backfill schema compatibility, and expose it through link/candidate data paths
- include link language hints in clustering prompts and propagate candidate `lang_hint` into generated story jobs
- add and update unit tests for utility behaviour, DB enrichment, prompt rendering, and run-job generation

## Testing
- `uv run pytest newsroom/tests/test_lang_hint.py newsroom/tests/test_event_manager.py newsroom/tests/test_news_pool_db.py newsroom/tests/test_write_run_job.py`
- `uv run pytest newsroom/tests`

Closes #14