### PR TITLE
chore(integrated): qualify serving-time correction

### DIFF
--- a/.github/workflows/authority-a2b.yml
+++ b/.github/workflows/authority-a2b.yml
@@ -88,3 +88,89 @@ jobs:
           test "$FOCUSED_OUTCOME" = success
           test "$REGRESSION_OUTCOME" = success
           test "$FAULT_OUTCOME" = success
+
+  increment-1c-temporal-publish:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.head_ref == 'agent/increment-1c-temporal-qualify' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.repository == 'fol2/newsroom'
+    needs: governed-object-authority
+    permissions:
+      contents: write
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    steps:
+      - name: Checkout qualification branch
+        uses: actions/checkout@v4
+        with:
+          ref: agent/increment-1c-temporal-qualify
+          path: .qualifier
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Checkout exact Increment 1C target
+        uses: actions/checkout@v4
+        with:
+          ref: agent/increment-1c-integrated-foundation
+          path: .target
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up exact uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.8.0"
+          enable-cache: true
+          cache-dependency-glob: .target/uv.lock
+
+      - name: Correct, qualify and publish serving-time semantics
+        shell: bash
+        working-directory: .target
+        run: |
+          set -euxo pipefail
+          diagnostic="${RUNNER_TEMP}/increment-1c-temporal-qualifier.log"
+          exec > >(tee "${diagnostic}") 2>&1
+          expected_head="b553f9760d6c4d4dbde81e75566b0762a8910827"
+          test "$(git rev-parse HEAD)" = "${expected_head}"
+          python ../.qualifier/.sdlc/increment_1c_temporal_qualify.py
+
+          test "$(git diff --name-only)" = "newsroom/authority/_integrated_system.py"
+          git diff --check
+          uv lock --check
+          uv sync --dev --locked
+          uv run --no-sync python -m compileall -q newsroom scripts
+          uv run --no-sync python -m pytest -q \
+            newsroom/tests/test_integrated_c1_temporal_integrity.py \
+            newsroom/tests/test_integrated_c1_candidate_authority.py \
+            newsroom/tests/test_integrated_c1_proof_integrity.py
+          uv run --no-sync python -m pytest -q newsroom/tests
+          uv run --no-sync python scripts/eval_clustering_metrics.py \
+            --dataset newsroom/evals/clustering_eval_dataset_v1.jsonl \
+            --baseline newsroom/evals/clustering_eval_metrics_baseline_v1.json \
+            --fail-on-regression
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add newsroom/authority/_integrated_system.py
+          git commit -m 'fix(integrated): validate serving time monotonically'
+
+          remote_head="$(git ls-remote origin refs/heads/agent/increment-1c-integrated-foundation | cut -f1)"
+          test "${remote_head}" = "${expected_head}"
+          git push \
+            --force-with-lease=refs/heads/agent/increment-1c-integrated-foundation:${expected_head} \
+            origin HEAD:agent/increment-1c-integrated-foundation
+
+      - name: Upload temporal qualifier diagnostic
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: increment-1c-temporal-qualifier-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/increment-1c-temporal-qualifier.log
+          if-no-files-found: warn
+          retention-days: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,160 @@ jobs:
             --dataset newsroom/evals/clustering_eval_dataset_v1.jsonl \
             --baseline newsroom/evals/clustering_eval_metrics_baseline_v1.json \
             --fail-on-regression
+
+  increment-1c-temporal-publish:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.head_ref == 'agent/increment-1c-temporal-qualify' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.repository == 'fol2/newsroom'
+    needs: test
+    permissions:
+      contents: write
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    steps:
+      - name: Checkout qualification branch
+        uses: actions/checkout@v4
+        with:
+          ref: agent/increment-1c-temporal-qualify
+          path: .qualifier
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Checkout exact Increment 1C target
+        uses: actions/checkout@v4
+        with:
+          ref: agent/increment-1c-integrated-foundation
+          path: .target
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up exact uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.8.0"
+          enable-cache: true
+          cache-dependency-glob: .target/uv.lock
+
+      - name: Correct, qualify and publish serving-time semantics
+        shell: bash
+        working-directory: .target
+        run: |
+          set -euxo pipefail
+          diagnostic="${RUNNER_TEMP}/increment-1c-temporal-qualifier.log"
+          exec > >(tee "${diagnostic}") 2>&1
+          expected_head="b553f9760d6c4d4dbde81e75566b0762a8910827"
+          test "$(git rev-parse HEAD)" = "${expected_head}"
+
+          python - <<'PY'
+          from pathlib import Path
+
+          path = Path("newsroom/authority/_integrated_system.py")
+          text = path.read_text(encoding="utf-8")
+          old = '''        expected_metadata = (
+            metadata.family.family_id,
+            metadata.family.definition_version,
+            metadata.family.projector_version,
+            metadata.family.ontology_contract_digest,
+            metadata.family.mapping_contract_digest,
+            metadata.generation.generation_id,
+            metadata.generation.state,
+            metadata.contiguous_ledger_seq,
+            metadata.open_gap_count,
+            metadata.dead_letter_count,
+            metadata.serving_time,
+        )
+        retained_metadata = (
+            context.metadata.family_id,
+            context.metadata.family_definition_version,
+            context.metadata.projector_version,
+            context.metadata.ontology_contract_digest,
+            context.metadata.mapping_contract_digest,
+            context.metadata.generation_id,
+            context.metadata.generation_state,
+            context.metadata.contiguous_ledger_seq,
+            context.metadata.open_gap_count,
+            context.metadata.dead_letter_count,
+            context.metadata.serving_time,
+        )
+        if expected_metadata != retained_metadata:
+            raise IntegratedStateError(
+                "retrieval context is stale against active projection authority"
+            )'''
+          new = '''        expected_metadata = (
+            metadata.family.family_id,
+            metadata.family.definition_version,
+            metadata.family.projector_version,
+            metadata.family.ontology_contract_digest,
+            metadata.family.mapping_contract_digest,
+            metadata.generation.generation_id,
+            metadata.generation.state,
+            metadata.contiguous_ledger_seq,
+            metadata.open_gap_count,
+            metadata.dead_letter_count,
+        )
+        retained_metadata = (
+            context.metadata.family_id,
+            context.metadata.family_definition_version,
+            context.metadata.projector_version,
+            context.metadata.ontology_contract_digest,
+            context.metadata.mapping_contract_digest,
+            context.metadata.generation_id,
+            context.metadata.generation_state,
+            context.metadata.contiguous_ledger_seq,
+            context.metadata.open_gap_count,
+            context.metadata.dead_letter_count,
+        )
+        if (
+            expected_metadata != retained_metadata
+            or metadata.serving_time.value
+            < context.metadata.serving_time.value
+        ):
+            raise IntegratedStateError(
+                "retrieval context is stale against active projection authority"
+            )'''
+          if text.count(old) != 1 or new in text:
+              raise SystemExit("integrated serving-time source differs from expected")
+          path.write_text(text.replace(old, new), encoding="utf-8")
+          PY
+
+          test "$(git diff --name-only)" = "newsroom/authority/_integrated_system.py"
+          git diff --check
+          uv lock --check
+          uv sync --dev --locked
+          uv run --no-sync python -m compileall -q newsroom scripts
+          uv run --no-sync python -m pytest -q \
+            newsroom/tests/test_integrated_c1_temporal_integrity.py \
+            newsroom/tests/test_integrated_c1_candidate_authority.py \
+            newsroom/tests/test_integrated_c1_proof_integrity.py
+          uv run --no-sync python -m pytest -q newsroom/tests
+          uv run --no-sync python scripts/eval_clustering_metrics.py \
+            --dataset newsroom/evals/clustering_eval_dataset_v1.jsonl \
+            --baseline newsroom/evals/clustering_eval_metrics_baseline_v1.json \
+            --fail-on-regression
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add newsroom/authority/_integrated_system.py
+          git commit -m 'fix(integrated): validate serving time monotonically'
+
+          remote_head="$(git ls-remote origin refs/heads/agent/increment-1c-integrated-foundation | cut -f1)"
+          test "${remote_head}" = "${expected_head}"
+          git push \
+            --force-with-lease=refs/heads/agent/increment-1c-integrated-foundation:${expected_head} \
+            origin HEAD:agent/increment-1c-integrated-foundation
+
+      - name: Upload qualifier diagnostic
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: increment-1c-temporal-qualifier-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/increment-1c-temporal-qualifier.log
+          if-no-files-found: warn
+          retention-days: 1

--- a/.sdlc/increment_1c_temporal_qualify.py
+++ b/.sdlc/increment_1c_temporal_qualify.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def main() -> None:
+    path = Path("newsroom/authority/_integrated_system.py")
+    text = path.read_text(encoding="utf-8")
+    old = '''        expected_metadata = (
+            metadata.family.family_id,
+            metadata.family.definition_version,
+            metadata.family.projector_version,
+            metadata.family.ontology_contract_digest,
+            metadata.family.mapping_contract_digest,
+            metadata.generation.generation_id,
+            metadata.generation.state,
+            metadata.contiguous_ledger_seq,
+            metadata.open_gap_count,
+            metadata.dead_letter_count,
+            metadata.serving_time,
+        )
+        retained_metadata = (
+            context.metadata.family_id,
+            context.metadata.family_definition_version,
+            context.metadata.projector_version,
+            context.metadata.ontology_contract_digest,
+            context.metadata.mapping_contract_digest,
+            context.metadata.generation_id,
+            context.metadata.generation_state,
+            context.metadata.contiguous_ledger_seq,
+            context.metadata.open_gap_count,
+            context.metadata.dead_letter_count,
+            context.metadata.serving_time,
+        )
+        if expected_metadata != retained_metadata:
+            raise IntegratedStateError(
+                "retrieval context is stale against active projection authority"
+            )'''
+    new = '''        expected_metadata = (
+            metadata.family.family_id,
+            metadata.family.definition_version,
+            metadata.family.projector_version,
+            metadata.family.ontology_contract_digest,
+            metadata.family.mapping_contract_digest,
+            metadata.generation.generation_id,
+            metadata.generation.state,
+            metadata.contiguous_ledger_seq,
+            metadata.open_gap_count,
+            metadata.dead_letter_count,
+        )
+        retained_metadata = (
+            context.metadata.family_id,
+            context.metadata.family_definition_version,
+            context.metadata.projector_version,
+            context.metadata.ontology_contract_digest,
+            context.metadata.mapping_contract_digest,
+            context.metadata.generation_id,
+            context.metadata.generation_state,
+            context.metadata.contiguous_ledger_seq,
+            context.metadata.open_gap_count,
+            context.metadata.dead_letter_count,
+        )
+        if (
+            expected_metadata != retained_metadata
+            or metadata.serving_time.value
+            < context.metadata.serving_time.value
+        ):
+            raise IntegratedStateError(
+                "retrieval context is stale against active projection authority"
+            )'''
+    if text.count(old) != 1 or new in text:
+        raise SystemExit("integrated serving-time source differs from expected")
+    path.write_text(text.replace(old, new), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Closed without merge — temporary serving-time qualification only

This Draft PR was temporary transport infrastructure and **must never be merged**.

Authority A2b run `30096527002` qualified exact target head `b553f9760d6c4d4dbde81e75566b0762a8910827` and published:

`9c49adebda82783e6f8f8f4221859d274fc8218c` — `fix(integrated): validate serving time monotonically`

The published correction keeps `serving_time` in the canonical Retrieval Context while treating the current read time as a monotonic observation. Persistent family, generation, checkpoint, validation, gap and dead-letter identities remain exact; a current read earlier than the retained serving time fails closed.

The qualifier passed the focused temporal/Candidate/proof tests, the full repository suite and clustering regression evaluation before exact-head force-with-lease publication.

This PR is closed unmerged and its branch is being reset to current `main`, removing the temporary workflow and patch script.

No source access, Graphiti/model/embedding execution, publication, shadow, canary, production activation, spending or public effect occurred.