### PR TITLE
chore(integrated): qualify C1 SDLC service routing

### DIFF
--- a/.github/workflows/authority-a2b.yml
+++ b/.github/workflows/authority-a2b.yml
@@ -88,3 +88,102 @@ jobs:
           test "$FOCUSED_OUTCOME" = success
           test "$REGRESSION_OUTCOME" = success
           test "$FAULT_OUTCOME" = success
+
+  increment-1c-sdlc-publish:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.head_ref == 'agent/increment-1c-sdlc-qualify' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.repository == 'fol2/newsroom'
+    needs: governed-object-authority
+    permissions:
+      contents: write
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout qualification branch
+        uses: actions/checkout@v4
+        with:
+          ref: agent/increment-1c-sdlc-qualify
+          path: .qualifier
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Checkout exact Increment 1C target
+        uses: actions/checkout@v4
+        with:
+          ref: agent/increment-1c-integrated-foundation
+          path: .target
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up exact uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.8.0"
+          enable-cache: true
+          cache-dependency-glob: .target/uv.lock
+
+      - name: Correct, qualify and publish C1 SDLC topology
+        shell: bash
+        working-directory: .target
+        run: |
+          set -euxo pipefail
+          diagnostic="${RUNNER_TEMP}/increment-1c-sdlc-qualifier.log"
+          exec > >(tee "${diagnostic}") 2>&1
+          expected_head="42a01379b89be81fdf769b72b0f588f8fc66bdff"
+          test "$(git rev-parse HEAD)" = "${expected_head}"
+          python ../.qualifier/.sdlc/increment_1c_sdlc_qualify.py
+
+          actual_files="$(git diff --name-only | sort)"
+          expected_files="$(printf '%s\n' \
+            .sdlc/gates.toml \
+            newsroom/tests/test_sdlc_classifier.py \
+            newsroom/tests/test_sdlc_workflow_lane.py \
+            scripts/sdlc/classify_change.py \
+            scripts/sdlc/workflow_lane.py | sort)"
+          test "${actual_files}" = "${expected_files}"
+          git diff --check
+          uv lock --check
+          uv sync --dev --locked
+          uv run --no-sync python -m compileall -q newsroom scripts
+          uv run --no-sync python -m pytest -q \
+            newsroom/tests/test_integrated_c1_sdlc_contract.py \
+            newsroom/tests/test_sdlc_classifier.py \
+            newsroom/tests/test_sdlc_workflow_lane.py \
+            newsroom/tests/test_sdlc_evidence.py
+          uv run --no-sync python -m pytest -q newsroom/tests
+          uv run --no-sync python scripts/eval_clustering_metrics.py \
+            --dataset newsroom/evals/clustering_eval_dataset_v1.jsonl \
+            --baseline newsroom/evals/clustering_eval_metrics_baseline_v1.json \
+            --fail-on-regression
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add \
+            .sdlc/gates.toml \
+            newsroom/tests/test_sdlc_classifier.py \
+            newsroom/tests/test_sdlc_workflow_lane.py \
+            scripts/sdlc/classify_change.py \
+            scripts/sdlc/workflow_lane.py
+          git commit -m 'fix(sdlc): route Increment 1C actual service'
+
+          remote_head="$(git ls-remote origin refs/heads/agent/increment-1c-integrated-foundation | cut -f1)"
+          test "${remote_head}" = "${expected_head}"
+          git push \
+            --force-with-lease=refs/heads/agent/increment-1c-integrated-foundation:${expected_head} \
+            origin HEAD:agent/increment-1c-integrated-foundation
+
+      - name: Upload C1 SDLC qualifier diagnostic
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: increment-1c-sdlc-qualifier-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/increment-1c-sdlc-qualifier.log
+          if-no-files-found: warn
+          retention-days: 1

--- a/.github/workflows/authority-a2b.yml
+++ b/.github/workflows/authority-a2b.yml
@@ -139,10 +139,12 @@ jobs:
           expected_head="42a01379b89be81fdf769b72b0f588f8fc66bdff"
           test "$(git rev-parse HEAD)" = "${expected_head}"
           python ../.qualifier/.sdlc/increment_1c_sdlc_qualify.py
+          python ../.qualifier/.sdlc/increment_1c_sdlc_test_fix.py
 
           actual_files="$(git diff --name-only | sort)"
           expected_files="$(printf '%s\n' \
             .sdlc/gates.toml \
+            newsroom/tests/test_integrated_c1_sdlc_contract.py \
             newsroom/tests/test_sdlc_classifier.py \
             newsroom/tests/test_sdlc_workflow_lane.py \
             scripts/sdlc/classify_change.py \
@@ -167,6 +169,7 @@ jobs:
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add \
             .sdlc/gates.toml \
+            newsroom/tests/test_integrated_c1_sdlc_contract.py \
             newsroom/tests/test_sdlc_classifier.py \
             newsroom/tests/test_sdlc_workflow_lane.py \
             scripts/sdlc/classify_change.py \

--- a/.sdlc/increment_1c_sdlc_qualify.py
+++ b/.sdlc/increment_1c_sdlc_qualify.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def replace_exact(path: str, old: str, new: str) -> None:
+    target = Path(path)
+    text = target.read_text(encoding="utf-8")
+    if text.count(old) != 1 or new in text:
+        raise SystemExit(f"qualifier source mismatch in {path}: {old}")
+    target.write_text(text.replace(old, new), encoding="utf-8")
+
+
+def main() -> None:
+    replace_exact(
+        "scripts/sdlc/classify_change.py",
+        '''            for path in (repo_root / "newsroom" / "tests").glob(
+                "test_projection_*_neo4j_service.py"
+            )''',
+        '''            for path in (repo_root / "newsroom" / "tests").glob(
+                "test_*_neo4j_service.py"
+            )''',
+    )
+    replace_exact(
+        "scripts/sdlc/workflow_lane.py",
+        '''_OPTIONAL_CORE_TEST_IDS = (
+    "newsroom.tests.test_projection_b2_neo4j_service::test_actual_service_private_adapter_exact_duplicate_and_digest_conflict",''',
+        '''_OPTIONAL_CORE_TEST_IDS = (
+    "newsroom.tests.test_integrated_c1_neo4j_service::test_actual_service_integrated_foundation_replay_recovery_and_tombstone",
+    "newsroom.tests.test_projection_b2_neo4j_service::test_actual_service_private_adapter_exact_duplicate_and_digest_conflict",''',
+    )
+    replace_exact(
+        "scripts/sdlc/workflow_lane.py",
+        '''            for path in (repo_root / "newsroom" / "tests").glob(
+                "test_projection_*_neo4j_service.py"
+            )''',
+        '''            for path in (repo_root / "newsroom" / "tests").glob(
+                "test_*_neo4j_service.py"
+            )''',
+    )
+    replace_exact(
+        ".sdlc/gates.toml",
+        '''contract_control = [
+  ".sdlc/**",
+  "docs/specs/sdlc/**",
+  "docs/plans/*sdlc*",
+  ".github/workflows/**",
+  "scripts/sdlc/**",
+  "newsroom/tests/test_sdlc_*.py",
+]''',
+        '''contract_control = [
+  ".sdlc/**",
+  "docs/specs/sdlc/**",
+  "docs/plans/*sdlc*",
+  ".github/workflows/**",
+  "scripts/sdlc/**",
+  "newsroom/tests/test_sdlc_*.py",
+  "newsroom/tests/test_integrated_c1_sdlc_contract.py",
+  "newsroom/tests/test_integrated_c1_workflow_contract.py",
+]''',
+    )
+    replace_exact(
+        ".sdlc/gates.toml",
+        '''stateful_contract = [
+  "newsroom/authority/**",
+  "newsroom/projection/models.py",''',
+        '''stateful_contract = [
+  "newsroom/authority/**",
+  "newsroom/integrated/**",
+  "newsroom/projection/models.py",''',
+    )
+    replace_exact(
+        ".sdlc/gates.toml",
+        '''  "newsroom/authority/_neo4j_projection_system.py",
+  "newsroom/authority/neo4j_projection_system.py",
+  "newsroom/authority/_projection_store.py",''',
+        '''  "newsroom/authority/_neo4j_projection_system.py",
+  "newsroom/authority/neo4j_projection_system.py",
+  "newsroom/authority/_integrated_system.py",
+  "newsroom/authority/integrated_system.py",
+  "newsroom/integrated/proof.py",
+  "newsroom/authority/_projection_store.py",''',
+    )
+    replace_exact(
+        ".sdlc/gates.toml",
+        '''  "newsroom/tests/test_projection_b1_*.py",
+  "newsroom/tests/test_projection_b2_*.py",''',
+        '''  "newsroom/tests/test_integrated_c1_neo4j_service.py",
+  "newsroom/tests/test_projection_b1_*.py",
+  "newsroom/tests/test_projection_b2_*.py",''',
+    )
+    replace_exact(
+        "newsroom/tests/test_sdlc_classifier.py",
+        '''    paths = (
+        "scripts/sdlc/classify_change.py",
+        "newsroom/tests/test_sdlc_classifier.py",
+        "newsroom/projection/policy.py",
+        ".github/workflows/evidence.yml",
+    )''',
+        '''    paths = (
+        "scripts/sdlc/classify_change.py",
+        "newsroom/tests/test_sdlc_classifier.py",
+        "newsroom/projection/policy.py",
+        "newsroom/authority/_integrated_system.py",
+        "newsroom/authority/integrated_system.py",
+        "newsroom/integrated/proof.py",
+        "newsroom/tests/test_integrated_c1_neo4j_service.py",
+        ".github/workflows/evidence.yml",
+    )''',
+    )
+    replace_exact(
+        "newsroom/tests/test_sdlc_classifier.py",
+        '''        assert route["service_tests"] == [
+            "newsroom/tests/test_projection_b2_neo4j_service.py",
+            "newsroom/tests/test_projection_b3_neo4j_service.py",
+        ]''',
+        '''        assert route["service_tests"] == [
+            "newsroom/tests/test_integrated_c1_neo4j_service.py",
+            "newsroom/tests/test_projection_b2_neo4j_service.py",
+            "newsroom/tests/test_projection_b3_neo4j_service.py",
+        ]''',
+    )
+    replace_exact(
+        "newsroom/tests/test_sdlc_workflow_lane.py",
+        '''        "service_tests": (
+            ["newsroom/tests/test_projection_b2_neo4j_service.py"] if service else []
+        ),''',
+        '''        "service_tests": (
+            [
+                "newsroom/tests/test_integrated_c1_neo4j_service.py",
+                "newsroom/tests/test_projection_b2_neo4j_service.py",
+                "newsroom/tests/test_projection_b3_neo4j_service.py",
+            ]
+            if service
+            else []
+        ),''',
+    )
+    replace_exact(
+        "newsroom/tests/test_sdlc_workflow_lane.py",
+        '''    expected = (
+        "newsroom.tests.test_projection_b2_neo4j_service::test_actual_service_private_adapter_exact_duplicate_and_digest_conflict",''',
+        '''    expected = (
+        "newsroom.tests.test_integrated_c1_neo4j_service::test_actual_service_integrated_foundation_replay_recovery_and_tombstone",
+        "newsroom.tests.test_projection_b2_neo4j_service::test_actual_service_private_adapter_exact_duplicate_and_digest_conflict",''',
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.sdlc/increment_1c_sdlc_test_fix.py
+++ b/.sdlc/increment_1c_sdlc_test_fix.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def replace_exact(path: str, old: str, new: str) -> None:
+    target = Path(path)
+    text = target.read_text(encoding="utf-8")
+    if text.count(old) != 1 or new in text:
+        raise SystemExit(f"qualifier source mismatch in {path}: {old}")
+    target.write_text(text.replace(old, new), encoding="utf-8")
+
+
+def main() -> None:
+    replace_exact(
+        "newsroom/tests/test_integrated_c1_sdlc_contract.py",
+        '''def test_increment_1c_contract_models_are_stateful_even_without_service_execution() -> None:
+    for path in (
+        "newsroom/integrated/models.py",
+        "newsroom/integrated/policy.py",
+        "newsroom/integrated/traceability.py",
+    ):
+        route = _route(path)
+        assert route["risk_tier"] == "R2_STATEFUL_CONTRACT"
+        assert route["core_required"] is True''',
+        '''def test_increment_1c_contract_models_are_stateful_and_service_qualified() -> None:
+    for path in (
+        "newsroom/integrated/models.py",
+        "newsroom/integrated/policy.py",
+        "newsroom/integrated/traceability.py",
+    ):
+        route = _route(path)
+        assert route["risk_tier"] == "R3_EXTERNAL_SERVICE_SECURITY"
+        assert route["core_required"] is True
+        assert route["service_required"] is True
+        assert (
+            f"path:{path}:stateful_contract:R2_STATEFUL_CONTRACT"
+            in route["reasons"]
+        )''',
+    )
+    replace_exact(
+        "newsroom/tests/test_sdlc_workflow_lane.py",
+        '''    service_tests = ("newsroom/tests/test_projection_b2_neo4j_service.py",)''',
+        '''    service_tests = (
+        "newsroom/tests/test_integrated_c1_neo4j_service.py",
+        "newsroom/tests/test_projection_b2_neo4j_service.py",
+        "newsroom/tests/test_projection_b3_neo4j_service.py",
+    )''',
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Closed without merge — temporary C1 SDLC qualification only

This Draft PR was temporary transport infrastructure and **must never be merged**.

Authority A2b run `30098694621` qualified exact target head `42a01379b89be81fdf769b72b0f588f8fc66bdff` and published:

`364577c7feaee248a4ab5dcdd0ce4dd5656f150d` — `fix(sdlc): route Increment 1C actual service`

The published unit:

- classifies `newsroom/integrated/**` as stateful contract code;
- routes integrated Neo4j proof/runtime paths through R3 external-service evidence;
- discovers `test_integrated_c1_neo4j_service.py` with B2 and B3 service tests;
- permits the C1 actual-service case as the single new expected core skip;
- updates classifier and workflow-lane tests to pin the exact three-file topology.

The qualifier passed locked Python 3.12 compile, focused SDLC tests, the full repository suite and clustering regression evaluation before exact-head force-with-lease publication.

This PR is closed unmerged and its branch is being reset to current `main`, removing the temporary workflow and patch scripts.

No live source access, Graphiti/model/embedding execution, publication, shadow, canary, production activation, spending or public effect occurred.