### PR TITLE
feat(sdlc): bind exact canonical command specifications

### DIFF
--- a/newsroom/tests/test_sdlc_command_spec.py
+++ b/newsroom/tests/test_sdlc_command_spec.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+import os
+from pathlib import Path
+import stat
+import sys
+
+import pytest
+
+import scripts.sdlc.command_spec as command_spec_module
+from scripts.sdlc.command_spec import (
+    CommandSpecError,
+    build_environment,
+    execute_command_spec,
+    load_command_spec,
+    main as command_main,
+    parse_command_spec,
+)
+from scripts.sdlc.contracts import SdlcContract, load_contract
+
+
+REPO_ROOT = Path(__file__).parents[2]
+FIXED_DIGEST = "sha256:a06f3cb359bd3b59d89b388130577ca4b54c30139cc3ef8dc902ac8272456063"
+
+
+def _contract(root: Path = REPO_ROOT) -> SdlcContract:
+    source = load_contract(REPO_ROOT)
+    if root == REPO_ROOT:
+        return source
+    return SdlcContract(root, source.source_path, source.data)
+
+
+def _value(
+    *,
+    argv: list[str] | None = None,
+    cwd: str = ".",
+    static_env: dict[str, str] | None = None,
+    pass_env: list[str] | None = None,
+    redact_env: list[str] | None = None,
+) -> dict[str, object]:
+    return {
+        "schema_version": "newsroom.sdlc.command-spec.v1",
+        "gate_id": "route",
+        "phase": "unit",
+        "argv": argv or [sys.executable, "-c", "print('ok')"],
+        "cwd": cwd,
+        "static_env": static_env or {},
+        "pass_env": pass_env or [],
+        "redact_env": redact_env or [],
+        "output_limit_bytes": 65_536,
+        "termination_grace_ms": 500,
+    }
+
+
+def _write_spec(root: Path, name: str, value: dict[str, object]) -> Path:
+    path = root / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value), encoding="utf-8")
+    return path
+
+
+def test_command_spec_has_fixed_canonical_digest() -> None:
+    value = _value(
+        argv=["python", "-c", "print('ok')"],
+        static_env={"PYTHONHASHSEED": "0"},
+        pass_env=["PATH"],
+    )
+
+    spec = parse_command_spec(value, contract=_contract())
+
+    assert spec.digest == FIXED_DIGEST
+    assert spec.as_dict() == value
+
+
+def test_order_is_normalized_but_each_execution_input_changes_digest(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "sub").mkdir()
+    contract = _contract(tmp_path)
+    baseline_value = _value(
+        static_env={"B": "2", "A": "1"},
+        pass_env=["VISIBLE", "CUSTOM_VALUE"],
+        redact_env=["CUSTOM_VALUE"],
+    )
+    baseline = parse_command_spec(baseline_value, contract=contract)
+    reordered = deepcopy(baseline_value)
+    reordered["static_env"] = {"A": "1", "B": "2"}
+    reordered["pass_env"] = ["CUSTOM_VALUE", "VISIBLE"]
+    assert parse_command_spec(reordered, contract=contract).digest == baseline.digest
+
+    variants: list[dict[str, object]] = []
+    for field, value in (
+        ("argv", [sys.executable, "-c", "print('changed')"]),
+        ("cwd", "sub"),
+        ("static_env", {"A": "1", "B": "3"}),
+        ("pass_env", ["VISIBLE", "CUSTOM_VALUE", "PATH"]),
+        ("redact_env", []),
+        ("output_limit_bytes", 4096),
+        ("termination_grace_ms", 250),
+    ):
+        changed = deepcopy(baseline_value)
+        changed[field] = value
+        variants.append(changed)
+
+    assert all(
+        parse_command_spec(value, contract=contract).digest != baseline.digest
+        for value in variants
+    )
+
+
+def test_same_spec_drives_execution_digest_and_minimal_redacted_environment(
+    tmp_path: Path,
+) -> None:
+    source = (
+        "import os; "
+        "print('|'.join([os.environ.get('STATIC_VALUE','missing'),"
+        "os.environ.get('VISIBLE','missing'),"
+        "os.environ.get('CUSTOM_VALUE','missing'),"
+        "os.environ.get('UNLISTED','missing')]))"
+    )
+    contract = _contract(tmp_path)
+    spec = parse_command_spec(
+        _value(
+            argv=[sys.executable, "-c", source],
+            static_env={"STATIC_VALUE": "fixed"},
+            pass_env=["VISIBLE", "CUSTOM_VALUE"],
+            redact_env=["CUSTOM_VALUE"],
+        ),
+        contract=contract,
+    )
+
+    command_run = execute_command_spec(
+        contract=contract,
+        spec=spec,
+        ambient_env={
+            "VISIBLE": "allowed",
+            "CUSTOM_VALUE": "sensitive-value",
+            "UNLISTED": "must-not-leak",
+        },
+    )
+
+    assert command_run.command_spec_digest == spec.digest
+    assert command_run.gate_run.result == "PASS"
+    assert command_run.gate_run.stdout == "fixed|allowed|***|missing\n"
+    assert "sensitive-value" not in command_run.gate_run.stdout
+    assert "must-not-leak" not in command_run.gate_run.stdout
+
+
+def test_secret_static_environment_and_unscoped_redaction_are_rejected(
+    tmp_path: Path,
+) -> None:
+    contract = _contract(tmp_path)
+    secret = _value(static_env={"API_TOKEN": "not-allowed"})
+    with pytest.raises(CommandSpecError, match="static_secret_name"):
+        parse_command_spec(secret, contract=contract)
+
+    unscoped = _value(redact_env=["MISSING"])
+    with pytest.raises(CommandSpecError, match="redact_env_scope"):
+        parse_command_spec(unscoped, contract=contract)
+
+    overlap = _value(static_env={"VALUE": "x"}, pass_env=["VALUE"])
+    with pytest.raises(CommandSpecError, match="environment_overlap"):
+        parse_command_spec(overlap, contract=contract)
+
+
+def test_missing_environment_fails_without_echoing_name_or_value(tmp_path: Path) -> None:
+    contract = _contract(tmp_path)
+    spec = parse_command_spec(
+        _value(pass_env=["PRIVATE_MISSING_VALUE"]),
+        contract=contract,
+    )
+
+    with pytest.raises(CommandSpecError) as failure:
+        build_environment(spec, {})
+
+    assert str(failure.value) == "missing_environment"
+    assert "PRIVATE_MISSING_VALUE" not in str(failure.value)
+
+
+def test_shape_identifiers_and_numeric_limits_fail_closed(tmp_path: Path) -> None:
+    contract = _contract(tmp_path)
+    cases = []
+    unknown = _value()
+    unknown["extra"] = True
+    cases.append((unknown, "shape"))
+    bad_gate = _value()
+    bad_gate["gate_id"] = "not-a-gate"
+    cases.append((bad_gate, "gate_id"))
+    bad_phase = _value()
+    bad_phase["phase"] = "bad:phase"
+    cases.append((bad_phase, "phase"))
+    bad_output = _value()
+    bad_output["output_limit_bytes"] = True
+    cases.append((bad_output, "output_limit"))
+    bad_grace = _value()
+    bad_grace["termination_grace_ms"] = 5001
+    cases.append((bad_grace, "termination_grace"))
+
+    for value, code in cases:
+        with pytest.raises(CommandSpecError, match=code):
+            parse_command_spec(value, contract=contract)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="symlink evidence is POSIX-specific")
+def test_cwd_and_spec_symlinks_or_path_escape_are_rejected(tmp_path: Path) -> None:
+    contract = _contract(tmp_path)
+    outside = tmp_path.parent / f"outside-{tmp_path.name}"
+    outside.mkdir()
+    (tmp_path / "linked").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(CommandSpecError, match="cwd_symlink"):
+        parse_command_spec(_value(cwd="linked"), contract=contract)
+    with pytest.raises(CommandSpecError, match="cwd"):
+        parse_command_spec(_value(cwd="../outside"), contract=contract)
+
+    target = _write_spec(tmp_path, "real.json", _value())
+    (tmp_path / "link.json").symlink_to(target)
+    with pytest.raises(CommandSpecError, match="spec_symlink"):
+        load_command_spec(tmp_path, "link.json", contract=contract)
+
+
+def test_cli_writes_private_atomic_result_and_never_overwrites(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    contract = _contract(tmp_path)
+    monkeypatch.setattr(command_spec_module, "load_contract", lambda _root: contract)
+    _write_spec(
+        tmp_path,
+        "command.json",
+        _value(static_env={"PYTHONUTF8": "1"}),
+    )
+
+    assert command_main(
+        (
+            "--repo-root",
+            str(tmp_path),
+            "--spec",
+            "command.json",
+            "--output",
+            "run.json",
+        )
+    ) == 0
+    payload = json.loads((tmp_path / "run.json").read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "newsroom.sdlc.command-run.v1"
+    assert payload["gate_run"]["result"] == "PASS"
+    assert payload["command_spec_digest"].startswith("sha256:")
+    assert stat.S_IMODE((tmp_path / "run.json").stat().st_mode) == 0o600
+
+    original = (tmp_path / "run.json").read_bytes()
+    assert command_main(
+        (
+            "--repo-root",
+            str(tmp_path),
+            "--spec",
+            "command.json",
+            "--output",
+            "run.json",
+        )
+    ) == 3
+    assert (tmp_path / "run.json").read_bytes() == original
+    assert capsys.readouterr().err.strip() == (
+        "ENVIRONMENT_ERROR:command-spec:output_exists"
+    )
+
+
+def test_cli_preserves_gate_exit_semantics_and_hides_input_details(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    contract = _contract(tmp_path)
+    monkeypatch.setattr(command_spec_module, "load_contract", lambda _root: contract)
+    _write_spec(
+        tmp_path,
+        "failure.json",
+        _value(argv=[sys.executable, "-c", "raise SystemExit(7)"]),
+    )
+
+    assert command_main(
+        ("--repo-root", str(tmp_path), "--spec", "failure.json")
+    ) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["gate_run"]["result"] == "FAIL"
+    assert payload["gate_run"]["returncode"] == 7
+
+    private_name = "PRIVATE_MISSING_VALUE_12345"
+    _write_spec(
+        tmp_path,
+        "missing.json",
+        _value(pass_env=[private_name]),
+    )
+    assert command_main(
+        ("--repo-root", str(tmp_path), "--spec", "missing.json")
+    ) == 3
+    error = capsys.readouterr().err.strip()
+    assert error == "ENVIRONMENT_ERROR:command-spec:missing_environment"
+    assert private_name not in error

--- a/newsroom/tests/test_sdlc_command_spec.py
+++ b/newsroom/tests/test_sdlc_command_spec.py
@@ -253,6 +253,16 @@ def test_executable_is_resolved_and_content_bound(tmp_path: Path) -> None:
     assert spec.executable_digest == digest
 
 
+@pytest.mark.skipif(os.name != "posix", reason="executable mode evidence is POSIX-specific")
+def test_shebang_executable_is_rejected_as_unbound_interpreter(tmp_path: Path) -> None:
+    script = tmp_path / "runner"
+    script.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    script.chmod(0o700)
+
+    with pytest.raises(CommandSpecError, match="executable_interpreter_unbound"):
+        executable_digest(script)
+
+
 def test_all_ambient_values_are_redacted_and_bounded(tmp_path: Path) -> None:
     contract = _contract(tmp_path)
     unbound = _value(pass_env=["VALUE"], redact_env=[])

--- a/newsroom/tests/test_sdlc_command_spec.py
+++ b/newsroom/tests/test_sdlc_command_spec.py
@@ -11,9 +11,11 @@ import pytest
 
 import scripts.sdlc.command_spec as command_spec_module
 from scripts.sdlc.command_spec import (
+    CommandSpec,
     CommandSpecError,
     build_environment,
     execute_command_spec,
+    executable_digest,
     load_command_spec,
     main as command_main,
     parse_command_spec,
@@ -22,7 +24,7 @@ from scripts.sdlc.contracts import SdlcContract, load_contract
 
 
 REPO_ROOT = Path(__file__).parents[2]
-FIXED_DIGEST = "sha256:a06f3cb359bd3b59d89b388130577ca4b54c30139cc3ef8dc902ac8272456063"
+FIXED_DIGEST = "sha256:4a0780dacdf4bc9f4864efd7f5ff10b123131788af556c5bd4b254f1b63e6108"
 
 
 def _contract(root: Path = REPO_ROOT) -> SdlcContract:
@@ -39,16 +41,20 @@ def _value(
     static_env: dict[str, str] | None = None,
     pass_env: list[str] | None = None,
     redact_env: list[str] | None = None,
+    executable_sha: str | None = None,
 ) -> dict[str, object]:
+    selected_argv = argv or [sys.executable, "-c", "print('ok')"]
+    _, actual_digest = executable_digest(selected_argv[0])
     return {
         "schema_version": "newsroom.sdlc.command-spec.v1",
         "gate_id": "route",
         "phase": "unit",
-        "argv": argv or [sys.executable, "-c", "print('ok')"],
+        "argv": selected_argv,
         "cwd": cwd,
         "static_env": static_env or {},
         "pass_env": pass_env or [],
         "redact_env": redact_env or [],
+        "executable_digest": executable_sha or actual_digest,
         "output_limit_bytes": 65_536,
         "termination_grace_ms": 500,
     }
@@ -62,16 +68,21 @@ def _write_spec(root: Path, name: str, value: dict[str, object]) -> Path:
 
 
 def test_command_spec_has_fixed_canonical_digest() -> None:
-    value = _value(
-        argv=["python", "-c", "print('ok')"],
-        static_env={"PYTHONHASHSEED": "0"},
-        pass_env=["PATH"],
+    spec = CommandSpec(
+        gate_id="route",
+        phase="unit",
+        argv=("/usr/bin/python", "-c", "print('ok')"),
+        cwd=".",
+        static_env=(("PYTHONHASHSEED", "0"),),
+        pass_env=(),
+        redact_env=(),
+        executable_digest="sha256:" + "1" * 64,
+        output_limit_bytes=65_536,
+        termination_grace_ms=500,
     )
 
-    spec = parse_command_spec(value, contract=_contract())
-
     assert spec.digest == FIXED_DIGEST
-    assert spec.as_dict() == value
+    assert spec.as_dict()["executable_digest"] == "sha256:" + "1" * 64
 
 
 def test_order_is_normalized_but_each_execution_input_changes_digest(
@@ -81,13 +92,14 @@ def test_order_is_normalized_but_each_execution_input_changes_digest(
     contract = _contract(tmp_path)
     baseline_value = _value(
         static_env={"B": "2", "A": "1"},
-        pass_env=["VISIBLE", "CUSTOM_VALUE"],
-        redact_env=["CUSTOM_VALUE"],
+        pass_env=["SECRET_TWO", "SECRET_ONE"],
+        redact_env=["SECRET_ONE", "SECRET_TWO"],
     )
     baseline = parse_command_spec(baseline_value, contract=contract)
     reordered = deepcopy(baseline_value)
     reordered["static_env"] = {"A": "1", "B": "2"}
-    reordered["pass_env"] = ["CUSTOM_VALUE", "VISIBLE"]
+    reordered["pass_env"] = ["SECRET_ONE", "SECRET_TWO"]
+    reordered["redact_env"] = ["SECRET_TWO", "SECRET_ONE"]
     assert parse_command_spec(reordered, contract=contract).digest == baseline.digest
 
     variants: list[dict[str, object]] = []
@@ -95,14 +107,16 @@ def test_order_is_normalized_but_each_execution_input_changes_digest(
         ("argv", [sys.executable, "-c", "print('changed')"]),
         ("cwd", "sub"),
         ("static_env", {"A": "1", "B": "3"}),
-        ("pass_env", ["VISIBLE", "CUSTOM_VALUE", "PATH"]),
-        ("redact_env", []),
         ("output_limit_bytes", 4096),
         ("termination_grace_ms", 250),
     ):
         changed = deepcopy(baseline_value)
         changed[field] = value
         variants.append(changed)
+    changed_environment = deepcopy(baseline_value)
+    changed_environment["pass_env"] = ["SECRET_ONE", "SECRET_TWO", "SECRET_THREE"]
+    changed_environment["redact_env"] = ["SECRET_ONE", "SECRET_TWO", "SECRET_THREE"]
+    variants.append(changed_environment)
 
     assert all(
         parse_command_spec(value, contract=contract).digest != baseline.digest
@@ -124,8 +138,8 @@ def test_same_spec_drives_execution_digest_and_minimal_redacted_environment(
     spec = parse_command_spec(
         _value(
             argv=[sys.executable, "-c", source],
-            static_env={"STATIC_VALUE": "fixed"},
-            pass_env=["VISIBLE", "CUSTOM_VALUE"],
+            static_env={"STATIC_VALUE": "fixed", "VISIBLE": "allowed"},
+            pass_env=["CUSTOM_VALUE"],
             redact_env=["CUSTOM_VALUE"],
         ),
         contract=contract,
@@ -135,7 +149,6 @@ def test_same_spec_drives_execution_digest_and_minimal_redacted_environment(
         contract=contract,
         spec=spec,
         ambient_env={
-            "VISIBLE": "allowed",
             "CUSTOM_VALUE": "sensitive-value",
             "UNLISTED": "must-not-leak",
         },
@@ -157,10 +170,14 @@ def test_secret_static_environment_and_unscoped_redaction_are_rejected(
         parse_command_spec(secret, contract=contract)
 
     unscoped = _value(redact_env=["MISSING"])
-    with pytest.raises(CommandSpecError, match="redact_env_scope"):
+    with pytest.raises(CommandSpecError, match="unbound_environment"):
         parse_command_spec(unscoped, contract=contract)
 
-    overlap = _value(static_env={"VALUE": "x"}, pass_env=["VALUE"])
+    overlap = _value(
+        static_env={"VALUE": "x"},
+        pass_env=["VALUE"],
+        redact_env=["VALUE"],
+    )
     with pytest.raises(CommandSpecError, match="environment_overlap"):
         parse_command_spec(overlap, contract=contract)
 
@@ -168,7 +185,10 @@ def test_secret_static_environment_and_unscoped_redaction_are_rejected(
 def test_missing_environment_fails_without_echoing_name_or_value(tmp_path: Path) -> None:
     contract = _contract(tmp_path)
     spec = parse_command_spec(
-        _value(pass_env=["PRIVATE_MISSING_VALUE"]),
+        _value(
+            pass_env=["PRIVATE_MISSING_VALUE"],
+            redact_env=["PRIVATE_MISSING_VALUE"],
+        ),
         contract=contract,
     )
 
@@ -197,10 +217,81 @@ def test_shape_identifiers_and_numeric_limits_fail_closed(tmp_path: Path) -> Non
     bad_grace = _value()
     bad_grace["termination_grace_ms"] = 5001
     cases.append((bad_grace, "termination_grace"))
+    bad_executable = _value(executable_sha="sha256:" + "0" * 64)
+    cases.append((bad_executable, "executable_digest"))
+    relative_executable = _value()
+    relative_executable["argv"] = ["python", "-c", "pass"]
+    cases.append((relative_executable, "executable_path"))
 
     for value, code in cases:
         with pytest.raises(CommandSpecError, match=code):
             parse_command_spec(value, contract=contract)
+
+
+def test_direct_dataclass_cannot_bypass_parser_invariants(tmp_path: Path) -> None:
+    contract = _contract(tmp_path)
+    parsed = parse_command_spec(_value(), contract=contract)
+    bypass = CommandSpec(
+        gate_id=parsed.gate_id,
+        phase=parsed.phase,
+        argv=parsed.argv,
+        cwd=parsed.cwd,
+        static_env=parsed.static_env,
+        pass_env=("UNBOUND_VALUE",),
+        redact_env=(),
+        executable_digest=parsed.executable_digest,
+        output_limit_bytes=parsed.output_limit_bytes,
+        termination_grace_ms=parsed.termination_grace_ms,
+    )
+
+    with pytest.raises(CommandSpecError, match="unbound_environment"):
+        execute_command_spec(
+            contract=contract,
+            spec=bypass,
+            ambient_env={"UNBOUND_VALUE": "secret"},
+        )
+
+
+def test_executable_is_resolved_and_content_bound(tmp_path: Path) -> None:
+    contract = _contract(tmp_path)
+    resolved, digest = executable_digest(sys.executable)
+    spec = parse_command_spec(_value(), contract=contract)
+
+    assert spec.argv[0] == resolved
+    assert spec.executable_digest == digest
+
+
+def test_all_ambient_values_are_redacted_and_bounded(tmp_path: Path) -> None:
+    contract = _contract(tmp_path)
+    unbound = _value(pass_env=["VALUE"], redact_env=[])
+    with pytest.raises(CommandSpecError, match="unbound_environment"):
+        parse_command_spec(unbound, contract=contract)
+
+    spec = parse_command_spec(
+        _value(pass_env=["VALUE"], redact_env=["VALUE"]),
+        contract=contract,
+    )
+    with pytest.raises(CommandSpecError, match="environment_value"):
+        build_environment(spec, {"VALUE": "x" * 65_537})
+    with pytest.raises(CommandSpecError, match="environment_value"):
+        build_environment(spec, {"VALUE": "bad\x00value"})
+
+
+def test_duplicate_json_keys_fail_closed(tmp_path: Path) -> None:
+    contract = _contract(tmp_path)
+    _, digest = executable_digest(sys.executable)
+    payload = (
+        '{"schema_version":"newsroom.sdlc.command-spec.v1",'
+        '"gate_id":"route","gate_id":"route","phase":"unit",'
+        f'"argv":[{json.dumps(sys.executable)},"-c","pass"],'
+        '"cwd":".","static_env":{},"pass_env":[],"redact_env":[],'
+        f'"executable_digest":"{digest}",'
+        '"output_limit_bytes":65536,"termination_grace_ms":500}'
+    )
+    (tmp_path / "duplicate.json").write_text(payload, encoding="utf-8")
+
+    with pytest.raises(CommandSpecError, match="spec_duplicate_key"):
+        load_command_spec(tmp_path, "duplicate.json", contract=contract)
 
 
 @pytest.mark.skipif(os.name != "posix", reason="symlink evidence is POSIX-specific")
@@ -291,7 +382,7 @@ def test_cli_preserves_gate_exit_semantics_and_hides_input_details(
     _write_spec(
         tmp_path,
         "missing.json",
-        _value(pass_env=[private_name]),
+        _value(pass_env=[private_name], redact_env=[private_name]),
     )
     assert command_main(
         ("--repo-root", str(tmp_path), "--spec", "missing.json")

--- a/newsroom/tests/test_sdlc_command_spec.py
+++ b/newsroom/tests/test_sdlc_command_spec.py
@@ -131,7 +131,7 @@ def test_same_spec_drives_execution_digest_and_minimal_redacted_environment(
         "import os; "
         "print('|'.join([os.environ.get('STATIC_VALUE','missing'),"
         "os.environ.get('VISIBLE','missing'),"
-        "os.environ.get('CUSTOM_VALUE','missing'),"
+        "os.environ.get('CUSTOM_SECRET','missing'),"
         "os.environ.get('UNLISTED','missing')]))"
     )
     contract = _contract(tmp_path)
@@ -139,8 +139,8 @@ def test_same_spec_drives_execution_digest_and_minimal_redacted_environment(
         _value(
             argv=[sys.executable, "-c", source],
             static_env={"STATIC_VALUE": "fixed", "VISIBLE": "allowed"},
-            pass_env=["CUSTOM_VALUE"],
-            redact_env=["CUSTOM_VALUE"],
+            pass_env=["CUSTOM_SECRET"],
+            redact_env=["CUSTOM_SECRET"],
         ),
         contract=contract,
     )
@@ -149,7 +149,7 @@ def test_same_spec_drives_execution_digest_and_minimal_redacted_environment(
         contract=contract,
         spec=spec,
         ambient_env={
-            "CUSTOM_VALUE": "sensitive-value",
+            "CUSTOM_SECRET": "sensitive-value",
             "UNLISTED": "must-not-leak",
         },
     )
@@ -173,21 +173,13 @@ def test_secret_static_environment_and_unscoped_redaction_are_rejected(
     with pytest.raises(CommandSpecError, match="unbound_environment"):
         parse_command_spec(unscoped, contract=contract)
 
-    overlap = _value(
-        static_env={"VALUE": "x"},
-        pass_env=["VALUE"],
-        redact_env=["VALUE"],
-    )
-    with pytest.raises(CommandSpecError, match="environment_overlap"):
-        parse_command_spec(overlap, contract=contract)
-
 
 def test_missing_environment_fails_without_echoing_name_or_value(tmp_path: Path) -> None:
     contract = _contract(tmp_path)
     spec = parse_command_spec(
         _value(
-            pass_env=["PRIVATE_MISSING_VALUE"],
-            redact_env=["PRIVATE_MISSING_VALUE"],
+            pass_env=["PRIVATE_MISSING_SECRET"],
+            redact_env=["PRIVATE_MISSING_SECRET"],
         ),
         contract=contract,
     )
@@ -196,7 +188,7 @@ def test_missing_environment_fails_without_echoing_name_or_value(tmp_path: Path)
         build_environment(spec, {})
 
     assert str(failure.value) == "missing_environment"
-    assert "PRIVATE_MISSING_VALUE" not in str(failure.value)
+    assert "PRIVATE_MISSING_SECRET" not in str(failure.value)
 
 
 def test_shape_identifiers_and_numeric_limits_fail_closed(tmp_path: Path) -> None:
@@ -268,13 +260,13 @@ def test_all_ambient_values_are_redacted_and_bounded(tmp_path: Path) -> None:
         parse_command_spec(unbound, contract=contract)
 
     spec = parse_command_spec(
-        _value(pass_env=["VALUE"], redact_env=["VALUE"]),
+        _value(pass_env=["CUSTOM_SECRET"], redact_env=["CUSTOM_SECRET"]),
         contract=contract,
     )
     with pytest.raises(CommandSpecError, match="environment_value"):
-        build_environment(spec, {"VALUE": "x" * 65_537})
+        build_environment(spec, {"CUSTOM_SECRET": "x" * 65_537})
     with pytest.raises(CommandSpecError, match="environment_value"):
-        build_environment(spec, {"VALUE": "bad\x00value"})
+        build_environment(spec, {"CUSTOM_SECRET": "bad\x00value"})
 
 
 def test_duplicate_json_keys_fail_closed(tmp_path: Path) -> None:
@@ -378,7 +370,7 @@ def test_cli_preserves_gate_exit_semantics_and_hides_input_details(
     assert payload["gate_run"]["result"] == "FAIL"
     assert payload["gate_run"]["returncode"] == 7
 
-    private_name = "PRIVATE_MISSING_VALUE_12345"
+    private_name = "PRIVATE_MISSING_SECRET_12345"
     _write_spec(
         tmp_path,
         "missing.json",

--- a/scripts/sdlc/command_spec.py
+++ b/scripts/sdlc/command_spec.py
@@ -172,6 +172,10 @@ def executable_digest(path: str | Path) -> tuple[str, str]:
         ):
             raise CommandSpecError("executable_file")
         with os.fdopen(descriptor, "rb", closefd=False) as stream:
+            header = stream.read(2)
+            if header == b"#!":
+                raise CommandSpecError("executable_interpreter_unbound")
+            digest.update(header)
             while payload := stream.read(1024 * 1024):
                 digest.update(payload)
     finally:

--- a/scripts/sdlc/command_spec.py
+++ b/scripts/sdlc/command_spec.py
@@ -1,0 +1,425 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import re
+import stat
+import sys
+import tempfile
+from typing import Mapping, Sequence
+
+from .contracts import ContractError, SdlcContract, load_contract
+from .emit_evidence import EvidenceError, canonical_json_bytes, sha256_identity
+from .run_gate import GateRunError, GateRunResult, run_configured_gate
+
+
+SCHEMA_VERSION = "newsroom.sdlc.command-spec.v1"
+RUN_SCHEMA_VERSION = "newsroom.sdlc.command-run.v1"
+_MAX_SPEC_BYTES = 256 * 1024
+_MAX_ARGUMENTS = 256
+_MAX_ARGUMENT_CHARS = 4096
+_MAX_ENVIRONMENT_ITEMS = 128
+_MAX_ENVIRONMENT_VALUE_CHARS = 4096
+_MAX_OUTPUT_BYTES = 1_048_576
+_ENVIRONMENT_NAME = re.compile(r"[A-Za-z_][A-Za-z0-9_]{0,127}")
+_SAFE_ID = re.compile(r"[A-Za-z0-9_.*-]{1,128}")
+_SECRET_NAME = re.compile(
+    r"(?:AUTH|CREDENTIAL|KEY|PASSWORD|SECRET|TOKEN)", re.IGNORECASE
+)
+_REQUIRED_KEYS = frozenset(
+    {
+        "schema_version",
+        "gate_id",
+        "phase",
+        "argv",
+        "cwd",
+        "static_env",
+        "pass_env",
+        "redact_env",
+        "output_limit_bytes",
+        "termination_grace_ms",
+    }
+)
+
+
+class CommandSpecError(ValueError):
+    """Raised when a command specification cannot safely drive a gate."""
+
+
+@dataclass(frozen=True)
+class CommandSpec:
+    gate_id: str
+    phase: str
+    argv: tuple[str, ...]
+    cwd: str
+    static_env: tuple[tuple[str, str], ...]
+    pass_env: tuple[str, ...]
+    redact_env: tuple[str, ...]
+    output_limit_bytes: int
+    termination_grace_ms: int
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "gate_id": self.gate_id,
+            "phase": self.phase,
+            "argv": list(self.argv),
+            "cwd": self.cwd,
+            "static_env": dict(self.static_env),
+            "pass_env": list(self.pass_env),
+            "redact_env": list(self.redact_env),
+            "output_limit_bytes": self.output_limit_bytes,
+            "termination_grace_ms": self.termination_grace_ms,
+        }
+
+    @property
+    def digest(self) -> str:
+        try:
+            return sha256_identity(self.as_dict())
+        except EvidenceError as exc:
+            raise CommandSpecError("canonicalization") from exc
+
+
+@dataclass(frozen=True)
+class CommandRun:
+    command_spec_digest: str
+    gate_run: GateRunResult
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": RUN_SCHEMA_VERSION,
+            "command_spec_digest": self.command_spec_digest,
+            "gate_run": self.gate_run.as_dict(),
+        }
+
+
+def _bounded_string(
+    value: object,
+    code: str,
+    *,
+    maximum: int,
+    allow_empty: bool = False,
+) -> str:
+    if (
+        not isinstance(value, str)
+        or (not value and not allow_empty)
+        or len(value) > maximum
+    ):
+        raise CommandSpecError(code)
+    if any(ord(character) < 32 or ord(character) == 127 for character in value):
+        raise CommandSpecError(code)
+    return value
+
+
+def _environment_name(value: object) -> str:
+    if not isinstance(value, str) or _ENVIRONMENT_NAME.fullmatch(value) is None:
+        raise CommandSpecError("environment_name")
+    return value
+
+
+def _safe_relative_directory(repo_root: Path, relative: object) -> tuple[str, Path]:
+    text = _bounded_string(relative, "cwd", maximum=512)
+    candidate = Path(text)
+    if candidate.is_absolute() or ".." in candidate.parts or "\\" in text:
+        raise CommandSpecError("cwd")
+    current = repo_root
+    for part in candidate.parts:
+        current /= part
+        if current.is_symlink():
+            raise CommandSpecError("cwd_symlink")
+    resolved = current.resolve()
+    if not resolved.is_relative_to(repo_root) or not resolved.is_dir():
+        raise CommandSpecError("cwd")
+    normalized = resolved.relative_to(repo_root).as_posix()
+    return normalized if normalized != "." else ".", resolved
+
+
+def _accepted_gate_ids(contract: SdlcContract) -> frozenset[str]:
+    return frozenset(str(gate["id"]) for gate in contract.data["gate"].values())
+
+
+def parse_command_spec(
+    value: object,
+    *,
+    contract: SdlcContract,
+) -> CommandSpec:
+    if not isinstance(value, dict) or frozenset(value) != _REQUIRED_KEYS:
+        raise CommandSpecError("shape")
+    if value.get("schema_version") != SCHEMA_VERSION:
+        raise CommandSpecError("schema_version")
+
+    gate_id = _bounded_string(value.get("gate_id"), "gate_id", maximum=128)
+    if _SAFE_ID.fullmatch(gate_id) is None or gate_id not in _accepted_gate_ids(contract):
+        raise CommandSpecError("gate_id")
+    phase = _bounded_string(value.get("phase"), "phase", maximum=128)
+    if _SAFE_ID.fullmatch(phase) is None:
+        raise CommandSpecError("phase")
+
+    raw_argv = value.get("argv")
+    if not isinstance(raw_argv, list) or not 0 < len(raw_argv) <= _MAX_ARGUMENTS:
+        raise CommandSpecError("argv")
+    argv = tuple(
+        _bounded_string(item, "argv", maximum=_MAX_ARGUMENT_CHARS)
+        for item in raw_argv
+    )
+
+    cwd, _ = _safe_relative_directory(contract.repo_root, value.get("cwd"))
+
+    raw_static = value.get("static_env")
+    if not isinstance(raw_static, dict) or len(raw_static) > _MAX_ENVIRONMENT_ITEMS:
+        raise CommandSpecError("static_env")
+    static: dict[str, str] = {}
+    for raw_name, raw_value in raw_static.items():
+        name = _environment_name(raw_name)
+        if _SECRET_NAME.search(name):
+            raise CommandSpecError("static_secret_name")
+        static[name] = _bounded_string(
+            raw_value,
+            "static_env_value",
+            maximum=_MAX_ENVIRONMENT_VALUE_CHARS,
+            allow_empty=True,
+        )
+
+    raw_pass = value.get("pass_env")
+    if not isinstance(raw_pass, list) or len(raw_pass) > _MAX_ENVIRONMENT_ITEMS:
+        raise CommandSpecError("pass_env")
+    passed = tuple(sorted(_environment_name(item) for item in raw_pass))
+    if len(set(passed)) != len(passed):
+        raise CommandSpecError("pass_env_duplicate")
+    if set(static) & set(passed):
+        raise CommandSpecError("environment_overlap")
+
+    raw_redact = value.get("redact_env")
+    if not isinstance(raw_redact, list) or len(raw_redact) > _MAX_ENVIRONMENT_ITEMS:
+        raise CommandSpecError("redact_env")
+    redacted = tuple(sorted(_environment_name(item) for item in raw_redact))
+    if len(set(redacted)) != len(redacted):
+        raise CommandSpecError("redact_env_duplicate")
+    if not set(redacted).issubset(passed):
+        raise CommandSpecError("redact_env_scope")
+
+    output_limit = value.get("output_limit_bytes")
+    if (
+        isinstance(output_limit, bool)
+        or not isinstance(output_limit, int)
+        or not 0 < output_limit <= _MAX_OUTPUT_BYTES
+    ):
+        raise CommandSpecError("output_limit")
+
+    grace_ms = value.get("termination_grace_ms")
+    if (
+        isinstance(grace_ms, bool)
+        or not isinstance(grace_ms, int)
+        or not 0 < grace_ms <= 5000
+    ):
+        raise CommandSpecError("termination_grace")
+
+    return CommandSpec(
+        gate_id=gate_id,
+        phase=phase,
+        argv=argv,
+        cwd=cwd,
+        static_env=tuple(sorted(static.items())),
+        pass_env=passed,
+        redact_env=redacted,
+        output_limit_bytes=output_limit,
+        termination_grace_ms=grace_ms,
+    )
+
+
+def _safe_input_path(repo_root: Path, relative: str | Path) -> Path:
+    candidate = Path(relative)
+    if (
+        candidate.is_absolute()
+        or not candidate.parts
+        or ".." in candidate.parts
+        or "\\" in str(relative)
+    ):
+        raise CommandSpecError("spec_path")
+    current = repo_root
+    for part in candidate.parts:
+        current /= part
+        if current.is_symlink():
+            raise CommandSpecError("spec_symlink")
+    resolved = current.resolve()
+    if not resolved.is_relative_to(repo_root):
+        raise CommandSpecError("spec_path")
+    try:
+        metadata = os.lstat(current)
+    except OSError as exc:
+        raise CommandSpecError("spec_stat") from exc
+    if not stat.S_ISREG(metadata.st_mode) or not 0 < metadata.st_size <= _MAX_SPEC_BYTES:
+        raise CommandSpecError("spec_file")
+    return current
+
+
+def load_command_spec(
+    repo_root: str | Path,
+    spec_path: str | Path,
+    *,
+    contract: SdlcContract | None = None,
+) -> CommandSpec:
+    root = Path(repo_root).resolve()
+    accepted = contract or load_contract(root)
+    if accepted.repo_root != root:
+        raise CommandSpecError("contract_root")
+    path = _safe_input_path(root, spec_path)
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise CommandSpecError("spec_open") from exc
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode) or not 0 < metadata.st_size <= _MAX_SPEC_BYTES:
+            raise CommandSpecError("spec_file")
+        with os.fdopen(descriptor, "rb", closefd=False) as stream:
+            payload = stream.read(_MAX_SPEC_BYTES + 1)
+    finally:
+        os.close(descriptor)
+    if not payload or len(payload) > _MAX_SPEC_BYTES:
+        raise CommandSpecError("spec_file")
+    try:
+        value = json.loads(payload.decode("utf-8"))
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        raise CommandSpecError("spec_json") from exc
+    return parse_command_spec(value, contract=accepted)
+
+
+def build_environment(
+    spec: CommandSpec,
+    ambient: Mapping[str, str],
+) -> dict[str, str]:
+    if any(
+        not isinstance(name, str) or not isinstance(value, str)
+        for name, value in ambient.items()
+    ):
+        raise CommandSpecError("ambient_environment")
+    environment = dict(spec.static_env)
+    for name in spec.pass_env:
+        value = ambient.get(name)
+        if value is None:
+            raise CommandSpecError("missing_environment")
+        environment[name] = value
+    return environment
+
+
+def execute_command_spec(
+    *,
+    contract: SdlcContract,
+    spec: CommandSpec,
+    ambient_env: Mapping[str, str] | None = None,
+) -> CommandRun:
+    _, cwd = _safe_relative_directory(contract.repo_root, spec.cwd)
+    environment = build_environment(spec, os.environ if ambient_env is None else ambient_env)
+    result = run_configured_gate(
+        contract=contract,
+        gate_id=spec.gate_id,
+        phase=spec.phase,
+        argv=spec.argv,
+        cwd=cwd,
+        env=environment,
+        redact_values=tuple(
+            environment[name] for name in spec.redact_env if environment[name]
+        ),
+        output_limit_bytes=spec.output_limit_bytes,
+        termination_grace_seconds=spec.termination_grace_ms / 1000.0,
+    )
+    return CommandRun(spec.digest, result)
+
+
+def _safe_output_path(repo_root: Path, relative: str | Path) -> Path:
+    candidate = Path(relative)
+    if (
+        candidate.is_absolute()
+        or not candidate.parts
+        or ".." in candidate.parts
+        or "\\" in str(relative)
+        or candidate.suffix != ".json"
+    ):
+        raise CommandSpecError("output_path")
+    current = repo_root
+    for part in candidate.parts[:-1]:
+        current /= part
+        if current.is_symlink():
+            raise CommandSpecError("output_parent")
+    parent = current.resolve()
+    if not parent.is_relative_to(repo_root) or not parent.is_dir():
+        raise CommandSpecError("output_parent")
+    return current / candidate.name
+
+
+def _publish_output(path: Path, payload: bytes) -> None:
+    if path.exists() or path.is_symlink():
+        raise CommandSpecError("output_exists")
+    descriptor, temporary = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        dir=path.parent,
+    )
+    temporary_path = Path(temporary)
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        try:
+            os.link(temporary_path, path)
+        except FileExistsError as exc:
+            raise CommandSpecError("output_exists") from exc
+        try:
+            directory = os.open(
+                path.parent,
+                os.O_RDONLY | getattr(os, "O_DIRECTORY", 0),
+            )
+        except OSError:
+            directory = -1
+        if directory >= 0:
+            try:
+                os.fsync(directory)
+            finally:
+                os.close(directory)
+    finally:
+        try:
+            temporary_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Execute one canonical Newsroom command specification"
+    )
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--spec", required=True)
+    parser.add_argument("--output")
+    arguments = parser.parse_args(argv)
+    root = Path(arguments.repo_root).resolve()
+    try:
+        contract = load_contract(root)
+        spec = load_command_spec(root, arguments.spec, contract=contract)
+        command_run = execute_command_spec(contract=contract, spec=spec)
+        rendered = canonical_json_bytes(command_run.as_dict()) + b"\n"
+        if arguments.output:
+            _publish_output(_safe_output_path(root, arguments.output), rendered)
+        else:
+            sys.stdout.write(rendered.decode("utf-8"))
+    except (CommandSpecError, ContractError, GateRunError, EvidenceError, OSError) as exc:
+        code = (
+            str(exc)
+            if isinstance(exc, CommandSpecError) and str(exc)
+            else type(exc).__name__
+        )
+        print(f"ENVIRONMENT_ERROR:command-spec:{code}", file=sys.stderr)
+        return 3
+    return {
+        "PASS": 0,
+        "FAIL": 1,
+        "BUDGET_EXCEEDED": 2,
+    }.get(command_run.gate_run.result, 3)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sdlc/command_spec.py
+++ b/scripts/sdlc/command_spec.py
@@ -236,8 +236,8 @@ def parse_command_spec(
     passed = tuple(sorted(_environment_name(item) for item in raw_pass))
     if len(set(passed)) != len(passed):
         raise CommandSpecError("pass_env_duplicate")
-    if set(static) & set(passed):
-        raise CommandSpecError("environment_overlap")
+    if any(_SECRET_NAME.search(name) is None for name in passed):
+        raise CommandSpecError("unbound_environment")
 
     raw_redact = value.get("redact_env")
     if not isinstance(raw_redact, list) or len(raw_redact) > _MAX_ENVIRONMENT_ITEMS:

--- a/scripts/sdlc/command_spec.py
+++ b/scripts/sdlc/command_spec.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import dataclass
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -24,6 +25,10 @@ _MAX_ARGUMENT_CHARS = 4096
 _MAX_ENVIRONMENT_ITEMS = 128
 _MAX_ENVIRONMENT_VALUE_CHARS = 4096
 _MAX_OUTPUT_BYTES = 1_048_576
+_MAX_EXECUTABLE_BYTES = 512 * 1024 * 1024
+_MAX_PASSED_ENV_VALUE_CHARS = 65_536
+_MAX_PASSED_ENV_TOTAL_CHARS = 262_144
+_SHA256 = re.compile(r"sha256:[0-9a-f]{64}")
 _ENVIRONMENT_NAME = re.compile(r"[A-Za-z_][A-Za-z0-9_]{0,127}")
 _SAFE_ID = re.compile(r"[A-Za-z0-9_.*-]{1,128}")
 _SECRET_NAME = re.compile(
@@ -39,6 +44,7 @@ _REQUIRED_KEYS = frozenset(
         "static_env",
         "pass_env",
         "redact_env",
+        "executable_digest",
         "output_limit_bytes",
         "termination_grace_ms",
     }
@@ -58,6 +64,7 @@ class CommandSpec:
     static_env: tuple[tuple[str, str], ...]
     pass_env: tuple[str, ...]
     redact_env: tuple[str, ...]
+    executable_digest: str
     output_limit_bytes: int
     termination_grace_ms: int
 
@@ -71,6 +78,7 @@ class CommandSpec:
             "static_env": dict(self.static_env),
             "pass_env": list(self.pass_env),
             "redact_env": list(self.redact_env),
+            "executable_digest": self.executable_digest,
             "output_limit_bytes": self.output_limit_bytes,
             "termination_grace_ms": self.termination_grace_ms,
         }
@@ -141,6 +149,45 @@ def _accepted_gate_ids(contract: SdlcContract) -> frozenset[str]:
     return frozenset(str(gate["id"]) for gate in contract.data["gate"].values())
 
 
+def executable_digest(path: str | Path) -> tuple[str, str]:
+    candidate = Path(path)
+    if not candidate.is_absolute():
+        raise CommandSpecError("executable_path")
+    try:
+        resolved = candidate.resolve(strict=True)
+    except OSError as exc:
+        raise CommandSpecError("executable_path") from exc
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(resolved, flags)
+    except OSError as exc:
+        raise CommandSpecError("executable_open") from exc
+    digest = hashlib.sha256()
+    try:
+        metadata = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or not 0 < metadata.st_size <= _MAX_EXECUTABLE_BYTES
+            or not os.access(resolved, os.X_OK)
+        ):
+            raise CommandSpecError("executable_file")
+        with os.fdopen(descriptor, "rb", closefd=False) as stream:
+            while payload := stream.read(1024 * 1024):
+                digest.update(payload)
+    finally:
+        os.close(descriptor)
+    return resolved.as_posix(), "sha256:" + digest.hexdigest()
+
+
+def _verified_executable(path: str, expected_digest: object) -> tuple[str, str]:
+    if not isinstance(expected_digest, str) or _SHA256.fullmatch(expected_digest) is None:
+        raise CommandSpecError("executable_digest")
+    resolved, actual = executable_digest(path)
+    if actual != expected_digest:
+        raise CommandSpecError("executable_digest")
+    return resolved, actual
+
+
 def parse_command_spec(
     value: object,
     *,
@@ -161,7 +208,7 @@ def parse_command_spec(
     raw_argv = value.get("argv")
     if not isinstance(raw_argv, list) or not 0 < len(raw_argv) <= _MAX_ARGUMENTS:
         raise CommandSpecError("argv")
-    argv = tuple(
+    argv_values = tuple(
         _bounded_string(item, "argv", maximum=_MAX_ARGUMENT_CHARS)
         for item in raw_argv
     )
@@ -198,8 +245,14 @@ def parse_command_spec(
     redacted = tuple(sorted(_environment_name(item) for item in raw_redact))
     if len(set(redacted)) != len(redacted):
         raise CommandSpecError("redact_env_duplicate")
-    if not set(redacted).issubset(passed):
-        raise CommandSpecError("redact_env_scope")
+    if redacted != passed:
+        raise CommandSpecError("unbound_environment")
+
+    resolved_executable, expected_executable_digest = _verified_executable(
+        argv_values[0],
+        value.get("executable_digest"),
+    )
+    argv = (resolved_executable, *argv_values[1:])
 
     output_limit = value.get("output_limit_bytes")
     if (
@@ -225,6 +278,7 @@ def parse_command_spec(
         static_env=tuple(sorted(static.items())),
         pass_env=passed,
         redact_env=redacted,
+        executable_digest=expected_executable_digest,
         output_limit_bytes=output_limit,
         termination_grace_ms=grace_ms,
     )
@@ -256,6 +310,15 @@ def _safe_input_path(repo_root: Path, relative: str | Path) -> Path:
     return current
 
 
+def _unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    value: dict[str, object] = {}
+    for name, item in pairs:
+        if name in value:
+            raise CommandSpecError("spec_duplicate_key")
+        value[name] = item
+    return value
+
+
 def load_command_spec(
     repo_root: str | Path,
     spec_path: str | Path,
@@ -283,7 +346,10 @@ def load_command_spec(
     if not payload or len(payload) > _MAX_SPEC_BYTES:
         raise CommandSpecError("spec_file")
     try:
-        value = json.loads(payload.decode("utf-8"))
+        value = json.loads(
+            payload.decode("utf-8"),
+            object_pairs_hook=_unique_object,
+        )
     except (UnicodeError, json.JSONDecodeError) as exc:
         raise CommandSpecError("spec_json") from exc
     return parse_command_spec(value, contract=accepted)
@@ -299,10 +365,16 @@ def build_environment(
     ):
         raise CommandSpecError("ambient_environment")
     environment = dict(spec.static_env)
+    total = 0
     for name in spec.pass_env:
         value = ambient.get(name)
         if value is None:
             raise CommandSpecError("missing_environment")
+        if "\x00" in value or len(value) > _MAX_PASSED_ENV_VALUE_CHARS:
+            raise CommandSpecError("environment_value")
+        total += len(value)
+        if total > _MAX_PASSED_ENV_TOTAL_CHARS:
+            raise CommandSpecError("environment_size")
         environment[name] = value
     return environment
 
@@ -313,22 +385,29 @@ def execute_command_spec(
     spec: CommandSpec,
     ambient_env: Mapping[str, str] | None = None,
 ) -> CommandRun:
-    _, cwd = _safe_relative_directory(contract.repo_root, spec.cwd)
-    environment = build_environment(spec, os.environ if ambient_env is None else ambient_env)
+    validated = parse_command_spec(spec.as_dict(), contract=contract)
+    if validated != spec:
+        raise CommandSpecError("spec_not_normalized")
+    _, cwd = _safe_relative_directory(contract.repo_root, validated.cwd)
+    environment = build_environment(
+        validated, os.environ if ambient_env is None else ambient_env
+    )
     result = run_configured_gate(
         contract=contract,
-        gate_id=spec.gate_id,
-        phase=spec.phase,
-        argv=spec.argv,
+        gate_id=validated.gate_id,
+        phase=validated.phase,
+        argv=validated.argv,
         cwd=cwd,
         env=environment,
         redact_values=tuple(
-            environment[name] for name in spec.redact_env if environment[name]
+            environment[name]
+            for name in validated.redact_env
+            if environment[name]
         ),
-        output_limit_bytes=spec.output_limit_bytes,
-        termination_grace_seconds=spec.termination_grace_ms / 1000.0,
+        output_limit_bytes=validated.output_limit_bytes,
+        termination_grace_seconds=validated.termination_grace_ms / 1000.0,
     )
-    return CommandRun(spec.digest, result)
+    return CommandRun(validated.digest, result)
 
 
 def _safe_output_path(repo_root: Path, relative: str | Path) -> Path:


### PR DESCRIPTION
## Status

Phase **2A1** of issue #100 under accepted SDLC #98. Source-only, exact-head green and ready for review.

Reviewed head:

`574209ad4bdd6a44512f606c5981785902e1abff`

Base:

`main@5eee7164409bce2f1c92d510f1809283f97e6391`

This unit makes one validated canonical command specification drive both the actual bounded watchdog invocation and the digest later supplied to canonical gate evidence. Existing required workflows are unchanged.

## Scope

- exact `newsroom.sdlc.command-spec.v1` shape with duplicate-key rejection;
- accepted gate ID and safe phase binding;
- fixed-vector canonical command-spec digest;
- absolute executable resolution plus exact executable-byte SHA-256 verification before execution;
- reject shebang executables whose interpreter is not independently bound;
- argv, repository-relative cwd, static environment, secret pass-through names, redaction names, executable digest, output limit and termination grace all bound into the digest;
- only secret-like environment names may be inherited from the ambient process, and every inherited value is redacted;
- all ordinary environment values must be static and therefore digest-bound;
- minimal child environment rather than ambient inheritance;
- direct `CommandSpec` construction is reparsed before execution and cannot bypass accepted invariants;
- missing, oversized or NUL-containing secret environment values fail closed without naming or exposing values;
- cwd/spec path escape and symlink rejection;
- the same normalized specification drives `run_configured_gate()` and emits its digest beside the typed gate result;
- private atomic non-overwriting command-run JSON;
- CLI preserves PASS/FAIL/BUDGET exit semantics.

## Review-trigger decomposition note

The accepted trigger is 400 net executable lines / 12 files. This PR changes only two files but exceeds the line trigger because normalization, executable identity, execution binding, minimal environment, atomic publication and their adversarial matrix form one command-authority boundary. Cross-job artifact provenance and the GitHub shadow workflow remain separate Phase 2A2/2B review units.

## Substantive review corrections

P1: 0. P2 found and corrected: 3. Unresolved P1/P2: 0.

1. Ambient `PATH` or another pass-through value could change actual execution while the command-spec digest stayed constant. Executable paths are now absolute and content-hashed; ordinary environment values must be static and digest-bound. Only secret-like values may pass through, and all are redacted.
2. A caller could instantiate the dataclass directly and obtain or execute a structurally invalid specification. The execution entrypoint now reparses and requires normalized equality before running.
3. Hashing a shebang script did not bind the interpreter selected by the kernel or `/usr/bin/env`. Shebang executables are rejected; callers must invoke a verified native interpreter/binary explicitly and rely on the exact repository tree or later artifact envelope for script inputs.

Additional adversarial evidence covers fixed canonicalization, order normalization, every execution-affecting field changing the digest, executable mismatch, relative executable rejection, duplicate JSON keys, secret/static environment separation, ambient-value bounds, cwd/spec symlinks, output non-overwrite, private mode and CLI error privacy.

## Exact-head validation

Head `574209ad4bdd6a44512f606c5981785902e1abff`:

- Authority A2a run `29925112170`: success;
- Authority A2b run `29925113465`: success;
- Projection B1 run `29925113431`: success;
- Projection B2 Neo4j run `29925113412`: success;
- complete repository CI and clustering run `29925112353`: success;
- unresolved inline review threads: zero.

## Changed files

- `scripts/sdlc/command_spec.py`;
- `newsroom/tests/test_sdlc_command_spec.py`.

## Phase 2A2 boundary

This unit intentionally does not claim cross-job proof. The next unit must bind route, command-run, JUnit and gate-evidence artifacts to exact repository/head/tree, workflow run, job and artifact digests before the final decision consumes them.

## Exclusions

No cross-job artifact envelope, GitHub workflow, cache implementation, test selection, Neo4j process change, current required-check change, release, production, Graphiti/model/embedding/live-source execution, publication, product shadow, canary, spending or public effect.