### PR TITLE
Automate clustering eval metrics with baseline CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,10 @@ jobs:
 
       - name: Tests
         run: uv run python -m pytest -q
+
+      - name: Clustering Eval Gate
+        run: |
+          uv run python scripts/eval_clustering_metrics.py \
+            --dataset newsroom/evals/clustering_eval_dataset_v1.jsonl \
+            --baseline newsroom/evals/clustering_eval_metrics_baseline_v1.json \
+            --fail-on-regression

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ uv run python scripts/newsroom_runner.py --dry-run
 | `news_pool_restore_jsonl.py` | Restores a JSONL dump into a fresh SQLite DB (refuses to overwrite without `--overwrite`). |
 | `build_clustering_eval_dataset.py` | Builds a reproducible labelled clustering evaluation dataset from `clustering_decisions`. |
 | `replay_clustering_eval_dataset.py` | Replays dataset rows through parser logic and reports label consistency metrics. |
+| `eval_clustering_metrics.py` | Computes clustering quality metrics and enforces baseline regression thresholds for CI/local checks. |
 
 All scripts live in the `scripts/` directory and are invoked as standalone Python scripts.
 
@@ -132,6 +133,15 @@ the last 168 hours, plus any events referenced by those links (and their parents
 
 ```bash
 uv run python -m pytest newsroom/tests/ -v
+```
+
+Run the clustering eval regression gate locally:
+
+```bash
+uv run python scripts/eval_clustering_metrics.py \
+  --dataset newsroom/evals/clustering_eval_dataset_v1.jsonl \
+  --baseline newsroom/evals/clustering_eval_metrics_baseline_v1.json \
+  --fail-on-regression
 ```
 
 ## Key Modules

--- a/newsroom/eval_metrics.py
+++ b/newsroom/eval_metrics.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from typing import Any, Literal
+
+EvalTarget = int | Literal["new_event"]
+
+METRIC_KEYS: tuple[str, ...] = (
+    "duplicate_rate_fragmentation",
+    "misassignment_rate",
+    "fragmentation_score",
+    "snowball_sink_metric",
+    "parse_error_rate",
+)
+
+
+def coerce_target(value: Any) -> EvalTarget | None:
+    """Normalise event targets from dataset/replay payloads."""
+    if value == "new_event":
+        return "new_event"
+    if isinstance(value, int) and value > 0:
+        return value
+    if isinstance(value, str):
+        text = value.strip()
+        if text == "new_event":
+            return "new_event"
+        if text.isdigit():
+            parsed = int(text)
+            if parsed > 0:
+                return parsed
+    return None
+
+
+def parse_threshold_overrides(tokens: list[str] | None) -> dict[str, float]:
+    """Parse repeated/comma-separated `metric=value` threshold tokens."""
+    overrides: dict[str, float] = {}
+    for raw in tokens or []:
+        for part in str(raw).split(","):
+            token = part.strip()
+            if not token:
+                continue
+            if "=" not in token:
+                raise ValueError(f"Invalid threshold token: {token!r} (expected metric=value)")
+            metric, value = token.split("=", 1)
+            key = metric.strip()
+            if key not in METRIC_KEYS:
+                raise ValueError(f"Unknown threshold metric: {key!r}")
+            try:
+                parsed = float(value.strip())
+            except ValueError as exc:
+                raise ValueError(f"Invalid numeric threshold value in token: {token!r}") from exc
+            if parsed < 0:
+                raise ValueError(f"Threshold must be >= 0 for metric {key!r}")
+            overrides[key] = parsed
+    return overrides
+
+
+def compute_clustering_quality_metrics(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Compute evaluation metrics from replay rows.
+
+    Each row should provide:
+    - `expected_target`: int or `"new_event"` (or value coercible by `coerce_target`)
+    - `predicted_target`: int or `"new_event"` (or value coercible by `coerce_target`)
+    - `parse_ok`: bool
+    """
+    normalised: list[dict[str, Any]] = []
+    for row in rows:
+        expected = coerce_target(row.get("expected_target"))
+        predicted = coerce_target(row.get("predicted_target"))
+        parse_ok = bool(row.get("parse_ok"))
+        if not parse_ok:
+            predicted = None
+        normalised.append(
+            {
+                "sample_id": row.get("sample_id"),
+                "expected_target": expected,
+                "predicted_target": predicted,
+                "parse_ok": parse_ok,
+            }
+        )
+
+    total_rows = len(normalised)
+    parse_ok_rows = sum(1 for row in normalised if bool(row["parse_ok"]))
+    parse_error_rows = total_rows - parse_ok_rows
+
+    expected_existing_rows = [row for row in normalised if isinstance(row["expected_target"], int)]
+    predicted_assign_rows = [row for row in normalised if isinstance(row["predicted_target"], int)]
+
+    duplicate_fragmentation_rows = [
+        row
+        for row in expected_existing_rows
+        if row["predicted_target"] == "new_event"
+    ]
+    misassignment_rows = [
+        row
+        for row in predicted_assign_rows
+        if row["expected_target"] != row["predicted_target"]
+    ]
+
+    # Event-level fragmentation:
+    # for each expected event, measure how widely rows get split across predictions.
+    preds_by_expected: dict[int, list[EvalTarget | Literal["parse_error"]]] = defaultdict(list)
+    for row in expected_existing_rows:
+        expected = row["expected_target"]
+        if not isinstance(expected, int):
+            continue
+        predicted = row["predicted_target"] if row["parse_ok"] else "parse_error"
+        if not isinstance(predicted, int) and predicted not in {"new_event", "parse_error"}:
+            predicted = "parse_error"
+        preds_by_expected[expected].append(predicted)
+
+    dominant_sum = 0
+    fragmented_events = 0
+    for preds in preds_by_expected.values():
+        if not preds:
+            continue
+        counts = Counter(preds)
+        dominant_sum += int(max(counts.values()))
+        if len(counts) > 1:
+            fragmented_events += 1
+
+    expected_existing_count = len(expected_existing_rows)
+    fragmentation_score = (
+        1.0 - (float(dominant_sum) / float(expected_existing_count))
+        if expected_existing_count > 0
+        else 0.0
+    )
+
+    # Snowball sink proxy: assignment concentration in one sink event.
+    assign_counts = Counter(int(row["predicted_target"]) for row in predicted_assign_rows)
+    sink_event_id: int | None = None
+    sink_assign_count = 0
+    if assign_counts:
+        sink_event_id, sink_assign_count = assign_counts.most_common(1)[0]
+    predicted_assign_count = len(predicted_assign_rows)
+    snowball_sink_metric = (
+        float(sink_assign_count) / float(predicted_assign_count)
+        if predicted_assign_count > 0
+        else 0.0
+    )
+
+    metrics = {
+        "duplicate_rate_fragmentation": (
+            float(len(duplicate_fragmentation_rows)) / float(expected_existing_count)
+            if expected_existing_count > 0
+            else 0.0
+        ),
+        "misassignment_rate": (
+            float(len(misassignment_rows)) / float(predicted_assign_count)
+            if predicted_assign_count > 0
+            else 0.0
+        ),
+        "fragmentation_score": fragmentation_score,
+        "snowball_sink_metric": snowball_sink_metric,
+        "parse_error_rate": (float(parse_error_rows) / float(total_rows)) if total_rows > 0 else 0.0,
+    }
+
+    return {
+        "rows": total_rows,
+        "metrics": metrics,
+        "counts": {
+            "parse_ok_rows": parse_ok_rows,
+            "parse_error_rows": parse_error_rows,
+            "expected_existing_rows": expected_existing_count,
+            "predicted_assign_rows": predicted_assign_count,
+            "duplicate_fragmentation_rows": len(duplicate_fragmentation_rows),
+            "misassignment_rows": len(misassignment_rows),
+            "fragmented_events": fragmented_events,
+            "snowball_sink_event_id": sink_event_id,
+            "snowball_sink_assign_count": sink_assign_count,
+            "snowball_sink_unique_assigned_events": len(assign_counts),
+        },
+    }
+
+
+def evaluate_regression(
+    *,
+    current_metrics: dict[str, Any],
+    baseline_metrics: dict[str, Any],
+    thresholds: dict[str, Any],
+) -> dict[str, Any]:
+    """Compare current metrics against baseline + allowed regression thresholds."""
+    regressions: list[dict[str, Any]] = []
+    for key in METRIC_KEYS:
+        current = float(current_metrics.get(key, 0.0))
+        baseline = float(baseline_metrics.get(key, 0.0))
+        allowed = float(thresholds.get(key, 0.0))
+        delta = current - baseline
+        if delta > allowed:
+            regressions.append(
+                {
+                    "metric": key,
+                    "current": current,
+                    "baseline": baseline,
+                    "delta": delta,
+                    "allowed_regression": allowed,
+                }
+            )
+
+    return {
+        "ok": not regressions,
+        "regressions": regressions,
+    }

--- a/newsroom/evals/clustering_eval_metrics_baseline_v1.json
+++ b/newsroom/evals/clustering_eval_metrics_baseline_v1.json
@@ -1,0 +1,24 @@
+{
+  "dataset": {
+    "path": "newsroom/evals/clustering_eval_dataset_v1.jsonl",
+    "rows": 240,
+    "sha256": "9e23774d645c42c68ae58c1f7fb29c4bd8b6b4db54c8b443acf4ded785d9439b"
+  },
+  "generated_at": "2026-02-11T11:39:36+00:00",
+  "low_score_threshold": 0.22,
+  "metrics": {
+    "duplicate_rate_fragmentation": 0.0,
+    "fragmentation_score": 0.0,
+    "misassignment_rate": 0.1016949152542373,
+    "parse_error_rate": 0.0,
+    "snowball_sink_metric": 0.11864406779661017
+  },
+  "regression_thresholds": {
+    "duplicate_rate_fragmentation": 0.01,
+    "fragmentation_score": 0.01,
+    "misassignment_rate": 0.02,
+    "parse_error_rate": 0.0,
+    "snowball_sink_metric": 0.03
+  },
+  "schema_version": "clustering_eval_metrics_baseline_v1"
+}

--- a/newsroom/tests/test_eval_metrics.py
+++ b/newsroom/tests/test_eval_metrics.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from newsroom.eval_metrics import (
+    compute_clustering_quality_metrics,
+    evaluate_regression,
+    parse_threshold_overrides,
+)
+from scripts.eval_clustering_metrics import main as eval_main
+
+
+def _base_replay_row(*, expected_target: int | str) -> dict:
+    return {
+        "schema_version": "clustering_eval_sample_v1",
+        "sample_id": "sample_0001",
+        "labels": {
+            "event_id_or_new_event": expected_target,
+            "language": "en",
+            "correctness": "correct",
+            "flags": [],
+        },
+        "replay": {
+            "link": {
+                "id": 1,
+                "url": "https://example.com/a",
+                "norm_url": "https://example.com/a",
+                "title": "Government policy update",
+                "description": "Cabinet confirms policy package and timeline",
+                "lang_hint": "en",
+            },
+            "candidate_events": [
+                {
+                    "id": 101,
+                    "status": "new",
+                    "summary_en": "Government policy update and next steps",
+                }
+            ],
+            "raw_llm_response": {
+                "action": "assign",
+                "event_id": 101,
+                "confidence": 0.91,
+                "summary_en": "Government policy update and next steps",
+                "match_basis": ["entity_overlap", "timeline_match"],
+                "link_flags": [],
+            },
+        },
+    }
+
+
+def test_compute_clustering_quality_metrics_core_rates() -> None:
+    rows = [
+        {"sample_id": "s1", "expected_target": 10, "predicted_target": 10, "parse_ok": True},
+        {"sample_id": "s2", "expected_target": 10, "predicted_target": "new_event", "parse_ok": True},
+        {"sample_id": "s3", "expected_target": 11, "predicted_target": 12, "parse_ok": True},
+        {"sample_id": "s4", "expected_target": "new_event", "predicted_target": 12, "parse_ok": True},
+        {"sample_id": "s5", "expected_target": 11, "predicted_target": None, "parse_ok": False},
+    ]
+
+    report = compute_clustering_quality_metrics(rows)
+    metrics = report["metrics"]
+    counts = report["counts"]
+
+    assert report["rows"] == 5
+    assert counts["parse_error_rows"] == 1
+    assert counts["expected_existing_rows"] == 4
+    assert counts["predicted_assign_rows"] == 3
+    assert counts["duplicate_fragmentation_rows"] == 1
+    assert counts["misassignment_rows"] == 2
+
+    assert metrics["duplicate_rate_fragmentation"] == 0.25
+    assert metrics["misassignment_rate"] == (2.0 / 3.0)
+    assert metrics["fragmentation_score"] == 0.5
+    assert metrics["snowball_sink_metric"] == (2.0 / 3.0)
+    assert metrics["parse_error_rate"] == 0.2
+
+    assert counts["snowball_sink_event_id"] == 12
+    assert counts["snowball_sink_assign_count"] == 2
+    assert counts["fragmented_events"] == 2
+
+
+def test_parse_threshold_overrides_supports_repeatable_and_comma_tokens() -> None:
+    overrides = parse_threshold_overrides(
+        [
+            "misassignment_rate=0.05",
+            "fragmentation_score=0.02,snowball_sink_metric=0.03",
+        ]
+    )
+
+    assert overrides == {
+        "misassignment_rate": 0.05,
+        "fragmentation_score": 0.02,
+        "snowball_sink_metric": 0.03,
+    }
+
+
+def test_parse_threshold_overrides_rejects_unknown_metric() -> None:
+    try:
+        parse_threshold_overrides(["unknown_metric=0.1"])
+    except ValueError as exc:
+        assert "Unknown threshold metric" in str(exc)
+        return
+    raise AssertionError("Expected ValueError for unknown threshold metric")
+
+
+def test_evaluate_regression_respects_allowed_slack() -> None:
+    result = evaluate_regression(
+        current_metrics={
+            "duplicate_rate_fragmentation": 0.03,
+            "misassignment_rate": 0.12,
+            "fragmentation_score": 0.02,
+            "snowball_sink_metric": 0.20,
+            "parse_error_rate": 0.00,
+        },
+        baseline_metrics={
+            "duplicate_rate_fragmentation": 0.02,
+            "misassignment_rate": 0.10,
+            "fragmentation_score": 0.02,
+            "snowball_sink_metric": 0.19,
+            "parse_error_rate": 0.00,
+        },
+        thresholds={
+            "duplicate_rate_fragmentation": 0.01,
+            "misassignment_rate": 0.01,
+            "fragmentation_score": 0.00,
+            "snowball_sink_metric": 0.00,
+            "parse_error_rate": 0.00,
+        },
+    )
+
+    assert result["ok"] is False
+    metrics = {row["metric"] for row in result["regressions"]}
+    assert metrics == {"misassignment_rate", "snowball_sink_metric"}
+
+
+def test_eval_metrics_cli_writes_baseline(tmp_path: Path) -> None:
+    dataset_path = tmp_path / "dataset.jsonl"
+    baseline_path = tmp_path / "baseline.json"
+
+    row = _base_replay_row(expected_target=101)
+    dataset_path.write_text(json.dumps(row, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    rc = eval_main(
+        [
+            "--dataset",
+            str(dataset_path),
+            "--baseline-out",
+            str(baseline_path),
+            "--write-baseline",
+            "--overwrite",
+        ]
+    )
+
+    assert rc == 0
+    baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+    assert baseline["schema_version"] == "clustering_eval_metrics_baseline_v1"
+    assert baseline["dataset"]["rows"] == 1
+    assert "misassignment_rate" in baseline["metrics"]
+
+
+def test_eval_metrics_cli_fails_on_metric_regression(tmp_path: Path) -> None:
+    dataset_path = tmp_path / "dataset.jsonl"
+    baseline_path = tmp_path / "baseline.json"
+
+    row = _base_replay_row(expected_target="new_event")
+    payload = json.dumps(row, ensure_ascii=False, separators=(",", ":")) + "\n"
+    dataset_path.write_text(payload, encoding="utf-8")
+
+    sha = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    baseline = {
+        "schema_version": "clustering_eval_metrics_baseline_v1",
+        "generated_at": "2026-02-11T00:00:00+00:00",
+        "dataset": {"path": str(dataset_path), "sha256": sha, "rows": 1},
+        "low_score_threshold": 0.22,
+        "metrics": {
+            "duplicate_rate_fragmentation": 0.0,
+            "misassignment_rate": 0.0,
+            "fragmentation_score": 0.0,
+            "snowball_sink_metric": 0.0,
+            "parse_error_rate": 0.0,
+        },
+        "regression_thresholds": {
+            "duplicate_rate_fragmentation": 0.0,
+            "misassignment_rate": 0.0,
+            "fragmentation_score": 0.0,
+            "snowball_sink_metric": 0.0,
+            "parse_error_rate": 0.0,
+        },
+    }
+    baseline_path.write_text(json.dumps(baseline, ensure_ascii=False), encoding="utf-8")
+
+    rc = eval_main(
+        [
+            "--dataset",
+            str(dataset_path),
+            "--baseline",
+            str(baseline_path),
+            "--fail-on-regression",
+        ]
+    )
+    assert rc == 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dev = [
 
 [project.scripts]
 build-clustering-eval-dataset = "scripts._cli:build_clustering_eval_dataset"
+eval-clustering-metrics = "scripts._cli:eval_clustering_metrics"
 gdelt-pool-update = "scripts._cli:gdelt_pool_update"
 news-pool-status = "scripts._cli:news_pool_status"
 news-pool-update = "scripts._cli:news_pool_update"

--- a/scripts/_cli.py
+++ b/scripts/_cli.py
@@ -62,6 +62,13 @@ def build_clustering_eval_dataset() -> None:
 def replay_clustering_eval_dataset() -> None:
     from scripts.replay_clustering_eval_dataset import main
     raise SystemExit(main(sys.argv[1:]))
+
+
+def eval_clustering_metrics() -> None:
+    from scripts.eval_clustering_metrics import main
+    raise SystemExit(main(sys.argv[1:]))
+
+
 def rss_pool_update() -> None:
     from scripts.rss_pool_update import main
     raise SystemExit(main(sys.argv[1:]))

--- a/scripts/eval_clustering_metrics.py
+++ b/scripts/eval_clustering_metrics.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+OPENCLAW_HOME = Path(__file__).resolve().parents[1]
+os.environ.setdefault("OPENCLAW_HOME", str(OPENCLAW_HOME))
+sys.path.insert(0, str(OPENCLAW_HOME))
+
+from newsroom.eval_dataset import replay_record  # noqa: E402
+from newsroom.eval_metrics import (  # noqa: E402
+    METRIC_KEYS,
+    compute_clustering_quality_metrics,
+    evaluate_regression,
+    parse_threshold_overrides,
+)
+
+DEFAULT_REGRESSION_THRESHOLDS: dict[str, float] = {
+    "duplicate_rate_fragmentation": 0.01,
+    "misassignment_rate": 0.02,
+    "fragmentation_score": 0.01,
+    "snowball_sink_metric": 0.03,
+    "parse_error_rate": 0.0,
+}
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as fh:
+        for lineno, raw in enumerate(fh, start=1):
+            text = raw.strip()
+            if not text:
+                continue
+            try:
+                obj = json.loads(text)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"Invalid JSON on line {lineno}: {exc}") from exc
+            if not isinstance(obj, dict):
+                raise ValueError(f"Line {lineno} is not a JSON object")
+            rows.append(obj)
+    return rows
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _write_json(path: Path, obj: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as fh:
+        json.dump(obj, fh, ensure_ascii=False, indent=2, sort_keys=True)
+        fh.write("\n")
+    tmp.replace(path)
+
+
+def _build_eval_rows(
+    dataset_rows: list[dict[str, Any]],
+    *,
+    low_score_threshold: float,
+) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for rec in dataset_rows:
+        replay = replay_record(rec, low_score_threshold=float(low_score_threshold))
+        labels = rec.get("labels") if isinstance(rec.get("labels"), dict) else {}
+        out.append(
+            {
+                "sample_id": rec.get("sample_id"),
+                "expected_target": labels.get("event_id_or_new_event"),
+                "predicted_target": replay.get("predicted_target"),
+                "parse_ok": bool(replay.get("parse_ok")),
+                "parse_error": replay.get("error"),
+            }
+        )
+    return out
+
+
+def _baseline_thresholds(baseline_obj: dict[str, Any]) -> dict[str, float]:
+    base = baseline_obj.get("regression_thresholds")
+    if not isinstance(base, dict):
+        return dict(DEFAULT_REGRESSION_THRESHOLDS)
+
+    out = dict(DEFAULT_REGRESSION_THRESHOLDS)
+    for key in METRIC_KEYS:
+        value = base.get(key)
+        if isinstance(value, (int, float)):
+            out[key] = float(value)
+    return out
+
+
+def main(argv: list[str]) -> int:
+    # Keep CI/log output stable even when old replay rows miss confidence.
+    logging.getLogger("newsroom.event_manager").setLevel(logging.ERROR)
+
+    parser = argparse.ArgumentParser(description="Compute clustering quality metrics and enforce a baseline regression gate.")
+    parser.add_argument(
+        "--dataset",
+        default=str(OPENCLAW_HOME / "newsroom" / "evals" / "clustering_eval_dataset_v1.jsonl"),
+        help="Dataset JSONL path.",
+    )
+    parser.add_argument(
+        "--summary-out",
+        default="",
+        help="Optional output path for metrics summary JSON.",
+    )
+    parser.add_argument(
+        "--baseline",
+        default="",
+        help="Optional baseline JSON path for regression checks.",
+    )
+    parser.add_argument(
+        "--baseline-out",
+        default="",
+        help="Optional output path for writing/refreshing baseline JSON.",
+    )
+    parser.add_argument(
+        "--write-baseline",
+        action="store_true",
+        help="Write baseline JSON using current metrics (requires --baseline-out or --baseline).",
+    )
+    parser.add_argument(
+        "--threshold",
+        action="append",
+        default=[],
+        help="Override threshold(s) as metric=value. Repeatable or comma-separated.",
+    )
+    parser.add_argument(
+        "--low-score-threshold",
+        type=float,
+        default=0.22,
+        help="Passed into replay_record for consistency with dataset labels.",
+    )
+    parser.add_argument(
+        "--fail-on-regression",
+        action="store_true",
+        help="Exit non-zero when current metrics regress beyond thresholds.",
+    )
+    parser.add_argument(
+        "--allow-dataset-drift",
+        action="store_true",
+        help="Allow baseline checks when dataset hash differs.",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Allow overwriting --baseline-out when writing a baseline.",
+    )
+    args = parser.parse_args(argv)
+
+    dataset_path = Path(args.dataset).expanduser()
+    if not dataset_path.exists():
+        raise SystemExit(f"Dataset not found: {dataset_path}")
+
+    dataset_rows = _load_jsonl(dataset_path)
+    dataset_sha256 = _sha256_file(dataset_path)
+    eval_rows = _build_eval_rows(dataset_rows, low_score_threshold=float(args.low_score_threshold))
+    metrics_payload = compute_clustering_quality_metrics(eval_rows)
+
+    generated_at = datetime.now(tz=UTC).isoformat(timespec="seconds")
+    output: dict[str, Any] = {
+        "schema_version": "clustering_eval_metrics_v1",
+        "generated_at": generated_at,
+        "dataset": {
+            "path": str(dataset_path),
+            "sha256": dataset_sha256,
+            "rows": len(dataset_rows),
+        },
+        "low_score_threshold": float(args.low_score_threshold),
+        **metrics_payload,
+    }
+
+    baseline_result: dict[str, Any] = {
+        "enabled": False,
+        "ok": None,
+        "dataset_match": None,
+        "dataset_match_reason": None,
+        "thresholds": {},
+        "regressions": [],
+    }
+
+    baseline_obj: dict[str, Any] | None = None
+    baseline_path = Path(args.baseline).expanduser() if args.baseline else None
+    if baseline_path:
+        if not baseline_path.exists():
+            raise SystemExit(f"Baseline not found: {baseline_path}")
+        loaded = json.loads(baseline_path.read_text(encoding="utf-8"))
+        if not isinstance(loaded, dict):
+            raise SystemExit(f"Baseline JSON is not an object: {baseline_path}")
+        baseline_obj = loaded
+
+    thresholds = dict(DEFAULT_REGRESSION_THRESHOLDS)
+    if baseline_obj is not None:
+        thresholds = _baseline_thresholds(baseline_obj)
+    thresholds.update(parse_threshold_overrides(list(args.threshold or [])))
+
+    if baseline_obj is not None:
+        baseline_dataset = baseline_obj.get("dataset") if isinstance(baseline_obj.get("dataset"), dict) else {}
+        baseline_sha = baseline_dataset.get("sha256")
+        baseline_rows = baseline_dataset.get("rows")
+
+        dataset_match = True
+        dataset_match_reason = "ok"
+        if baseline_sha and baseline_sha != dataset_sha256:
+            dataset_match = False
+            dataset_match_reason = "sha256_mismatch"
+        if isinstance(baseline_rows, int) and int(baseline_rows) != len(dataset_rows):
+            dataset_match = False
+            dataset_match_reason = (
+                dataset_match_reason if dataset_match_reason != "ok" else "row_count_mismatch"
+            )
+
+        baseline_metrics = baseline_obj.get("metrics") if isinstance(baseline_obj.get("metrics"), dict) else {}
+        regression = evaluate_regression(
+            current_metrics=output["metrics"],
+            baseline_metrics=baseline_metrics,
+            thresholds=thresholds,
+        )
+
+        baseline_ok = bool(regression["ok"])
+        if not dataset_match and not bool(args.allow_dataset_drift):
+            baseline_ok = False
+
+        baseline_result = {
+            "enabled": True,
+            "baseline_path": str(baseline_path),
+            "ok": baseline_ok,
+            "dataset_match": dataset_match,
+            "dataset_match_reason": dataset_match_reason if not dataset_match else "ok",
+            "thresholds": thresholds,
+            "regressions": regression["regressions"],
+            "baseline_metrics": baseline_metrics,
+        }
+
+        if not dataset_match and not bool(args.allow_dataset_drift):
+            baseline_result["regressions"].append(
+                {
+                    "metric": "dataset_sha256",
+                    "current": dataset_sha256,
+                    "baseline": baseline_sha,
+                    "delta": "mismatch",
+                    "allowed_regression": "none",
+                }
+            )
+
+    output["baseline_check"] = baseline_result
+
+    baseline_out_path: Path | None = None
+    if bool(args.write_baseline):
+        if args.baseline_out:
+            baseline_out_path = Path(args.baseline_out).expanduser()
+        elif baseline_path is not None:
+            baseline_out_path = baseline_path
+        else:
+            raise SystemExit("--write-baseline requires --baseline-out or --baseline")
+
+        if baseline_out_path.exists() and not bool(args.overwrite):
+            raise SystemExit(f"Baseline output exists: {baseline_out_path} (use --overwrite)")
+
+        baseline_doc = {
+            "schema_version": "clustering_eval_metrics_baseline_v1",
+            "generated_at": generated_at,
+            "dataset": {
+                "path": str(dataset_path),
+                "sha256": dataset_sha256,
+                "rows": len(dataset_rows),
+            },
+            "low_score_threshold": float(args.low_score_threshold),
+            "metrics": output["metrics"],
+            "regression_thresholds": thresholds,
+        }
+        _write_json(baseline_out_path, baseline_doc)
+        output["baseline_written_to"] = str(baseline_out_path)
+
+    if args.summary_out:
+        _write_json(Path(args.summary_out).expanduser(), output)
+
+    print(json.dumps(output, ensure_ascii=False))
+
+    if bool(args.fail_on_regression):
+        if baseline_obj is None:
+            raise SystemExit("--fail-on-regression requires --baseline")
+        if not bool(output["baseline_check"]["ok"]):
+            return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- add a dedicated clustering eval metrics module and CLI to compute duplicate/fragmentation, misassignment, fragmentation score, and snowball sink metrics from the labelled replay dataset
- commit a baseline metrics artefact at `newsroom/evals/clustering_eval_metrics_baseline_v1.json` and support threshold overrides for controlled regressions
- wire CI to run the eval gate after tests and fail when metrics regress beyond baseline thresholds
- document local run and baseline refresh workflows, and add tests for metric computation and regression parsing/gating logic

## Validation
- `uv run python -m pytest -q newsroom/tests/test_eval_dataset.py newsroom/tests/test_eval_metrics.py`
- `uv run python -m pytest -q`
- `uv run python scripts/eval_clustering_metrics.py --dataset newsroom/evals/clustering_eval_dataset_v1.jsonl --baseline newsroom/evals/clustering_eval_metrics_baseline_v1.json --fail-on-regression`

Closes #26