### PR TITLE
feat(sdlc): add accepted-budget gate watchdog

### DIFF
--- a/newsroom/tests/test_sdlc_watchdog.py
+++ b/newsroom/tests/test_sdlc_watchdog.py
@@ -24,12 +24,11 @@ def _python(source: str, *arguments: str) -> tuple[str, ...]:
 
 
 def test_success_and_nonzero_exit_are_typed() -> None:
-    deadline = LaneDeadline.start(2)
     passed = run_gate_command(
         gate_id="route",
         phase="unit",
         argv=_python("print('ok')"),
-        deadline=deadline,
+        deadline=LaneDeadline.start(2),
         command_timeout_seconds=1,
     )
     failed = run_gate_command(
@@ -68,13 +67,14 @@ def test_expired_shared_deadline_prevents_process_start(tmp_path: Path) -> None:
 
 
 def test_multiple_commands_share_one_lane_deadline() -> None:
-    deadline = LaneDeadline.start(0.4)
+    deadline = LaneDeadline.start(0.5)
     first = run_gate_command(
         gate_id="core-deterministic",
         phase="first",
         argv=_python("import time; time.sleep(0.1)"),
         deadline=deadline,
         command_timeout_seconds=0.3,
+        termination_grace_seconds=0.05,
     )
     second = run_gate_command(
         gate_id="core-deterministic",
@@ -87,7 +87,7 @@ def test_multiple_commands_share_one_lane_deadline() -> None:
 
     assert first.result == "PASS"
     assert second.result == "BUDGET_EXCEEDED"
-    assert second.execution_ms < 400
+    assert second.execution_ms < 450
     assert deadline.remaining_seconds() == 0
 
 
@@ -123,9 +123,9 @@ time.sleep(30)
         gate_id="core-deterministic",
         phase="descendants",
         argv=_python(parent, child, str(marker), str(pid_file)),
-        deadline=LaneDeadline.start(0.7),
-        command_timeout_seconds=0.65,
-        termination_grace_seconds=0.4,
+        deadline=LaneDeadline.start(1.2),
+        command_timeout_seconds=0.9,
+        termination_grace_seconds=0.35,
     )
 
     stop_at = time.monotonic() + 1
@@ -134,27 +134,57 @@ time.sleep(30)
     assert pid_file.exists()
     assert marker.read_text(encoding="utf-8") == "terminated"
     assert result.result == "BUDGET_EXCEEDED"
+    assert result.execution_ms < 900
     assert result.result_reason == "BUDGET_EXCEEDED:core-deterministic:descendants"
 
 
-def test_output_is_bounded_and_secret_values_are_redacted() -> None:
+@pytest.mark.skipif(os.name != "posix", reason="process-group evidence is POSIX-specific")
+def test_successful_parent_cannot_leave_background_process(tmp_path: Path) -> None:
+    pid_file = tmp_path / "background-pid"
+    parent = """
+import subprocess
+from pathlib import Path
+import sys
+
+process = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(30)'])
+Path(sys.argv[1]).write_text(str(process.pid), encoding='utf-8')
+"""
+    result = run_gate_command(
+        gate_id="core-deterministic",
+        phase="background",
+        argv=_python(parent, str(pid_file)),
+        deadline=LaneDeadline.start(2),
+        command_timeout_seconds=1,
+        termination_grace_seconds=0.3,
+    )
+
+    assert pid_file.exists()
+    assert result.result == "UNAUTHORISED_EFFECT"
+    assert result.result_reason.endswith(":background_process")
+
+
+def test_output_is_memory_bounded_and_secret_boundary_is_redacted() -> None:
+    secret = "ultra-sensitive-boundary"
     environment = dict(os.environ)
-    environment["NEWSROOM_TEST_API_TOKEN"] = "highly-sensitive-value"
+    environment["NEWSROOM_TEST_API_TOKEN"] = secret
     result = run_gate_command(
         gate_id="core-deterministic",
         phase="output",
         argv=_python(
-            "import os; print('x' * 4096); print(os.environ['NEWSROOM_TEST_API_TOKEN'])"
+            "import os, sys; "
+            "sys.stdout.write('x' * 2000000); "
+            "sys.stdout.write(os.environ['NEWSROOM_TEST_API_TOKEN'] + 'z' * 124)"
         ),
-        deadline=LaneDeadline.start(2),
-        command_timeout_seconds=1,
+        deadline=LaneDeadline.start(3),
+        command_timeout_seconds=2,
         env=environment,
         output_limit_bytes=128,
     )
 
     assert result.result == "PASS"
     assert result.stdout_truncated is True
-    assert "highly-sensitive-value" not in result.stdout
+    assert secret not in result.stdout
+    assert "sensitive-boundary" not in result.stdout
     assert "***" in result.stdout
     assert len(result.stdout.encode("utf-8")) <= 128
 
@@ -167,6 +197,7 @@ def test_environment_error_does_not_echo_command_or_exception_message() -> None:
         argv=(missing,),
         deadline=LaneDeadline.start(1),
         command_timeout_seconds=0.5,
+        termination_grace_seconds=0.1,
     )
 
     assert result.result == "ENVIRONMENT_ERROR"
@@ -175,7 +206,7 @@ def test_environment_error_does_not_echo_command_or_exception_message() -> None:
     assert result.result_reason.endswith(":FileNotFoundError")
 
 
-def test_invalid_budget_or_identifier_is_rejected() -> None:
+def test_invalid_budget_identifier_and_output_limit_are_rejected() -> None:
     with pytest.raises(GateRunError, match="below 60"):
         LaneDeadline.start(60)
     with pytest.raises(GateRunError, match="unsupported characters"):
@@ -185,6 +216,24 @@ def test_invalid_budget_or_identifier_is_rejected() -> None:
             argv=_python("pass"),
             deadline=LaneDeadline.start(1),
             command_timeout_seconds=0.5,
+        )
+    with pytest.raises(GateRunError, match="output limit"):
+        run_gate_command(
+            gate_id="route",
+            phase="unit",
+            argv=_python("pass"),
+            deadline=LaneDeadline.start(2),
+            command_timeout_seconds=1,
+            output_limit_bytes=1_048_577,
+        )
+    with pytest.raises(GateRunError, match="five seconds"):
+        run_gate_command(
+            gate_id="route",
+            phase="unit",
+            argv=_python("pass"),
+            deadline=LaneDeadline.start(10),
+            command_timeout_seconds=9,
+            termination_grace_seconds=5.1,
         )
 
 

--- a/newsroom/tests/test_sdlc_watchdog.py
+++ b/newsroom/tests/test_sdlc_watchdog.py
@@ -28,15 +28,15 @@ def test_success_and_nonzero_exit_are_typed() -> None:
         gate_id="route",
         phase="unit",
         argv=_python("print('ok')"),
-        deadline=LaneDeadline.start(2),
-        command_timeout_seconds=1,
+        deadline=LaneDeadline.start(4),
+        command_timeout_seconds=3,
     )
     failed = run_gate_command(
         gate_id="route",
         phase="unit",
         argv=_python("raise SystemExit(7)"),
-        deadline=LaneDeadline.start(2),
-        command_timeout_seconds=1,
+        deadline=LaneDeadline.start(4),
+        command_timeout_seconds=3,
     )
 
     assert passed.result == "PASS"
@@ -55,7 +55,10 @@ def test_expired_shared_deadline_prevents_process_start(tmp_path: Path) -> None:
     result = run_gate_command(
         gate_id="core-deterministic",
         phase="tests",
-        argv=_python("from pathlib import Path; Path(__import__('sys').argv[1]).touch()", str(marker)),
+        argv=_python(
+            "from pathlib import Path; Path(__import__('sys').argv[1]).touch()",
+            str(marker),
+        ),
         deadline=deadline,
         command_timeout_seconds=1,
     )
@@ -67,28 +70,29 @@ def test_expired_shared_deadline_prevents_process_start(tmp_path: Path) -> None:
 
 
 def test_multiple_commands_share_one_lane_deadline() -> None:
-    deadline = LaneDeadline.start(0.5)
+    deadline = LaneDeadline.start(2.5)
+    started = time.monotonic()
     first = run_gate_command(
         gate_id="core-deterministic",
         phase="first",
         argv=_python("import time; time.sleep(0.1)"),
         deadline=deadline,
-        command_timeout_seconds=0.3,
-        termination_grace_seconds=0.05,
+        command_timeout_seconds=1.5,
+        termination_grace_seconds=0.1,
     )
     second = run_gate_command(
         gate_id="core-deterministic",
         phase="second",
-        argv=_python("import time; time.sleep(1)"),
+        argv=_python("import time; time.sleep(5)"),
         deadline=deadline,
-        command_timeout_seconds=0.9,
-        termination_grace_seconds=0.1,
+        command_timeout_seconds=3,
+        termination_grace_seconds=0.2,
     )
 
     assert first.result == "PASS"
     assert second.result == "BUDGET_EXCEEDED"
-    assert second.execution_ms < 450
-    assert deadline.remaining_seconds() == 0
+    assert time.monotonic() - started < 2.5
+    assert deadline.remaining_seconds() <= 0.25
 
 
 @pytest.mark.skipif(os.name != "posix", reason="process-group evidence is POSIX-specific")
@@ -123,9 +127,9 @@ time.sleep(30)
         gate_id="core-deterministic",
         phase="descendants",
         argv=_python(parent, child, str(marker), str(pid_file)),
-        deadline=LaneDeadline.start(1.2),
-        command_timeout_seconds=0.9,
-        termination_grace_seconds=0.35,
+        deadline=LaneDeadline.start(3),
+        command_timeout_seconds=2.5,
+        termination_grace_seconds=0.5,
     )
 
     stop_at = time.monotonic() + 1
@@ -134,7 +138,7 @@ time.sleep(30)
     assert pid_file.exists()
     assert marker.read_text(encoding="utf-8") == "terminated"
     assert result.result == "BUDGET_EXCEEDED"
-    assert result.execution_ms < 900
+    assert result.execution_ms < 2_500
     assert result.result_reason == "BUDGET_EXCEEDED:core-deterministic:descendants"
 
 
@@ -153,9 +157,9 @@ Path(sys.argv[1]).write_text(str(process.pid), encoding='utf-8')
         gate_id="core-deterministic",
         phase="background",
         argv=_python(parent, str(pid_file)),
-        deadline=LaneDeadline.start(2),
-        command_timeout_seconds=1,
-        termination_grace_seconds=0.3,
+        deadline=LaneDeadline.start(4),
+        command_timeout_seconds=3,
+        termination_grace_seconds=0.5,
     )
 
     assert pid_file.exists()
@@ -175,8 +179,8 @@ def test_output_is_memory_bounded_and_secret_boundary_is_redacted() -> None:
             "sys.stdout.write('x' * 2000000); "
             "sys.stdout.write(os.environ['NEWSROOM_TEST_API_TOKEN'] + 'z' * 124)"
         ),
-        deadline=LaneDeadline.start(3),
-        command_timeout_seconds=2,
+        deadline=LaneDeadline.start(5),
+        command_timeout_seconds=3.5,
         env=environment,
         output_limit_bytes=128,
     )
@@ -195,8 +199,8 @@ def test_environment_error_does_not_echo_command_or_exception_message() -> None:
         gate_id="route",
         phase="spawn",
         argv=(missing,),
-        deadline=LaneDeadline.start(1),
-        command_timeout_seconds=0.5,
+        deadline=LaneDeadline.start(2),
+        command_timeout_seconds=1,
         termination_grace_seconds=0.1,
     )
 
@@ -237,7 +241,9 @@ def test_invalid_budget_identifier_and_output_limit_are_rejected() -> None:
         )
 
 
-def test_cli_uses_accepted_gate_and_lane_budget(capsys: pytest.CaptureFixture[str]) -> None:
+def test_cli_uses_accepted_gate_and_lane_budget(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     exit_code = watchdog_main(
         (
             "--repo-root",

--- a/newsroom/tests/test_sdlc_watchdog.py
+++ b/newsroom/tests/test_sdlc_watchdog.py
@@ -8,11 +8,14 @@ import time
 
 import pytest
 
+from scripts.sdlc.contracts import load_contract
 from scripts.sdlc.run_gate import (
     GateRunError,
     LaneDeadline,
+    _run_gate_command,
     main as watchdog_main,
-    run_gate_command,
+    run_configured_gate,
+    start_lane_deadline,
 )
 
 
@@ -24,14 +27,14 @@ def _python(source: str, *arguments: str) -> tuple[str, ...]:
 
 
 def test_success_and_nonzero_exit_are_typed() -> None:
-    passed = run_gate_command(
+    passed = _run_gate_command(
         gate_id="route",
         phase="unit",
         argv=_python("print('ok')"),
         deadline=LaneDeadline.start(4),
         command_timeout_seconds=3,
     )
-    failed = run_gate_command(
+    failed = _run_gate_command(
         gate_id="route",
         phase="unit",
         argv=_python("raise SystemExit(7)"),
@@ -52,7 +55,7 @@ def test_expired_shared_deadline_prevents_process_start(tmp_path: Path) -> None:
     marker = tmp_path / "must-not-exist"
     deadline = LaneDeadline(time.monotonic_ns() - 2_000_000_000, 10)
 
-    result = run_gate_command(
+    result = _run_gate_command(
         gate_id="core-deterministic",
         phase="tests",
         argv=_python(
@@ -72,7 +75,7 @@ def test_expired_shared_deadline_prevents_process_start(tmp_path: Path) -> None:
 def test_multiple_commands_share_one_lane_deadline() -> None:
     deadline = LaneDeadline.start(2.5)
     started = time.monotonic()
-    first = run_gate_command(
+    first = _run_gate_command(
         gate_id="core-deterministic",
         phase="first",
         argv=_python("import time; time.sleep(0.1)"),
@@ -80,7 +83,7 @@ def test_multiple_commands_share_one_lane_deadline() -> None:
         command_timeout_seconds=1.5,
         termination_grace_seconds=0.1,
     )
-    second = run_gate_command(
+    second = _run_gate_command(
         gate_id="core-deterministic",
         phase="second",
         argv=_python("import time; time.sleep(5)"),
@@ -123,7 +126,7 @@ Path(sys.argv[3]).write_text(str(process.pid), encoding='utf-8')
 time.sleep(30)
 """
 
-    result = run_gate_command(
+    result = _run_gate_command(
         gate_id="core-deterministic",
         phase="descendants",
         argv=_python(parent, child, str(marker), str(pid_file)),
@@ -153,7 +156,7 @@ import sys
 process = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(30)'])
 Path(sys.argv[1]).write_text(str(process.pid), encoding='utf-8')
 """
-    result = run_gate_command(
+    result = _run_gate_command(
         gate_id="core-deterministic",
         phase="background",
         argv=_python(parent, str(pid_file)),
@@ -171,7 +174,7 @@ def test_output_is_memory_bounded_and_secret_boundary_is_redacted() -> None:
     secret = "ultra-sensitive-boundary"
     environment = dict(os.environ)
     environment["NEWSROOM_TEST_API_TOKEN"] = secret
-    result = run_gate_command(
+    result = _run_gate_command(
         gate_id="core-deterministic",
         phase="output",
         argv=_python(
@@ -195,7 +198,7 @@ def test_output_is_memory_bounded_and_secret_boundary_is_redacted() -> None:
 
 def test_environment_error_does_not_echo_command_or_exception_message() -> None:
     missing = "/definitely-not-a-newsroom-command/secret-value"
-    result = run_gate_command(
+    result = _run_gate_command(
         gate_id="route",
         phase="spawn",
         argv=(missing,),
@@ -210,11 +213,27 @@ def test_environment_error_does_not_echo_command_or_exception_message() -> None:
     assert result.result_reason.endswith(":FileNotFoundError")
 
 
+def test_deadline_and_configured_budget_cannot_be_raised() -> None:
+    contract = load_contract(REPO_ROOT)
+    assert start_lane_deadline(contract, "route").timeout_ms == 55_000
+
+    with pytest.raises(GateRunError, match="below 60"):
+        LaneDeadline(0, 60_000)
+    with pytest.raises(GateRunError, match="accepted lane timeout"):
+        run_configured_gate(
+            contract=contract,
+            gate_id="route",
+            phase="oversized",
+            argv=_python("pass"),
+            deadline=LaneDeadline.start(59),
+        )
+
+
 def test_invalid_budget_identifier_and_output_limit_are_rejected() -> None:
     with pytest.raises(GateRunError, match="below 60"):
         LaneDeadline.start(60)
     with pytest.raises(GateRunError, match="unsupported characters"):
-        run_gate_command(
+        _run_gate_command(
             gate_id="bad:gate",
             phase="unit",
             argv=_python("pass"),
@@ -222,7 +241,7 @@ def test_invalid_budget_identifier_and_output_limit_are_rejected() -> None:
             command_timeout_seconds=0.5,
         )
     with pytest.raises(GateRunError, match="output limit"):
-        run_gate_command(
+        _run_gate_command(
             gate_id="route",
             phase="unit",
             argv=_python("pass"),
@@ -231,7 +250,7 @@ def test_invalid_budget_identifier_and_output_limit_are_rejected() -> None:
             output_limit_bytes=1_048_577,
         )
     with pytest.raises(GateRunError, match="five seconds"):
-        run_gate_command(
+        _run_gate_command(
             gate_id="route",
             phase="unit",
             argv=_python("pass"),

--- a/newsroom/tests/test_sdlc_watchdog.py
+++ b/newsroom/tests/test_sdlc_watchdog.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import sys
+import time
+
+import pytest
+
+from scripts.sdlc.run_gate import (
+    GateRunError,
+    LaneDeadline,
+    main as watchdog_main,
+    run_gate_command,
+)
+
+
+REPO_ROOT = Path(__file__).parents[2]
+
+
+def _python(source: str, *arguments: str) -> tuple[str, ...]:
+    return (sys.executable, "-c", source, *arguments)
+
+
+def test_success_and_nonzero_exit_are_typed() -> None:
+    deadline = LaneDeadline.start(2)
+    passed = run_gate_command(
+        gate_id="route",
+        phase="unit",
+        argv=_python("print('ok')"),
+        deadline=deadline,
+        command_timeout_seconds=1,
+    )
+    failed = run_gate_command(
+        gate_id="route",
+        phase="unit",
+        argv=_python("raise SystemExit(7)"),
+        deadline=LaneDeadline.start(2),
+        command_timeout_seconds=1,
+    )
+
+    assert passed.result == "PASS"
+    assert passed.returncode == 0
+    assert passed.stdout == "ok\n"
+    assert passed.result_reason == "PASS:route:unit"
+    assert failed.result == "FAIL"
+    assert failed.returncode == 7
+    assert failed.result_reason == "FAIL:route:unit:exit=7"
+
+
+def test_expired_shared_deadline_prevents_process_start(tmp_path: Path) -> None:
+    marker = tmp_path / "must-not-exist"
+    deadline = LaneDeadline(time.monotonic_ns() - 2_000_000_000, 10)
+
+    result = run_gate_command(
+        gate_id="core-deterministic",
+        phase="tests",
+        argv=_python("from pathlib import Path; Path(__import__('sys').argv[1]).touch()", str(marker)),
+        deadline=deadline,
+        command_timeout_seconds=1,
+    )
+
+    assert result.result == "BUDGET_EXCEEDED"
+    assert result.returncode is None
+    assert result.execution_ms == 0
+    assert not marker.exists()
+
+
+def test_multiple_commands_share_one_lane_deadline() -> None:
+    deadline = LaneDeadline.start(0.4)
+    first = run_gate_command(
+        gate_id="core-deterministic",
+        phase="first",
+        argv=_python("import time; time.sleep(0.1)"),
+        deadline=deadline,
+        command_timeout_seconds=0.3,
+    )
+    second = run_gate_command(
+        gate_id="core-deterministic",
+        phase="second",
+        argv=_python("import time; time.sleep(1)"),
+        deadline=deadline,
+        command_timeout_seconds=0.9,
+        termination_grace_seconds=0.1,
+    )
+
+    assert first.result == "PASS"
+    assert second.result == "BUDGET_EXCEEDED"
+    assert second.execution_ms < 400
+    assert deadline.remaining_seconds() == 0
+
+
+@pytest.mark.skipif(os.name != "posix", reason="process-group evidence is POSIX-specific")
+def test_timeout_terminates_descendant_process_group(tmp_path: Path) -> None:
+    marker = tmp_path / "child-terminated"
+    pid_file = tmp_path / "child-pid"
+    child = """
+import signal
+from pathlib import Path
+import sys
+import time
+
+def stop(*_args):
+    Path(sys.argv[1]).write_text('terminated', encoding='utf-8')
+    raise SystemExit(0)
+
+signal.signal(signal.SIGTERM, stop)
+time.sleep(30)
+"""
+    parent = """
+import subprocess
+from pathlib import Path
+import sys
+import time
+
+process = subprocess.Popen([sys.executable, '-c', sys.argv[1], sys.argv[2]])
+Path(sys.argv[3]).write_text(str(process.pid), encoding='utf-8')
+time.sleep(30)
+"""
+
+    result = run_gate_command(
+        gate_id="core-deterministic",
+        phase="descendants",
+        argv=_python(parent, child, str(marker), str(pid_file)),
+        deadline=LaneDeadline.start(0.7),
+        command_timeout_seconds=0.65,
+        termination_grace_seconds=0.4,
+    )
+
+    stop_at = time.monotonic() + 1
+    while time.monotonic() < stop_at and not marker.exists():
+        time.sleep(0.01)
+    assert pid_file.exists()
+    assert marker.read_text(encoding="utf-8") == "terminated"
+    assert result.result == "BUDGET_EXCEEDED"
+    assert result.result_reason == "BUDGET_EXCEEDED:core-deterministic:descendants"
+
+
+def test_output_is_bounded_and_secret_values_are_redacted() -> None:
+    environment = dict(os.environ)
+    environment["NEWSROOM_TEST_API_TOKEN"] = "highly-sensitive-value"
+    result = run_gate_command(
+        gate_id="core-deterministic",
+        phase="output",
+        argv=_python(
+            "import os; print('x' * 4096); print(os.environ['NEWSROOM_TEST_API_TOKEN'])"
+        ),
+        deadline=LaneDeadline.start(2),
+        command_timeout_seconds=1,
+        env=environment,
+        output_limit_bytes=128,
+    )
+
+    assert result.result == "PASS"
+    assert result.stdout_truncated is True
+    assert "highly-sensitive-value" not in result.stdout
+    assert "***" in result.stdout
+    assert len(result.stdout.encode("utf-8")) <= 128
+
+
+def test_environment_error_does_not_echo_command_or_exception_message() -> None:
+    missing = "/definitely-not-a-newsroom-command/secret-value"
+    result = run_gate_command(
+        gate_id="route",
+        phase="spawn",
+        argv=(missing,),
+        deadline=LaneDeadline.start(1),
+        command_timeout_seconds=0.5,
+    )
+
+    assert result.result == "ENVIRONMENT_ERROR"
+    assert result.returncode is None
+    assert "secret-value" not in result.result_reason
+    assert result.result_reason.endswith(":FileNotFoundError")
+
+
+def test_invalid_budget_or_identifier_is_rejected() -> None:
+    with pytest.raises(GateRunError, match="below 60"):
+        LaneDeadline.start(60)
+    with pytest.raises(GateRunError, match="unsupported characters"):
+        run_gate_command(
+            gate_id="bad:gate",
+            phase="unit",
+            argv=_python("pass"),
+            deadline=LaneDeadline.start(1),
+            command_timeout_seconds=0.5,
+        )
+
+
+def test_cli_uses_accepted_gate_and_lane_budget(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = watchdog_main(
+        (
+            "--repo-root",
+            str(REPO_ROOT),
+            "--gate-id",
+            "route",
+            "--phase",
+            "cli",
+            "--",
+            sys.executable,
+            "-c",
+            "print('cli-ok')",
+        )
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["schema_version"] == "newsroom.sdlc.gate-run.v1"
+    assert payload["result"] == "PASS"
+    assert payload["stdout"] == "cli-ok\n"

--- a/scripts/sdlc/run_gate.py
+++ b/scripts/sdlc/run_gate.py
@@ -20,6 +20,7 @@ SCHEMA_VERSION = "newsroom.sdlc.gate-run.v1"
 _SECRET_NAME = re.compile(r"(?:AUTH|CREDENTIAL|KEY|PASSWORD|SECRET|TOKEN)", re.IGNORECASE)
 _SAFE_ID = re.compile(r"[A-Za-z0-9_.*-]{1,128}")
 _MAX_OUTPUT_BYTES = 1_048_576
+_SCHEDULER_MARGIN_SECONDS = 0.05
 
 
 class GateRunError(ValueError):
@@ -243,9 +244,10 @@ def run_gate_command(
         raise GateRunError("output limit must be between 1 and 1048576 bytes")
 
     budget = min(deadline.remaining_seconds(), command_timeout)
-    if budget <= grace:
+    margin = min(_SCHEDULER_MARGIN_SECONDS, budget / 10)
+    if budget <= grace + margin:
         return _budget_result(gate_id, phase)
-    run_timeout = budget - grace
+    run_timeout = budget - grace - margin
 
     environment = dict(os.environ if env is None else env)
     secrets = _secret_values(environment, redact_values)
@@ -311,7 +313,7 @@ def run_gate_command(
 
     cleanup_stop = time.monotonic() + max(
         0.0,
-        min(grace, deadline.remaining_seconds()),
+        min(grace + margin, deadline.remaining_seconds()),
     )
     for reader in readers:
         reader.join(timeout=max(0.0, cleanup_stop - time.monotonic()))

--- a/scripts/sdlc/run_gate.py
+++ b/scripts/sdlc/run_gate.py
@@ -9,9 +9,9 @@ import re
 import signal
 import subprocess
 import sys
-import tempfile
+import threading
 import time
-from typing import Mapping, Sequence
+from typing import BinaryIO, Mapping, Sequence
 
 from .contracts import ContractError, SdlcContract, load_contract
 
@@ -19,6 +19,7 @@ from .contracts import ContractError, SdlcContract, load_contract
 SCHEMA_VERSION = "newsroom.sdlc.gate-run.v1"
 _SECRET_NAME = re.compile(r"(?:AUTH|CREDENTIAL|KEY|PASSWORD|SECRET|TOKEN)", re.IGNORECASE)
 _SAFE_ID = re.compile(r"[A-Za-z0-9_.*-]{1,128}")
+_MAX_OUTPUT_BYTES = 1_048_576
 
 
 class GateRunError(ValueError):
@@ -32,10 +33,8 @@ class LaneDeadline:
 
     @classmethod
     def start(cls, timeout_seconds: float) -> "LaneDeadline":
-        timeout_ms = int(timeout_seconds * 1000)
-        if timeout_ms <= 0 or timeout_ms >= 60_000:
-            raise GateRunError("lane timeout must be positive and below 60 seconds")
-        return cls(time.monotonic_ns(), timeout_ms)
+        timeout = _timeout_seconds(timeout_seconds, "lane timeout")
+        return cls(time.monotonic_ns(), int(timeout * 1000))
 
     def remaining_seconds(self, *, now_ns: int | None = None) -> float:
         current = time.monotonic_ns() if now_ns is None else now_ns
@@ -72,18 +71,54 @@ class GateRunResult:
         }
 
 
+class _TailBuffer:
+    def __init__(self, retained_bytes: int) -> None:
+        self._retained_bytes = retained_bytes
+        self._data = bytearray()
+        self.total_bytes = 0
+
+    def feed(self, payload: bytes) -> None:
+        self.total_bytes += len(payload)
+        if len(payload) >= self._retained_bytes:
+            self._data[:] = payload[-self._retained_bytes :]
+            return
+        self._data.extend(payload)
+        overflow = len(self._data) - self._retained_bytes
+        if overflow > 0:
+            del self._data[:overflow]
+
+    def render(self, *, output_limit: int, secrets: Sequence[str], incomplete: bool) -> tuple[str, bool]:
+        text = bytes(self._data).decode("utf-8", errors="replace")
+        for secret in secrets:
+            text = text.replace(secret, "***")
+        encoded = text.encode("utf-8")
+        if len(encoded) > output_limit:
+            encoded = encoded[-output_limit:]
+            text = encoded.decode("utf-8", errors="replace")
+            while len(text.encode("utf-8")) > output_limit:
+                text = text[1:]
+        return text, incomplete or self.total_bytes > output_limit
+
+
 def _validate_id(value: str, name: str) -> None:
     if _SAFE_ID.fullmatch(value) is None:
         raise GateRunError(f"{name} contains unsupported characters")
 
 
-def _timeout_seconds(value: float, name: str) -> float:
-    if isinstance(value, bool) or value <= 0 or value >= 60:
+def _timeout_seconds(value: object, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise GateRunError(f"{name} must be numeric")
+    timeout = float(value)
+    if timeout <= 0 or timeout >= 60:
         raise GateRunError(f"{name} must be positive and below 60 seconds")
-    return float(value)
+    return timeout
 
 
 def _secret_values(environment: Mapping[str, str], explicit: Sequence[str]) -> tuple[str, ...]:
+    if any(not isinstance(name, str) or not isinstance(value, str) for name, value in environment.items()):
+        raise GateRunError("environment names and values must be strings")
+    if any(not isinstance(value, str) for value in explicit):
+        raise GateRunError("redaction values must be strings")
     values = {
         value
         for name, value in environment.items()
@@ -91,23 +126,6 @@ def _secret_values(environment: Mapping[str, str], explicit: Sequence[str]) -> t
     }
     values.update(value for value in explicit if value)
     return tuple(sorted(values, key=lambda item: (-len(item), item)))
-
-
-def _redact(value: str, secrets: Sequence[str]) -> str:
-    for secret in secrets:
-        value = value.replace(secret, "***")
-    return value
-
-
-def _read_tail(stream: object, limit: int) -> tuple[str, bool]:
-    if limit <= 0:
-        raise GateRunError("output limit must be positive")
-    stream.seek(0, os.SEEK_END)  # type: ignore[attr-defined]
-    size = stream.tell()  # type: ignore[attr-defined]
-    truncated = size > limit
-    stream.seek(max(0, size - limit))  # type: ignore[attr-defined]
-    payload = stream.read()  # type: ignore[attr-defined]
-    return payload.decode("utf-8", errors="replace"), truncated
 
 
 def _group_exists(process_group: int) -> bool:
@@ -120,34 +138,60 @@ def _group_exists(process_group: int) -> bool:
     return True
 
 
-def _terminate(process: subprocess.Popen[bytes], grace_seconds: float) -> None:
-    if os.name != "posix":
-        process.terminate()
-        try:
-            process.wait(timeout=grace_seconds)
-        except subprocess.TimeoutExpired:
-            process.kill()
-            process.wait()
-        return
+def _wait_group_gone(process_group: int, timeout_seconds: float) -> bool:
+    stop_at = time.monotonic() + timeout_seconds
+    while time.monotonic() < stop_at:
+        if not _group_exists(process_group):
+            return True
+        time.sleep(0.01)
+    return not _group_exists(process_group)
 
+
+def _terminate_group(process: subprocess.Popen[bytes], grace_seconds: float) -> None:
     process_group = process.pid
     try:
         os.killpg(process_group, signal.SIGTERM)
     except ProcessLookupError:
-        return
-    stop_at = time.monotonic() + grace_seconds
-    while time.monotonic() < stop_at and _group_exists(process_group):
-        time.sleep(0.01)
-    if _group_exists(process_group):
+        pass
+    if not _wait_group_gone(process_group, grace_seconds):
         try:
             os.killpg(process_group, signal.SIGKILL)
         except ProcessLookupError:
             pass
+    if process.poll() is None:
+        try:
+            process.wait(timeout=max(0.05, grace_seconds))
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
+
+
+def _drain(stream: BinaryIO, buffer: _TailBuffer, errors: list[str]) -> None:
     try:
-        process.wait(timeout=max(0.1, grace_seconds))
-    except subprocess.TimeoutExpired:
-        process.kill()
-        process.wait()
+        while payload := stream.read(65_536):
+            buffer.feed(payload)
+    except (OSError, ValueError) as exc:
+        errors.append(type(exc).__name__)
+    finally:
+        try:
+            stream.close()
+        except OSError:
+            pass
+
+
+def _budget_result(gate_id: str, phase: str) -> GateRunResult:
+    return GateRunResult(
+        gate_id,
+        phase,
+        "BUDGET_EXCEEDED",
+        f"BUDGET_EXCEEDED:{gate_id}:{phase}",
+        None,
+        0,
+        "",
+        "",
+        False,
+        False,
+    )
 
 
 def run_gate_command(
@@ -165,74 +209,105 @@ def run_gate_command(
 ) -> GateRunResult:
     _validate_id(gate_id, "gate_id")
     _validate_id(phase, "phase")
+    if os.name != "posix":
+        raise GateRunError("bounded process-group execution requires POSIX")
     if not argv or any(not isinstance(item, str) or not item for item in argv):
         raise GateRunError("argv must contain non-empty strings")
     command_timeout = _timeout_seconds(command_timeout_seconds, "command timeout")
-    if termination_grace_seconds <= 0:
-        raise GateRunError("termination grace must be positive")
+    grace = _timeout_seconds(termination_grace_seconds, "termination grace")
+    if grace > 5:
+        raise GateRunError("termination grace must not exceed five seconds")
+    if isinstance(output_limit_bytes, bool) or not isinstance(output_limit_bytes, int):
+        raise GateRunError("output limit must be an integer")
+    if not 0 < output_limit_bytes <= _MAX_OUTPUT_BYTES:
+        raise GateRunError("output limit must be between 1 and 1048576 bytes")
 
-    remaining = min(deadline.remaining_seconds(), command_timeout)
-    if remaining <= 0:
+    budget = min(deadline.remaining_seconds(), command_timeout)
+    if budget <= grace:
+        return _budget_result(gate_id, phase)
+    run_timeout = budget - grace
+
+    environment = dict(os.environ if env is None else env)
+    secrets = _secret_values(environment, redact_values)
+    overlap = max((len(secret.encode("utf-8")) for secret in secrets), default=0)
+    stdout_buffer = _TailBuffer(output_limit_bytes + overlap)
+    stderr_buffer = _TailBuffer(output_limit_bytes + overlap)
+    capture_errors: list[str] = []
+    started_ns = time.monotonic_ns()
+    try:
+        process = subprocess.Popen(
+            tuple(argv),
+            cwd=cwd,
+            env=environment,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            shell=False,
+            start_new_session=True,
+            close_fds=True,
+        )
+    except OSError as exc:
+        elapsed = max(0, (time.monotonic_ns() - started_ns) // 1_000_000)
         return GateRunResult(
             gate_id,
             phase,
-            "BUDGET_EXCEEDED",
-            f"BUDGET_EXCEEDED:{gate_id}:{phase}",
+            "ENVIRONMENT_ERROR",
+            f"ENVIRONMENT_ERROR:{gate_id}:{phase}:{type(exc).__name__}",
             None,
-            0,
+            elapsed,
             "",
             "",
             False,
             False,
         )
 
-    environment = dict(os.environ if env is None else env)
-    secrets = _secret_values(environment, redact_values)
-    started_ns = time.monotonic_ns()
-    with tempfile.TemporaryFile() as stdout_file, tempfile.TemporaryFile() as stderr_file:
-        try:
-            process = subprocess.Popen(
-                tuple(argv),
-                cwd=cwd,
-                env=environment,
-                stdin=subprocess.DEVNULL,
-                stdout=stdout_file,
-                stderr=stderr_file,
-                shell=False,
-                start_new_session=True,
-                close_fds=True,
-            )
-        except OSError as exc:
-            elapsed = max(0, (time.monotonic_ns() - started_ns) // 1_000_000)
-            return GateRunResult(
-                gate_id,
-                phase,
-                "ENVIRONMENT_ERROR",
-                f"ENVIRONMENT_ERROR:{gate_id}:{phase}:{type(exc).__name__}",
-                None,
-                elapsed,
-                "",
-                "",
-                False,
-                False,
-            )
+    assert process.stdout is not None and process.stderr is not None
+    readers = (
+        threading.Thread(target=_drain, args=(process.stdout, stdout_buffer, capture_errors), daemon=True),
+        threading.Thread(target=_drain, args=(process.stderr, stderr_buffer, capture_errors), daemon=True),
+    )
+    for reader in readers:
+        reader.start()
 
-        timed_out = False
-        try:
-            process.wait(timeout=remaining)
-        except subprocess.TimeoutExpired:
-            timed_out = True
-            _terminate(process, termination_grace_seconds)
+    timed_out = False
+    background_process = False
+    try:
+        process.wait(timeout=run_timeout)
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        _terminate_group(process, grace)
+    else:
+        if not _wait_group_gone(process.pid, min(0.05, grace / 2)):
+            background_process = True
+            _terminate_group(process, grace)
 
-        execution_ms = max(0, (time.monotonic_ns() - started_ns) // 1_000_000)
-        stdout, stdout_truncated = _read_tail(stdout_file, output_limit_bytes)
-        stderr, stderr_truncated = _read_tail(stderr_file, output_limit_bytes)
-        stdout = _redact(stdout, secrets)
-        stderr = _redact(stderr, secrets)
+    cleanup_stop = time.monotonic() + max(0.0, min(grace, deadline.remaining_seconds()))
+    for reader in readers:
+        reader.join(timeout=max(0.0, cleanup_stop - time.monotonic()))
+    capture_incomplete = any(reader.is_alive() for reader in readers)
+    execution_ms = max(0, (time.monotonic_ns() - started_ns) // 1_000_000)
+    if deadline.remaining_seconds() <= 0 or execution_ms > int(budget * 1000):
+        timed_out = True
+    stdout, stdout_truncated = stdout_buffer.render(
+        output_limit=output_limit_bytes,
+        secrets=secrets,
+        incomplete=capture_incomplete,
+    )
+    stderr, stderr_truncated = stderr_buffer.render(
+        output_limit=output_limit_bytes,
+        secrets=secrets,
+        incomplete=capture_incomplete,
+    )
 
     if timed_out:
         result = "BUDGET_EXCEEDED"
         reason = f"BUDGET_EXCEEDED:{gate_id}:{phase}"
+    elif capture_errors or capture_incomplete:
+        result = "ENVIRONMENT_ERROR"
+        reason = f"ENVIRONMENT_ERROR:{gate_id}:{phase}:output_capture"
+    elif background_process:
+        result = "UNAUTHORISED_EFFECT"
+        reason = f"UNAUTHORISED_EFFECT:{gate_id}:{phase}:background_process"
     elif process.returncode == 0:
         result = "PASS"
         reason = f"PASS:{gate_id}:{phase}"

--- a/scripts/sdlc/run_gate.py
+++ b/scripts/sdlc/run_gate.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import re
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from typing import Mapping, Sequence
+
+from .contracts import ContractError, SdlcContract, load_contract
+
+
+SCHEMA_VERSION = "newsroom.sdlc.gate-run.v1"
+_SECRET_NAME = re.compile(r"(?:AUTH|CREDENTIAL|KEY|PASSWORD|SECRET|TOKEN)", re.IGNORECASE)
+_SAFE_ID = re.compile(r"[A-Za-z0-9_.*-]{1,128}")
+
+
+class GateRunError(ValueError):
+    """Raised when a bounded gate invocation is invalid."""
+
+
+@dataclass(frozen=True)
+class LaneDeadline:
+    started_ns: int
+    timeout_ms: int
+
+    @classmethod
+    def start(cls, timeout_seconds: float) -> "LaneDeadline":
+        timeout_ms = int(timeout_seconds * 1000)
+        if timeout_ms <= 0 or timeout_ms >= 60_000:
+            raise GateRunError("lane timeout must be positive and below 60 seconds")
+        return cls(time.monotonic_ns(), timeout_ms)
+
+    def remaining_seconds(self, *, now_ns: int | None = None) -> float:
+        current = time.monotonic_ns() if now_ns is None else now_ns
+        elapsed_ms = max(0, (current - self.started_ns) // 1_000_000)
+        return max(0.0, (self.timeout_ms - elapsed_ms) / 1000.0)
+
+
+@dataclass(frozen=True)
+class GateRunResult:
+    gate_id: str
+    phase: str
+    result: str
+    result_reason: str
+    returncode: int | None
+    execution_ms: int
+    stdout: str
+    stderr: str
+    stdout_truncated: bool
+    stderr_truncated: bool
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "gate_id": self.gate_id,
+            "phase": self.phase,
+            "result": self.result,
+            "result_reason": self.result_reason,
+            "returncode": self.returncode,
+            "execution_ms": self.execution_ms,
+            "stdout": self.stdout,
+            "stderr": self.stderr,
+            "stdout_truncated": self.stdout_truncated,
+            "stderr_truncated": self.stderr_truncated,
+        }
+
+
+def _validate_id(value: str, name: str) -> None:
+    if _SAFE_ID.fullmatch(value) is None:
+        raise GateRunError(f"{name} contains unsupported characters")
+
+
+def _timeout_seconds(value: float, name: str) -> float:
+    if isinstance(value, bool) or value <= 0 or value >= 60:
+        raise GateRunError(f"{name} must be positive and below 60 seconds")
+    return float(value)
+
+
+def _secret_values(environment: Mapping[str, str], explicit: Sequence[str]) -> tuple[str, ...]:
+    values = {
+        value
+        for name, value in environment.items()
+        if value and _SECRET_NAME.search(name)
+    }
+    values.update(value for value in explicit if value)
+    return tuple(sorted(values, key=lambda item: (-len(item), item)))
+
+
+def _redact(value: str, secrets: Sequence[str]) -> str:
+    for secret in secrets:
+        value = value.replace(secret, "***")
+    return value
+
+
+def _read_tail(stream: object, limit: int) -> tuple[str, bool]:
+    if limit <= 0:
+        raise GateRunError("output limit must be positive")
+    stream.seek(0, os.SEEK_END)  # type: ignore[attr-defined]
+    size = stream.tell()  # type: ignore[attr-defined]
+    truncated = size > limit
+    stream.seek(max(0, size - limit))  # type: ignore[attr-defined]
+    payload = stream.read()  # type: ignore[attr-defined]
+    return payload.decode("utf-8", errors="replace"), truncated
+
+
+def _group_exists(process_group: int) -> bool:
+    try:
+        os.killpg(process_group, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _terminate(process: subprocess.Popen[bytes], grace_seconds: float) -> None:
+    if os.name != "posix":
+        process.terminate()
+        try:
+            process.wait(timeout=grace_seconds)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
+        return
+
+    process_group = process.pid
+    try:
+        os.killpg(process_group, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    stop_at = time.monotonic() + grace_seconds
+    while time.monotonic() < stop_at and _group_exists(process_group):
+        time.sleep(0.01)
+    if _group_exists(process_group):
+        try:
+            os.killpg(process_group, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+    try:
+        process.wait(timeout=max(0.1, grace_seconds))
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait()
+
+
+def run_gate_command(
+    *,
+    gate_id: str,
+    phase: str,
+    argv: Sequence[str],
+    deadline: LaneDeadline,
+    command_timeout_seconds: float,
+    cwd: str | Path | None = None,
+    env: Mapping[str, str] | None = None,
+    redact_values: Sequence[str] = (),
+    output_limit_bytes: int = 65_536,
+    termination_grace_seconds: float = 0.5,
+) -> GateRunResult:
+    _validate_id(gate_id, "gate_id")
+    _validate_id(phase, "phase")
+    if not argv or any(not isinstance(item, str) or not item for item in argv):
+        raise GateRunError("argv must contain non-empty strings")
+    command_timeout = _timeout_seconds(command_timeout_seconds, "command timeout")
+    if termination_grace_seconds <= 0:
+        raise GateRunError("termination grace must be positive")
+
+    remaining = min(deadline.remaining_seconds(), command_timeout)
+    if remaining <= 0:
+        return GateRunResult(
+            gate_id,
+            phase,
+            "BUDGET_EXCEEDED",
+            f"BUDGET_EXCEEDED:{gate_id}:{phase}",
+            None,
+            0,
+            "",
+            "",
+            False,
+            False,
+        )
+
+    environment = dict(os.environ if env is None else env)
+    secrets = _secret_values(environment, redact_values)
+    started_ns = time.monotonic_ns()
+    with tempfile.TemporaryFile() as stdout_file, tempfile.TemporaryFile() as stderr_file:
+        try:
+            process = subprocess.Popen(
+                tuple(argv),
+                cwd=cwd,
+                env=environment,
+                stdin=subprocess.DEVNULL,
+                stdout=stdout_file,
+                stderr=stderr_file,
+                shell=False,
+                start_new_session=True,
+                close_fds=True,
+            )
+        except OSError as exc:
+            elapsed = max(0, (time.monotonic_ns() - started_ns) // 1_000_000)
+            return GateRunResult(
+                gate_id,
+                phase,
+                "ENVIRONMENT_ERROR",
+                f"ENVIRONMENT_ERROR:{gate_id}:{phase}:{type(exc).__name__}",
+                None,
+                elapsed,
+                "",
+                "",
+                False,
+                False,
+            )
+
+        timed_out = False
+        try:
+            process.wait(timeout=remaining)
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            _terminate(process, termination_grace_seconds)
+
+        execution_ms = max(0, (time.monotonic_ns() - started_ns) // 1_000_000)
+        stdout, stdout_truncated = _read_tail(stdout_file, output_limit_bytes)
+        stderr, stderr_truncated = _read_tail(stderr_file, output_limit_bytes)
+        stdout = _redact(stdout, secrets)
+        stderr = _redact(stderr, secrets)
+
+    if timed_out:
+        result = "BUDGET_EXCEEDED"
+        reason = f"BUDGET_EXCEEDED:{gate_id}:{phase}"
+    elif process.returncode == 0:
+        result = "PASS"
+        reason = f"PASS:{gate_id}:{phase}"
+    else:
+        result = "FAIL"
+        reason = f"FAIL:{gate_id}:{phase}:exit={process.returncode}"
+    return GateRunResult(
+        gate_id,
+        phase,
+        result,
+        reason,
+        process.returncode,
+        execution_ms,
+        stdout,
+        stderr,
+        stdout_truncated,
+        stderr_truncated,
+    )
+
+
+def _gate_configuration(contract: SdlcContract, gate_id: str) -> tuple[float, float]:
+    for gate in contract.data["gate"].values():
+        if gate["id"] != gate_id:
+            continue
+        lane = contract.data["lanes"][gate["lane"]]
+        lane_timeout = lane.get(
+            "hard_timeout_seconds",
+            lane.get("per_shard_hard_timeout_seconds"),
+        )
+        return float(gate["hard_timeout_seconds"]), float(lane_timeout)
+    raise GateRunError(f"unknown gate id: {gate_id}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run one Newsroom gate command within its accepted budget")
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--gate-id", required=True)
+    parser.add_argument("--phase", required=True)
+    parser.add_argument("--output")
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    arguments = parser.parse_args(argv)
+    command = arguments.command[1:] if arguments.command[:1] == ["--"] else arguments.command
+    try:
+        contract = load_contract(arguments.repo_root)
+        command_timeout, lane_timeout = _gate_configuration(contract, arguments.gate_id)
+        result = run_gate_command(
+            gate_id=arguments.gate_id,
+            phase=arguments.phase,
+            argv=command,
+            deadline=LaneDeadline.start(lane_timeout),
+            command_timeout_seconds=command_timeout,
+            cwd=arguments.repo_root,
+        )
+    except (ContractError, GateRunError, OSError) as exc:
+        print(f"ENVIRONMENT_ERROR:{type(exc).__name__}", file=sys.stderr)
+        return 3
+    rendered = json.dumps(result.as_dict(), sort_keys=True, separators=(",", ":")) + "\n"
+    if arguments.output:
+        Path(arguments.output).write_text(rendered, encoding="utf-8")
+    else:
+        sys.stdout.write(rendered)
+    return {"PASS": 0, "FAIL": 1, "BUDGET_EXCEEDED": 2}.get(result.result, 3)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sdlc/run_gate.py
+++ b/scripts/sdlc/run_gate.py
@@ -32,10 +32,24 @@ class LaneDeadline:
     started_ns: int
     timeout_ms: int
 
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.started_ns, bool)
+            or not isinstance(self.started_ns, int)
+            or self.started_ns < 0
+        ):
+            raise GateRunError("deadline start must be a nonnegative monotonic integer")
+        if (
+            isinstance(self.timeout_ms, bool)
+            or not isinstance(self.timeout_ms, int)
+            or not 0 < self.timeout_ms < 60_000
+        ):
+            raise GateRunError("lane timeout must be positive and below 60 seconds")
+
     @classmethod
     def start(cls, timeout_seconds: float) -> "LaneDeadline":
         timeout = _timeout_seconds(timeout_seconds, "lane timeout")
-        return cls(time.monotonic_ns(), int(timeout * 1000))
+        return cls(time.monotonic_ns(), max(1, int(timeout * 1000)))
 
     def remaining_seconds(self, *, now_ns: int | None = None) -> float:
         current = time.monotonic_ns() if now_ns is None else now_ns
@@ -215,7 +229,7 @@ def _budget_result(gate_id: str, phase: str) -> GateRunResult:
     )
 
 
-def run_gate_command(
+def _run_gate_command(
     *,
     gate_id: str,
     phase: str,
@@ -374,6 +388,42 @@ def _gate_configuration(contract: SdlcContract, gate_id: str) -> tuple[float, fl
     raise GateRunError(f"unknown gate id: {gate_id}")
 
 
+def start_lane_deadline(contract: SdlcContract, gate_id: str) -> LaneDeadline:
+    _, lane_timeout = _gate_configuration(contract, gate_id)
+    return LaneDeadline.start(lane_timeout)
+
+
+def run_configured_gate(
+    *,
+    contract: SdlcContract,
+    gate_id: str,
+    phase: str,
+    argv: Sequence[str],
+    deadline: LaneDeadline | None = None,
+    cwd: str | Path | None = None,
+    env: Mapping[str, str] | None = None,
+    redact_values: Sequence[str] = (),
+    output_limit_bytes: int = 65_536,
+    termination_grace_seconds: float = 0.5,
+) -> GateRunResult:
+    command_timeout, lane_timeout = _gate_configuration(contract, gate_id)
+    active_deadline = deadline or LaneDeadline.start(lane_timeout)
+    if active_deadline.timeout_ms > int(lane_timeout * 1000):
+        raise GateRunError("deadline exceeds the accepted lane timeout")
+    return _run_gate_command(
+        gate_id=gate_id,
+        phase=phase,
+        argv=argv,
+        deadline=active_deadline,
+        command_timeout_seconds=command_timeout,
+        cwd=cwd,
+        env=env,
+        redact_values=redact_values,
+        output_limit_bytes=output_limit_bytes,
+        termination_grace_seconds=termination_grace_seconds,
+    )
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Run one Newsroom gate command within its accepted budget"
@@ -391,16 +441,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     try:
         contract = load_contract(arguments.repo_root)
-        command_timeout, lane_timeout = _gate_configuration(
-            contract,
-            arguments.gate_id,
-        )
-        result = run_gate_command(
+        result = run_configured_gate(
+            contract=contract,
             gate_id=arguments.gate_id,
             phase=arguments.phase,
             argv=command,
-            deadline=LaneDeadline.start(lane_timeout),
-            command_timeout_seconds=command_timeout,
             cwd=arguments.repo_root,
         )
     except (ContractError, GateRunError, OSError) as exc:

--- a/scripts/sdlc/run_gate.py
+++ b/scripts/sdlc/run_gate.py
@@ -87,7 +87,13 @@ class _TailBuffer:
         if overflow > 0:
             del self._data[:overflow]
 
-    def render(self, *, output_limit: int, secrets: Sequence[str], incomplete: bool) -> tuple[str, bool]:
+    def render(
+        self,
+        *,
+        output_limit: int,
+        secrets: Sequence[str],
+        incomplete: bool,
+    ) -> tuple[str, bool]:
         text = bytes(self._data).decode("utf-8", errors="replace")
         for secret in secrets:
             text = text.replace(secret, "***")
@@ -114,8 +120,13 @@ def _timeout_seconds(value: object, name: str) -> float:
     return timeout
 
 
-def _secret_values(environment: Mapping[str, str], explicit: Sequence[str]) -> tuple[str, ...]:
-    if any(not isinstance(name, str) or not isinstance(value, str) for name, value in environment.items()):
+def _secret_values(
+    environment: Mapping[str, str], explicit: Sequence[str]
+) -> tuple[str, ...]:
+    if any(
+        not isinstance(name, str) or not isinstance(value, str)
+        for name, value in environment.items()
+    ):
         raise GateRunError("environment names and values must be strings")
     if any(not isinstance(value, str) for value in explicit):
         raise GateRunError("redaction values must be strings")
@@ -138,12 +149,21 @@ def _group_exists(process_group: int) -> bool:
     return True
 
 
-def _wait_group_gone(process_group: int, timeout_seconds: float) -> bool:
+def _wait_group_gone(
+    process_group: int,
+    timeout_seconds: float,
+    *,
+    leader: subprocess.Popen[bytes] | None = None,
+) -> bool:
     stop_at = time.monotonic() + timeout_seconds
     while time.monotonic() < stop_at:
+        if leader is not None:
+            leader.poll()
         if not _group_exists(process_group):
             return True
         time.sleep(0.01)
+    if leader is not None:
+        leader.poll()
     return not _group_exists(process_group)
 
 
@@ -153,7 +173,7 @@ def _terminate_group(process: subprocess.Popen[bytes], grace_seconds: float) -> 
         os.killpg(process_group, signal.SIGTERM)
     except ProcessLookupError:
         pass
-    if not _wait_group_gone(process_group, grace_seconds):
+    if not _wait_group_gone(process_group, grace_seconds, leader=process):
         try:
             os.killpg(process_group, signal.SIGKILL)
         except ProcessLookupError:
@@ -263,8 +283,16 @@ def run_gate_command(
 
     assert process.stdout is not None and process.stderr is not None
     readers = (
-        threading.Thread(target=_drain, args=(process.stdout, stdout_buffer, capture_errors), daemon=True),
-        threading.Thread(target=_drain, args=(process.stderr, stderr_buffer, capture_errors), daemon=True),
+        threading.Thread(
+            target=_drain,
+            args=(process.stdout, stdout_buffer, capture_errors),
+            daemon=True,
+        ),
+        threading.Thread(
+            target=_drain,
+            args=(process.stderr, stderr_buffer, capture_errors),
+            daemon=True,
+        ),
     )
     for reader in readers:
         reader.start()
@@ -281,7 +309,10 @@ def run_gate_command(
             background_process = True
             _terminate_group(process, grace)
 
-    cleanup_stop = time.monotonic() + max(0.0, min(grace, deadline.remaining_seconds()))
+    cleanup_stop = time.monotonic() + max(
+        0.0,
+        min(grace, deadline.remaining_seconds()),
+    )
     for reader in readers:
         reader.join(timeout=max(0.0, cleanup_stop - time.monotonic()))
     capture_incomplete = any(reader.is_alive() for reader in readers)
@@ -342,17 +373,26 @@ def _gate_configuration(contract: SdlcContract, gate_id: str) -> tuple[float, fl
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Run one Newsroom gate command within its accepted budget")
+    parser = argparse.ArgumentParser(
+        description="Run one Newsroom gate command within its accepted budget"
+    )
     parser.add_argument("--repo-root", default=".")
     parser.add_argument("--gate-id", required=True)
     parser.add_argument("--phase", required=True)
     parser.add_argument("--output")
     parser.add_argument("command", nargs=argparse.REMAINDER)
     arguments = parser.parse_args(argv)
-    command = arguments.command[1:] if arguments.command[:1] == ["--"] else arguments.command
+    command = (
+        arguments.command[1:]
+        if arguments.command[:1] == ["--"]
+        else arguments.command
+    )
     try:
         contract = load_contract(arguments.repo_root)
-        command_timeout, lane_timeout = _gate_configuration(contract, arguments.gate_id)
+        command_timeout, lane_timeout = _gate_configuration(
+            contract,
+            arguments.gate_id,
+        )
         result = run_gate_command(
             gate_id=arguments.gate_id,
             phase=arguments.phase,
@@ -364,7 +404,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     except (ContractError, GateRunError, OSError) as exc:
         print(f"ENVIRONMENT_ERROR:{type(exc).__name__}", file=sys.stderr)
         return 3
-    rendered = json.dumps(result.as_dict(), sort_keys=True, separators=(",", ":")) + "\n"
+    rendered = json.dumps(
+        result.as_dict(),
+        sort_keys=True,
+        separators=(",", ":"),
+    ) + "\n"
     if arguments.output:
         Path(arguments.output).write_text(rendered, encoding="utf-8")
     else:


### PR DESCRIPTION
## Status

Phase **1B1** of issue #100 under accepted SDLC #98. Source-only, exact-head green and ready for review.

Reviewed head:

`65ece2090fe2db21c9ba850451bccdd14ad148f6`

Base:

`main@ef1ca1f2a2f1b29c1c88e1f413ae53476e261fcc`

This unit implements the shared sub-minute lane deadline and process-group watchdog only. Evidence identity/JUnit semantics remain Phase 1B2; workflow orchestration remains Phase 2. Existing required workflows are unchanged.

## Scope

- monotonic `LaneDeadline` with constructor invariants below 60 seconds;
- accepted-contract `run_configured_gate()` entrypoint with no caller-supplied command timeout;
- one shared lane deadline across sequential commands;
- command execution capped by the smaller accepted command budget and remaining lane budget;
- scheduler and termination reserves kept inside the same budget;
- typed `PASS`, `FAIL`, `BUDGET_EXCEEDED`, `ENVIRONMENT_ERROR` and `UNAUTHORISED_EFFECT` results;
- exact `BUDGET_EXCEEDED:<gate>:<phase>` reason;
- `shell=False`, new POSIX session and process-group cleanup;
- successful parents cannot leave background children;
- bounded in-memory stdout/stderr tail capture;
- secret-value overlap retention so truncation cannot expose a partial boundary value;
- environment and explicit redaction values never enter error reasons;
- CLI derives both command and lane budgets from accepted `.sdlc/gates.toml`.

## Review-trigger decomposition note

The accepted trigger is 400 net executable lines / 12 files. This PR changes only two files but exceeds the line trigger because the watchdog and its process/output adversarial matrix are one indivisible safety concept: timeout code without descendant, output-pressure, redaction-boundary and background-process evidence would not be independently trustworthy. Canonical evidence/JUnit logic and workflow orchestration remain separate PRs.

## Substantive review corrections

P1: 0. P2 found and corrected: 4. Unresolved P1/P2: 0.

1. Temporary-file capture bounded only the returned tail while allowing unbounded disk writes; capture now uses continuously drained, fixed-size memory tails.
2. Termination grace and scheduler jitter could extend execution beyond the lane deadline, and an unreaped group leader consumed the full grace; cleanup and margin are now reserved inside the accepted budget and leaders are reaped while waiting.
3. Early adversarial tests accidentally measured Python process startup rather than deadline semantics; test budgets now isolate the intended invariant without increasing production budgets.
4. The low-level runner and direct deadline construction could supply larger values than the accepted gate/lane contract; arbitrary-timeout execution is private, the official entrypoint derives accepted budgets, and constructed deadlines enforce sub-minute limits.

Additional adversarial evidence covers descendant termination, post-success background processes, 2 MB output pressure, truncation-boundary secret redaction, spawn failures, oversized output limits and CLI budget binding.

## Exact-head validation

Head `65ece2090fe2db21c9ba850451bccdd14ad148f6`:

- Authority A2a run `29898475526`: success;
- Authority A2b run `29898475452`: success;
- Projection B1 run `29898475579`: success;
- Projection B2 Neo4j run `29898475435`: success;
- complete repository CI and clustering run `29898475422`: success;
- unresolved inline review threads: zero.

## Changed files

- `scripts/sdlc/run_gate.py`;
- `newsroom/tests/test_sdlc_watchdog.py`.

## Exclusions

No canonical gate evidence builder, JUnit parser, GitHub workflow, cache, test selection, Neo4j process change, current required-check change, release, production, Graphiti/model/embedding/live-source execution, publication, product shadow, canary, spending or public effect.