### PR TITLE
chore(integrated): qualify retained context integrity

### DIFF
--- a/.github/workflows/authority-a2b.yml
+++ b/.github/workflows/authority-a2b.yml
@@ -88,3 +88,89 @@ jobs:
           test "$FOCUSED_OUTCOME" = success
           test "$REGRESSION_OUTCOME" = success
           test "$FAULT_OUTCOME" = success
+
+  increment-1c-context-publish:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.head_ref == 'agent/increment-1c-context-qualify' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.repository == 'fol2/newsroom'
+    needs: governed-object-authority
+    permissions:
+      contents: write
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout qualification branch
+        uses: actions/checkout@v4
+        with:
+          ref: agent/increment-1c-context-qualify
+          path: .qualifier
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Checkout exact Increment 1C target
+        uses: actions/checkout@v4
+        with:
+          ref: agent/increment-1c-integrated-foundation
+          path: .target
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up exact uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.8.0"
+          enable-cache: true
+          cache-dependency-glob: .target/uv.lock
+
+      - name: Correct, qualify and publish retained context integrity
+        shell: bash
+        working-directory: .target
+        run: |
+          set -euxo pipefail
+          diagnostic="${RUNNER_TEMP}/increment-1c-context-qualifier.log"
+          exec > >(tee "${diagnostic}") 2>&1
+          expected_head="3c59f95e927570cf100b27aff1c08d64b8ca51b4"
+          test "$(git rev-parse HEAD)" = "${expected_head}"
+          python ../.qualifier/.sdlc/increment_1c_context_qualify.py
+
+          test "$(git diff --name-only)" = "newsroom/authority/_integrated_store.py"
+          git diff --check
+          uv lock --check
+          uv sync --dev --locked
+          uv run --no-sync python -m compileall -q newsroom scripts
+          uv run --no-sync python -m pytest -q \
+            newsroom/tests/test_integrated_c1_context_integrity_faults.py \
+            newsroom/tests/test_integrated_c1_integrity_faults.py \
+            newsroom/tests/test_integrated_c1_persisted_context.py
+          uv run --no-sync python -m pytest -q newsroom/tests
+          uv run --no-sync python scripts/eval_clustering_metrics.py \
+            --dataset newsroom/evals/clustering_eval_dataset_v1.jsonl \
+            --baseline newsroom/evals/clustering_eval_metrics_baseline_v1.json \
+            --fail-on-regression
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add newsroom/authority/_integrated_store.py
+          git commit -m 'fix(integrated): verify retained context authority'
+
+          remote_head="$(git ls-remote origin refs/heads/agent/increment-1c-integrated-foundation | cut -f1)"
+          test "${remote_head}" = "${expected_head}"
+          git push \
+            --force-with-lease=refs/heads/agent/increment-1c-integrated-foundation:${expected_head} \
+            origin HEAD:agent/increment-1c-integrated-foundation
+
+      - name: Upload retained-context qualifier diagnostic
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: increment-1c-context-qualifier-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/increment-1c-context-qualifier.log
+          if-no-files-found: warn
+          retention-days: 1

--- a/.sdlc/increment_1c_context_qualify.py
+++ b/.sdlc/increment_1c_context_qualify.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def replace_exact(path: str, old: str, new: str) -> None:
+    target = Path(path)
+    text = target.read_text(encoding="utf-8")
+    if text.count(old) != 1 or new in text:
+        raise SystemExit(f"qualifier source mismatch in {path}: {old}")
+    target.write_text(text.replace(old, new), encoding="utf-8")
+
+
+def main() -> None:
+    path = "newsroom/authority/_integrated_store.py"
+    replace_exact(
+        path,
+        '''        value = self._canonical_row_value(
+            row, identity="integrated retrieval context"
+        )
+        canonical_digest = str(row["canonical_digest"])''',
+        '''        value = self._canonical_row_value(
+            row, identity="integrated retrieval context"
+        )
+        context = self._context_from_row(row)
+        canonical_digest = str(row["canonical_digest"])''',
+    )
+    replace_exact(
+        path,
+        '''        event = conn.execute(
+            "SELECT aggregate_type,aggregate_id,object_admission_id,payload_digest "
+            "FROM ledger_events WHERE event_id=?",
+            (str(row["fixture_event_id"]),),
+        ).fetchone()
+        if (
+            event is None
+            or str(event["aggregate_type"]) != "integrated_fixture"
+            or str(event["aggregate_id"]) != str(row["fixture_aggregate_id"])
+            or str(event["object_admission_id"]) != str(row["admission_id"])
+            or str(event["payload_digest"]) != str(row["manifest_digest"])
+        ):
+            raise AuthorityPersistenceError(
+                "integrated retrieval context lacks exact fixture authority"
+            )''',
+        '''        event = conn.execute(
+            "SELECT event_type,aggregate_type,aggregate_id,object_admission_id,"
+            "payload_digest,trust_scope,security_scope,retention_scope "
+            "FROM ledger_events WHERE event_id=?",
+            (str(row["fixture_event_id"]),),
+        ).fetchone()
+        if (
+            event is None
+            or str(event["event_type"]) != "authority.aggregate.versioned"
+            or str(event["aggregate_type"]) != "integrated_fixture"
+            or str(event["aggregate_id"]) != str(row["fixture_aggregate_id"])
+            or str(event["object_admission_id"]) != str(row["admission_id"])
+            or str(event["payload_digest"]) != str(row["manifest_digest"])
+            or context.hydrated_blob_digest != str(row["manifest_digest"])
+            or str(event["trust_scope"]) != "OBSERVED"
+            or str(event["security_scope"]) != "authority.protected"
+            or str(event["retention_scope"]) != "source.short"
+        ):
+            raise AuthorityPersistenceError(
+                "integrated retrieval context lacks exact fixture authority"
+            )''',
+    )
+    replace_exact(
+        path,
+        '''        access_value = self._canonical_row_value(
+            access, identity="integrated hydration decision"
+        )
+        if (
+            str(access["admission_id"]) != str(row["admission_id"])
+            or access_value.get("admission_id") != str(row["admission_id"])
+        ):
+            raise AuthorityPersistenceError(
+                "integrated hydration decision belongs to another admission"
+            )
+
+        nodes = value.get("nodes")''',
+        '''        access_value = self._canonical_row_value(
+            access, identity="integrated hydration decision"
+        )
+        cutoff = access_value.get("state_cutoff")
+        if not isinstance(cutoff, dict):
+            raise AuthorityPersistenceError(
+                "integrated hydration decision lacks an exact state cutoff"
+            )
+        if (
+            str(access["admission_id"]) != str(row["admission_id"])
+            or access_value.get("admission_id") != str(row["admission_id"])
+            or str(access["hydration_policy_contract_digest"])
+            != context.hydration_policy_contract_digest
+            or access_value.get("policy_contract_digest")
+            != context.hydration_policy_contract_digest
+            or int(access["byte_offset"]) != 0
+            or int(access["allowed_bytes"]) <= 0
+            or cutoff.get("admission_id") != str(row["admission_id"])
+            or cutoff.get("blob_digest") != context.hydrated_blob_digest
+            or cutoff.get("admission_state") != "ACTIVE"
+            or cutoff.get("blob_state") != "ACTIVE"
+            or cutoff.get("blob_integrity_state") != "VERIFIED"
+            or cutoff.get("deletion_state") is not None
+            or cutoff.get("offset") != 0
+            or cutoff.get("length") != int(access["allowed_bytes"])
+        ):
+            raise AuthorityPersistenceError(
+                "integrated hydration decision differs from retained context"
+            )
+
+        generation = conn.execute(
+            "SELECT g.family_id,d.definition_version,d.projector_version,"
+            "d.ontology_contract_digest,d.mapping_contract_digest "
+            "FROM projection_generations g "
+            "JOIN projection_families f ON f.family_id=g.family_id "
+            "JOIN projection_family_definitions d "
+            "ON d.definition_digest=f.definition_digest "
+            "WHERE g.generation_id=?",
+            (str(row["generation_id"]),),
+        ).fetchone()
+        active_version = conn.execute(
+            "SELECT 1 FROM projection_generation_versions "
+            "WHERE generation_id=? AND state='ACTIVE' LIMIT 1",
+            (str(row["generation_id"]),),
+        ).fetchone()
+        checkpoint = conn.execute(
+            "SELECT 1 FROM projection_checkpoint_versions "
+            "WHERE generation_id=? AND contiguous_ledger_seq=? LIMIT 1",
+            (
+                str(row["generation_id"]),
+                int(row["projected_through_ledger_seq"]),
+            ),
+        ).fetchone()
+        validation = conn.execute(
+            "SELECT 1 FROM projection_generation_validations "
+            "WHERE generation_id=? AND checkpoint_ledger_seq=? "
+            "AND ontology_contract_digest=? AND mapping_contract_digest=? "
+            "AND projector_version=? LIMIT 1",
+            (
+                str(row["generation_id"]),
+                int(row["projected_through_ledger_seq"]),
+                context.metadata.ontology_contract_digest,
+                context.metadata.mapping_contract_digest,
+                context.metadata.projector_version,
+            ),
+        ).fetchone()
+        promotion = conn.execute(
+            "SELECT 1 FROM projection_generation_promotions "
+            "WHERE generation_id=? AND checkpoint_ledger_seq=? LIMIT 1",
+            (
+                str(row["generation_id"]),
+                int(row["projected_through_ledger_seq"]),
+            ),
+        ).fetchone()
+        if (
+            generation is None
+            or str(generation["family_id"]) != context.metadata.family_id
+            or str(generation["definition_version"])
+            != context.metadata.family_definition_version
+            or str(generation["projector_version"])
+            != context.metadata.projector_version
+            or str(generation["ontology_contract_digest"])
+            != context.metadata.ontology_contract_digest
+            or str(generation["mapping_contract_digest"])
+            != context.metadata.mapping_contract_digest
+            or active_version is None
+            or checkpoint is None
+            or validation is None
+            or promotion is None
+        ):
+            raise AuthorityPersistenceError(
+                "integrated retrieval context lacks retained ACTIVE projection evidence"
+            )
+
+        nodes = value.get("nodes")''',
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Closed without merge — temporary retained-context integrity qualification only

This Draft PR was temporary transport infrastructure and **must never be merged**.

Authority A2b run `30099869548` qualified exact target head `3c59f95e927570cf100b27aff1c08d64b8ca51b4` and published:

`a904410bcd3a7eeb5886e751a9cbf786ca975f64` — `fix(integrated): verify retained context authority`

The published unit closes a second substantive-review P2 integrity finding. Every retained Retrieval Context now:

- rehydrates through the complete typed contract during startup integrity validation;
- binds exact fixture event type, trust, security and retention authority;
- binds the hydration policy, blob identity and complete access-decision state cutoff;
- binds the retained family definition, historical ACTIVE lifecycle version, exact checkpoint, validation and promotion evidence;
- rejects non-ACTIVE authority selection and policy/blob rebinding even when canonical bytes and digests are rewritten consistently.

Adversarial direct-insert tests cover both contract-state and hydration rebinding. The qualifier passed locked Python 3.12 compile, focused tests, the full repository suite and clustering regression evaluation before exact-head force-with-lease publication.

This PR is closed unmerged and its branch is being reset to current `main`, removing the temporary workflow and patch script.

No live source access, Graphiti/model/embedding execution, publication, shadow, canary, production activation, spending or public effect occurred.