### PR TITLE
Add stale unposted event GC and wire into daily/hourly inputs

### DIFF
--- a/newsroom/event_gc.py
+++ b/newsroom/event_gc.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+
+from .news_pool_db import NewsPoolDB
+
+
+def run_periodic_unposted_event_gc(
+    *,
+    db_path: Path,
+    state_key: str,
+    min_interval_seconds: int,
+    stale_after_hours: int = 96,
+    low_link_max: int = 1,
+    low_quality_summary_chars: int = 80,
+    now_ts: int | None = None,
+) -> dict[str, Any]:
+    """Run periodic stale-event GC and return a compact execution summary."""
+    now = int(time.time()) if now_ts is None else int(now_ts)
+    interval = max(0, int(min_interval_seconds))
+    key = str(state_key).strip() or "event_gc_unposted"
+
+    with NewsPoolDB(path=Path(db_path).expanduser()) as db:
+        state = db.fetch_state(key)
+        last_gc_ts = int(state.get("last_fetch_ts", 0))
+        run_count = int(state.get("run_count", 0))
+        should_gc = (now - last_gc_ts) >= interval
+
+        out: dict[str, Any] = {
+            "ok": True,
+            "state_key": key,
+            "should_gc": bool(should_gc),
+            "run_count": run_count,
+            "last_gc_ts": last_gc_ts,
+            "criteria": {
+                "stale_after_hours": int(stale_after_hours),
+                "low_link_max": int(low_link_max),
+                "low_quality_summary_chars": int(low_quality_summary_chars),
+            },
+        }
+
+        if not should_gc:
+            out["pruned"] = 0
+            out["reason"] = "min_interval"
+            return out
+
+        pruned = db.prune_stale_unposted_events(
+            stale_after_hours=int(stale_after_hours),
+            low_link_max=int(low_link_max),
+            low_quality_summary_chars=int(low_quality_summary_chars),
+            now_ts=now,
+        )
+        next_run = run_count + 1
+        db.update_fetch_state(key=key, last_fetch_ts=now, last_offset=0, run_count=next_run)
+        out["pruned"] = int(pruned)
+        out["run_count"] = int(next_run)
+        out["last_gc_ts"] = int(now)
+        return out

--- a/newsroom/tests/test_event_gc.py
+++ b/newsroom/tests/test_event_gc.py
@@ -1,0 +1,72 @@
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+from newsroom.event_gc import run_periodic_unposted_event_gc
+from newsroom.news_pool_db import NewsPoolDB
+
+
+class TestPeriodicUnpostedEventGc(unittest.TestCase):
+    def test_periodic_gc_runs_and_prunes_when_due(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "news_pool.sqlite3"
+            now = int(time.time())
+
+            with NewsPoolDB(path=db_path) as db:
+                eid = db.create_event(summary_en="Old stale event", category="AI", jurisdiction="US")
+                db._conn.execute(
+                    """
+                    UPDATE events
+                    SET created_at_ts = ?, updated_at_ts = ?, expires_at_ts = ?, link_count = 1
+                    WHERE id = ?
+                    """,
+                    (now - 120 * 3600, now - 110 * 3600, now - 24 * 3600, eid),
+                )
+
+            out = run_periodic_unposted_event_gc(
+                db_path=db_path,
+                state_key="event_gc_test",
+                min_interval_seconds=0,
+                stale_after_hours=96,
+                low_link_max=1,
+                low_quality_summary_chars=80,
+                now_ts=now,
+            )
+            self.assertEqual(out.get("ok"), True)
+            self.assertEqual(out.get("should_gc"), True)
+            self.assertEqual(out.get("pruned"), 1)
+            self.assertEqual(out.get("run_count"), 1)
+
+            with NewsPoolDB(path=db_path) as db:
+                self.assertIsNone(db.get_event(eid))
+
+    def test_periodic_gc_skips_when_min_interval_not_elapsed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "news_pool.sqlite3"
+            t0 = int(time.time())
+
+            first = run_periodic_unposted_event_gc(
+                db_path=db_path,
+                state_key="event_gc_test",
+                min_interval_seconds=0,
+                now_ts=t0,
+            )
+            self.assertEqual(first.get("should_gc"), True)
+            self.assertEqual(first.get("run_count"), 1)
+
+            second = run_periodic_unposted_event_gc(
+                db_path=db_path,
+                state_key="event_gc_test",
+                min_interval_seconds=3600,
+                now_ts=t0 + 300,
+            )
+            self.assertEqual(second.get("ok"), True)
+            self.assertEqual(second.get("should_gc"), False)
+            self.assertEqual(second.get("reason"), "min_interval")
+            self.assertEqual(second.get("pruned"), 0)
+            self.assertEqual(second.get("run_count"), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/newsroom/tests/test_inputs_event_gc_hooks.py
+++ b/newsroom/tests/test_inputs_event_gc_hooks.py
@@ -1,0 +1,131 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import scripts.newsroom_daily_inputs as newsroom_daily_inputs
+import scripts.newsroom_hourly_inputs as newsroom_hourly_inputs
+
+
+class _FakeDailyDB:
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    def get_daily_candidates(self, *, limit: int) -> list[dict]:
+        _ = limit
+        return [
+            {
+                "id": 101,
+                "event_id": 101,
+                "title": "Daily candidate",
+                "primary_url": "https://example.com/daily",
+                "supporting_urls": [],
+            }
+        ]
+
+    def close(self) -> None:
+        return None
+
+
+class _FakeHourlyDB:
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    def get_hourly_candidates(self, *, limit: int) -> list[dict]:
+        _ = limit
+        return [
+            {
+                "id": 201,
+                "event_id": 201,
+                "title": "Hourly candidate",
+                "primary_url": "https://example.com/hourly",
+                "supporting_urls": [],
+            }
+        ]
+
+    def close(self) -> None:
+        return None
+
+
+class TestInputsEventGcHooks(unittest.TestCase):
+    def test_daily_invokes_gc_hook_and_records_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            out_path = Path(td) / "daily_inputs_last.json"
+            gc_summary = {
+                "ok": True,
+                "state_key": "gc_key_daily",
+                "should_gc": True,
+                "pruned": 3,
+                "run_count": 2,
+                "last_gc_ts": 123,
+                "criteria": {
+                    "stale_after_hours": 96,
+                    "low_link_max": 1,
+                    "low_quality_summary_chars": 80,
+                },
+            }
+
+            with patch.object(newsroom_daily_inputs, "_run_json", return_value={"ok": True}):
+                with patch.object(newsroom_daily_inputs.time, "sleep", return_value=None):
+                    with patch.object(newsroom_daily_inputs, "NewsPoolDB", _FakeDailyDB):
+                        with patch.object(
+                            newsroom_daily_inputs,
+                            "run_periodic_unposted_event_gc",
+                            return_value=gc_summary,
+                        ) as gc_mock:
+                            rc = newsroom_daily_inputs.main(
+                                [
+                                    "--no-llm",
+                                    "--no-gdelt",
+                                    "--no-rss",
+                                    "--event-gc-state-key",
+                                    "gc_key_daily",
+                                    "--write-path",
+                                    str(out_path),
+                                ]
+                            )
+
+            self.assertEqual(rc, 0)
+            gc_mock.assert_called_once()
+            self.assertEqual(gc_mock.call_args.kwargs.get("state_key"), "gc_key_daily")
+
+            payload = json.loads(out_path.read_text(encoding="utf-8"))
+            self.assertEqual(payload.get("event_gc", {}).get("pruned"), 3)
+            self.assertEqual(payload.get("candidate_count"), 1)
+
+    def test_hourly_gc_failure_is_non_fatal(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            out_path = Path(td) / "hourly_inputs_last.json"
+
+            with patch.object(newsroom_hourly_inputs, "_run_json", return_value={"ok": True}):
+                with patch.object(newsroom_hourly_inputs, "NewsPoolDB", _FakeHourlyDB):
+                    with patch.object(
+                        newsroom_hourly_inputs,
+                        "run_periodic_unposted_event_gc",
+                        side_effect=RuntimeError("gc failure"),
+                    ) as gc_mock:
+                        rc = newsroom_hourly_inputs.main(
+                            [
+                                "--no-llm",
+                                "--no-rss",
+                                "--event-gc-state-key",
+                                "gc_key_hourly",
+                                "--write-path",
+                                str(out_path),
+                            ]
+                        )
+
+            self.assertEqual(rc, 0)
+            gc_mock.assert_called_once()
+
+            payload = json.loads(out_path.read_text(encoding="utf-8"))
+            event_gc = payload.get("event_gc", {})
+            self.assertEqual(event_gc.get("ok"), False)
+            self.assertEqual(event_gc.get("state_key"), "gc_key_hourly")
+            self.assertIn("gc failure", str(event_gc.get("error")))
+            self.assertEqual(payload.get("candidate_count"), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/newsroom/tests/test_news_pool_db.py
+++ b/newsroom/tests/test_news_pool_db.py
@@ -1386,6 +1386,141 @@ class TestPruneExpiredEvents(unittest.TestCase):
                 self.assertEqual(pruned, 0)
 
 
+class TestPruneStaleUnpostedEvents(unittest.TestCase):
+    """Test NewsPoolDB.prune_stale_unposted_events()."""
+
+    def _setup_db(self, td: str) -> NewsPoolDB:
+        return NewsPoolDB(path=Path(td) / "news_pool.sqlite3")
+
+    def test_prunes_expired_stale_low_link_event(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            with self._setup_db(td) as db:
+                now = int(time.time())
+                eid = db.create_event(summary_en="Low-link stale event", category="AI", jurisdiction="US")
+                db._conn.execute(
+                    """
+                    UPDATE events
+                    SET created_at_ts = ?, updated_at_ts = ?, expires_at_ts = ?, link_count = 1
+                    WHERE id = ?
+                    """,
+                    (now - 120 * 3600, now - 110 * 3600, now - 24 * 3600, eid),
+                )
+
+                pruned = db.prune_stale_unposted_events(
+                    stale_after_hours=96,
+                    low_link_max=1,
+                    low_quality_summary_chars=80,
+                    now_ts=now,
+                )
+                self.assertEqual(pruned, 1)
+                self.assertIsNone(db.get_event(eid))
+
+    def test_prunes_expired_stale_low_quality_event(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            with self._setup_db(td) as db:
+                now = int(time.time())
+                eid = db.create_event(summary_en="Brief", category="AI", jurisdiction="US")
+                db._conn.execute(
+                    """
+                    UPDATE events
+                    SET created_at_ts = ?, updated_at_ts = ?, expires_at_ts = ?, link_count = 5
+                    WHERE id = ?
+                    """,
+                    (now - 120 * 3600, now - 110 * 3600, now - 24 * 3600, eid),
+                )
+
+                pruned = db.prune_stale_unposted_events(
+                    stale_after_hours=96,
+                    low_link_max=1,
+                    low_quality_summary_chars=80,
+                    now_ts=now,
+                )
+                self.assertEqual(pruned, 1)
+                self.assertIsNone(db.get_event(eid))
+
+    def test_posted_events_are_never_pruned(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            with self._setup_db(td) as db:
+                now = int(time.time())
+                eid = db.create_event(summary_en="Posted stale event", category="AI", jurisdiction="US")
+                db.mark_event_posted(eid, thread_id="thread-1", run_id="run-1")
+                db._conn.execute(
+                    """
+                    UPDATE events
+                    SET created_at_ts = ?, updated_at_ts = ?, expires_at_ts = ?, link_count = 0
+                    WHERE id = ?
+                    """,
+                    (now - 120 * 3600, now - 110 * 3600, now - 24 * 3600, eid),
+                )
+
+                pruned = db.prune_stale_unposted_events(
+                    stale_after_hours=96,
+                    low_link_max=1,
+                    low_quality_summary_chars=80,
+                    now_ts=now,
+                )
+                self.assertEqual(pruned, 0)
+                self.assertIsNotNone(db.get_event(eid))
+
+    def test_expired_stale_but_good_events_are_kept(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            with self._setup_db(td) as db:
+                now = int(time.time())
+                eid = db.create_event(
+                    summary_en="This summary is intentionally long enough to clear the low-quality threshold for stale GC.",
+                    category="AI",
+                    jurisdiction="US",
+                    title="High-quality event",
+                    primary_url="https://example.com/high-quality",
+                )
+                db._conn.execute(
+                    """
+                    UPDATE events
+                    SET created_at_ts = ?, updated_at_ts = ?, expires_at_ts = ?, link_count = 4
+                    WHERE id = ?
+                    """,
+                    (now - 120 * 3600, now - 110 * 3600, now - 24 * 3600, eid),
+                )
+
+                pruned = db.prune_stale_unposted_events(
+                    stale_after_hours=96,
+                    low_link_max=1,
+                    low_quality_summary_chars=80,
+                    now_ts=now,
+                )
+                self.assertEqual(pruned, 0)
+                self.assertIsNotNone(db.get_event(eid))
+
+    def test_parent_with_child_is_not_pruned(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            with self._setup_db(td) as db:
+                now = int(time.time())
+                parent_id = db.create_event(summary_en="Parent stale event", category="Politics", jurisdiction="UK")
+                db.create_event(
+                    summary_en="Child event",
+                    category="Politics",
+                    jurisdiction="UK",
+                    parent_event_id=parent_id,
+                )
+                db._conn.execute(
+                    """
+                    UPDATE events
+                    SET created_at_ts = ?, updated_at_ts = ?, expires_at_ts = ?, link_count = 0
+                    WHERE id = ?
+                    """,
+                    (now - 120 * 3600, now - 110 * 3600, now - 24 * 3600, parent_id),
+                )
+
+                pruned = db.prune_stale_unposted_events(
+                    stale_after_hours=96,
+                    low_link_max=1,
+                    low_quality_summary_chars=80,
+                    now_ts=now,
+                )
+                self.assertEqual(pruned, 0)
+                self.assertIsNotNone(db.get_event(parent_id))
+
+
 class TestLinkCountDrift(unittest.TestCase):
     """Test that link_count stays accurate across reassignments and pruning."""
 

--- a/scripts/newsroom_hourly_inputs.py
+++ b/scripts/newsroom_hourly_inputs.py
@@ -19,6 +19,7 @@ OPENCLAW_HOME = Path(__file__).resolve().parents[1]
 os.environ.setdefault("OPENCLAW_HOME", str(OPENCLAW_HOME))
 sys.path.insert(0, str(OPENCLAW_HOME))
 
+from newsroom.event_gc import run_periodic_unposted_event_gc  # noqa: E402
 from newsroom.event_manager import cluster_all_pending, merge_events  # noqa: E402
 from newsroom.gemini_client import GeminiClient  # noqa: E402
 from newsroom.news_pool_db import NewsPoolDB  # noqa: E402
@@ -67,6 +68,35 @@ def main(argv: list[str]) -> int:
     parser.add_argument("--limit-candidates", type=int, default=3, help="Max events to output (default: 3).")
     parser.add_argument("--no-llm", action="store_true", help="Skip LLM clustering.")
     parser.add_argument("--no-rss", action="store_true", help="Skip RSS pool update.")
+    parser.add_argument(
+        "--event-gc-state-key",
+        default="event_gc_unposted",
+        help="Fetch-state key used by periodic stale-event GC.",
+    )
+    parser.add_argument(
+        "--event-gc-min-interval-seconds",
+        type=int,
+        default=6 * 3600,
+        help="Minimum seconds between stale-event GC runs (default: 21600).",
+    )
+    parser.add_argument(
+        "--event-gc-stale-hours",
+        type=int,
+        default=96,
+        help="Staleness threshold in hours for stale-event GC (default: 96).",
+    )
+    parser.add_argument(
+        "--event-gc-low-link-max",
+        type=int,
+        default=1,
+        help="Maximum link_count treated as low-link for stale-event GC (default: 1).",
+    )
+    parser.add_argument(
+        "--event-gc-summary-min-chars",
+        type=int,
+        default=80,
+        help="Minimum summary chars used by stale-event low-quality rule (default: 80).",
+    )
     parser.add_argument(
         "--write-path",
         default=str(OPENCLAW_HOME / "data" / "newsroom" / "hourly_inputs_last.json"),
@@ -151,6 +181,28 @@ def main(argv: list[str]) -> int:
             merge_stats = {"error": str(e)}
 
     # ---------------------------------------------------------------
+    # Step 2c: Periodic stale-event GC (non-fatal)
+    # ---------------------------------------------------------------
+    event_gc: dict[str, Any]
+    gc_state_key = str(args.event_gc_state_key).strip() or "event_gc_unposted"
+    try:
+        event_gc = run_periodic_unposted_event_gc(
+            db_path=_DB_PATH,
+            state_key=gc_state_key,
+            min_interval_seconds=int(args.event_gc_min_interval_seconds),
+            stale_after_hours=int(args.event_gc_stale_hours),
+            low_link_max=int(args.event_gc_low_link_max),
+            low_quality_summary_chars=int(args.event_gc_summary_min_chars),
+        )
+    except Exception as e:
+        event_gc = {
+            "ok": False,
+            "state_key": gc_state_key,
+            "should_gc": True,
+            "error": str(e),
+        }
+
+    # ---------------------------------------------------------------
     # Step 3: Event selection (hourly: 1-3, development priority, freshness)
     # ---------------------------------------------------------------
     candidates: list[dict[str, Any]] = []
@@ -199,6 +251,7 @@ def main(argv: list[str]) -> int:
         },
         "clustering": clustering_stats,
         "merge": merge_stats,
+        "event_gc": event_gc,
         "candidates": candidates,
         "candidate_count": len(candidates),
     }


### PR DESCRIPTION
## Summary
- add a periodic stale-event GC helper for unposted expired low-quality/low-link events
- wire automatic GC invocation into daily and hourly input orchestration with non-fatal error handling
- ensure posted events are never GC'd via explicit criteria and tests
- add tests for GC criteria, periodic helper behaviour, and orchestration hooks

## Testing
- PYTHONPATH=. pytest newsroom/tests/test_news_pool_db.py newsroom/tests/test_event_gc.py newsroom/tests/test_inputs_event_gc_hooks.py

Closes #21