### PR TITLE
chore(integrated): qualify exact source correction

### DIFF
--- a/.github/workflows/increment-1c-source-qualify.yml
+++ b/.github/workflows/increment-1c-source-qualify.yml
@@ -60,11 +60,25 @@ jobs:
 
           path = Path("newsroom/authority/_integrated_store.py")
           text = path.read_text(encoding="utf-8")
-          old = "from .policy import CANDIDATE_ADMISSION_COMMAND"
-          new = "from newsroom.integrated.policy import CANDIDATE_ADMISSION_COMMAND"
-          if text.count(old) != 1 or new in text:
-              raise SystemExit("integrated store import does not match exact expected source")
-          path.write_text(text.replace(old, new), encoding="utf-8")
+          replacements = (
+              (
+                  "from .policy import CANDIDATE_ADMISSION_COMMAND",
+                  "from newsroom.integrated.policy import CANDIDATE_ADMISSION_COMMAND",
+              ),
+              (
+                  "def _decode_canonical(data: bytes, *, identity: str) -> dict[str, Any]:",
+                  "def _decode_integrated_canonical(data: bytes, *, identity: str) -> dict[str, Any]:",
+              ),
+              (
+                  "return cls._decode_canonical(canonical, identity=identity)",
+                  "return cls._decode_integrated_canonical(canonical, identity=identity)",
+              ),
+          )
+          for old, new in replacements:
+              if text.count(old) != 1 or new in text:
+                  raise SystemExit(f"integrated store source mismatch: {old}")
+              text = text.replace(old, new)
+          path.write_text(text, encoding="utf-8")
           PY
 
           test "$(git diff --name-only)" = "newsroom/authority/_integrated_store.py"
@@ -85,7 +99,7 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add newsroom/authority/_integrated_store.py
-          git commit -m 'fix(integrated): resolve candidate command policy'
+          git commit -m 'fix(integrated): isolate candidate store helpers'
 
           remote_head="$(git ls-remote origin refs/heads/agent/increment-1c-integrated-foundation | cut -f1)"
           test "${remote_head}" = "${expected_head}"

--- a/.github/workflows/increment-1c-source-qualify.yml
+++ b/.github/workflows/increment-1c-source-qualify.yml
@@ -58,9 +58,9 @@ jobs:
           python - <<'PY'
           from pathlib import Path
 
-          path = Path("newsroom/authority/_integrated_store.py")
-          text = path.read_text(encoding="utf-8")
-          replacements = (
+          store_path = Path("newsroom/authority/_integrated_store.py")
+          store_text = store_path.read_text(encoding="utf-8")
+          store_replacements = (
               (
                   "from .policy import CANDIDATE_ADMISSION_COMMAND",
                   "from newsroom.integrated.policy import CANDIDATE_ADMISSION_COMMAND",
@@ -74,14 +74,66 @@ jobs:
                   "return cls._decode_integrated_canonical(canonical, identity=identity)",
               ),
           )
-          for old, new in replacements:
-              if text.count(old) != 1 or new in text:
+          for old, new in store_replacements:
+              if store_text.count(old) != 1 or new in store_text:
                   raise SystemExit(f"integrated store source mismatch: {old}")
-              text = text.replace(old, new)
-          path.write_text(text, encoding="utf-8")
+              store_text = store_text.replace(old, new)
+          store_path.write_text(store_text, encoding="utf-8")
+
+          graph_path = Path("newsroom/authority/_neo4j_projection_system.py")
+          graph_text = graph_path.read_text(encoding="utf-8")
+          graph_anchor = '''    def close(self) -> None:
+                  ...
+
+
+          class Neo4jStructuralProjector:'''.replace("          ", "")
+          graph_replacement = '''    def close(self) -> None:
+                  ...
+
+
+          def _open_structural_graph_adapter(
+              config: Neo4jProjectorConfig,
+          ) -> _StructuralGraphAdapter:
+              return _open_neo4j_adapter(config)
+
+
+          class Neo4jStructuralProjector:'''.replace("          ", "")
+          if graph_text.count(graph_anchor) != 1 or "def _open_structural_graph_adapter(" in graph_text:
+              raise SystemExit("Neo4j adapter factory anchor differs from expected source")
+          graph_path.write_text(
+              graph_text.replace(graph_anchor, graph_replacement),
+              encoding="utf-8",
+          )
+
+          system_path = Path("newsroom/authority/_integrated_system.py")
+          system_text = system_path.read_text(encoding="utf-8")
+          system_replacements = (
+              (
+                  "from ._neo4j_projection_system import _build_structural_batch",
+                  "from ._neo4j_projection_system import (\n    _build_structural_batch,\n    _open_structural_graph_adapter,\n)",
+              ),
+              (
+                  "from newsroom.projection.neo4j._adapter import _open_neo4j_adapter\n",
+                  "",
+              ),
+              (
+                  "adapter = _open_neo4j_adapter(neo4j_config)",
+                  "adapter = _open_structural_graph_adapter(neo4j_config)",
+              ),
+          )
+          for old, new in system_replacements:
+              if system_text.count(old) != 1 or (new and new in system_text):
+                  raise SystemExit(f"integrated system source mismatch: {old}")
+              system_text = system_text.replace(old, new)
+          system_path.write_text(system_text, encoding="utf-8")
           PY
 
-          test "$(git diff --name-only)" = "newsroom/authority/_integrated_store.py"
+          actual_files="$(git diff --name-only | sort)"
+          expected_files="$(printf '%s\n' \
+            newsroom/authority/_integrated_store.py \
+            newsroom/authority/_integrated_system.py \
+            newsroom/authority/_neo4j_projection_system.py | sort)"
+          test "${actual_files}" = "${expected_files}"
           git diff --check
           uv lock --check
           uv sync --dev --locked
@@ -89,7 +141,8 @@ jobs:
           uv run --no-sync python -m pytest -q \
             newsroom/tests/test_integrated_c1_contracts.py \
             newsroom/tests/test_integrated_c1_policy.py \
-            newsroom/tests/test_integrated_c1_candidate_authority.py
+            newsroom/tests/test_integrated_c1_candidate_authority.py \
+            newsroom/tests/test_projection_b2_boundaries.py
           uv run --no-sync python -m pytest -q newsroom/tests
           uv run --no-sync python scripts/eval_clustering_metrics.py \
             --dataset newsroom/evals/clustering_eval_dataset_v1.jsonl \
@@ -98,8 +151,11 @@ jobs:
 
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add newsroom/authority/_integrated_store.py
-          git commit -m 'fix(integrated): isolate candidate store helpers'
+          git add \
+            newsroom/authority/_integrated_store.py \
+            newsroom/authority/_integrated_system.py \
+            newsroom/authority/_neo4j_projection_system.py
+          git commit -m 'fix(integrated): preserve adapter import boundary'
 
           remote_head="$(git ls-remote origin refs/heads/agent/increment-1c-integrated-foundation | cut -f1)"
           test "${remote_head}" = "${expected_head}"

--- a/.github/workflows/increment-1c-source-qualify.yml
+++ b/.github/workflows/increment-1c-source-qualify.yml
@@ -1,0 +1,103 @@
+name: Increment 1C Source Qualifier
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/increment-1c-source-qualify.yml
+
+permissions:
+  contents: write
+
+jobs:
+  qualify-and-publish:
+    if: >-
+      github.head_ref == 'agent/increment-1c-source-qualify' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.repository == 'fol2/newsroom'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    steps:
+      - name: Checkout qualification branch
+        uses: actions/checkout@v4
+        with:
+          ref: agent/increment-1c-source-qualify
+          path: .qualifier
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Checkout exact Increment 1C target
+        uses: actions/checkout@v4
+        with:
+          ref: agent/increment-1c-integrated-foundation
+          path: .target
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up exact uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.8.0"
+          enable-cache: true
+          cache-dependency-glob: .target/uv.lock
+
+      - name: Correct, qualify and publish target source
+        shell: bash
+        working-directory: .target
+        run: |
+          set -euxo pipefail
+          diagnostic="${RUNNER_TEMP}/increment-1c-source-qualifier.log"
+          exec > >(tee "${diagnostic}") 2>&1
+          expected_head="e95d796cb258f64665bc92acd7aae9f4bb2bdb57"
+          test "$(git rev-parse HEAD)" = "${expected_head}"
+
+          python - <<'PY'
+          from pathlib import Path
+
+          path = Path("newsroom/authority/_integrated_store.py")
+          text = path.read_text(encoding="utf-8")
+          old = "from .policy import CANDIDATE_ADMISSION_COMMAND"
+          new = "from newsroom.integrated.policy import CANDIDATE_ADMISSION_COMMAND"
+          if text.count(old) != 1 or new in text:
+              raise SystemExit("integrated store import does not match exact expected source")
+          path.write_text(text.replace(old, new), encoding="utf-8")
+          PY
+
+          test "$(git diff --name-only)" = "newsroom/authority/_integrated_store.py"
+          git diff --check
+          uv lock --check
+          uv sync --dev --locked
+          uv run --no-sync python -m compileall -q newsroom scripts
+          uv run --no-sync python -m pytest -q \
+            newsroom/tests/test_integrated_c1_contracts.py \
+            newsroom/tests/test_integrated_c1_policy.py \
+            newsroom/tests/test_integrated_c1_candidate_authority.py
+          uv run --no-sync python -m pytest -q newsroom/tests
+          uv run --no-sync python scripts/eval_clustering_metrics.py \
+            --dataset newsroom/evals/clustering_eval_dataset_v1.jsonl \
+            --baseline newsroom/evals/clustering_eval_metrics_baseline_v1.json \
+            --fail-on-regression
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add newsroom/authority/_integrated_store.py
+          git commit -m 'fix(integrated): resolve candidate command policy'
+
+          remote_head="$(git ls-remote origin refs/heads/agent/increment-1c-integrated-foundation | cut -f1)"
+          test "${remote_head}" = "${expected_head}"
+          git push \
+            --force-with-lease=refs/heads/agent/increment-1c-integrated-foundation:${expected_head} \
+            origin HEAD:agent/increment-1c-integrated-foundation
+
+      - name: Upload qualifier diagnostic
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: increment-1c-source-qualifier-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/increment-1c-source-qualifier.log
+          if-no-files-found: warn
+          retention-days: 1


### PR DESCRIPTION
## Closed without merge — temporary Increment 1C source qualification only

This Draft PR was temporary transport infrastructure and **must never be merged**.

Run `30093113051` applied three exact source corrections to `agent/increment-1c-integrated-foundation@e95d796cb258f64665bc92acd7aae9f4bb2bdb57`:

- resolved the Candidate command policy from `newsroom.integrated.policy`;
- renamed an integrated canonical decoder so it no longer overrode the authority store base helper;
- restored the single production Neo4j adapter import path through a private authority factory.

The run passed:

- locked Python 3.12 environment;
- compile;
- focused Increment 1C and adapter-boundary tests;
- full repository tests: 942 passed, 10 expected actual-service skips;
- clustering regression gate;
- exact-head force-with-lease publication.

Published target commit:

`b81a3228f785267562563a525f364457986c286c` — `fix(integrated): preserve adapter import boundary`

The temporary same-branch qualifier on PR #122 was removed immediately afterward. This PR is closed unmerged, and its branch is being reset to current `main` so the workflow is not retained as live transport material.

No source access, Graphiti/model/embedding execution, publication, shadow, canary, production activation, spending or public effect occurred.