### PR TITLE
feat(sdlc): compose exact canonical gate evidence

### DIFF
--- a/.sdlc/evidence.schema.json
+++ b/.sdlc/evidence.schema.json
@@ -6,6 +6,7 @@
   "additionalProperties": false,
   "required": [
     "schema_version",
+    "evidence_identity",
     "gate_id",
     "gate_contract_version",
     "risk_classifier_version",
@@ -48,14 +49,19 @@
     "schema_version": {
       "const": "newsroom.sdlc.evidence.v1"
     },
+    "evidence_identity": {
+      "$ref": "#/$defs/sha256"
+    },
     "gate_id": {
       "type": "string",
       "minLength": 1,
-      "maxLength": 128
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9_.*-]+$"
     },
     "gate_contract_version": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "maxLength": 128
     },
     "repository": {
       "const": "fol2/newsroom"
@@ -82,8 +88,10 @@
       "type": "array",
       "items": {
         "type": "string",
-        "minLength": 1
+        "minLength": 1,
+        "maxLength": 512
       },
+      "maxItems": 4096,
       "uniqueItems": true
     },
     "runner_kind": {
@@ -110,18 +118,21 @@
       "type": [
         "string",
         "null"
-      ]
+      ],
+      "maxLength": 512
     },
     "cache_hit": {
       "type": "boolean"
     },
     "python_version": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "maxLength": 128
     },
     "uv_version": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "maxLength": 128
     },
     "lockfile_digest": {
       "$ref": "#/$defs/sha256"
@@ -146,30 +157,37 @@
       "type": "array",
       "items": {
         "type": "string",
-        "minLength": 1
+        "minLength": 1,
+        "maxLength": 1024
       },
+      "maxItems": 100000,
       "uniqueItems": true
     },
     "sentinel_tests": {
       "type": "array",
       "items": {
         "type": "string",
-        "minLength": 1
+        "minLength": 1,
+        "maxLength": 1024
       },
+      "maxItems": 10000,
       "uniqueItems": true
     },
     "random_sample_seed": {
       "type": [
         "string",
         "null"
-      ]
+      ],
+      "maxLength": 256
     },
     "random_sample_tests": {
       "type": "array",
       "items": {
         "type": "string",
-        "minLength": 1
+        "minLength": 1,
+        "maxLength": 1024
       },
+      "maxItems": 100000,
       "uniqueItems": true
     },
     "test_count": {
@@ -185,9 +203,13 @@
       "$ref": "#/$defs/nonnegativeInteger"
     },
     "first_failure_fingerprint": {
-      "type": [
-        "string",
-        "null"
+      "oneOf": [
+        {
+          "$ref": "#/$defs/sha256"
+        },
+        {
+          "type": "null"
+        }
       ]
     },
     "result": {
@@ -203,7 +225,8 @@
     },
     "result_reason": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "maxLength": 512
     },
     "created_at": {
       "type": "string",
@@ -211,7 +234,8 @@
     },
     "risk_classifier_version": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "maxLength": 128
     },
     "base_tree_sha": {
       "$ref": "#/$defs/gitSha"
@@ -234,7 +258,8 @@
     },
     "nonnegativeInteger": {
       "type": "integer",
-      "minimum": 0
+      "minimum": 0,
+      "maximum": 9223372036854775807
     }
   },
   "allOf": [
@@ -259,6 +284,9 @@
           },
           "required_skip_count": {
             "const": 0
+          },
+          "first_failure_fingerprint": {
+            "type": "null"
           }
         }
       }

--- a/newsroom/tests/test_sdlc_evidence.py
+++ b/newsroom/tests/test_sdlc_evidence.py
@@ -11,6 +11,7 @@ import subprocess
 from jsonschema import Draft202012Validator, FormatChecker
 import pytest
 
+from scripts.sdlc import emit_evidence
 from scripts.sdlc.classify_change import resolve_commit, resolve_tree
 from scripts.sdlc.contracts import SdlcContract, load_contract
 from scripts.sdlc.emit_evidence import (
@@ -346,6 +347,28 @@ def test_claimed_uv_version_must_match_the_executable(tmp_path: Path) -> None:
         )
 
 
+def test_gate_run_reason_is_bound_to_gate_phase_and_exit_code(
+    tmp_path: Path,
+) -> None:
+    contract, head, tree = _repository(tmp_path)
+    route = _route(contract, head, tree)
+
+    wrong_gate = _gate_run()
+    wrong_gate["result_reason"] = "PASS:route:tests"
+    with pytest.raises(EvidenceError, match="gate_run_reason"):
+        _build(contract, route, gate_run=wrong_gate)
+
+    wrong_phase = _gate_run()
+    wrong_phase["result_reason"] = "PASS:core-deterministic:other"
+    with pytest.raises(EvidenceError, match="gate_run_reason"):
+        _build(contract, route, gate_run=wrong_phase)
+
+    wrong_exit = _gate_run(result="FAIL")
+    wrong_exit["result_reason"] = "FAIL:core-deterministic:tests:exit=8"
+    with pytest.raises(EvidenceError, match="gate_run_reason"):
+        _build(contract, route, gate_run=wrong_exit, junit=None)
+
+
 def test_gate_run_and_junit_internal_inconsistency_are_rejected(
     tmp_path: Path,
 ) -> None:
@@ -362,18 +385,29 @@ def test_gate_run_and_junit_internal_inconsistency_are_rejected(
         _build(contract, route, junit=invalid_junit)
 
 
-def test_exact_git_blob_wins_over_dirty_worktree_lockfile(tmp_path: Path) -> None:
+def test_exact_git_blob_wins_over_dirty_untracked_lockfile_bytes(
+    tmp_path: Path,
+) -> None:
     contract, head, tree = _repository(tmp_path)
-    (tmp_path / "uv.lock").write_text("tampered = true\n", encoding="utf-8")
+    (tmp_path / "untracked-evidence.json").write_text("{}", encoding="utf-8")
 
     record = _build(contract, _route(contract, head, tree))
 
     assert record["lockfile_digest"] == (
         "sha256:" + hashlib.sha256(b"version = 1\n").hexdigest()
     )
-    assert record["lockfile_digest"] != (
-        "sha256:" + hashlib.sha256(b"tampered = true\n").hexdigest()
+
+
+def test_tracked_worktree_drift_blocks_evidence(tmp_path: Path) -> None:
+    contract, head, tree = _repository(tmp_path)
+    contract_path = tmp_path / ".sdlc" / "gates.toml"
+    contract_path.write_text(
+        contract_path.read_text(encoding="utf-8") + "\n# dirty\n",
+        encoding="utf-8",
     )
+
+    with pytest.raises(EvidenceError, match="tracked_checkout_dirty"):
+        _build(contract, _route(contract, head, tree))
 
 
 def test_head_or_base_tree_mismatch_is_rejected(tmp_path: Path) -> None:
@@ -387,6 +421,21 @@ def test_head_or_base_tree_mismatch_is_rejected(tmp_path: Path) -> None:
     wrong_tree["base_tree_sha"] = "1" * 40
     with pytest.raises(EvidenceError, match="base_tree_mismatch"):
         _build(contract, wrong_tree)
+
+
+def test_atomic_output_failure_leaves_no_target_or_temporary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_link(*_args: object, **_kwargs: object) -> None:
+        raise OSError("simulated")
+
+    monkeypatch.setattr(emit_evidence.os, "link", fail_link)
+    with pytest.raises(EvidenceError, match="output_open"):
+        emit_evidence._write_json(tmp_path, "evidence.json", {"value": 1})
+
+    assert not (tmp_path / "evidence.json").exists()
+    assert list(tmp_path.glob(".evidence.json.*.tmp")) == []
 
 
 def test_cli_emits_private_schema_valid_record_and_never_overwrites(

--- a/newsroom/tests/test_sdlc_evidence.py
+++ b/newsroom/tests/test_sdlc_evidence.py
@@ -29,6 +29,7 @@ SERVICE_DIGEST = "sha256:" + "b" * 64
 REPORT_DIGEST = "sha256:" + "c" * 64
 TEST_IDS_DIGEST = "sha256:" + "d" * 64
 FAILURE_DIGEST = "sha256:" + "e" * 64
+_MISSING = object()
 
 
 def _git(repo: Path, *arguments: str) -> str:
@@ -160,7 +161,7 @@ def _build(
     route: dict[str, object],
     *,
     gate_run: dict[str, object] | None = None,
-    junit: dict[str, object] | None = None,
+    junit: object = _MISSING,
     command_digest: str = COMMAND_DIGEST,
     service_digest: str | None = None,
     queue_ms: int = 1,
@@ -169,7 +170,12 @@ def _build(
     created_at: str = "2026-07-22T07:30:00Z",
 ) -> dict[str, object]:
     run = gate_run or _gate_run()
-    selected_junit = _junit() if junit is None and run["result"] == "PASS" else junit
+    if junit is _MISSING:
+        selected_junit: object | None = (
+            _junit() if run["result"] == "PASS" else None
+        )
+    else:
+        selected_junit = junit
     return build_gate_evidence(
         repo_root=contract.repo_root,
         contract=contract,

--- a/newsroom/tests/test_sdlc_evidence.py
+++ b/newsroom/tests/test_sdlc_evidence.py
@@ -17,6 +17,7 @@ from scripts.sdlc.emit_evidence import (
     EvidenceError,
     build_gate_evidence,
     canonical_json_bytes,
+    installed_uv_version,
     main as evidence_main,
     sha256_identity,
     validate_evidence_record,
@@ -164,6 +165,7 @@ def _build(
     junit: object = _MISSING,
     command_digest: str = COMMAND_DIGEST,
     service_digest: str | None = None,
+    uv_version: str | None = None,
     queue_ms: int = 1,
     bootstrap_ms: int = 2,
     finalize_ms: int = 3,
@@ -188,7 +190,7 @@ def _build(
         finalize_ms=finalize_ms,
         cache_key=None,
         cache_hit=False,
-        uv_version="0.8.0",
+        uv_version=uv_version or installed_uv_version(),
         command_spec_digest=command_digest,
         service_compatibility_digest=service_digest,
         created_at=created_at,
@@ -223,6 +225,7 @@ def test_pass_record_is_exact_schema_valid_and_omits_process_output(
     )
     assert record["selected_tests"] == ["newsroom/tests"]
     assert record["test_count"] == 3
+    assert record["uv_version"] == installed_uv_version()
     assert "stdout" not in record
     assert "stderr" not in record
 
@@ -267,6 +270,11 @@ def test_required_skip_downgrades_process_pass_and_pass_tamper_is_rejected(
     assert record["result_reason"] == "FAIL:core-deterministic:junit"
     assert record["required_skip_count"] == 1
     assert record["first_failure_fingerprint"] == FAILURE_DIGEST
+
+    missing_fingerprint = deepcopy(record)
+    missing_fingerprint["first_failure_fingerprint"] = None
+    with pytest.raises(EvidenceError, match="failure_fingerprint_invariant"):
+        validate_evidence_record(missing_fingerprint)
 
     tampered = deepcopy(record)
     tampered["result"] = "PASS"
@@ -324,6 +332,17 @@ def test_selected_gate_requires_junit_and_service_gate_requires_compatibility(
             contract,
             route,
             service_digest=SERVICE_DIGEST,
+        )
+
+
+def test_claimed_uv_version_must_match_the_executable(tmp_path: Path) -> None:
+    contract, head, tree = _repository(tmp_path)
+
+    with pytest.raises(EvidenceError, match="uv_version_mismatch"):
+        _build(
+            contract,
+            _route(contract, head, tree),
+            uv_version="999.999.999-fake",
         )
 
 
@@ -405,7 +424,7 @@ def test_cli_emits_private_schema_valid_record_and_never_overwrites(
         "--finalize-ms",
         "3",
         "--uv-version",
-        "0.8.0",
+        installed_uv_version(),
         "--command-spec-digest",
         COMMAND_DIGEST,
         "--created-at",

--- a/newsroom/tests/test_sdlc_evidence.py
+++ b/newsroom/tests/test_sdlc_evidence.py
@@ -1,0 +1,417 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import hashlib
+import json
+from pathlib import Path
+import shutil
+import stat
+import subprocess
+
+from jsonschema import Draft202012Validator, FormatChecker
+import pytest
+
+from scripts.sdlc.classify_change import resolve_commit, resolve_tree
+from scripts.sdlc.contracts import SdlcContract, load_contract
+from scripts.sdlc.emit_evidence import (
+    EvidenceError,
+    build_gate_evidence,
+    canonical_json_bytes,
+    main as evidence_main,
+    sha256_identity,
+    validate_evidence_record,
+)
+
+
+REPO_ROOT = Path(__file__).parents[2]
+COMMAND_DIGEST = "sha256:" + "a" * 64
+SERVICE_DIGEST = "sha256:" + "b" * 64
+REPORT_DIGEST = "sha256:" + "c" * 64
+TEST_IDS_DIGEST = "sha256:" + "d" * 64
+FAILURE_DIGEST = "sha256:" + "e" * 64
+
+
+def _git(repo: Path, *arguments: str) -> str:
+    completed = subprocess.run(
+        ("git", *arguments),
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def _copy_contract(root: Path) -> None:
+    paths = (
+        ".sdlc/gates.toml",
+        ".sdlc/evidence.schema.json",
+        ".sdlc/route.schema.json",
+        "docs/specs/sdlc/high-performance-evidence-sdlc.md",
+        "docs/specs/sdlc/2026-07-22-sdlc-v2-owner-acceptance.md",
+    )
+    for relative in paths:
+        target = root / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(REPO_ROOT / relative, target)
+
+
+def _repository(tmp_path: Path) -> tuple[SdlcContract, str, str]:
+    _git(tmp_path, "init", "-b", "main")
+    _git(tmp_path, "config", "user.email", "test@example.invalid")
+    _git(tmp_path, "config", "user.name", "SDLC Test")
+    _copy_contract(tmp_path)
+    (tmp_path / "uv.lock").write_text("version = 1\n", encoding="utf-8")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-m", "fixture")
+    head = resolve_commit(tmp_path, "HEAD")
+    tree = resolve_tree(tmp_path, head)
+    return load_contract(tmp_path), head, tree
+
+
+def _route(
+    contract: SdlcContract,
+    head: str,
+    tree: str,
+    *,
+    risk_tier: str = "R0_DOCUMENTATION",
+) -> dict[str, object]:
+    service_required = contract.service_required(risk_tier)
+    core_tests = ["newsroom/tests"]
+    service_tests = (
+        ["newsroom/tests/test_projection_b2_neo4j_service.py"]
+        if service_required
+        else []
+    )
+    sentinels = list(contract.sentinels)
+    manifest_digest = sha256_identity(
+        {
+            "core_tests": core_tests,
+            "service_tests": service_tests,
+            "sentinels": sentinels,
+        }
+    )
+    return {
+        "schema_version": "newsroom.sdlc.route.v1",
+        "contract_version": contract.contract_version,
+        "base_sha": head,
+        "head_sha": head,
+        "base_tree_sha": tree,
+        "head_tree_sha": tree,
+        "risk_tier": risk_tier,
+        "reasons": ["no_changes"],
+        "core_required": True,
+        "service_required": service_required,
+        "clustering_required": False,
+        "owner_authority_required": contract.owner_authority_required(risk_tier),
+        "core_tests": core_tests,
+        "service_tests": service_tests,
+        "sentinels": sentinels,
+        "selected_test_manifest_digest": manifest_digest,
+    }
+
+
+def _gate_run(
+    gate_id: str = "core-deterministic",
+    *,
+    result: str = "PASS",
+) -> dict[str, object]:
+    returncode = 0 if result == "PASS" else 7 if result == "FAIL" else None
+    reason = (
+        f"PASS:{gate_id}:tests"
+        if result == "PASS"
+        else f"FAIL:{gate_id}:tests:exit=7"
+        if result == "FAIL"
+        else f"{result}:{gate_id}:tests"
+    )
+    return {
+        "schema_version": "newsroom.sdlc.gate-run.v1",
+        "gate_id": gate_id,
+        "phase": "tests",
+        "result": result,
+        "result_reason": reason,
+        "returncode": returncode,
+        "execution_ms": 321,
+        "stdout": "",
+        "stderr": "",
+        "stdout_truncated": False,
+        "stderr_truncated": False,
+    }
+
+
+def _junit(*, required_skip: bool = False) -> dict[str, object]:
+    return {
+        "schema_version": "newsroom.sdlc.junit-summary.v1",
+        "outcome": "FAIL" if required_skip else "PASS",
+        "reports": [{"path": "results.xml", "digest": REPORT_DIGEST}],
+        "test_ids_digest": TEST_IDS_DIGEST,
+        "test_count": 3,
+        "failure_count": 0,
+        "error_count": 0,
+        "skip_count": 1 if required_skip else 0,
+        "required_skip_count": 1 if required_skip else 0,
+        "duration_ms": 42,
+        "first_failure_fingerprint": FAILURE_DIGEST if required_skip else None,
+    }
+
+
+def _build(
+    contract: SdlcContract,
+    route: dict[str, object],
+    *,
+    gate_run: dict[str, object] | None = None,
+    junit: dict[str, object] | None = None,
+    command_digest: str = COMMAND_DIGEST,
+    service_digest: str | None = None,
+    queue_ms: int = 1,
+    bootstrap_ms: int = 2,
+    finalize_ms: int = 3,
+    created_at: str = "2026-07-22T07:30:00Z",
+) -> dict[str, object]:
+    run = gate_run or _gate_run()
+    selected_junit = _junit() if junit is None and run["result"] == "PASS" else junit
+    return build_gate_evidence(
+        repo_root=contract.repo_root,
+        contract=contract,
+        route=route,
+        gate_run=run,
+        junit_summary=selected_junit,
+        runner_kind="github-hosted",
+        queue_ms=queue_ms,
+        bootstrap_ms=bootstrap_ms,
+        finalize_ms=finalize_ms,
+        cache_key=None,
+        cache_hit=False,
+        uv_version="0.8.0",
+        command_spec_digest=command_digest,
+        service_compatibility_digest=service_digest,
+        created_at=created_at,
+    )
+
+
+def test_canonical_json_has_a_fixed_no_float_vector() -> None:
+    value = {"b": ["x", None, True], "a": 1}
+
+    assert canonical_json_bytes(value) == b'{"a":1,"b":["x",null,true]}'
+    assert sha256_identity(value) == (
+        "sha256:f3b8a4ec6b2ad1666747731d5601847491e0ae81f0585f2b1edb8aa823e8f3ff"
+    )
+    with pytest.raises(EvidenceError, match="canonical_value_type"):
+        canonical_json_bytes({"not_allowed": 1.5})
+
+
+def test_pass_record_is_exact_schema_valid_and_omits_process_output(
+    tmp_path: Path,
+) -> None:
+    contract, head, tree = _repository(tmp_path)
+    record = _build(contract, _route(contract, head, tree))
+    schema = json.loads(
+        (REPO_ROOT / ".sdlc" / "evidence.schema.json").read_text(encoding="utf-8")
+    )
+
+    Draft202012Validator(schema, format_checker=FormatChecker()).validate(record)
+    assert record["result"] == "PASS"
+    assert record["evidence_identity"].startswith("sha256:")
+    assert record["lockfile_digest"] == (
+        "sha256:" + hashlib.sha256(b"version = 1\n").hexdigest()
+    )
+    assert record["selected_tests"] == ["newsroom/tests"]
+    assert record["test_count"] == 3
+    assert "stdout" not in record
+    assert "stderr" not in record
+
+
+def test_identity_ignores_observation_time_but_changes_with_command_inputs(
+    tmp_path: Path,
+) -> None:
+    contract, head, tree = _repository(tmp_path)
+    route = _route(contract, head, tree)
+    first = _build(contract, route)
+    different_timings = _build(
+        contract,
+        route,
+        queue_ms=999,
+        bootstrap_ms=888,
+        finalize_ms=777,
+        created_at="2026-07-22T08:00:00Z",
+    )
+    different_command = _build(
+        contract,
+        route,
+        command_digest="sha256:" + "f" * 64,
+    )
+
+    assert first["evidence_identity"] == different_timings["evidence_identity"]
+    assert first["gate_inputs_digest"] == different_timings["gate_inputs_digest"]
+    assert first["evidence_identity"] != different_command["evidence_identity"]
+    assert first["gate_inputs_digest"] != different_command["gate_inputs_digest"]
+
+
+def test_required_skip_downgrades_process_pass_and_pass_tamper_is_rejected(
+    tmp_path: Path,
+) -> None:
+    contract, head, tree = _repository(tmp_path)
+    record = _build(
+        contract,
+        _route(contract, head, tree),
+        junit=_junit(required_skip=True),
+    )
+
+    assert record["result"] == "FAIL"
+    assert record["result_reason"] == "FAIL:core-deterministic:junit"
+    assert record["required_skip_count"] == 1
+    assert record["first_failure_fingerprint"] == FAILURE_DIGEST
+
+    tampered = deepcopy(record)
+    tampered["result"] = "PASS"
+    tampered["result_reason"] = "PASS:core-deterministic:junit"
+    with pytest.raises(EvidenceError, match="pass_invariant"):
+        validate_evidence_record(tampered)
+
+
+def test_route_manifest_and_identity_tamper_fail_closed(tmp_path: Path) -> None:
+    contract, head, tree = _repository(tmp_path)
+    route = _route(contract, head, tree)
+    route["core_tests"] = ["newsroom/other-tests"]
+    with pytest.raises(EvidenceError, match="route_selected_manifest_mismatch"):
+        _build(contract, route)
+
+    valid = _build(contract, _route(contract, head, tree))
+    valid["gate_inputs_digest"] = "sha256:" + "0" * 64
+    with pytest.raises(EvidenceError, match="evidence_identity_mismatch"):
+        validate_evidence_record(valid)
+
+
+def test_selected_gate_requires_junit_and_service_gate_requires_compatibility(
+    tmp_path: Path,
+) -> None:
+    contract, head, tree = _repository(tmp_path)
+    route = _route(contract, head, tree)
+    with pytest.raises(EvidenceError, match="junit_required"):
+        _build(contract, route, junit=None, gate_run=_gate_run())
+
+    service_route = _route(
+        contract,
+        head,
+        tree,
+        risk_tier="R3_EXTERNAL_SERVICE_SECURITY",
+    )
+    service_run = _gate_run("service-neo4j")
+    with pytest.raises(EvidenceError, match="service_compatibility_required"):
+        _build(
+            contract,
+            service_route,
+            gate_run=service_run,
+            junit=_junit(),
+        )
+    service_record = _build(
+        contract,
+        service_route,
+        gate_run=service_run,
+        junit=_junit(),
+        service_digest=SERVICE_DIGEST,
+    )
+    assert service_record["service_compatibility_digest"] == SERVICE_DIGEST
+
+    with pytest.raises(EvidenceError, match="service_compatibility_unexpected"):
+        _build(
+            contract,
+            route,
+            service_digest=SERVICE_DIGEST,
+        )
+
+
+def test_gate_run_and_junit_internal_inconsistency_are_rejected(
+    tmp_path: Path,
+) -> None:
+    contract, head, tree = _repository(tmp_path)
+    route = _route(contract, head, tree)
+    invalid_run = _gate_run()
+    invalid_run["result_reason"] = "FAIL:core-deterministic:tests:exit=7"
+    with pytest.raises(EvidenceError, match="gate_run_reason"):
+        _build(contract, route, gate_run=invalid_run, junit=_junit())
+
+    invalid_junit = _junit()
+    invalid_junit["required_skip_count"] = 1
+    with pytest.raises(EvidenceError, match="junit_required_skip_count"):
+        _build(contract, route, junit=invalid_junit)
+
+
+def test_exact_git_blob_wins_over_dirty_worktree_lockfile(tmp_path: Path) -> None:
+    contract, head, tree = _repository(tmp_path)
+    (tmp_path / "uv.lock").write_text("tampered = true\n", encoding="utf-8")
+
+    record = _build(contract, _route(contract, head, tree))
+
+    assert record["lockfile_digest"] == (
+        "sha256:" + hashlib.sha256(b"version = 1\n").hexdigest()
+    )
+    assert record["lockfile_digest"] != (
+        "sha256:" + hashlib.sha256(b"tampered = true\n").hexdigest()
+    )
+
+
+def test_head_or_base_tree_mismatch_is_rejected(tmp_path: Path) -> None:
+    contract, head, tree = _repository(tmp_path)
+    wrong_head = _route(contract, head, tree)
+    wrong_head["head_sha"] = "0" * 40
+    with pytest.raises(EvidenceError, match="head_mismatch"):
+        _build(contract, wrong_head)
+
+    wrong_tree = _route(contract, head, tree)
+    wrong_tree["base_tree_sha"] = "1" * 40
+    with pytest.raises(EvidenceError, match="base_tree_mismatch"):
+        _build(contract, wrong_tree)
+
+
+def test_cli_emits_private_schema_valid_record_and_never_overwrites(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    contract, head, tree = _repository(tmp_path)
+    route = _route(contract, head, tree)
+    inputs = {
+        "route.json": route,
+        "gate-run.json": _gate_run(),
+        "junit.json": _junit(),
+    }
+    for name, value in inputs.items():
+        (tmp_path / name).write_text(
+            json.dumps(value, sort_keys=True, separators=(",", ":")),
+            encoding="utf-8",
+        )
+
+    arguments = (
+        "--repo-root",
+        str(tmp_path),
+        "--route",
+        "route.json",
+        "--gate-run",
+        "gate-run.json",
+        "--junit-summary",
+        "junit.json",
+        "--runner-kind",
+        "github-hosted",
+        "--queue-ms",
+        "1",
+        "--bootstrap-ms",
+        "2",
+        "--finalize-ms",
+        "3",
+        "--uv-version",
+        "0.8.0",
+        "--command-spec-digest",
+        COMMAND_DIGEST,
+        "--created-at",
+        "2026-07-22T07:30:00Z",
+        "--output",
+        "evidence.json",
+    )
+    assert evidence_main(arguments) == 0
+    record = json.loads((tmp_path / "evidence.json").read_text(encoding="utf-8"))
+    assert validate_evidence_record(record) == record
+    assert stat.S_IMODE((tmp_path / "evidence.json").stat().st_mode) == 0o600
+    assert capsys.readouterr().err == ""
+
+    assert evidence_main(arguments) == 2
+    assert "EVIDENCE_MISMATCH:gate:output_exists" in capsys.readouterr().err

--- a/scripts/sdlc/emit_evidence.py
+++ b/scripts/sdlc/emit_evidence.py
@@ -13,7 +13,7 @@ import subprocess
 import sys
 from typing import Mapping, Sequence
 
-from .classify_change import resolve_commit, resolve_tree
+from .classify_change import GitRouteError, resolve_commit, resolve_tree
 from .contracts import ContractError, SdlcContract, load_contract
 
 
@@ -39,6 +39,15 @@ _RESULTS = frozenset(
         "ENVIRONMENT_ERROR",
         "EVIDENCE_MISMATCH",
         "UNAUTHORISED_EFFECT",
+    }
+)
+_RISK_TIERS = frozenset(
+    {
+        "R0_DOCUMENTATION",
+        "R1_LOCAL_CODE",
+        "R2_STATEFUL_CONTRACT",
+        "R3_EXTERNAL_SERVICE_SECURITY",
+        "R4_RELEASE_OPERATIONAL",
     }
 )
 _RUNNER_KINDS = frozenset(
@@ -89,6 +98,56 @@ _EVIDENCE_KEYS = frozenset(
         "created_at",
     }
 )
+_ROUTE_KEYS = frozenset(
+    {
+        "schema_version",
+        "contract_version",
+        "base_sha",
+        "head_sha",
+        "base_tree_sha",
+        "head_tree_sha",
+        "risk_tier",
+        "reasons",
+        "core_required",
+        "service_required",
+        "clustering_required",
+        "owner_authority_required",
+        "core_tests",
+        "service_tests",
+        "sentinels",
+        "selected_test_manifest_digest",
+    }
+)
+_GATE_RUN_KEYS = frozenset(
+    {
+        "schema_version",
+        "gate_id",
+        "phase",
+        "result",
+        "result_reason",
+        "returncode",
+        "execution_ms",
+        "stdout",
+        "stderr",
+        "stdout_truncated",
+        "stderr_truncated",
+    }
+)
+_JUNIT_KEYS = frozenset(
+    {
+        "schema_version",
+        "outcome",
+        "reports",
+        "test_ids_digest",
+        "test_count",
+        "failure_count",
+        "error_count",
+        "skip_count",
+        "required_skip_count",
+        "duration_ms",
+        "first_failure_fingerprint",
+    }
+)
 
 
 class EvidenceError(ValueError):
@@ -136,15 +195,24 @@ def _mapping(value: object, name: str) -> Mapping[str, object]:
     return value
 
 
-def _string(value: object, name: str, *, maximum: int = 512) -> str:
-    if not isinstance(value, str) or not value or len(value) > maximum:
-        raise EvidenceError(f"{name}_string")
-    if any(ord(character) < 32 for character in value):
-        raise EvidenceError(f"{name}_control")
+def _text(value: object, name: str, *, maximum: int) -> str:
+    if not isinstance(value, str) or len(value) > maximum:
+        raise EvidenceError(f"{name}_text")
     return value
 
 
-def _optional_string(value: object, name: str, *, maximum: int = 512) -> str | None:
+def _string(value: object, name: str, *, maximum: int = 512) -> str:
+    text = _text(value, name, maximum=maximum)
+    if not text:
+        raise EvidenceError(f"{name}_string")
+    if any(ord(character) < 32 for character in text):
+        raise EvidenceError(f"{name}_control")
+    return text
+
+
+def _optional_string(
+    value: object, name: str, *, maximum: int = 512
+) -> str | None:
     if value is None:
         return None
     return _string(value, name, maximum=maximum)
@@ -189,13 +257,13 @@ def _string_list(
     maximum_items: int,
     maximum_length: int,
     sorted_required: bool = False,
+    nonempty: bool = False,
 ) -> list[str]:
     if not isinstance(value, list) or len(value) > maximum_items:
         raise EvidenceError(f"{name}_array")
-    result = [
-        _string(item, name, maximum=maximum_length)
-        for item in value
-    ]
+    result = [_string(item, name, maximum=maximum_length) for item in value]
+    if nonempty and not result:
+        raise EvidenceError(f"{name}_empty")
     if len(set(result)) != len(result):
         raise EvidenceError(f"{name}_duplicate")
     if sorted_required and result != sorted(result):
@@ -276,29 +344,12 @@ def _validate_route(
     route_value: object,
 ) -> dict[str, object]:
     route = dict(_mapping(route_value, "route"))
+    if set(route) != _ROUTE_KEYS:
+        raise EvidenceError("route_shape")
     if route.get("schema_version") != _ROUTE_SCHEMA_VERSION:
         raise EvidenceError("route_schema")
     if route.get("contract_version") != contract.contract_version:
         raise EvidenceError("route_contract_version")
-    if set(route) != {
-        "schema_version",
-        "contract_version",
-        "base_sha",
-        "head_sha",
-        "base_tree_sha",
-        "head_tree_sha",
-        "risk_tier",
-        "reasons",
-        "core_required",
-        "service_required",
-        "clustering_required",
-        "owner_authority_required",
-        "core_tests",
-        "service_tests",
-        "sentinels",
-        "selected_test_manifest_digest",
-    }:
-        raise EvidenceError("route_shape")
     for field in ("base_sha", "head_sha", "base_tree_sha", "head_tree_sha"):
         route[field] = _git_sha(route.get(field), f"route_{field}")
     risk_tier = _string(route.get("risk_tier"), "route_risk", maximum=64)
@@ -310,6 +361,7 @@ def _validate_route(
         maximum_items=4096,
         maximum_length=512,
         sorted_required=True,
+        nonempty=True,
     )
     for field in (
         "core_required",
@@ -332,6 +384,7 @@ def _validate_route(
         maximum_items=100000,
         maximum_length=1024,
         sorted_required=True,
+        nonempty=True,
     )
     route["service_tests"] = _string_list(
         route.get("service_tests"),
@@ -340,34 +393,35 @@ def _validate_route(
         maximum_length=1024,
         sorted_required=True,
     )
+    if expected_service != bool(route["service_tests"]):
+        raise EvidenceError("route_service_tests")
     route["sentinels"] = _string_list(
         route.get("sentinels"),
         "route_sentinels",
         maximum_items=10000,
         maximum_length=1024,
+        nonempty=True,
     )
-    route["selected_test_manifest_digest"] = _sha(
+    selected_digest = _sha(
         route.get("selected_test_manifest_digest"),
         "route_selected_manifest",
     )
+    expected_digest = sha256_identity(
+        {
+            "core_tests": route["core_tests"],
+            "service_tests": route["service_tests"],
+            "sentinels": route["sentinels"],
+        }
+    )
+    if selected_digest != expected_digest:
+        raise EvidenceError("route_selected_manifest_mismatch")
+    route["selected_test_manifest_digest"] = selected_digest
     return route
 
 
 def _validate_gate_run(gate_id: str, value: object) -> dict[str, object]:
     run = dict(_mapping(value, "gate_run"))
-    if set(run) != {
-        "schema_version",
-        "gate_id",
-        "phase",
-        "result",
-        "result_reason",
-        "returncode",
-        "execution_ms",
-        "stdout",
-        "stderr",
-        "stdout_truncated",
-        "stderr_truncated",
-    }:
+    if set(run) != _GATE_RUN_KEYS:
         raise EvidenceError("gate_run_shape")
     if run.get("schema_version") != _GATE_RUN_SCHEMA_VERSION:
         raise EvidenceError("gate_run_schema")
@@ -385,9 +439,13 @@ def _validate_gate_run(gate_id: str, value: object) -> dict[str, object]:
         isinstance(returncode, bool) or not isinstance(returncode, int)
     ):
         raise EvidenceError("gate_run_returncode")
+    if result == "PASS" and returncode != 0:
+        raise EvidenceError("gate_run_pass_returncode")
+    if result == "FAIL" and (returncode is None or returncode == 0):
+        raise EvidenceError("gate_run_fail_returncode")
     run["execution_ms"] = _nonnegative(run.get("execution_ms"), "execution_ms")
-    _string(run.get("stdout"), "gate_run_stdout", maximum=1_048_576)
-    _string(run.get("stderr"), "gate_run_stderr", maximum=1_048_576)
+    _text(run.get("stdout"), "gate_run_stdout", maximum=1_048_576)
+    _text(run.get("stderr"), "gate_run_stderr", maximum=1_048_576)
     _boolean(run.get("stdout_truncated"), "stdout_truncated")
     _boolean(run.get("stderr_truncated"), "stderr_truncated")
     return run
@@ -397,20 +455,7 @@ def _validate_junit(value: object | None) -> dict[str, object] | None:
     if value is None:
         return None
     summary = dict(_mapping(value, "junit"))
-    expected = {
-        "schema_version",
-        "outcome",
-        "reports",
-        "test_ids_digest",
-        "test_count",
-        "failure_count",
-        "error_count",
-        "skip_count",
-        "required_skip_count",
-        "duration_ms",
-        "first_failure_fingerprint",
-    }
-    if set(summary) != expected or summary.get("schema_version") != _JUNIT_SCHEMA_VERSION:
+    if set(summary) != _JUNIT_KEYS or summary.get("schema_version") != _JUNIT_SCHEMA_VERSION:
         raise EvidenceError("junit_shape")
     outcome = _string(summary.get("outcome"), "junit_outcome", maximum=16)
     if outcome not in {"PASS", "FAIL"}:
@@ -520,13 +565,16 @@ def validate_evidence_record(record_value: object) -> dict[str, object]:
         "risk_classifier_version",
         maximum=128,
     )
-    record["risk_tier"] = _string(record.get("risk_tier"), "risk_tier", maximum=64)
+    risk_tier = _string(record.get("risk_tier"), "risk_tier", maximum=64)
+    if risk_tier not in _RISK_TIERS:
+        raise EvidenceError("risk_tier")
     record["risk_reasons"] = _string_list(
         record.get("risk_reasons"),
         "risk_reasons",
         maximum_items=4096,
         maximum_length=512,
         sorted_required=True,
+        nonempty=True,
     )
     runner_kind = _string(record.get("runner_kind"), "runner_kind", maximum=64)
     if runner_kind not in _RUNNER_KINDS:
@@ -545,7 +593,12 @@ def validate_evidence_record(record_value: object) -> dict[str, object]:
         record[field] = _nonnegative(record.get(field), field)
     if record["required_skip_count"] > record["skip_count"]:
         raise EvidenceError("required_skip_count")
-    if record["failure_count"] + record["error_count"] + record["skip_count"] > record["test_count"]:
+    if (
+        record["failure_count"]
+        + record["error_count"]
+        + record["skip_count"]
+        > record["test_count"]
+    ):
         raise EvidenceError("test_counts")
     cache_key = _optional_string(record.get("cache_key"), "cache_key")
     cache_hit = _boolean(record.get("cache_hit"), "cache_hit")
@@ -554,7 +607,9 @@ def validate_evidence_record(record_value: object) -> dict[str, object]:
     record["python_version"] = _string(
         record.get("python_version"), "python_version", maximum=128
     )
-    record["uv_version"] = _string(record.get("uv_version"), "uv_version", maximum=128)
+    record["uv_version"] = _string(
+        record.get("uv_version"), "uv_version", maximum=128
+    )
     for field in (
         "lockfile_digest",
         "toolchain_digest",
@@ -577,6 +632,7 @@ def validate_evidence_record(record_value: object) -> dict[str, object]:
         "sentinel_tests",
         maximum_items=10000,
         maximum_length=1024,
+        nonempty=True,
     )
     record["random_sample_seed"] = _optional_string(
         record.get("random_sample_seed"),
@@ -596,10 +652,12 @@ def validate_evidence_record(record_value: object) -> dict[str, object]:
     result = _string(record.get("result"), "result", maximum=64)
     if result not in _RESULTS:
         raise EvidenceError("result")
-    record["result_reason"] = _string(
-        record.get("result_reason"), "result_reason", maximum=512
+    reason = _string(record.get("result_reason"), "result_reason", maximum=512)
+    if _RESULT_REASON.fullmatch(reason) is None or not reason.startswith(result + ":"):
+        raise EvidenceError("result_reason")
+    record["created_at"] = _created_at(
+        _string(record.get("created_at"), "created_at", maximum=64)
     )
-    record["created_at"] = _created_at(_string(record.get("created_at"), "created_at", maximum=64))
     if result == "PASS" and (
         record["failure_count"]
         or record["error_count"]
@@ -640,7 +698,10 @@ def build_gate_evidence(
         raise EvidenceError("head_mismatch")
     if resolve_tree(root, current_head) != normalized_route["head_tree_sha"]:
         raise EvidenceError("head_tree_mismatch")
-    if resolve_tree(root, str(normalized_route["base_sha"])) != normalized_route["base_tree_sha"]:
+    if (
+        resolve_tree(root, str(normalized_route["base_sha"]))
+        != normalized_route["base_tree_sha"]
+    ):
         raise EvidenceError("base_tree_mismatch")
 
     gate_id = _string(
@@ -651,8 +712,7 @@ def build_gate_evidence(
     if _SAFE_ID.fullmatch(gate_id) is None:
         raise EvidenceError("gate_id")
     accepted_gate_ids = {
-        str(value["id"])
-        for value in contract.data["gate"].values()
+        str(value["id"]) for value in contract.data["gate"].values()
     }
     if gate_id not in accepted_gate_ids:
         raise EvidenceError("gate_not_accepted")
@@ -664,7 +724,11 @@ def build_gate_evidence(
     if not selected_tests and junit is not None:
         raise EvidenceError("junit_unexpected")
 
-    if normalized_run["result"] == "PASS" and junit is not None and junit["outcome"] == "FAIL":
+    if (
+        normalized_run["result"] == "PASS"
+        and junit is not None
+        and junit["outcome"] == "FAIL"
+    ):
         result = "FAIL"
         result_reason = f"FAIL:{gate_id}:junit"
     else:
@@ -776,7 +840,12 @@ def build_gate_evidence(
 
 def _safe_json_path(root: Path, relative: str, *, output: bool) -> Path:
     candidate = Path(relative)
-    if candidate.is_absolute() or not candidate.parts or ".." in candidate.parts:
+    if (
+        candidate.is_absolute()
+        or not candidate.parts
+        or ".." in candidate.parts
+        or "\\" in relative
+    ):
         raise EvidenceError("json_path")
     path = root / candidate
     current = root
@@ -788,27 +857,42 @@ def _safe_json_path(root: Path, relative: str, *, output: bool) -> Path:
         raise EvidenceError("json_path")
     if path.suffix != ".json":
         raise EvidenceError("json_extension")
-    if output:
-        if not path.parent.is_dir():
-            raise EvidenceError("output_parent")
-    else:
-        try:
-            metadata = os.lstat(path)
-        except OSError as exc:
-            raise EvidenceError("json_input") from exc
-        if not stat.S_ISREG(metadata.st_mode) or metadata.st_size > _MAX_JSON_BYTES:
-            raise EvidenceError("json_input")
+    if output and not path.parent.is_dir():
+        raise EvidenceError("output_parent")
     return path
 
 
 def _load_json(root: Path, relative: str) -> object:
     path = _safe_json_path(root, relative, output=False)
     try:
-        payload = path.read_bytes()
-        if not payload or len(payload) > _MAX_JSON_BYTES:
+        metadata = os.lstat(path)
+    except OSError as exc:
+        raise EvidenceError("json_input") from exc
+    if not stat.S_ISREG(metadata.st_mode) or not 0 < metadata.st_size <= _MAX_JSON_BYTES:
+        raise EvidenceError("json_input")
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_NONBLOCK", 0)
+    )
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise EvidenceError("json_input") from exc
+    try:
+        current = os.fstat(descriptor)
+        if not stat.S_ISREG(current.st_mode) or not 0 < current.st_size <= _MAX_JSON_BYTES:
             raise EvidenceError("json_input")
+        with os.fdopen(descriptor, "rb", closefd=False) as stream:
+            payload = stream.read(_MAX_JSON_BYTES + 1)
+    finally:
+        os.close(descriptor)
+    if not payload or len(payload) > _MAX_JSON_BYTES:
+        raise EvidenceError("json_input")
+    try:
         return json.loads(payload.decode("utf-8"))
-    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+    except (UnicodeError, json.JSONDecodeError) as exc:
         raise EvidenceError("json_input") from exc
 
 
@@ -872,9 +956,14 @@ def main(argv: Sequence[str] | None = None) -> int:
             _write_json(root, arguments.output, record)
         else:
             sys.stdout.buffer.write(canonical_json_bytes(record) + b"\n")
-    except (ContractError, EvidenceError, OSError, UnicodeError) as exc:
-        reason = str(exc) or type(exc).__name__
-        print(f"EVIDENCE_MISMATCH:gate:{reason}", file=sys.stderr)
+    except EvidenceError as exc:
+        print(f"EVIDENCE_MISMATCH:gate:{str(exc)}", file=sys.stderr)
+        return 2
+    except (ContractError, GitRouteError, OSError, UnicodeError) as exc:
+        print(
+            f"EVIDENCE_MISMATCH:gate:{type(exc).__name__}",
+            file=sys.stderr,
+        )
         return 2
     return 0
 

--- a/scripts/sdlc/emit_evidence.py
+++ b/scripts/sdlc/emit_evidence.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 from datetime import datetime, timezone
+from functools import lru_cache
 import hashlib
 import json
 import os
@@ -25,6 +26,7 @@ _REPOSITORY = "fol2/newsroom"
 _SHA256 = re.compile(r"sha256:[0-9a-f]{64}")
 _GIT_SHA = re.compile(r"[0-9a-f]{40}")
 _SAFE_ID = re.compile(r"[A-Za-z0-9_.*-]{1,128}")
+_UV_OUTPUT = re.compile(r"uv ([^\s]+)(?:\s.*)?")
 _RESULT_REASON = re.compile(
     r"(?:PASS|FAIL|BUDGET_EXCEEDED|CLASSIFIER_ERROR|ENVIRONMENT_ERROR|"
     r"EVIDENCE_MISMATCH|UNAUTHORISED_EFFECT):[A-Za-z0-9_.*-]+:"
@@ -311,6 +313,31 @@ def _git_bytes(
     if len(completed.stdout) > maximum:
         raise EvidenceError("git_blob_size")
     return completed.stdout
+
+
+@lru_cache(maxsize=1)
+def installed_uv_version() -> str:
+    try:
+        completed = subprocess.run(
+            ("uv", "--version"),
+            check=False,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise EvidenceError("uv_environment") from exc
+    if completed.returncode != 0 or not completed.stdout or len(completed.stdout) > 256:
+        raise EvidenceError("uv_environment")
+    try:
+        rendered = completed.stdout.decode("utf-8").strip()
+    except UnicodeError as exc:
+        raise EvidenceError("uv_environment") from exc
+    matched = _UV_OUTPUT.fullmatch(rendered)
+    if matched is None:
+        raise EvidenceError("uv_version_output")
+    return _string(matched.group(1), "installed_uv_version", maximum=128)
 
 
 def git_blob_digest(repo_root: str | Path, commit_sha: str, path: str) -> str:
@@ -645,10 +672,18 @@ def validate_evidence_record(record_value: object) -> dict[str, object]:
         maximum_items=100000,
         maximum_length=1024,
     )
-    record["first_failure_fingerprint"] = _optional_sha(
+    fingerprint = _optional_sha(
         record.get("first_failure_fingerprint"),
         "first_failure_fingerprint",
     )
+    record["first_failure_fingerprint"] = fingerprint
+    has_test_failure = bool(
+        record["failure_count"]
+        or record["error_count"]
+        or record["required_skip_count"]
+    )
+    if has_test_failure != (fingerprint is not None):
+        raise EvidenceError("failure_fingerprint_invariant")
     result = _string(record.get("result"), "result", maximum=64)
     if result not in _RESULTS:
         raise EvidenceError("result")
@@ -658,12 +693,7 @@ def validate_evidence_record(record_value: object) -> dict[str, object]:
     record["created_at"] = _created_at(
         _string(record.get("created_at"), "created_at", maximum=64)
     )
-    if result == "PASS" and (
-        record["failure_count"]
-        or record["error_count"]
-        or record["required_skip_count"]
-        or record["first_failure_fingerprint"] is not None
-    ):
+    if result == "PASS" and has_test_failure:
         raise EvidenceError("pass_invariant")
     expected_identity = sha256_identity(_identity_inputs(record))
     if record["evidence_identity"] != expected_identity:
@@ -767,7 +797,10 @@ def build_gate_evidence(
         raise EvidenceError("service_compatibility_unexpected")
 
     actual_python = platform.python_version()
-    normalized_uv = _string(uv_version, "uv_version", maximum=128)
+    claimed_uv = _string(uv_version, "uv_version", maximum=128)
+    actual_uv = installed_uv_version()
+    if claimed_uv != actual_uv:
+        raise EvidenceError("uv_version_mismatch")
     normalized_runner = _string(runner_kind, "runner_kind", maximum=64)
     if normalized_runner not in _RUNNER_KINDS:
         raise EvidenceError("runner_kind")
@@ -778,7 +811,7 @@ def build_gate_evidence(
             "python_version": actual_python,
             "runner_arch": platform.machine(),
             "runner_os": platform.system().lower(),
-            "uv_version": normalized_uv,
+            "uv_version": actual_uv,
         }
     )
     command_digest = _sha(command_spec_digest, "command_spec_digest")
@@ -817,7 +850,7 @@ def build_gate_evidence(
         "cache_key": _optional_string(cache_key, "cache_key"),
         "cache_hit": _boolean(cache_hit, "cache_hit"),
         "python_version": actual_python,
-        "uv_version": normalized_uv,
+        "uv_version": actual_uv,
         "lockfile_digest": lockfile_digest,
         "toolchain_digest": toolchain_digest,
         "service_compatibility_digest": service_digest,

--- a/scripts/sdlc/emit_evidence.py
+++ b/scripts/sdlc/emit_evidence.py
@@ -1,0 +1,883 @@
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path
+import platform
+import re
+import stat
+import subprocess
+import sys
+from typing import Mapping, Sequence
+
+from .classify_change import resolve_commit, resolve_tree
+from .contracts import ContractError, SdlcContract, load_contract
+
+
+SCHEMA_VERSION = "newsroom.sdlc.evidence.v1"
+_ROUTE_SCHEMA_VERSION = "newsroom.sdlc.route.v1"
+_GATE_RUN_SCHEMA_VERSION = "newsroom.sdlc.gate-run.v1"
+_JUNIT_SCHEMA_VERSION = "newsroom.sdlc.junit-summary.v1"
+_REPOSITORY = "fol2/newsroom"
+_SHA256 = re.compile(r"sha256:[0-9a-f]{64}")
+_GIT_SHA = re.compile(r"[0-9a-f]{40}")
+_SAFE_ID = re.compile(r"[A-Za-z0-9_.*-]{1,128}")
+_RESULT_REASON = re.compile(
+    r"(?:PASS|FAIL|BUDGET_EXCEEDED|CLASSIFIER_ERROR|ENVIRONMENT_ERROR|"
+    r"EVIDENCE_MISMATCH|UNAUTHORISED_EFFECT):[A-Za-z0-9_.*-]+:"
+    r"[A-Za-z0-9_.*-]+(?::[A-Za-z0-9_=.*-]+)?"
+)
+_RESULTS = frozenset(
+    {
+        "PASS",
+        "FAIL",
+        "BUDGET_EXCEEDED",
+        "CLASSIFIER_ERROR",
+        "ENVIRONMENT_ERROR",
+        "EVIDENCE_MISMATCH",
+        "UNAUTHORISED_EFFECT",
+    }
+)
+_RUNNER_KINDS = frozenset(
+    {"github-hosted", "ephemeral-prewarmed", "local", "other"}
+)
+_MAX_JSON_BYTES = 4 * 1024 * 1024
+_MAX_GIT_BLOB_BYTES = 16 * 1024 * 1024
+_EVIDENCE_KEYS = frozenset(
+    {
+        "schema_version",
+        "evidence_identity",
+        "gate_id",
+        "gate_contract_version",
+        "risk_classifier_version",
+        "repository",
+        "base_sha",
+        "head_sha",
+        "base_tree_sha",
+        "tree_sha",
+        "risk_tier",
+        "risk_reasons",
+        "runner_kind",
+        "queue_ms",
+        "bootstrap_ms",
+        "execution_ms",
+        "finalize_ms",
+        "cache_key",
+        "cache_hit",
+        "python_version",
+        "uv_version",
+        "lockfile_digest",
+        "toolchain_digest",
+        "service_compatibility_digest",
+        "selected_test_manifest_digest",
+        "gate_inputs_digest",
+        "selected_tests",
+        "sentinel_tests",
+        "random_sample_seed",
+        "random_sample_tests",
+        "test_count",
+        "failure_count",
+        "error_count",
+        "skip_count",
+        "required_skip_count",
+        "first_failure_fingerprint",
+        "result",
+        "result_reason",
+        "created_at",
+    }
+)
+
+
+class EvidenceError(ValueError):
+    """Raised when gate inputs cannot produce exact accepted evidence."""
+
+
+def canonical_json_bytes(value: object) -> bytes:
+    """Canonical JSON for the accepted no-float evidence identity domain."""
+
+    def validate(item: object) -> None:
+        if item is None or isinstance(item, (bool, int, str)):
+            return
+        if isinstance(item, list):
+            for child in item:
+                validate(child)
+            return
+        if isinstance(item, dict):
+            if any(not isinstance(key, str) for key in item):
+                raise EvidenceError("canonical_key_type")
+            for child in item.values():
+                validate(child)
+            return
+        raise EvidenceError("canonical_value_type")
+
+    validate(value)
+    try:
+        return json.dumps(
+            value,
+            ensure_ascii=False,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    except UnicodeError as exc:
+        raise EvidenceError("canonical_unicode") from exc
+
+
+def sha256_identity(value: object) -> str:
+    return "sha256:" + hashlib.sha256(canonical_json_bytes(value)).hexdigest()
+
+
+def _mapping(value: object, name: str) -> Mapping[str, object]:
+    if not isinstance(value, dict):
+        raise EvidenceError(f"{name}_mapping")
+    return value
+
+
+def _string(value: object, name: str, *, maximum: int = 512) -> str:
+    if not isinstance(value, str) or not value or len(value) > maximum:
+        raise EvidenceError(f"{name}_string")
+    if any(ord(character) < 32 for character in value):
+        raise EvidenceError(f"{name}_control")
+    return value
+
+
+def _optional_string(value: object, name: str, *, maximum: int = 512) -> str | None:
+    if value is None:
+        return None
+    return _string(value, name, maximum=maximum)
+
+
+def _sha(value: object, name: str) -> str:
+    text = _string(value, name, maximum=71)
+    if _SHA256.fullmatch(text) is None:
+        raise EvidenceError(f"{name}_sha256")
+    return text
+
+
+def _optional_sha(value: object, name: str) -> str | None:
+    return None if value is None else _sha(value, name)
+
+
+def _git_sha(value: object, name: str) -> str:
+    text = _string(value, name, maximum=40)
+    if _GIT_SHA.fullmatch(text) is None:
+        raise EvidenceError(f"{name}_git_sha")
+    return text
+
+
+def _nonnegative(value: object, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise EvidenceError(f"{name}_nonnegative")
+    if value > 9_223_372_036_854_775_807:
+        raise EvidenceError(f"{name}_range")
+    return value
+
+
+def _boolean(value: object, name: str) -> bool:
+    if not isinstance(value, bool):
+        raise EvidenceError(f"{name}_boolean")
+    return value
+
+
+def _string_list(
+    value: object,
+    name: str,
+    *,
+    maximum_items: int,
+    maximum_length: int,
+    sorted_required: bool = False,
+) -> list[str]:
+    if not isinstance(value, list) or len(value) > maximum_items:
+        raise EvidenceError(f"{name}_array")
+    result = [
+        _string(item, name, maximum=maximum_length)
+        for item in value
+    ]
+    if len(set(result)) != len(result):
+        raise EvidenceError(f"{name}_duplicate")
+    if sorted_required and result != sorted(result):
+        raise EvidenceError(f"{name}_order")
+    return result
+
+
+def _created_at(value: str | None) -> str:
+    if value is None:
+        return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace(
+            "+00:00", "Z"
+        )
+    text = _string(value, "created_at", maximum=64)
+    if not text.endswith("Z"):
+        raise EvidenceError("created_at_utc")
+    try:
+        parsed = datetime.fromisoformat(text[:-1] + "+00:00")
+    except ValueError as exc:
+        raise EvidenceError("created_at_format") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() != timezone.utc.utcoffset(parsed):
+        raise EvidenceError("created_at_utc")
+    return text
+
+
+def _git_bytes(
+    repo_root: Path,
+    arguments: Sequence[str],
+    *,
+    maximum: int,
+) -> bytes:
+    try:
+        completed = subprocess.run(
+            ("git", *arguments),
+            cwd=repo_root,
+            check=False,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise EvidenceError("git_environment") from exc
+    if completed.returncode != 0:
+        raise EvidenceError("git_evidence_input")
+    if len(completed.stdout) > maximum:
+        raise EvidenceError("git_blob_size")
+    return completed.stdout
+
+
+def git_blob_digest(repo_root: str | Path, commit_sha: str, path: str) -> str:
+    root = Path(repo_root).resolve()
+    _git_sha(commit_sha, "commit_sha")
+    if path != "uv.lock":
+        raise EvidenceError("unsupported_git_blob")
+    size_bytes = _git_bytes(
+        root,
+        ("cat-file", "-s", f"{commit_sha}:{path}"),
+        maximum=64,
+    )
+    try:
+        size = int(size_bytes.decode("ascii").strip())
+    except (UnicodeError, ValueError) as exc:
+        raise EvidenceError("git_blob_size") from exc
+    if size <= 0 or size > _MAX_GIT_BLOB_BYTES:
+        raise EvidenceError("git_blob_size")
+    payload = _git_bytes(
+        root,
+        ("cat-file", "blob", f"{commit_sha}:{path}"),
+        maximum=_MAX_GIT_BLOB_BYTES,
+    )
+    if len(payload) != size:
+        raise EvidenceError("git_blob_size_mismatch")
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def _validate_route(
+    contract: SdlcContract,
+    route_value: object,
+) -> dict[str, object]:
+    route = dict(_mapping(route_value, "route"))
+    if route.get("schema_version") != _ROUTE_SCHEMA_VERSION:
+        raise EvidenceError("route_schema")
+    if route.get("contract_version") != contract.contract_version:
+        raise EvidenceError("route_contract_version")
+    if set(route) != {
+        "schema_version",
+        "contract_version",
+        "base_sha",
+        "head_sha",
+        "base_tree_sha",
+        "head_tree_sha",
+        "risk_tier",
+        "reasons",
+        "core_required",
+        "service_required",
+        "clustering_required",
+        "owner_authority_required",
+        "core_tests",
+        "service_tests",
+        "sentinels",
+        "selected_test_manifest_digest",
+    }:
+        raise EvidenceError("route_shape")
+    for field in ("base_sha", "head_sha", "base_tree_sha", "head_tree_sha"):
+        route[field] = _git_sha(route.get(field), f"route_{field}")
+    risk_tier = _string(route.get("risk_tier"), "route_risk", maximum=64)
+    if risk_tier not in contract.risk_rank:
+        raise EvidenceError("route_risk")
+    route["reasons"] = _string_list(
+        route.get("reasons"),
+        "route_reasons",
+        maximum_items=4096,
+        maximum_length=512,
+        sorted_required=True,
+    )
+    for field in (
+        "core_required",
+        "service_required",
+        "clustering_required",
+        "owner_authority_required",
+    ):
+        route[field] = _boolean(route.get(field), f"route_{field}")
+    if route["core_required"] is not True:
+        raise EvidenceError("route_core_required")
+    expected_service = contract.service_required(risk_tier)
+    if route["service_required"] is not expected_service:
+        raise EvidenceError("route_service_required")
+    expected_owner = contract.owner_authority_required(risk_tier)
+    if route["owner_authority_required"] is not expected_owner:
+        raise EvidenceError("route_owner_authority")
+    route["core_tests"] = _string_list(
+        route.get("core_tests"),
+        "route_core_tests",
+        maximum_items=100000,
+        maximum_length=1024,
+        sorted_required=True,
+    )
+    route["service_tests"] = _string_list(
+        route.get("service_tests"),
+        "route_service_tests",
+        maximum_items=100000,
+        maximum_length=1024,
+        sorted_required=True,
+    )
+    route["sentinels"] = _string_list(
+        route.get("sentinels"),
+        "route_sentinels",
+        maximum_items=10000,
+        maximum_length=1024,
+    )
+    route["selected_test_manifest_digest"] = _sha(
+        route.get("selected_test_manifest_digest"),
+        "route_selected_manifest",
+    )
+    return route
+
+
+def _validate_gate_run(gate_id: str, value: object) -> dict[str, object]:
+    run = dict(_mapping(value, "gate_run"))
+    if set(run) != {
+        "schema_version",
+        "gate_id",
+        "phase",
+        "result",
+        "result_reason",
+        "returncode",
+        "execution_ms",
+        "stdout",
+        "stderr",
+        "stdout_truncated",
+        "stderr_truncated",
+    }:
+        raise EvidenceError("gate_run_shape")
+    if run.get("schema_version") != _GATE_RUN_SCHEMA_VERSION:
+        raise EvidenceError("gate_run_schema")
+    if run.get("gate_id") != gate_id:
+        raise EvidenceError("gate_run_id")
+    run["phase"] = _string(run.get("phase"), "gate_run_phase", maximum=128)
+    result = _string(run.get("result"), "gate_run_result", maximum=64)
+    if result not in _RESULTS:
+        raise EvidenceError("gate_run_result")
+    reason = _string(run.get("result_reason"), "gate_run_reason", maximum=512)
+    if _RESULT_REASON.fullmatch(reason) is None or not reason.startswith(result + ":"):
+        raise EvidenceError("gate_run_reason")
+    returncode = run.get("returncode")
+    if returncode is not None and (
+        isinstance(returncode, bool) or not isinstance(returncode, int)
+    ):
+        raise EvidenceError("gate_run_returncode")
+    run["execution_ms"] = _nonnegative(run.get("execution_ms"), "execution_ms")
+    _string(run.get("stdout"), "gate_run_stdout", maximum=1_048_576)
+    _string(run.get("stderr"), "gate_run_stderr", maximum=1_048_576)
+    _boolean(run.get("stdout_truncated"), "stdout_truncated")
+    _boolean(run.get("stderr_truncated"), "stderr_truncated")
+    return run
+
+
+def _validate_junit(value: object | None) -> dict[str, object] | None:
+    if value is None:
+        return None
+    summary = dict(_mapping(value, "junit"))
+    expected = {
+        "schema_version",
+        "outcome",
+        "reports",
+        "test_ids_digest",
+        "test_count",
+        "failure_count",
+        "error_count",
+        "skip_count",
+        "required_skip_count",
+        "duration_ms",
+        "first_failure_fingerprint",
+    }
+    if set(summary) != expected or summary.get("schema_version") != _JUNIT_SCHEMA_VERSION:
+        raise EvidenceError("junit_shape")
+    outcome = _string(summary.get("outcome"), "junit_outcome", maximum=16)
+    if outcome not in {"PASS", "FAIL"}:
+        raise EvidenceError("junit_outcome")
+    reports = summary.get("reports")
+    if not isinstance(reports, list) or not reports or len(reports) > 32:
+        raise EvidenceError("junit_reports")
+    normalized_reports: list[dict[str, str]] = []
+    seen_paths: set[str] = set()
+    for item in reports:
+        report = _mapping(item, "junit_report")
+        if set(report) != {"path", "digest"}:
+            raise EvidenceError("junit_report_shape")
+        path = _string(report.get("path"), "junit_report_path", maximum=1024)
+        digest = _sha(report.get("digest"), "junit_report_digest")
+        if path in seen_paths:
+            raise EvidenceError("junit_report_duplicate")
+        seen_paths.add(path)
+        normalized_reports.append({"path": path, "digest": digest})
+    if normalized_reports != sorted(normalized_reports, key=lambda item: item["path"]):
+        raise EvidenceError("junit_report_order")
+    summary["reports"] = normalized_reports
+    summary["test_ids_digest"] = _sha(
+        summary.get("test_ids_digest"),
+        "junit_test_ids_digest",
+    )
+    for field in (
+        "test_count",
+        "failure_count",
+        "error_count",
+        "skip_count",
+        "required_skip_count",
+        "duration_ms",
+    ):
+        summary[field] = _nonnegative(summary.get(field), f"junit_{field}")
+    if summary["required_skip_count"] > summary["skip_count"]:
+        raise EvidenceError("junit_required_skip_count")
+    terminal_count = (
+        summary["failure_count"] + summary["error_count"] + summary["skip_count"]
+    )
+    if terminal_count > summary["test_count"]:
+        raise EvidenceError("junit_counts")
+    fingerprint = _optional_sha(
+        summary.get("first_failure_fingerprint"),
+        "junit_first_failure",
+    )
+    summary["first_failure_fingerprint"] = fingerprint
+    expected_outcome = (
+        "FAIL"
+        if summary["failure_count"]
+        or summary["error_count"]
+        or summary["required_skip_count"]
+        else "PASS"
+    )
+    if outcome != expected_outcome:
+        raise EvidenceError("junit_outcome_counts")
+    if outcome == "PASS" and fingerprint is not None:
+        raise EvidenceError("junit_pass_fingerprint")
+    if outcome == "FAIL" and fingerprint is None:
+        raise EvidenceError("junit_fail_fingerprint")
+    return summary
+
+
+def _selected_tests(gate_id: str, route: Mapping[str, object]) -> list[str]:
+    if gate_id == "service-neo4j":
+        return list(route["service_tests"])
+    if gate_id in {"core-deterministic", "merge-exact"}:
+        return list(route["core_tests"])
+    return []
+
+
+def _identity_inputs(record: Mapping[str, object]) -> dict[str, object]:
+    return {
+        "repository_tree_sha": record["tree_sha"],
+        "base_tree_sha": record["base_tree_sha"],
+        "gate_contract_version": record["gate_contract_version"],
+        "risk_classifier_version": record["risk_classifier_version"],
+        "lockfile_digest": record["lockfile_digest"],
+        "toolchain_digest": record["toolchain_digest"],
+        "service_compatibility_digest": record["service_compatibility_digest"],
+        "selected_test_manifest_digest": record["selected_test_manifest_digest"],
+        "gate_inputs_digest": record["gate_inputs_digest"],
+    }
+
+
+def validate_evidence_record(record_value: object) -> dict[str, object]:
+    record = dict(_mapping(record_value, "evidence"))
+    if set(record) != _EVIDENCE_KEYS:
+        raise EvidenceError("evidence_shape")
+    if record.get("schema_version") != SCHEMA_VERSION:
+        raise EvidenceError("evidence_schema")
+    if record.get("repository") != _REPOSITORY:
+        raise EvidenceError("evidence_repository")
+    record["evidence_identity"] = _sha(
+        record.get("evidence_identity"), "evidence_identity"
+    )
+    gate_id = _string(record.get("gate_id"), "gate_id", maximum=128)
+    if _SAFE_ID.fullmatch(gate_id) is None:
+        raise EvidenceError("gate_id")
+    for field in ("base_sha", "head_sha", "base_tree_sha", "tree_sha"):
+        record[field] = _git_sha(record.get(field), field)
+    record["gate_contract_version"] = _string(
+        record.get("gate_contract_version"), "gate_contract_version", maximum=128
+    )
+    record["risk_classifier_version"] = _string(
+        record.get("risk_classifier_version"),
+        "risk_classifier_version",
+        maximum=128,
+    )
+    record["risk_tier"] = _string(record.get("risk_tier"), "risk_tier", maximum=64)
+    record["risk_reasons"] = _string_list(
+        record.get("risk_reasons"),
+        "risk_reasons",
+        maximum_items=4096,
+        maximum_length=512,
+        sorted_required=True,
+    )
+    runner_kind = _string(record.get("runner_kind"), "runner_kind", maximum=64)
+    if runner_kind not in _RUNNER_KINDS:
+        raise EvidenceError("runner_kind")
+    for field in (
+        "queue_ms",
+        "bootstrap_ms",
+        "execution_ms",
+        "finalize_ms",
+        "test_count",
+        "failure_count",
+        "error_count",
+        "skip_count",
+        "required_skip_count",
+    ):
+        record[field] = _nonnegative(record.get(field), field)
+    if record["required_skip_count"] > record["skip_count"]:
+        raise EvidenceError("required_skip_count")
+    if record["failure_count"] + record["error_count"] + record["skip_count"] > record["test_count"]:
+        raise EvidenceError("test_counts")
+    cache_key = _optional_string(record.get("cache_key"), "cache_key")
+    cache_hit = _boolean(record.get("cache_hit"), "cache_hit")
+    if cache_hit and cache_key is None:
+        raise EvidenceError("cache_hit_without_key")
+    record["python_version"] = _string(
+        record.get("python_version"), "python_version", maximum=128
+    )
+    record["uv_version"] = _string(record.get("uv_version"), "uv_version", maximum=128)
+    for field in (
+        "lockfile_digest",
+        "toolchain_digest",
+        "selected_test_manifest_digest",
+        "gate_inputs_digest",
+    ):
+        record[field] = _sha(record.get(field), field)
+    record["service_compatibility_digest"] = _optional_sha(
+        record.get("service_compatibility_digest"),
+        "service_compatibility_digest",
+    )
+    record["selected_tests"] = _string_list(
+        record.get("selected_tests"),
+        "selected_tests",
+        maximum_items=100000,
+        maximum_length=1024,
+    )
+    record["sentinel_tests"] = _string_list(
+        record.get("sentinel_tests"),
+        "sentinel_tests",
+        maximum_items=10000,
+        maximum_length=1024,
+    )
+    record["random_sample_seed"] = _optional_string(
+        record.get("random_sample_seed"),
+        "random_sample_seed",
+        maximum=256,
+    )
+    record["random_sample_tests"] = _string_list(
+        record.get("random_sample_tests"),
+        "random_sample_tests",
+        maximum_items=100000,
+        maximum_length=1024,
+    )
+    record["first_failure_fingerprint"] = _optional_sha(
+        record.get("first_failure_fingerprint"),
+        "first_failure_fingerprint",
+    )
+    result = _string(record.get("result"), "result", maximum=64)
+    if result not in _RESULTS:
+        raise EvidenceError("result")
+    record["result_reason"] = _string(
+        record.get("result_reason"), "result_reason", maximum=512
+    )
+    record["created_at"] = _created_at(_string(record.get("created_at"), "created_at", maximum=64))
+    if result == "PASS" and (
+        record["failure_count"]
+        or record["error_count"]
+        or record["required_skip_count"]
+        or record["first_failure_fingerprint"] is not None
+    ):
+        raise EvidenceError("pass_invariant")
+    expected_identity = sha256_identity(_identity_inputs(record))
+    if record["evidence_identity"] != expected_identity:
+        raise EvidenceError("evidence_identity_mismatch")
+    return record
+
+
+def build_gate_evidence(
+    *,
+    repo_root: str | Path,
+    contract: SdlcContract,
+    route: object,
+    gate_run: object,
+    junit_summary: object | None,
+    runner_kind: str,
+    queue_ms: int,
+    bootstrap_ms: int,
+    finalize_ms: int,
+    cache_key: str | None,
+    cache_hit: bool,
+    uv_version: str,
+    command_spec_digest: str,
+    service_compatibility_digest: str | None = None,
+    created_at: str | None = None,
+) -> dict[str, object]:
+    root = Path(repo_root).resolve()
+    if contract.repo_root != root:
+        raise EvidenceError("contract_repository")
+    normalized_route = _validate_route(contract, route)
+    current_head = resolve_commit(root, "HEAD")
+    if current_head != normalized_route["head_sha"]:
+        raise EvidenceError("head_mismatch")
+    if resolve_tree(root, current_head) != normalized_route["head_tree_sha"]:
+        raise EvidenceError("head_tree_mismatch")
+    if resolve_tree(root, str(normalized_route["base_sha"])) != normalized_route["base_tree_sha"]:
+        raise EvidenceError("base_tree_mismatch")
+
+    gate_id = _string(
+        _mapping(gate_run, "gate_run").get("gate_id"),
+        "gate_id",
+        maximum=128,
+    )
+    if _SAFE_ID.fullmatch(gate_id) is None:
+        raise EvidenceError("gate_id")
+    accepted_gate_ids = {
+        str(value["id"])
+        for value in contract.data["gate"].values()
+    }
+    if gate_id not in accepted_gate_ids:
+        raise EvidenceError("gate_not_accepted")
+    normalized_run = _validate_gate_run(gate_id, gate_run)
+    junit = _validate_junit(junit_summary)
+    selected_tests = _selected_tests(gate_id, normalized_route)
+    if normalized_run["result"] == "PASS" and selected_tests and junit is None:
+        raise EvidenceError("junit_required")
+    if not selected_tests and junit is not None:
+        raise EvidenceError("junit_unexpected")
+
+    if normalized_run["result"] == "PASS" and junit is not None and junit["outcome"] == "FAIL":
+        result = "FAIL"
+        result_reason = f"FAIL:{gate_id}:junit"
+    else:
+        result = str(normalized_run["result"])
+        result_reason = str(normalized_run["result_reason"])
+
+    if junit is None:
+        counts = {
+            "test_count": 0,
+            "failure_count": 0,
+            "error_count": 0,
+            "skip_count": 0,
+            "required_skip_count": 0,
+            "first_failure_fingerprint": None,
+        }
+    else:
+        counts = {
+            field: junit[field]
+            for field in (
+                "test_count",
+                "failure_count",
+                "error_count",
+                "skip_count",
+                "required_skip_count",
+                "first_failure_fingerprint",
+            )
+        }
+
+    service_digest = _optional_sha(
+        service_compatibility_digest,
+        "service_compatibility_digest",
+    )
+    if gate_id == "service-neo4j" and service_digest is None:
+        raise EvidenceError("service_compatibility_required")
+    if gate_id != "service-neo4j" and service_digest is not None:
+        raise EvidenceError("service_compatibility_unexpected")
+
+    actual_python = platform.python_version()
+    normalized_uv = _string(uv_version, "uv_version", maximum=128)
+    normalized_runner = _string(runner_kind, "runner_kind", maximum=64)
+    if normalized_runner not in _RUNNER_KINDS:
+        raise EvidenceError("runner_kind")
+    lockfile_digest = git_blob_digest(root, current_head, "uv.lock")
+    toolchain_digest = sha256_identity(
+        {
+            "python_implementation": platform.python_implementation(),
+            "python_version": actual_python,
+            "runner_arch": platform.machine(),
+            "runner_os": platform.system().lower(),
+            "uv_version": normalized_uv,
+        }
+    )
+    command_digest = _sha(command_spec_digest, "command_spec_digest")
+    route_digest = sha256_identity(normalized_route)
+    gate_inputs_digest = sha256_identity(
+        {
+            "command_spec_digest": command_digest,
+            "gate_id": gate_id,
+            "head_tree_sha": normalized_route["head_tree_sha"],
+            "phase": normalized_run["phase"],
+            "route_digest": route_digest,
+            "selected_test_manifest_digest": normalized_route[
+                "selected_test_manifest_digest"
+            ],
+        }
+    )
+
+    record: dict[str, object] = {
+        "schema_version": SCHEMA_VERSION,
+        "evidence_identity": "",
+        "gate_id": gate_id,
+        "gate_contract_version": contract.contract_version,
+        "risk_classifier_version": contract.classifier_version,
+        "repository": _REPOSITORY,
+        "base_sha": normalized_route["base_sha"],
+        "head_sha": normalized_route["head_sha"],
+        "base_tree_sha": normalized_route["base_tree_sha"],
+        "tree_sha": normalized_route["head_tree_sha"],
+        "risk_tier": normalized_route["risk_tier"],
+        "risk_reasons": normalized_route["reasons"],
+        "runner_kind": normalized_runner,
+        "queue_ms": _nonnegative(queue_ms, "queue_ms"),
+        "bootstrap_ms": _nonnegative(bootstrap_ms, "bootstrap_ms"),
+        "execution_ms": normalized_run["execution_ms"],
+        "finalize_ms": _nonnegative(finalize_ms, "finalize_ms"),
+        "cache_key": _optional_string(cache_key, "cache_key"),
+        "cache_hit": _boolean(cache_hit, "cache_hit"),
+        "python_version": actual_python,
+        "uv_version": normalized_uv,
+        "lockfile_digest": lockfile_digest,
+        "toolchain_digest": toolchain_digest,
+        "service_compatibility_digest": service_digest,
+        "selected_test_manifest_digest": normalized_route[
+            "selected_test_manifest_digest"
+        ],
+        "gate_inputs_digest": gate_inputs_digest,
+        "selected_tests": selected_tests,
+        "sentinel_tests": normalized_route["sentinels"],
+        "random_sample_seed": None,
+        "random_sample_tests": [],
+        **counts,
+        "result": result,
+        "result_reason": result_reason,
+        "created_at": _created_at(created_at),
+    }
+    record["evidence_identity"] = sha256_identity(_identity_inputs(record))
+    return validate_evidence_record(record)
+
+
+def _safe_json_path(root: Path, relative: str, *, output: bool) -> Path:
+    candidate = Path(relative)
+    if candidate.is_absolute() or not candidate.parts or ".." in candidate.parts:
+        raise EvidenceError("json_path")
+    path = root / candidate
+    current = root
+    for part in candidate.parts:
+        current /= part
+        if current.is_symlink():
+            raise EvidenceError("json_symlink")
+    if not path.resolve().is_relative_to(root):
+        raise EvidenceError("json_path")
+    if path.suffix != ".json":
+        raise EvidenceError("json_extension")
+    if output:
+        if not path.parent.is_dir():
+            raise EvidenceError("output_parent")
+    else:
+        try:
+            metadata = os.lstat(path)
+        except OSError as exc:
+            raise EvidenceError("json_input") from exc
+        if not stat.S_ISREG(metadata.st_mode) or metadata.st_size > _MAX_JSON_BYTES:
+            raise EvidenceError("json_input")
+    return path
+
+
+def _load_json(root: Path, relative: str) -> object:
+    path = _safe_json_path(root, relative, output=False)
+    try:
+        payload = path.read_bytes()
+        if not payload or len(payload) > _MAX_JSON_BYTES:
+            raise EvidenceError("json_input")
+        return json.loads(payload.decode("utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise EvidenceError("json_input") from exc
+
+
+def _write_json(root: Path, relative: str, value: object) -> None:
+    path = _safe_json_path(root, relative, output=True)
+    payload = canonical_json_bytes(value) + b"\n"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0)
+    try:
+        descriptor = os.open(path, flags, 0o600)
+    except FileExistsError as exc:
+        raise EvidenceError("output_exists") from exc
+    except OSError as exc:
+        raise EvidenceError("output_open") from exc
+    with os.fdopen(descriptor, "wb") as stream:
+        stream.write(payload)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Emit exact Newsroom SDLC gate evidence")
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--route", required=True)
+    parser.add_argument("--gate-run", required=True)
+    parser.add_argument("--junit-summary")
+    parser.add_argument("--runner-kind", required=True)
+    parser.add_argument("--queue-ms", type=int, required=True)
+    parser.add_argument("--bootstrap-ms", type=int, required=True)
+    parser.add_argument("--finalize-ms", type=int, required=True)
+    parser.add_argument("--cache-key")
+    parser.add_argument("--cache-hit", action="store_true")
+    parser.add_argument("--uv-version", required=True)
+    parser.add_argument("--command-spec-digest", required=True)
+    parser.add_argument("--service-compatibility-digest")
+    parser.add_argument("--created-at")
+    parser.add_argument("--output")
+    arguments = parser.parse_args(argv)
+    root = Path(arguments.repo_root).resolve()
+    try:
+        contract = load_contract(root)
+        record = build_gate_evidence(
+            repo_root=root,
+            contract=contract,
+            route=_load_json(root, arguments.route),
+            gate_run=_load_json(root, arguments.gate_run),
+            junit_summary=(
+                _load_json(root, arguments.junit_summary)
+                if arguments.junit_summary
+                else None
+            ),
+            runner_kind=arguments.runner_kind,
+            queue_ms=arguments.queue_ms,
+            bootstrap_ms=arguments.bootstrap_ms,
+            finalize_ms=arguments.finalize_ms,
+            cache_key=arguments.cache_key,
+            cache_hit=arguments.cache_hit,
+            uv_version=arguments.uv_version,
+            command_spec_digest=arguments.command_spec_digest,
+            service_compatibility_digest=arguments.service_compatibility_digest,
+            created_at=arguments.created_at,
+        )
+        if arguments.output:
+            _write_json(root, arguments.output, record)
+        else:
+            sys.stdout.buffer.write(canonical_json_bytes(record) + b"\n")
+    except (ContractError, EvidenceError, OSError, UnicodeError) as exc:
+        reason = str(exc) or type(exc).__name__
+        print(f"EVIDENCE_MISMATCH:gate:{reason}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sdlc/emit_evidence.py
+++ b/scripts/sdlc/emit_evidence.py
@@ -12,6 +12,7 @@ import re
 import stat
 import subprocess
 import sys
+import tempfile
 from typing import Mapping, Sequence
 
 from .classify_change import GitRouteError, resolve_commit, resolve_tree
@@ -26,12 +27,8 @@ _REPOSITORY = "fol2/newsroom"
 _SHA256 = re.compile(r"sha256:[0-9a-f]{64}")
 _GIT_SHA = re.compile(r"[0-9a-f]{40}")
 _SAFE_ID = re.compile(r"[A-Za-z0-9_.*-]{1,128}")
+_SAFE_REASON_SUFFIX = re.compile(r"[A-Za-z0-9_=.*-]{1,256}")
 _UV_OUTPUT = re.compile(r"uv ([^\s]+)(?:\s.*)?")
-_RESULT_REASON = re.compile(
-    r"(?:PASS|FAIL|BUDGET_EXCEEDED|CLASSIFIER_ERROR|ENVIRONMENT_ERROR|"
-    r"EVIDENCE_MISMATCH|UNAUTHORISED_EFFECT):[A-Za-z0-9_.*-]+:"
-    r"[A-Za-z0-9_.*-]+(?::[A-Za-z0-9_=.*-]+)?"
-)
 _RESULTS = frozenset(
     {
         "PASS",
@@ -315,6 +312,20 @@ def _git_bytes(
     return completed.stdout
 
 
+def verify_tracked_checkout(repo_root: str | Path, head_sha: str) -> None:
+    root = Path(repo_root).resolve()
+    expected_head = _git_sha(head_sha, "head_sha")
+    if resolve_commit(root, "HEAD") != expected_head:
+        raise EvidenceError("head_mismatch")
+    status = _git_bytes(
+        root,
+        ("status", "--porcelain=v1", "-z", "--untracked-files=no"),
+        maximum=_MAX_JSON_BYTES,
+    )
+    if status:
+        raise EvidenceError("tracked_checkout_dirty")
+
+
 @lru_cache(maxsize=1)
 def installed_uv_version() -> str:
     try:
@@ -446,6 +457,32 @@ def _validate_route(
     return route
 
 
+def _expected_gate_run_reason(
+    *,
+    result: str,
+    gate_id: str,
+    phase: str,
+    returncode: int | None,
+    reason: str,
+) -> None:
+    base = f"{result}:{gate_id}:{phase}"
+    if result in {"PASS", "BUDGET_EXCEEDED"}:
+        if reason != base:
+            raise EvidenceError("gate_run_reason")
+        return
+    if result == "FAIL":
+        if returncode is None or returncode == 0 or reason != f"{base}:exit={returncode}":
+            raise EvidenceError("gate_run_reason")
+        return
+    if reason == base:
+        return
+    prefix = base + ":"
+    if not reason.startswith(prefix) or _SAFE_REASON_SUFFIX.fullmatch(
+        reason[len(prefix) :]
+    ) is None:
+        raise EvidenceError("gate_run_reason")
+
+
 def _validate_gate_run(gate_id: str, value: object) -> dict[str, object]:
     run = dict(_mapping(value, "gate_run"))
     if set(run) != _GATE_RUN_KEYS:
@@ -454,13 +491,11 @@ def _validate_gate_run(gate_id: str, value: object) -> dict[str, object]:
         raise EvidenceError("gate_run_schema")
     if run.get("gate_id") != gate_id:
         raise EvidenceError("gate_run_id")
-    run["phase"] = _string(run.get("phase"), "gate_run_phase", maximum=128)
+    phase = _string(run.get("phase"), "gate_run_phase", maximum=128)
     result = _string(run.get("result"), "gate_run_result", maximum=64)
     if result not in _RESULTS:
         raise EvidenceError("gate_run_result")
     reason = _string(run.get("result_reason"), "gate_run_reason", maximum=512)
-    if _RESULT_REASON.fullmatch(reason) is None or not reason.startswith(result + ":"):
-        raise EvidenceError("gate_run_reason")
     returncode = run.get("returncode")
     if returncode is not None and (
         isinstance(returncode, bool) or not isinstance(returncode, int)
@@ -468,8 +503,14 @@ def _validate_gate_run(gate_id: str, value: object) -> dict[str, object]:
         raise EvidenceError("gate_run_returncode")
     if result == "PASS" and returncode != 0:
         raise EvidenceError("gate_run_pass_returncode")
-    if result == "FAIL" and (returncode is None or returncode == 0):
-        raise EvidenceError("gate_run_fail_returncode")
+    _expected_gate_run_reason(
+        result=result,
+        gate_id=gate_id,
+        phase=phase,
+        returncode=returncode,
+        reason=reason,
+    )
+    run["phase"] = phase
     run["execution_ms"] = _nonnegative(run.get("execution_ms"), "execution_ms")
     _text(run.get("stdout"), "gate_run_stdout", maximum=1_048_576)
     _text(run.get("stderr"), "gate_run_stderr", maximum=1_048_576)
@@ -688,7 +729,7 @@ def validate_evidence_record(record_value: object) -> dict[str, object]:
     if result not in _RESULTS:
         raise EvidenceError("result")
     reason = _string(record.get("result_reason"), "result_reason", maximum=512)
-    if _RESULT_REASON.fullmatch(reason) is None or not reason.startswith(result + ":"):
+    if not reason.startswith(result + ":"):
         raise EvidenceError("result_reason")
     record["created_at"] = _created_at(
         _string(record.get("created_at"), "created_at", maximum=64)
@@ -724,6 +765,7 @@ def build_gate_evidence(
         raise EvidenceError("contract_repository")
     normalized_route = _validate_route(contract, route)
     current_head = resolve_commit(root, "HEAD")
+    verify_tracked_checkout(root, current_head)
     if current_head != normalized_route["head_sha"]:
         raise EvidenceError("head_mismatch")
     if resolve_tree(root, current_head) != normalized_route["head_tree_sha"]:
@@ -931,16 +973,32 @@ def _load_json(root: Path, relative: str) -> object:
 
 def _write_json(root: Path, relative: str, value: object) -> None:
     path = _safe_json_path(root, relative, output=True)
+    if path.exists():
+        raise EvidenceError("output_exists")
     payload = canonical_json_bytes(value) + b"\n"
-    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=path.parent,
+    )
+    temporary = Path(temporary_name)
     try:
-        descriptor = os.open(path, flags, 0o600)
-    except FileExistsError as exc:
-        raise EvidenceError("output_exists") from exc
-    except OSError as exc:
-        raise EvidenceError("output_open") from exc
-    with os.fdopen(descriptor, "wb") as stream:
-        stream.write(payload)
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "wb", closefd=True) as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        try:
+            os.link(temporary, path, follow_symlinks=False)
+        except FileExistsError as exc:
+            raise EvidenceError("output_exists") from exc
+        except OSError as exc:
+            raise EvidenceError("output_open") from exc
+    finally:
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
 
 
 def main(argv: Sequence[str] | None = None) -> int:


### PR DESCRIPTION
## Status

Phase **1B2b** of issue #100 under accepted SDLC #98. Source-only, exact-head green and ready for review.

Reviewed head:

`b957088aac083e0a5a7428c9accf9317b8ef3b12`

Base:

`main@5b8a4695afe5bfb89ff07a83e3415c2ba2940de2`

This unit composes exact route, bounded gate-run and optional JUnit summary inputs into the accepted content-identified gate evidence record. GitHub workflow orchestration remains Phase 2; existing required workflows are unchanged.

## Scope

- add the missing required `evidence_identity` field to the pre-deployment evidence schema;
- deterministic no-float canonical JSON with a fixed SHA-256 vector;
- recompute and verify the route selected-test manifest;
- bind exact base/head commits and trees;
- reject any tracked worktree drift while allowing untracked test/evidence artifacts;
- read `uv.lock` from the exact head Git blob, not ambient worktree bytes;
- execute bounded `uv --version` and require the caller claim to match the actual executable;
- derive actual Python/OS/architecture/uv toolchain digest;
- bind the repository-supplied command-spec digest and exact route into `gate_inputs_digest`;
- compute evidence identity from the accepted v2.2 identity fields;
- reconcile watchdog result with JUnit required-skip/failure state;
- require JUnit evidence for successful selected-test gates;
- require compatibility digest only for the actual Neo4j service gate;
- bind watchdog reason to the same result, gate, phase and exit code;
- omit raw stdout/stderr from final evidence;
- manually revalidate exact shape, counts, failure fingerprint, result reason, PASS invariants and evidence identity before output;
- atomically publish private non-overwriting JSON; valid FAIL evidence still emits successfully.

## Review-trigger decomposition note

The accepted trigger is 400 net executable lines / 12 files. This PR changes three files but exceeds the line trigger because schema, identity construction and tamper/PASS invariant tests form one indivisible evidence contract. Splitting schema from the only producer would merge an unusable contract; splitting validation from identity construction would temporarily permit unverified evidence. Workflow topology remains a separate Phase 2 PR.

## Substantive review corrections

P1: 0. P2 found and corrected: 11. Unresolved P1/P2 within the declared composer boundary: 0.

1. The accepted evidence schema described content identity but omitted the machine `evidence_identity` field.
2. Empty watchdog stdout/stderr were initially rejected even though empty output is valid.
3. Selected-test lists could be changed while retaining an old route manifest digest.
4. JSON inputs could grow after metadata inspection and cause an unbounded read.
5. CLI exception rendering could expose Unicode/path details.
6. A test helper treated explicit missing JUnit as a default PASS summary, leaving the critical missing-evidence path untested.
7. The caller could claim an arbitrary uv version; the composer now verifies the actual bounded `uv --version` output.
8. Failure/error/required-skip counts and first-failure fingerprint were not bidirectionally consistent.
9. Watchdog `result_reason` could name a different gate, phase or exit code while preserving the nominal result.
10. Ambient tracked contract/source drift could produce evidence for an unchanged HEAD; tracked checkout equality is now mandatory.
11. A write failure could leave a partial evidence file that blocked deterministic replay; publication now writes and fsyncs a private temporary file, links it atomically without replacement, then removes the temporary name.

## Phase 2 integration requirements

This PR is a producer library, not the completed cross-job pipeline. Phase 2 must:

- derive one repository-owned command specification and use the same specification both to invoke the watchdog and to supply its digest;
- independently bind route/core/service artifacts to exact job/run/head provenance and verify their artifact digests in the final decision job;
- measure queue/bootstrap/finalization clocks from workflow timestamps rather than accepting arbitrary human-entered values;
- keep all five legacy workflows running as paired controls.

These requirements are explicit and are not claimed as already satisfied by this PR.

## Exact-head validation

Head `b957088aac083e0a5a7428c9accf9317b8ef3b12`:

- Authority A2a run `29903052757`: success;
- Authority A2b run `29903052810`: success;
- Projection B1 run `29903052774`: success;
- Projection B2 Neo4j run `29903052744`: success;
- complete repository CI and clustering run `29903052796`: success;
- unresolved inline review threads: zero.

## Changed files

- `.sdlc/evidence.schema.json`;
- `scripts/sdlc/emit_evidence.py`;
- `newsroom/tests/test_sdlc_evidence.py`.

## Exclusions

No GitHub workflow, cache implementation, test selection, Neo4j process change, current required-check change, release, production, Graphiti/model/embedding/live-source execution, publication, product shadow, canary, spending or public effect.