### PR TITLE
feat(sdlc): add exact JUnit evidence summary

### DIFF
--- a/newsroom/tests/test_sdlc_junit_encoding.py
+++ b/newsroom/tests/test_sdlc_junit_encoding.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.sdlc.junit_evidence import JUnitEvidenceError, summarize_junit
+
+
+def test_non_utf8_junit_cannot_bypass_declaration_scan(tmp_path: Path) -> None:
+    payload = (
+        '<!DOCTYPE x [<!ENTITY data SYSTEM "file:///etc/passwd">]>'
+        '<testsuite><testcase classname="x" name="y">'
+        "<failure>&data;</failure></testcase></testsuite>"
+    ).encode("utf-16")
+    (tmp_path / "encoded.xml").write_bytes(payload)
+
+    with pytest.raises(JUnitEvidenceError, match="invalid_encoding"):
+        summarize_junit(tmp_path, ("encoded.xml",))

--- a/newsroom/tests/test_sdlc_junit_evidence.py
+++ b/newsroom/tests/test_sdlc_junit_evidence.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import stat
+
+import pytest
+
+from scripts.sdlc.junit_evidence import (
+    JUnitEvidenceError,
+    main as junit_main,
+    summarize_junit,
+)
+
+
+def _write(root: Path, relative: str, content: str) -> Path:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _suite(*cases: str, attributes: str = "") -> str:
+    return f"<testsuite {attributes}>{''.join(cases)}</testsuite>"
+
+
+def _case(
+    name: str,
+    *,
+    classname: str = "tests.example",
+    time: str = "0.001",
+    terminal: str = "",
+) -> str:
+    return (
+        f'<testcase classname="{classname}" name="{name}" time="{time}">'
+        f"{terminal}</testcase>"
+    )
+
+
+def test_optional_skip_is_recorded_without_failing_the_gate(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "results.xml",
+        _suite(
+            _case("passes"),
+            _case("optional", terminal='<skipped message="not selected"/>'),
+            attributes='tests="999" failures="999" errors="999" skipped="999"',
+        ),
+    )
+
+    summary = summarize_junit(
+        tmp_path,
+        ("results.xml",),
+        optional_test_ids=("tests.example::optional",),
+    )
+
+    assert summary.outcome == "PASS"
+    assert summary.test_count == 2
+    assert summary.failure_count == 0
+    assert summary.error_count == 0
+    assert summary.skip_count == 1
+    assert summary.required_skip_count == 0
+    assert summary.duration_ms == 2
+    assert summary.first_failure_fingerprint is None
+
+
+def test_required_skip_fails_with_a_stable_fingerprint(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "results.xml",
+        _suite(_case("required", terminal='<skipped message="unavailable"/>')),
+    )
+
+    first = summarize_junit(tmp_path, ("results.xml",))
+    second = summarize_junit(tmp_path, ("results.xml",))
+
+    assert first.outcome == "FAIL"
+    assert first.required_skip_count == 1
+    assert first.failure_count == first.error_count == 0
+    assert first.first_failure_fingerprint == second.first_failure_fingerprint
+    assert first.first_failure_fingerprint is not None
+    assert first.first_failure_fingerprint.startswith("sha256:")
+
+
+def test_failure_error_and_first_fingerprint_are_order_independent(
+    tmp_path: Path,
+) -> None:
+    root_a = tmp_path / "one"
+    root_b = tmp_path / "two"
+    failure_a = (
+        '<failure type="AssertionError" message="bad">'
+        f"\x1b[31m{root_a}/module.py:7: assertion failed\x1b[0m"
+        "</failure>"
+    )
+    failure_b = failure_a.replace(str(root_a), str(root_b))
+    error = '<error type="RuntimeError" message="boom">trace</error>'
+    _write(root_a, "a.xml", _suite(_case("z_error", terminal=error)))
+    _write(root_a, "b.xml", _suite(_case("a_failure", terminal=failure_a)))
+    _write(root_b, "a.xml", _suite(_case("z_error", terminal=error)))
+    _write(root_b, "b.xml", _suite(_case("a_failure", terminal=failure_b)))
+
+    summary_a = summarize_junit(root_a, ("a.xml", "b.xml"))
+    reordered_a = summarize_junit(root_a, ("b.xml", "a.xml"))
+    summary_b = summarize_junit(root_b, ("a.xml", "b.xml"))
+
+    assert summary_a.outcome == "FAIL"
+    assert summary_a.failure_count == 1
+    assert summary_a.error_count == 1
+    assert summary_a.first_failure_fingerprint == reordered_a.first_failure_fingerprint
+    assert summary_a.first_failure_fingerprint == summary_b.first_failure_fingerprint
+    assert summary_a.test_ids_digest == reordered_a.test_ids_digest
+    assert summary_a.report_digests == reordered_a.report_digests
+
+
+def test_report_digest_tracks_exact_bytes_while_test_manifest_stays_stable(
+    tmp_path: Path,
+) -> None:
+    path = _write(tmp_path, "results.xml", _suite(_case("same")))
+    first = summarize_junit(tmp_path, ("results.xml",))
+    path.write_text(_suite(_case("same", time="0.002")), encoding="utf-8")
+    second = summarize_junit(tmp_path, ("results.xml",))
+
+    assert first.report_digests != second.report_digests
+    assert first.test_ids_digest == second.test_ids_digest
+    assert first.duration_ms != second.duration_ms
+
+
+def test_namespace_junit_is_supported(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "results.xml",
+        '<testsuites xmlns="urn:junit"><testsuite>'
+        '<testcase classname="tests.ns" name="works" time="0"/>'
+        "</testsuite></testsuites>",
+    )
+
+    summary = summarize_junit(tmp_path, ("results.xml",))
+
+    assert summary.outcome == "PASS"
+    assert summary.test_count == 1
+
+
+def test_duplicate_or_conflicting_cases_fail_closed_without_echoing_test_id(
+    tmp_path: Path,
+) -> None:
+    sensitive_id = "parameter-secret-value"
+    _write(tmp_path, "one.xml", _suite(_case(sensitive_id)))
+    _write(tmp_path, "two.xml", _suite(_case(sensitive_id)))
+    with pytest.raises(JUnitEvidenceError, match="duplicate_testcase") as duplicate:
+        summarize_junit(tmp_path, ("one.xml", "two.xml"))
+    assert sensitive_id not in str(duplicate.value)
+
+    _write(
+        tmp_path,
+        "conflict.xml",
+        _suite(
+            _case(
+                sensitive_id,
+                terminal="<failure>one</failure><error>two</error>",
+            )
+        ),
+    )
+    with pytest.raises(JUnitEvidenceError, match="conflicting_outcomes") as conflict:
+        summarize_junit(tmp_path, ("conflict.xml",))
+    assert sensitive_id not in str(conflict.value)
+
+
+@pytest.mark.parametrize("duration", ["-1", "NaN", "Infinity", "60.001", "1e999999"])
+def test_invalid_or_oversized_duration_is_rejected(
+    tmp_path: Path,
+    duration: str,
+) -> None:
+    _write(tmp_path, "results.xml", _suite(_case("bad", time=duration)))
+
+    with pytest.raises(JUnitEvidenceError, match="invalid_test_duration"):
+        summarize_junit(tmp_path, ("results.xml",))
+
+
+def test_empty_report_and_missing_optional_test_fail_closed(tmp_path: Path) -> None:
+    _write(tmp_path, "empty.xml", "<testsuite/>")
+    with pytest.raises(JUnitEvidenceError, match="no_testcases"):
+        summarize_junit(tmp_path, ("empty.xml",))
+
+    _write(tmp_path, "results.xml", _suite(_case("present")))
+    with pytest.raises(JUnitEvidenceError, match="optional_test_missing"):
+        summarize_junit(
+            tmp_path,
+            ("results.xml",),
+            optional_test_ids=("tests.example::missing",),
+        )
+
+
+def test_external_entity_declarations_are_rejected_before_parsing(
+    tmp_path: Path,
+) -> None:
+    _write(
+        tmp_path,
+        "results.xml",
+        '<!DOCTYPE x [<!ENTITY data SYSTEM "file:///etc/passwd">]>'
+        '<testsuite><testcase classname="x" name="y">'
+        "<failure>&data;</failure></testcase></testsuite>",
+    )
+
+    with pytest.raises(JUnitEvidenceError, match="xml_declaration_forbidden"):
+        summarize_junit(tmp_path, ("results.xml",))
+
+
+def test_path_escape_symlink_and_non_regular_report_are_rejected(
+    tmp_path: Path,
+) -> None:
+    outside = _write(tmp_path.parent, "outside.xml", _suite(_case("outside")))
+    with pytest.raises(JUnitEvidenceError, match="path_escape"):
+        summarize_junit(tmp_path, ("../outside.xml",))
+
+    link = tmp_path / "link.xml"
+    link.symlink_to(outside)
+    with pytest.raises(JUnitEvidenceError, match="symlink_input"):
+        summarize_junit(tmp_path, ("link.xml",))
+
+    if os.name == "posix":
+        fifo = tmp_path / "fifo.xml"
+        os.mkfifo(fifo)
+        with pytest.raises(JUnitEvidenceError, match="non_regular_report"):
+            summarize_junit(tmp_path, ("fifo.xml",))
+
+
+def test_cli_writes_private_new_json_and_does_not_overwrite_inputs(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    report = _write(
+        tmp_path,
+        "results.xml",
+        _suite(_case("required", terminal="<failure>no</failure>")),
+    )
+
+    exit_code = junit_main(
+        (
+            "--repo-root",
+            str(tmp_path),
+            "--report",
+            "results.xml",
+            "--output",
+            "summary.json",
+        )
+    )
+    payload = json.loads((tmp_path / "summary.json").read_text(encoding="utf-8"))
+
+    assert exit_code == 0
+    assert payload["outcome"] == "FAIL"
+    assert payload["required_skip_count"] == 0
+    assert stat.S_IMODE((tmp_path / "summary.json").stat().st_mode) == 0o600
+    assert report.read_text(encoding="utf-8").startswith("<testsuite")
+    assert capsys.readouterr().err == ""
+
+    assert junit_main(
+        (
+            "--repo-root",
+            str(tmp_path),
+            "--report",
+            "results.xml",
+            "--output",
+            "summary.json",
+        )
+    ) == 2
+    assert "output_exists" in capsys.readouterr().err
+
+    assert junit_main(
+        (
+            "--repo-root",
+            str(tmp_path),
+            "--report",
+            "results.xml",
+            "--output",
+            "results.xml",
+        )
+    ) == 2
+    assert "output_overwrites_report" in capsys.readouterr().err
+
+
+def test_cli_invalid_xml_returns_typed_mismatch_without_raw_xml(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    sensitive = "xml-secret-value"
+    _write(tmp_path, "bad.xml", f"<testsuite>{sensitive}")
+
+    exit_code = junit_main(
+        (
+            "--repo-root",
+            str(tmp_path),
+            "--report",
+            "bad.xml",
+        )
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert captured.out == ""
+    assert captured.err.strip() == "EVIDENCE_MISMATCH:junit:invalid_xml"
+    assert sensitive not in captured.err

--- a/newsroom/tests/test_sdlc_junit_evidence.py
+++ b/newsroom/tests/test_sdlc_junit_evidence.py
@@ -90,7 +90,7 @@ def test_failure_error_and_first_fingerprint_are_order_independent(
     root_b = tmp_path / "two"
     failure_a = (
         '<failure type="AssertionError" message="bad">'
-        f"\x1b[31m{root_a}/module.py:7: assertion failed\x1b[0m"
+        f"{root_a}/module.py:7: assertion failed"
         "</failure>"
     )
     failure_b = failure_a.replace(str(root_a), str(root_b))
@@ -166,6 +166,13 @@ def test_duplicate_or_conflicting_cases_fail_closed_without_echoing_test_id(
     assert sensitive_id not in str(conflict.value)
 
 
+def test_normalized_duplicate_report_path_is_rejected(tmp_path: Path) -> None:
+    _write(tmp_path, "results.xml", _suite(_case("one")))
+
+    with pytest.raises(JUnitEvidenceError, match="duplicate_report"):
+        summarize_junit(tmp_path, ("results.xml", "./results.xml"))
+
+
 @pytest.mark.parametrize("duration", ["-1", "NaN", "Infinity", "60.001", "1e999999"])
 def test_invalid_or_oversized_duration_is_rejected(
     tmp_path: Path,
@@ -209,9 +216,13 @@ def test_external_entity_declarations_are_rejected_before_parsing(
 def test_path_escape_symlink_and_non_regular_report_are_rejected(
     tmp_path: Path,
 ) -> None:
-    outside = _write(tmp_path.parent, "outside.xml", _suite(_case("outside")))
+    outside = _write(
+        tmp_path.parent,
+        f"outside-{tmp_path.name}.xml",
+        _suite(_case("outside")),
+    )
     with pytest.raises(JUnitEvidenceError, match="path_escape"):
-        summarize_junit(tmp_path, ("../outside.xml",))
+        summarize_junit(tmp_path, (f"../{outside.name}",))
 
     link = tmp_path / "link.xml"
     link.symlink_to(outside)

--- a/scripts/sdlc/junit_evidence.py
+++ b/scripts/sdlc/junit_evidence.py
@@ -18,6 +18,7 @@ SCHEMA_VERSION = "newsroom.sdlc.junit-summary.v1"
 _MAX_REPORTS = 32
 _MAX_REPORT_BYTES = 16 * 1024 * 1024
 _MAX_TESTS = 100_000
+_MAX_TEST_SECONDS = Decimal("60")
 _MAX_FIELD_CHARS = 262_144
 _ANSI = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 
@@ -78,7 +79,12 @@ def _local_name(tag: str) -> str:
 
 def _safe_relative(root: Path, relative: str | Path, *, must_exist: bool) -> Path:
     candidate = Path(relative)
-    if candidate.is_absolute() or not candidate.parts or ".." in candidate.parts:
+    if (
+        candidate.is_absolute()
+        or not candidate.parts
+        or ".." in candidate.parts
+        or "\\" in str(relative)
+    ):
         raise JUnitEvidenceError("path_escape")
     unresolved = root / candidate
     current = root
@@ -89,22 +95,30 @@ def _safe_relative(root: Path, relative: str | Path, *, must_exist: bool) -> Pat
     resolved = unresolved.resolve()
     if not resolved.is_relative_to(root):
         raise JUnitEvidenceError("path_escape")
-    if must_exist:
-        try:
-            mode = os.lstat(unresolved).st_mode
-        except OSError as exc:
-            raise JUnitEvidenceError("missing_report") from exc
-        if not stat.S_ISREG(mode):
-            raise JUnitEvidenceError("non_regular_report")
+    if must_exist and not unresolved.exists():
+        raise JUnitEvidenceError("missing_report")
     return unresolved
 
 
 def _read_report(root: Path, relative: str) -> tuple[bytes, str]:
     path = _safe_relative(root, relative, must_exist=True)
-    size = path.stat().st_size
-    if size <= 0 or size > _MAX_REPORT_BYTES:
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise JUnitEvidenceError("report_open") from exc
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise JUnitEvidenceError("non_regular_report")
+        if metadata.st_size <= 0 or metadata.st_size > _MAX_REPORT_BYTES:
+            raise JUnitEvidenceError("report_size")
+        with os.fdopen(descriptor, "rb", closefd=False) as stream:
+            payload = stream.read(_MAX_REPORT_BYTES + 1)
+    finally:
+        os.close(descriptor)
+    if not payload or len(payload) > _MAX_REPORT_BYTES:
         raise JUnitEvidenceError("report_size")
-    payload = path.read_bytes()
     upper = payload.upper()
     if b"<!DOCTYPE" in upper or b"<!ENTITY" in upper:
         raise JUnitEvidenceError("xml_declaration_forbidden")
@@ -136,7 +150,7 @@ def _duration_seconds(case: ET.Element) -> Decimal:
         value = Decimal(raw)
     except InvalidOperation as exc:
         raise JUnitEvidenceError("invalid_test_duration") from exc
-    if not value.is_finite() or value < 0:
+    if not value.is_finite() or value < 0 or value > _MAX_TEST_SECONDS:
         raise JUnitEvidenceError("invalid_test_duration")
     return value
 
@@ -175,19 +189,26 @@ def summarize_junit(
     optional_test_ids: Iterable[str] = (),
 ) -> JUnitSummary:
     root = Path(repo_root).resolve()
+    if not root.is_dir():
+        raise JUnitEvidenceError("repo_root_missing")
     report_names = tuple(str(item) for item in reports)
     if not report_names or len(report_names) > _MAX_REPORTS:
         raise JUnitEvidenceError("report_count")
-    if len(set(report_names)) != len(report_names):
-        raise JUnitEvidenceError("duplicate_report")
-    optional = frozenset(optional_test_ids)
-    if any(not item for item in optional):
-        raise JUnitEvidenceError("optional_test_id_empty")
+    optional_values = tuple(optional_test_ids)
+    if len(optional_values) > _MAX_TESTS:
+        raise JUnitEvidenceError("optional_test_count")
+    if any(not item or len(item) > _MAX_FIELD_CHARS for item in optional_values):
+        raise JUnitEvidenceError("optional_test_id_invalid")
+    optional = frozenset(optional_values)
 
     cases: dict[str, tuple[str, ET.Element | None, Decimal]] = {}
     report_digests: list[tuple[str, str]] = []
+    seen_reports: set[str] = set()
     for report in report_names:
         payload, normalized_path = _read_report(root, report)
+        if normalized_path in seen_reports:
+            raise JUnitEvidenceError("duplicate_report")
+        seen_reports.add(normalized_path)
         try:
             document = ET.fromstring(payload)
         except ET.ParseError as exc:
@@ -200,14 +221,14 @@ def summarize_junit(
         ):
             test_id = _case_id(case)
             if test_id in cases:
-                raise JUnitEvidenceError(f"duplicate_testcase:{test_id}")
+                raise JUnitEvidenceError("duplicate_testcase")
             terminals = [
                 child
                 for child in case
                 if _local_name(child.tag) in {"failure", "error", "skipped"}
             ]
             if len(terminals) > 1:
-                raise JUnitEvidenceError(f"conflicting_outcomes:{test_id}")
+                raise JUnitEvidenceError("conflicting_outcomes")
             outcome = _local_name(terminals[0].tag) if terminals else "passed"
             cases[test_id] = (
                 outcome,
@@ -219,8 +240,7 @@ def summarize_junit(
 
     if not cases:
         raise JUnitEvidenceError("no_testcases")
-    missing_optional = optional - cases.keys()
-    if missing_optional:
+    if optional - cases.keys():
         raise JUnitEvidenceError("optional_test_missing")
 
     failure_count = error_count = skip_count = required_skip_count = 0
@@ -281,11 +301,30 @@ def summarize_junit(
     )
 
 
-def _write_output(root: Path, relative: str, rendered: str) -> None:
+def _write_output(
+    root: Path,
+    relative: str,
+    rendered: str,
+    *,
+    report_paths: frozenset[str],
+) -> None:
     path = _safe_relative(root, relative, must_exist=False)
+    normalized = path.relative_to(root).as_posix()
+    if path.suffix != ".json":
+        raise JUnitEvidenceError("output_extension")
+    if normalized in report_paths:
+        raise JUnitEvidenceError("output_overwrites_report")
     if not path.parent.is_dir():
         raise JUnitEvidenceError("output_parent_missing")
-    path.write_text(rendered, encoding="utf-8")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0)
+    try:
+        descriptor = os.open(path, flags, 0o600)
+    except FileExistsError as exc:
+        raise JUnitEvidenceError("output_exists") from exc
+    except OSError as exc:
+        raise JUnitEvidenceError("output_open") from exc
+    with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+        stream.write(rendered)
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -308,7 +347,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             separators=(",", ":"),
         ) + "\n"
         if arguments.output:
-            _write_output(root, arguments.output, rendered)
+            _write_output(
+                root,
+                arguments.output,
+                rendered,
+                report_paths=frozenset(path for path, _ in summary.report_digests),
+            )
         else:
             sys.stdout.write(rendered)
     except (JUnitEvidenceError, OSError, UnicodeError) as exc:

--- a/scripts/sdlc/junit_evidence.py
+++ b/scripts/sdlc/junit_evidence.py
@@ -131,8 +131,12 @@ def _read_report(root: Path, relative: str) -> tuple[bytes, str]:
         os.close(descriptor)
     if not payload or len(payload) > _MAX_REPORT_BYTES:
         raise JUnitEvidenceError("report_size")
-    upper = payload.upper()
-    if b"<!DOCTYPE" in upper or b"<!ENTITY" in upper:
+    try:
+        decoded = payload.decode("utf-8-sig")
+    except UnicodeDecodeError as exc:
+        raise JUnitEvidenceError("invalid_encoding") from exc
+    upper = decoded.upper()
+    if "<!DOCTYPE" in upper or "<!ENTITY" in upper:
         raise JUnitEvidenceError("xml_declaration_forbidden")
     return payload, path.relative_to(root).as_posix()
 

--- a/scripts/sdlc/junit_evidence.py
+++ b/scripts/sdlc/junit_evidence.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import stat
+import sys
+from typing import Iterable, Sequence
+import xml.etree.ElementTree as ET
+
+
+SCHEMA_VERSION = "newsroom.sdlc.junit-summary.v1"
+_MAX_REPORTS = 32
+_MAX_REPORT_BYTES = 16 * 1024 * 1024
+_MAX_TESTS = 100_000
+_MAX_FIELD_CHARS = 262_144
+_ANSI = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+
+
+class JUnitEvidenceError(ValueError):
+    """Raised when JUnit bytes cannot become trustworthy gate evidence."""
+
+
+@dataclass(frozen=True)
+class JUnitSummary:
+    outcome: str
+    report_digests: tuple[tuple[str, str], ...]
+    test_ids_digest: str
+    test_count: int
+    failure_count: int
+    error_count: int
+    skip_count: int
+    required_skip_count: int
+    duration_ms: int
+    first_failure_fingerprint: str | None
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "outcome": self.outcome,
+            "reports": [
+                {"path": path, "digest": digest}
+                for path, digest in self.report_digests
+            ],
+            "test_ids_digest": self.test_ids_digest,
+            "test_count": self.test_count,
+            "failure_count": self.failure_count,
+            "error_count": self.error_count,
+            "skip_count": self.skip_count,
+            "required_skip_count": self.required_skip_count,
+            "duration_ms": self.duration_ms,
+            "first_failure_fingerprint": self.first_failure_fingerprint,
+        }
+
+
+def _canonical_json(value: object) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def _sha256(value: bytes) -> str:
+    return "sha256:" + hashlib.sha256(value).hexdigest()
+
+
+def _local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def _safe_relative(root: Path, relative: str | Path, *, must_exist: bool) -> Path:
+    candidate = Path(relative)
+    if candidate.is_absolute() or not candidate.parts or ".." in candidate.parts:
+        raise JUnitEvidenceError("path_escape")
+    unresolved = root / candidate
+    current = root
+    for part in candidate.parts:
+        current /= part
+        if current.is_symlink():
+            raise JUnitEvidenceError("symlink_input")
+    resolved = unresolved.resolve()
+    if not resolved.is_relative_to(root):
+        raise JUnitEvidenceError("path_escape")
+    if must_exist:
+        try:
+            mode = os.lstat(unresolved).st_mode
+        except OSError as exc:
+            raise JUnitEvidenceError("missing_report") from exc
+        if not stat.S_ISREG(mode):
+            raise JUnitEvidenceError("non_regular_report")
+    return unresolved
+
+
+def _read_report(root: Path, relative: str) -> tuple[bytes, str]:
+    path = _safe_relative(root, relative, must_exist=True)
+    size = path.stat().st_size
+    if size <= 0 or size > _MAX_REPORT_BYTES:
+        raise JUnitEvidenceError("report_size")
+    payload = path.read_bytes()
+    upper = payload.upper()
+    if b"<!DOCTYPE" in upper or b"<!ENTITY" in upper:
+        raise JUnitEvidenceError("xml_declaration_forbidden")
+    return payload, path.relative_to(root).as_posix()
+
+
+def _field(value: str | None, name: str) -> str:
+    text = value or ""
+    if len(text) > _MAX_FIELD_CHARS:
+        raise JUnitEvidenceError(f"field_too_large:{name}")
+    return text
+
+
+def _case_id(case: ET.Element) -> str:
+    name = _field(case.attrib.get("name"), "name").strip()
+    if not name:
+        raise JUnitEvidenceError("testcase_name_missing")
+    owner = (
+        _field(case.attrib.get("classname"), "classname").strip()
+        or _field(case.attrib.get("file"), "file").strip()
+        or "<unknown>"
+    )
+    return f"{owner}::{name}"
+
+
+def _duration_seconds(case: ET.Element) -> Decimal:
+    raw = case.attrib.get("time", "0").strip()
+    try:
+        value = Decimal(raw)
+    except InvalidOperation as exc:
+        raise JUnitEvidenceError("invalid_test_duration") from exc
+    if not value.is_finite() or value < 0:
+        raise JUnitEvidenceError("invalid_test_duration")
+    return value
+
+
+def _normalized_failure_text(value: str, root: Path) -> str:
+    text = _field(value, "failure_text")
+    text = _ANSI.sub("", text.replace("\r\n", "\n").replace("\r", "\n"))
+    text = text.replace(str(root), "<repo>")
+    return "\n".join(line.rstrip() for line in text.strip().splitlines())
+
+
+def _failure_fingerprint(
+    *,
+    test_id: str,
+    outcome: str,
+    element: ET.Element,
+    root: Path,
+) -> str:
+    payload = {
+        "test_id": test_id,
+        "outcome": outcome,
+        "type": _field(element.attrib.get("type"), "failure_type"),
+        "message": _normalized_failure_text(
+            _field(element.attrib.get("message"), "failure_message"),
+            root,
+        ),
+        "text": _normalized_failure_text("".join(element.itertext()), root),
+    }
+    return _sha256(_canonical_json(payload))
+
+
+def summarize_junit(
+    repo_root: str | Path,
+    reports: Iterable[str | Path],
+    *,
+    optional_test_ids: Iterable[str] = (),
+) -> JUnitSummary:
+    root = Path(repo_root).resolve()
+    report_names = tuple(str(item) for item in reports)
+    if not report_names or len(report_names) > _MAX_REPORTS:
+        raise JUnitEvidenceError("report_count")
+    if len(set(report_names)) != len(report_names):
+        raise JUnitEvidenceError("duplicate_report")
+    optional = frozenset(optional_test_ids)
+    if any(not item for item in optional):
+        raise JUnitEvidenceError("optional_test_id_empty")
+
+    cases: dict[str, tuple[str, ET.Element | None, Decimal]] = {}
+    report_digests: list[tuple[str, str]] = []
+    for report in report_names:
+        payload, normalized_path = _read_report(root, report)
+        try:
+            document = ET.fromstring(payload)
+        except ET.ParseError as exc:
+            raise JUnitEvidenceError("invalid_xml") from exc
+        if _local_name(document.tag) not in {"testsuite", "testsuites"}:
+            raise JUnitEvidenceError("invalid_junit_root")
+        report_digests.append((normalized_path, _sha256(payload)))
+        for case in (
+            item for item in document.iter() if _local_name(item.tag) == "testcase"
+        ):
+            test_id = _case_id(case)
+            if test_id in cases:
+                raise JUnitEvidenceError(f"duplicate_testcase:{test_id}")
+            terminals = [
+                child
+                for child in case
+                if _local_name(child.tag) in {"failure", "error", "skipped"}
+            ]
+            if len(terminals) > 1:
+                raise JUnitEvidenceError(f"conflicting_outcomes:{test_id}")
+            outcome = _local_name(terminals[0].tag) if terminals else "passed"
+            cases[test_id] = (
+                outcome,
+                terminals[0] if terminals else None,
+                _duration_seconds(case),
+            )
+            if len(cases) > _MAX_TESTS:
+                raise JUnitEvidenceError("test_count")
+
+    if not cases:
+        raise JUnitEvidenceError("no_testcases")
+    missing_optional = optional - cases.keys()
+    if missing_optional:
+        raise JUnitEvidenceError("optional_test_missing")
+
+    failure_count = error_count = skip_count = required_skip_count = 0
+    gate_failures: list[tuple[str, str, str]] = []
+    duration = Decimal(0)
+    for test_id in sorted(cases):
+        outcome, terminal, seconds = cases[test_id]
+        duration += seconds
+        if outcome == "failure":
+            failure_count += 1
+        elif outcome == "error":
+            error_count += 1
+        elif outcome == "skipped":
+            skip_count += 1
+            if test_id not in optional:
+                required_skip_count += 1
+        if outcome in {"failure", "error"} or (
+            outcome == "skipped" and test_id not in optional
+        ):
+            assert terminal is not None
+            gate_failures.append(
+                (
+                    test_id,
+                    outcome,
+                    _failure_fingerprint(
+                        test_id=test_id,
+                        outcome=outcome,
+                        element=terminal,
+                        root=root,
+                    ),
+                )
+            )
+
+    outcome = (
+        "FAIL"
+        if failure_count or error_count or required_skip_count
+        else "PASS"
+    )
+    duration_ms = int(
+        (duration * 1000).to_integral_value(rounding=ROUND_HALF_UP)
+    )
+    first_fingerprint = (
+        sorted(gate_failures, key=lambda item: (item[0], item[1]))[0][2]
+        if gate_failures
+        else None
+    )
+    return JUnitSummary(
+        outcome=outcome,
+        report_digests=tuple(sorted(report_digests)),
+        test_ids_digest=_sha256(_canonical_json(sorted(cases))),
+        test_count=len(cases),
+        failure_count=failure_count,
+        error_count=error_count,
+        skip_count=skip_count,
+        required_skip_count=required_skip_count,
+        duration_ms=duration_ms,
+        first_failure_fingerprint=first_fingerprint,
+    )
+
+
+def _write_output(root: Path, relative: str, rendered: str) -> None:
+    path = _safe_relative(root, relative, must_exist=False)
+    if not path.parent.is_dir():
+        raise JUnitEvidenceError("output_parent_missing")
+    path.write_text(rendered, encoding="utf-8")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Summarize exact JUnit evidence")
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--report", action="append", required=True)
+    parser.add_argument("--optional-test-id", action="append", default=[])
+    parser.add_argument("--output")
+    arguments = parser.parse_args(argv)
+    root = Path(arguments.repo_root).resolve()
+    try:
+        summary = summarize_junit(
+            root,
+            arguments.report,
+            optional_test_ids=arguments.optional_test_id,
+        )
+        rendered = json.dumps(
+            summary.as_dict(),
+            sort_keys=True,
+            separators=(",", ":"),
+        ) + "\n"
+        if arguments.output:
+            _write_output(root, arguments.output, rendered)
+        else:
+            sys.stdout.write(rendered)
+    except (JUnitEvidenceError, OSError, UnicodeError) as exc:
+        reason = str(exc) or type(exc).__name__
+        print(f"EVIDENCE_MISMATCH:junit:{reason}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sdlc/junit_evidence.py
+++ b/scripts/sdlc/junit_evidence.py
@@ -95,14 +95,26 @@ def _safe_relative(root: Path, relative: str | Path, *, must_exist: bool) -> Pat
     resolved = unresolved.resolve()
     if not resolved.is_relative_to(root):
         raise JUnitEvidenceError("path_escape")
-    if must_exist and not unresolved.exists():
-        raise JUnitEvidenceError("missing_report")
+    if must_exist:
+        try:
+            metadata = os.lstat(unresolved)
+        except FileNotFoundError as exc:
+            raise JUnitEvidenceError("missing_report") from exc
+        except OSError as exc:
+            raise JUnitEvidenceError("report_stat") from exc
+        if not stat.S_ISREG(metadata.st_mode):
+            raise JUnitEvidenceError("non_regular_report")
     return unresolved
 
 
 def _read_report(root: Path, relative: str) -> tuple[bytes, str]:
     path = _safe_relative(root, relative, must_exist=True)
-    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_NONBLOCK", 0)
+    )
     try:
         descriptor = os.open(path, flags)
     except OSError as exc:
@@ -310,10 +322,10 @@ def _write_output(
 ) -> None:
     path = _safe_relative(root, relative, must_exist=False)
     normalized = path.relative_to(root).as_posix()
-    if path.suffix != ".json":
-        raise JUnitEvidenceError("output_extension")
     if normalized in report_paths:
         raise JUnitEvidenceError("output_overwrites_report")
+    if path.suffix != ".json":
+        raise JUnitEvidenceError("output_extension")
     if not path.parent.is_dir():
         raise JUnitEvidenceError("output_parent_missing")
     flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0)


### PR DESCRIPTION
## Status

Phase **1B2a** of issue #100 under accepted SDLC #98. Source-only, exact-head green and ready for review.

Reviewed head:

`6171fe54c9e463e57aa66469c4b470e4cd0a3fa9`

Base:

`main@19099dd01c0db0db0505d73d784d445c3266b7be`

This unit converts one or more exact JUnit XML reports into a bounded deterministic summary. Canonical gate evidence identity/schema composition remains Phase 1B2b; GitHub workflow orchestration remains Phase 2. Existing required workflows are unchanged.

## Scope

- derive counts from exact testcase nodes rather than trusting suite summary attributes;
- exact report-byte SHA-256 and deterministic test-ID manifest digest;
- failure, error, skip and required-skip accounting;
- optional skips remain explicit without weakening required skips;
- stable first-failure fingerprint sorted by canonical test ID;
- normalize checkout-root paths and line endings before fingerprinting;
- report-order independence and namespace-aware JUnit parsing;
- bounded reports, bytes, fields, test counts and individual durations;
- reject duplicate testcase identities and conflicting terminal outcomes;
- reject non-UTF-8 input, DOCTYPE/ENTITY declarations, path escape, symlink and non-regular input;
- pre-open `lstat`, `O_NOFOLLOW`/`O_NONBLOCK`, descriptor `fstat` and exact-byte digesting;
- private new `.json` output only, with no report overwrite or existing-output replacement;
- a valid failing test result still produces valid summary evidence; nonzero CLI exit is reserved for evidence mismatch.

## Review-trigger decomposition note

The accepted trigger is 400 net executable lines / 12 files. This PR changes three files but exceeds the line trigger because parser/resource constraints and the adversarial matrix are one evidence boundary. Splitting the parser from required-skip, fingerprint, filesystem, encoding and malformed-XML tests would temporarily create an unqualified evidence producer. Canonical gate evidence and workflow use remain separate PRs.

## Substantive review corrections

P1: 0. P2 found and corrected: 6. Unresolved P1/P2: 0.

1. Duplicate/conflict errors could echo parameterized test IDs; all mismatch reasons are now bounded static codes.
2. Extreme Decimal durations could create disproportionate processing; each testcase duration must be finite, nonnegative and at most 60 seconds.
3. Summary output could overwrite an input report or existing result; output is new, private, `.json`-only and fail-closed on collision.
4. Opening a FIFO before type validation could block the evidence gate; non-regular inputs are rejected before open and revalidated on the descriptor.
5. Final-path replacement between validation and read required `O_NOFOLLOW`, `O_NONBLOCK` and descriptor `fstat`, while exact bytes read remain the digest source.
6. A UTF-16 report could bypass the byte-oriented DOCTYPE/ENTITY scan; JUnit is now restricted to UTF-8/UTF-8-BOM before declaration scanning.

The adversarial matrix also proves optional versus required skips, exact count derivation, report-order and checkout-root fingerprint stability, duplicate normalized report detection, namespace handling, report digest sensitivity, malformed XML privacy, path escape, symlink/non-regular rejection and 0600 output creation.

## Exact-head validation

Head `6171fe54c9e463e57aa66469c4b470e4cd0a3fa9`:

- Authority A2a run `29899346046`: success;
- Authority A2b run `29899345898`: success;
- Projection B1 run `29899345902`: success;
- Projection B2 Neo4j run `29899345914`: success;
- complete repository CI and clustering run `29899345881`: success;
- unresolved inline review threads: zero.

## Changed files

- `scripts/sdlc/junit_evidence.py`;
- `newsroom/tests/test_sdlc_junit_evidence.py`;
- `newsroom/tests/test_sdlc_junit_encoding.py`.

## Exclusions

No canonical gate evidence builder, evidence-schema composition, GitHub workflow, cache, test selection, Neo4j process change, current required-check change, release, production, Graphiti/model/embedding/live-source execution, publication, product shadow, canary, spending or public effect.