### PR TITLE
Writer quality gate before story job creation

### DIFF
--- a/newsroom/tests/test_write_run_job.py
+++ b/newsroom/tests/test_write_run_job.py
@@ -31,13 +31,15 @@ class TestWriteRunJobScript(unittest.TestCase):
                         "title": f"Example Title {i}",
                         "description": f"Example description {i}.",
                         "lang_hint": "en" if i % 2 == 0 else "zh",
-                        "primary_url": f"https://example.com/{i}",
-                        "supporting_urls": [f"https://example.org/{i}a", f"https://example.net/{i}b"],
+                        "primary_url": f"https://reuters.com/example-{i}",
+                        "supporting_urls": [f"https://theguardian.com/example-{i}", f"https://cnn.com/example-{i}"],
                         "age_minutes": 30 * i,
                         "is_breaking_2h": i == 1,
                         "is_developing_6h": i <= 3,
                         "cluster_size": 3,
-                        "domains": ["example.com", "example.org", "example.net"],
+                        "domains": ["reuters.com", "theguardian.com", "cnn.com"],
+                        "unique_domain_count": 3,
+                        "domain_tier_counts": {"tier_1": 1, "tier_2": 2},
                         "cluster_terms": ["foo", "bar"],
                     }
                 )
@@ -115,11 +117,13 @@ class TestWriteRunJobScript(unittest.TestCase):
                     "title": "Example Title 1",
                     "description": "Example description 1.",
                     "lang_hint": "en",
-                    "primary_url": "https://example.com/1",
-                    "supporting_urls": ["https://example.org/1a"],
+                    "primary_url": "https://reuters.com/example-1",
+                    "supporting_urls": ["https://cnn.com/example-1a"],
                     "age_minutes": 30,
                     "cluster_size": 1,
-                    "domains": ["example.com", "example.org"],
+                    "domains": ["reuters.com", "cnn.com"],
+                    "unique_domain_count": 2,
+                    "domain_tier_counts": {"tier_1": 1, "tier_2": 1},
                     "cluster_terms": ["foo"],
                 }
             ]
@@ -185,11 +189,13 @@ class TestWriteRunJobScript(unittest.TestCase):
                     "lang_hint": "en",
                     "summary_en": "UK PM faces renewed pressure",
                     "primary_url": "https://bbc.co.uk/pm-crisis",
-                    "supporting_urls": ["https://guardian.com/pm-crisis"],
+                    "supporting_urls": ["https://theguardian.com/pm-crisis"],
                     "age_minutes": 60,
                     "cluster_size": 3,
                     "link_count": 3,
-                    "domains": ["bbc.co.uk", "guardian.com"],
+                    "domains": ["bbc.co.uk", "theguardian.com"],
+                    "unique_domain_count": 2,
+                    "domain_tier_counts": {"tier_1": 1, "tier_2": 1},
                     "cluster_terms": [],
                     "anchor_terms": [],
                     "suggest_flags": [],
@@ -207,12 +213,14 @@ class TestWriteRunJobScript(unittest.TestCase):
                     "description": "Company releases AI model",
                     "lang_hint": "mixed",
                     "summary_en": "Company releases AI model",
-                    "primary_url": "https://techcrunch.com/ai-model",
-                    "supporting_urls": [],
+                    "primary_url": "https://cnn.com/ai-model",
+                    "supporting_urls": ["https://npr.org/ai-model"],
                     "age_minutes": 120,
                     "cluster_size": 2,
                     "link_count": 2,
-                    "domains": ["techcrunch.com"],
+                    "domains": ["cnn.com", "npr.org"],
+                    "unique_domain_count": 2,
+                    "domain_tier_counts": {"tier_2": 2},
                     "cluster_terms": [],
                     "anchor_terms": [],
                     "suggest_flags": [],
@@ -305,6 +313,164 @@ class TestWriteRunJobScript(unittest.TestCase):
             self.assertEqual(story["story"]["primary_url"], upgraded_primary)
             self.assertNotIn(upgraded_primary, story["story"]["supporting_urls"])
             self.assertIn(old_primary, story["story"]["supporting_urls"])
+
+    def test_write_run_job_quality_gate_accepts_two_mid_tier_domains(self) -> None:
+        root = Path(__file__).resolve().parents[2]
+
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            jobs_root = tmp / "jobs"
+            jobs_root.mkdir(parents=True, exist_ok=True)
+
+            inputs_obj = {
+                "ok": True,
+                "candidates": [
+                    {
+                        "i": 1,
+                        "event_key": "event:mid-tier-pass",
+                        "anchor_key": "event:mid-tier-pass",
+                        "suggested_category": "Global News",
+                        "title": "Mid-tier corroboration story",
+                        "description": "Developing story",
+                        "lang_hint": "en",
+                        "primary_url": "https://cnn.com/mid-tier-pass",
+                        "supporting_urls": ["https://npr.org/mid-tier-pass"],
+                        "domains": ["cnn.com", "npr.org"],
+                        "unique_domain_count": 2,
+                        "domain_tier_counts": {"tier_2": 2},
+                        "age_minutes": 45,
+                        "cluster_terms": [],
+                    }
+                ],
+                "candidate_count": 1,
+            }
+            inputs_path = tmp / "inputs.json"
+            inputs_path.write_text(json.dumps(inputs_obj) + "\n", encoding="utf-8")
+
+            cmd = [
+                sys.executable,
+                str(root / "scripts" / "newsroom_write_run_job.py"),
+                "--jobs-root",
+                str(jobs_root),
+                "--inputs-json-path",
+                str(inputs_path),
+                "--channel-id",
+                "1467628391082496041",
+                "--run-time-uk",
+                "2026-02-09 07:00",
+                "--trigger",
+                "cron_daily",
+                "--expected-stories",
+                "1",
+                "--pick",
+                "1",
+            ]
+
+            out = subprocess.check_output(cmd, text=True)
+            summary = json.loads(out)
+            self.assertEqual(summary["story_count"], 1)
+            self.assertEqual(summary["held_count"], 0)
+
+            run_dir = Path(summary["run_dir"])
+            story_files = sorted(run_dir.glob("story_*.json"))
+            self.assertEqual(len(story_files), 1)
+
+    def test_write_run_job_holds_daily_mail_single_source_and_logs_reason(self) -> None:
+        root = Path(__file__).resolve().parents[2]
+
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            jobs_root = tmp / "jobs"
+            jobs_root.mkdir(parents=True, exist_ok=True)
+
+            inputs_obj = {
+                "ok": True,
+                "candidates": [
+                    {
+                        "i": 1,
+                        "event_key": "event:daily-mail-only",
+                        "anchor_key": "event:daily-mail-only",
+                        "suggested_category": "Global News",
+                        "title": "Single source tabloid recap",
+                        "description": "Daily Mail only",
+                        "lang_hint": "en",
+                        "primary_url": "https://dailymail.co.uk/single-source",
+                        "supporting_urls": [],
+                        "domains": ["dailymail.co.uk"],
+                        "unique_domain_count": 1,
+                        "domain_tier_counts": {"tier_3": 1},
+                        "age_minutes": 30,
+                        "cluster_terms": [],
+                    },
+                    {
+                        "i": 2,
+                        "event_key": "event:trusted-pass",
+                        "anchor_key": "event:trusted-pass",
+                        "suggested_category": "Global News",
+                        "title": "Trusted multi-domain report",
+                        "description": "Strong corroboration",
+                        "lang_hint": "en",
+                        "primary_url": "https://reuters.com/trusted-pass",
+                        "supporting_urls": ["https://theguardian.com/trusted-pass"],
+                        "domains": ["reuters.com", "theguardian.com"],
+                        "unique_domain_count": 2,
+                        "domain_tier_counts": {"tier_1": 1, "tier_2": 1},
+                        "age_minutes": 25,
+                        "cluster_terms": [],
+                    },
+                ],
+                "candidate_count": 2,
+            }
+            inputs_path = tmp / "inputs.json"
+            inputs_path.write_text(json.dumps(inputs_obj) + "\n", encoding="utf-8")
+
+            cmd = [
+                sys.executable,
+                str(root / "scripts" / "newsroom_write_run_job.py"),
+                "--jobs-root",
+                str(jobs_root),
+                "--inputs-json-path",
+                str(inputs_path),
+                "--channel-id",
+                "1467628391082496041",
+                "--run-time-uk",
+                "2026-02-09 08:00",
+                "--trigger",
+                "cron_daily",
+                "--expected-stories",
+                "2",
+                "--pick",
+                "1",
+                "--pick",
+                "2",
+            ]
+
+            proc = subprocess.run(cmd, check=True, capture_output=True, text=True)
+            summary = json.loads(proc.stdout)
+            self.assertEqual(summary["story_count"], 1)
+            self.assertEqual(summary["held_count"], 1)
+            self.assertIn("held_candidates", summary)
+            self.assertIn("holds_log_path", summary)
+            self.assertIn("HOLD pick=1", proc.stderr)
+
+            held = summary["held_candidates"][0]
+            self.assertEqual(held["pick"], 1)
+            self.assertIn("source_quality_gate_failed", held["reason"])
+            self.assertIn("dailymail.co.uk", held["reason"])
+
+            holds_log_path = Path(summary["holds_log_path"])
+            self.assertTrue(holds_log_path.exists())
+            log_lines = [line for line in holds_log_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+            self.assertEqual(len(log_lines), 1)
+            log_entry = json.loads(log_lines[0])
+            self.assertEqual(log_entry["pick"], 1)
+            self.assertIn("source_quality_gate_failed", log_entry["reason"])
+
+            run_dir = Path(summary["run_dir"])
+            story_files = sorted(run_dir.glob("story_*.json"))
+            self.assertEqual(len(story_files), 1)
+            story = json.loads(story_files[0].read_text(encoding="utf-8"))
+            self.assertIn("reuters.com/trusted-pass", story["story"]["primary_url"])
 
 
 if __name__ == "__main__":

--- a/newsroom/tests/test_write_run_job.py
+++ b/newsroom/tests/test_write_run_job.py
@@ -31,13 +31,15 @@ class TestWriteRunJobScript(unittest.TestCase):
                         "title": f"Example Title {i}",
                         "description": f"Example description {i}.",
                         "lang_hint": "en" if i % 2 == 0 else "zh",
-                        "primary_url": f"https://example.com/{i}",
-                        "supporting_urls": [f"https://example.org/{i}a", f"https://example.net/{i}b"],
+                        "primary_url": f"https://reuters.com/example-{i}",
+                        "supporting_urls": [f"https://theguardian.com/example-{i}", f"https://cnn.com/example-{i}"],
                         "age_minutes": 30 * i,
                         "is_breaking_2h": i == 1,
                         "is_developing_6h": i <= 3,
                         "cluster_size": 3,
-                        "domains": ["example.com", "example.org", "example.net"],
+                        "domains": ["reuters.com", "theguardian.com", "cnn.com"],
+                        "unique_domain_count": 3,
+                        "domain_tier_counts": {"tier_1": 1, "tier_2": 2},
                         "cluster_terms": ["foo", "bar"],
                     }
                 )
@@ -115,11 +117,13 @@ class TestWriteRunJobScript(unittest.TestCase):
                     "title": "Example Title 1",
                     "description": "Example description 1.",
                     "lang_hint": "en",
-                    "primary_url": "https://example.com/1",
-                    "supporting_urls": ["https://example.org/1a"],
+                    "primary_url": "https://reuters.com/example-1",
+                    "supporting_urls": ["https://cnn.com/example-1a"],
                     "age_minutes": 30,
                     "cluster_size": 1,
-                    "domains": ["example.com", "example.org"],
+                    "domains": ["reuters.com", "cnn.com"],
+                    "unique_domain_count": 2,
+                    "domain_tier_counts": {"tier_1": 1, "tier_2": 1},
                     "cluster_terms": ["foo"],
                 }
             ]
@@ -185,11 +189,13 @@ class TestWriteRunJobScript(unittest.TestCase):
                     "lang_hint": "en",
                     "summary_en": "UK PM faces renewed pressure",
                     "primary_url": "https://bbc.co.uk/pm-crisis",
-                    "supporting_urls": ["https://guardian.com/pm-crisis"],
+                    "supporting_urls": ["https://theguardian.com/pm-crisis"],
                     "age_minutes": 60,
                     "cluster_size": 3,
                     "link_count": 3,
-                    "domains": ["bbc.co.uk", "guardian.com"],
+                    "domains": ["bbc.co.uk", "theguardian.com"],
+                    "unique_domain_count": 2,
+                    "domain_tier_counts": {"tier_1": 1, "tier_2": 1},
                     "cluster_terms": [],
                     "anchor_terms": [],
                     "suggest_flags": [],
@@ -207,12 +213,14 @@ class TestWriteRunJobScript(unittest.TestCase):
                     "description": "Company releases AI model",
                     "lang_hint": "mixed",
                     "summary_en": "Company releases AI model",
-                    "primary_url": "https://techcrunch.com/ai-model",
-                    "supporting_urls": [],
+                    "primary_url": "https://cnn.com/ai-model",
+                    "supporting_urls": ["https://npr.org/ai-model"],
                     "age_minutes": 120,
                     "cluster_size": 2,
                     "link_count": 2,
-                    "domains": ["techcrunch.com"],
+                    "domains": ["cnn.com", "npr.org"],
+                    "unique_domain_count": 2,
+                    "domain_tier_counts": {"tier_2": 2},
                     "cluster_terms": [],
                     "anchor_terms": [],
                     "suggest_flags": [],
@@ -254,6 +262,164 @@ class TestWriteRunJobScript(unittest.TestCase):
             self.assertEqual(s2["story"]["category"], "AI")
             self.assertEqual(s1["story"]["lang_hint"], "en")
             self.assertEqual(s2["story"]["lang_hint"], "mixed")
+
+    def test_write_run_job_quality_gate_accepts_two_mid_tier_domains(self) -> None:
+        root = Path(__file__).resolve().parents[2]
+
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            jobs_root = tmp / "jobs"
+            jobs_root.mkdir(parents=True, exist_ok=True)
+
+            inputs_obj = {
+                "ok": True,
+                "candidates": [
+                    {
+                        "i": 1,
+                        "event_key": "event:mid-tier-pass",
+                        "anchor_key": "event:mid-tier-pass",
+                        "suggested_category": "Global News",
+                        "title": "Mid-tier corroboration story",
+                        "description": "Developing story",
+                        "lang_hint": "en",
+                        "primary_url": "https://cnn.com/mid-tier-pass",
+                        "supporting_urls": ["https://npr.org/mid-tier-pass"],
+                        "domains": ["cnn.com", "npr.org"],
+                        "unique_domain_count": 2,
+                        "domain_tier_counts": {"tier_2": 2},
+                        "age_minutes": 45,
+                        "cluster_terms": [],
+                    }
+                ],
+                "candidate_count": 1,
+            }
+            inputs_path = tmp / "inputs.json"
+            inputs_path.write_text(json.dumps(inputs_obj) + "\n", encoding="utf-8")
+
+            cmd = [
+                sys.executable,
+                str(root / "scripts" / "newsroom_write_run_job.py"),
+                "--jobs-root",
+                str(jobs_root),
+                "--inputs-json-path",
+                str(inputs_path),
+                "--channel-id",
+                "1467628391082496041",
+                "--run-time-uk",
+                "2026-02-09 07:00",
+                "--trigger",
+                "cron_daily",
+                "--expected-stories",
+                "1",
+                "--pick",
+                "1",
+            ]
+
+            out = subprocess.check_output(cmd, text=True)
+            summary = json.loads(out)
+            self.assertEqual(summary["story_count"], 1)
+            self.assertEqual(summary["held_count"], 0)
+
+            run_dir = Path(summary["run_dir"])
+            story_files = sorted(run_dir.glob("story_*.json"))
+            self.assertEqual(len(story_files), 1)
+
+    def test_write_run_job_holds_daily_mail_single_source_and_logs_reason(self) -> None:
+        root = Path(__file__).resolve().parents[2]
+
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            jobs_root = tmp / "jobs"
+            jobs_root.mkdir(parents=True, exist_ok=True)
+
+            inputs_obj = {
+                "ok": True,
+                "candidates": [
+                    {
+                        "i": 1,
+                        "event_key": "event:daily-mail-only",
+                        "anchor_key": "event:daily-mail-only",
+                        "suggested_category": "Global News",
+                        "title": "Single source tabloid recap",
+                        "description": "Daily Mail only",
+                        "lang_hint": "en",
+                        "primary_url": "https://dailymail.co.uk/single-source",
+                        "supporting_urls": [],
+                        "domains": ["dailymail.co.uk"],
+                        "unique_domain_count": 1,
+                        "domain_tier_counts": {"tier_3": 1},
+                        "age_minutes": 30,
+                        "cluster_terms": [],
+                    },
+                    {
+                        "i": 2,
+                        "event_key": "event:trusted-pass",
+                        "anchor_key": "event:trusted-pass",
+                        "suggested_category": "Global News",
+                        "title": "Trusted multi-domain report",
+                        "description": "Strong corroboration",
+                        "lang_hint": "en",
+                        "primary_url": "https://reuters.com/trusted-pass",
+                        "supporting_urls": ["https://theguardian.com/trusted-pass"],
+                        "domains": ["reuters.com", "theguardian.com"],
+                        "unique_domain_count": 2,
+                        "domain_tier_counts": {"tier_1": 1, "tier_2": 1},
+                        "age_minutes": 25,
+                        "cluster_terms": [],
+                    },
+                ],
+                "candidate_count": 2,
+            }
+            inputs_path = tmp / "inputs.json"
+            inputs_path.write_text(json.dumps(inputs_obj) + "\n", encoding="utf-8")
+
+            cmd = [
+                sys.executable,
+                str(root / "scripts" / "newsroom_write_run_job.py"),
+                "--jobs-root",
+                str(jobs_root),
+                "--inputs-json-path",
+                str(inputs_path),
+                "--channel-id",
+                "1467628391082496041",
+                "--run-time-uk",
+                "2026-02-09 08:00",
+                "--trigger",
+                "cron_daily",
+                "--expected-stories",
+                "2",
+                "--pick",
+                "1",
+                "--pick",
+                "2",
+            ]
+
+            proc = subprocess.run(cmd, check=True, capture_output=True, text=True)
+            summary = json.loads(proc.stdout)
+            self.assertEqual(summary["story_count"], 1)
+            self.assertEqual(summary["held_count"], 1)
+            self.assertIn("held_candidates", summary)
+            self.assertIn("holds_log_path", summary)
+            self.assertIn("HOLD pick=1", proc.stderr)
+
+            held = summary["held_candidates"][0]
+            self.assertEqual(held["pick"], 1)
+            self.assertIn("source_quality_gate_failed", held["reason"])
+            self.assertIn("dailymail.co.uk", held["reason"])
+
+            holds_log_path = Path(summary["holds_log_path"])
+            self.assertTrue(holds_log_path.exists())
+            log_lines = [line for line in holds_log_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+            self.assertEqual(len(log_lines), 1)
+            log_entry = json.loads(log_lines[0])
+            self.assertEqual(log_entry["pick"], 1)
+            self.assertIn("source_quality_gate_failed", log_entry["reason"])
+
+            run_dir = Path(summary["run_dir"])
+            story_files = sorted(run_dir.glob("story_*.json"))
+            self.assertEqual(len(story_files), 1)
+            story = json.loads(story_files[0].read_text(encoding="utf-8"))
+            self.assertIn("reuters.com/trusted-pass", story["story"]["primary_url"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a configurable writer source-quality gate in `newsroom_write_run_job.py` before story job files are written
- enforce: at least 2 unique domains and either at least 1 tier_1 trusted domain or at least 2 tier_2 mid-tier domains
- hold low-quality picks (including Daily Mail-only/single-source patterns) with explicit reason logging to stderr and `held_candidates.jsonl`
- extend script output with gate config and held-candidate metadata for auditability
- add tests for gate pass, gate fail, and hold-log path coverage

## Testing
- python3 -m pytest newsroom/tests/test_write_run_job.py -q

Closes #23