### PR TITLE
Source-quality aware candidate selection with domain tiering

### DIFF
--- a/newsroom/tests/test_news_pool_db.py
+++ b/newsroom/tests/test_news_pool_db.py
@@ -931,6 +931,147 @@ class TestHourlySelection(unittest.TestCase):
                 self.assertIn("Sports", categories)
 
 
+class TestSourceQualityRanking(unittest.TestCase):
+    @staticmethod
+    def _add_link_to_event(db: NewsPoolDB, *, event_id: int, url: str, page_age: str) -> None:
+        domain = url.split("/", 3)[2]
+        link = PoolLink(
+            url=url,
+            norm_url=url,
+            domain=domain,
+            title="Source",
+            description="Source description",
+            age=None,
+            page_age=page_age,
+            query="test",
+            offset=1,
+            fetched_at_ts=int(time.time()),
+        )
+        db.upsert_links([link])
+        row = db._conn.execute("SELECT id FROM links WHERE norm_url = ?", (url,)).fetchone()
+        assert row is not None
+        db.assign_link_to_event(link_id=int(row["id"]), event_id=event_id)
+
+    def test_daily_ranking_prefers_trusted_diverse_sources_over_link_count(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "news_pool.sqlite3"
+            with NewsPoolDB(path=db_path) as db:
+                low_quality_id = db.create_event(
+                    summary_en="High-volume but low-trust coverage",
+                    category="Global News",
+                    jurisdiction="US",
+                    title="Low trust event",
+                    primary_url="https://x.com/story-low",
+                )
+                trusted_id = db.create_event(
+                    summary_en="Lower-volume but trusted multi-domain coverage",
+                    category="Global News",
+                    jurisdiction="US",
+                    title="Trusted event",
+                    primary_url="https://reuters.com/story-trusted",
+                )
+
+                for i, dom in enumerate(["x.com", "tiktok.com", "youtube.com", "reddit.com", "medium.com", "substack.com"]):
+                    self._add_link_to_event(
+                        db,
+                        event_id=low_quality_id,
+                        url=f"https://{dom}/story-{i}",
+                        page_age=f"2026-02-07T10:0{i}:00",
+                    )
+                for i, dom in enumerate(["reuters.com", "bbc.co.uk", "ft.com"]):
+                    self._add_link_to_event(
+                        db,
+                        event_id=trusted_id,
+                        url=f"https://{dom}/story-{i}",
+                        page_age=f"2026-02-07T10:1{i}:00",
+                    )
+
+                candidates = db.get_daily_candidates(limit=2, now_ts=int(time.time()))
+                self.assertEqual([c["id"] for c in candidates], [trusted_id, low_quality_id])
+
+                trusted = candidates[0]
+                low_quality = candidates[1]
+                self.assertGreater(trusted["trusted_domain_count"], low_quality["trusted_domain_count"])
+                self.assertGreater(trusted["weighted_score"], low_quality["weighted_score"])
+                self.assertGreater(low_quality["link_count"], trusted["link_count"])
+
+    def test_hourly_ranking_prefers_source_quality_when_recency_equal(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "news_pool.sqlite3"
+            with NewsPoolDB(path=db_path) as db:
+                root_id = db.create_event(summary_en="Root event", category="Politics", jurisdiction="UK")
+                low_quality_id = db.create_event(
+                    summary_en="Low-trust development",
+                    category="Politics",
+                    jurisdiction="UK",
+                    parent_event_id=root_id,
+                    development="New low-trust development",
+                    primary_url="https://x.com/dev-low",
+                )
+                trusted_id = db.create_event(
+                    summary_en="Trusted development",
+                    category="Politics",
+                    jurisdiction="UK",
+                    parent_event_id=root_id,
+                    development="New trusted development",
+                    primary_url="https://reuters.com/dev-trusted",
+                )
+
+                # Keep recency equal so source-quality score drives ordering.
+                ts = int(time.time())
+                db._conn.execute(
+                    "UPDATE events SET created_at_ts = ?, updated_at_ts = ? WHERE id IN (?, ?)",
+                    (ts, ts, low_quality_id, trusted_id),
+                )
+
+                for i, dom in enumerate(["x.com", "tiktok.com", "youtube.com", "reddit.com"]):
+                    self._add_link_to_event(
+                        db,
+                        event_id=low_quality_id,
+                        url=f"https://{dom}/dev-{i}",
+                        page_age=f"2026-02-07T09:0{i}:00",
+                    )
+                for i, dom in enumerate(["reuters.com", "bbc.co.uk", "apnews.com"]):
+                    self._add_link_to_event(
+                        db,
+                        event_id=trusted_id,
+                        url=f"https://{dom}/dev-{i}",
+                        page_age=f"2026-02-07T09:1{i}:00",
+                    )
+
+                candidates = db.get_hourly_candidates(limit=2, now_ts=ts)
+                self.assertEqual(candidates[0]["id"], trusted_id)
+                self.assertEqual(candidates[1]["id"], low_quality_id)
+
+    def test_candidate_metrics_include_domain_diversity_fields(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "news_pool.sqlite3"
+            with NewsPoolDB(path=db_path) as db:
+                eid = db.create_event(
+                    summary_en="Diversity metrics event",
+                    category="Global News",
+                    jurisdiction="US",
+                    title="Metrics event",
+                    primary_url="https://reuters.com/metrics-primary",
+                )
+                for i, dom in enumerate(["reuters.com", "bbc.co.uk", "x.com"]):
+                    self._add_link_to_event(
+                        db,
+                        event_id=eid,
+                        url=f"https://{dom}/metrics-{i}",
+                        page_age=f"2026-02-07T08:1{i}:00",
+                    )
+
+                candidates = db.get_daily_candidates(limit=1, now_ts=int(time.time()))
+                self.assertEqual(len(candidates), 1)
+                c = candidates[0]
+                self.assertEqual(c["unique_domain_count"], 3)
+                self.assertEqual(c["trusted_domain_count"], 2)
+                self.assertAlmostEqual(float(c["low_tier_ratio"]), 1.0 / 3.0, places=3)
+                self.assertIn("weighted_score", c)
+                self.assertEqual(c.get("domain_tier_counts"), {"tier_1": 2, "tier_3": 1})
+
+
 class TestPoolRunsLedger(unittest.TestCase):
     def test_pool_runs_ledger_records_requests(self) -> None:
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
## Summary
- add domain trust tier configuration and source-quality weighting for candidate scoring
- enrich candidates with `trusted_domain_count`, `unique_domain_count`, `low_tier_ratio`, `domain_tier_counts`, and `weighted_score`
- update daily/hourly ranking to prioritise trusted multi-domain coverage over raw `link_count` while preserving category balance/diversity logic
- add regression tests for ranking preference and domain-diversity metrics

## Testing
- uv run pytest newsroom/tests/test_news_pool_db.py
- uv run pytest newsroom/tests/test_write_run_job.py

Closes #22