### PR TITLE
chore(integrated): qualify recovery dedup authority

### DIFF
--- a/.github/workflows/authority-a2b.yml
+++ b/.github/workflows/authority-a2b.yml
@@ -140,7 +140,10 @@ jobs:
           test "$(git rev-parse HEAD)" = "${expected_head}"
           python ../.qualifier/.sdlc/increment_1c_recovery_qualify.py
 
-          actual_files="$(git diff --name-only | sort)"
+          actual_files="$({
+            git diff --name-only
+            git ls-files --others --exclude-standard
+          } | sort)"
           expected_files="$(printf '%s\n' \
             newsroom/authority/_integrated_store.py \
             newsroom/tests/test_integrated_c1_neo4j_service.py \

--- a/.github/workflows/authority-a2b.yml
+++ b/.github/workflows/authority-a2b.yml
@@ -88,3 +88,181 @@ jobs:
           test "$FOCUSED_OUTCOME" = success
           test "$REGRESSION_OUTCOME" = success
           test "$FAULT_OUTCOME" = success
+
+  increment-1c-recovery-publish:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.head_ref == 'agent/increment-1c-recovery-qualify' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.repository == 'fol2/newsroom'
+    needs: governed-object-authority
+    permissions:
+      contents: write
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+    steps:
+      - name: Checkout qualification branch
+        uses: actions/checkout@v4
+        with:
+          ref: agent/increment-1c-recovery-qualify
+          path: .qualifier
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Checkout exact Increment 1C target
+        uses: actions/checkout@v4
+        with:
+          ref: agent/increment-1c-integrated-foundation
+          path: .target
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up exact uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.8.0"
+          enable-cache: true
+          cache-dependency-glob: .target/uv.lock
+
+      - name: Correct, qualify and publish recovery integrity
+        shell: bash
+        working-directory: .target
+        run: |
+          set -euxo pipefail
+          diagnostic="${RUNNER_TEMP}/increment-1c-recovery-qualifier.log"
+          exec > >(tee "${diagnostic}") 2>&1
+          expected_head="e1e3ed2bc090e92989c438a76f1c1019024b1626"
+          test "$(git rev-parse HEAD)" = "${expected_head}"
+          python ../.qualifier/.sdlc/increment_1c_recovery_qualify.py
+
+          actual_files="$(git diff --name-only | sort)"
+          expected_files="$(printf '%s\n' \
+            newsroom/authority/_integrated_store.py \
+            newsroom/tests/test_integrated_c1_neo4j_service.py \
+            newsroom/tests/test_integrated_c1_recovery_integrity.py | sort)"
+          test "${actual_files}" = "${expected_files}"
+          git diff --check
+          uv lock --check
+          uv sync --dev --locked
+          uv run --no-sync python -m compileall -q newsroom scripts
+          uv run --no-sync python -m pytest -q \
+            newsroom/tests/test_integrated_c1_recovery_integrity.py \
+            newsroom/tests/test_integrated_c1_candidate_authority.py \
+            newsroom/tests/test_integrated_c1_integrity_faults.py \
+            newsroom/tests/test_integrated_c1_persisted_context.py
+          uv run --no-sync python -m pytest -q newsroom/tests
+          uv run --no-sync python scripts/eval_clustering_metrics.py \
+            --dataset newsroom/evals/clustering_eval_dataset_v1.jsonl \
+            --baseline newsroom/evals/clustering_eval_metrics_baseline_v1.json \
+            --fail-on-regression
+
+          NEO4J_ADMIN_PASSWORD="$(python - <<'PY'
+          import secrets
+          print(secrets.token_urlsafe(32))
+          PY
+          )"
+          NEWSROOM_NEO4J_PROJECTOR_PASSWORD="$(python - <<'PY'
+          import secrets
+          print(secrets.token_urlsafe(32))
+          PY
+          )"
+          export NEO4J_ADMIN_PASSWORD NEWSROOM_NEO4J_PROJECTOR_PASSWORD
+          export NEWSROOM_NEO4J_URI="bolt://localhost:7687"
+          export NEWSROOM_NEO4J_DATABASE="neo4j"
+          export NEWSROOM_NEO4J_PROJECTOR_USERNAME="newsroom_projector"
+          export NEWSROOM_NEO4J_SERVICE_REQUIRED="1"
+          echo "::add-mask::${NEO4J_ADMIN_PASSWORD}"
+          echo "::add-mask::${NEWSROOM_NEO4J_PROJECTOR_PASSWORD}"
+          docker run --detach \
+            --name newsroom-c1-recovery-neo4j \
+            --publish 127.0.0.1:7687:7687 \
+            --env "NEO4J_AUTH=neo4j/${NEO4J_ADMIN_PASSWORD}" \
+            neo4j:2026.06.0-community-trixie
+          trap 'docker rm --force newsroom-c1-recovery-neo4j || true' EXIT
+          uv run --no-sync python - <<'PY'
+          import os
+          import time
+          from neo4j import GraphDatabase
+
+          uri = os.environ["NEWSROOM_NEO4J_URI"]
+          admin = ("neo4j", os.environ["NEO4J_ADMIN_PASSWORD"])
+          last_error = None
+          for _ in range(120):
+              driver = None
+              try:
+                  driver = GraphDatabase.driver(uri, auth=admin)
+                  driver.verify_connectivity()
+                  break
+              except Exception as exc:
+                  last_error = exc
+                  if driver is not None:
+                      driver.close()
+                  time.sleep(2)
+          else:
+              raise RuntimeError("authenticated Neo4j readiness timed out") from last_error
+          try:
+              with driver.session(database="system") as session:
+                  session.run(
+                      "CREATE USER newsroom_projector IF NOT EXISTS "
+                      "SET PLAINTEXT PASSWORD $password CHANGE NOT REQUIRED",
+                      password=os.environ["NEWSROOM_NEO4J_PROJECTOR_PASSWORD"],
+                  ).consume()
+          finally:
+              driver.close()
+          projector = GraphDatabase.driver(
+              uri,
+              auth=(
+                  os.environ["NEWSROOM_NEO4J_PROJECTOR_USERNAME"],
+                  os.environ["NEWSROOM_NEO4J_PROJECTOR_PASSWORD"],
+              ),
+          )
+          try:
+              projector.verify_connectivity()
+          finally:
+              projector.close()
+          PY
+          uv run --no-sync python -m pytest -q \
+            newsroom/tests/test_integrated_c1_neo4j_service.py::test_actual_service_integrated_foundation_replay_recovery_and_tombstone \
+            --junitxml=increment-1c-recovery-neo4j.xml
+          uv run --no-sync python - <<'PY'
+          import xml.etree.ElementTree as ET
+          root = ET.parse("increment-1c-recovery-neo4j.xml").getroot()
+          cases = root.findall(".//testcase")
+          if len(cases) != 1:
+              raise SystemExit(f"expected one C1 recovery case, found {len(cases)}")
+          case = cases[0]
+          if case.find("skipped") is not None:
+              raise SystemExit("C1 recovery case was skipped")
+          if case.find("failure") is not None or case.find("error") is not None:
+              raise SystemExit("C1 recovery case failed")
+          PY
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add \
+            newsroom/authority/_integrated_store.py \
+            newsroom/tests/test_integrated_c1_neo4j_service.py \
+            newsroom/tests/test_integrated_c1_recovery_integrity.py
+          git commit -m 'fix(integrated): preserve recovery dedup authority'
+
+          remote_head="$(git ls-remote origin refs/heads/agent/increment-1c-integrated-foundation | cut -f1)"
+          test "${remote_head}" = "${expected_head}"
+          git push \
+            --force-with-lease=refs/heads/agent/increment-1c-integrated-foundation:${expected_head} \
+            origin HEAD:agent/increment-1c-integrated-foundation
+
+      - name: Upload recovery qualifier diagnostic
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: increment-1c-recovery-qualifier-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/increment-1c-recovery-qualifier.log
+            .target/increment-1c-recovery-neo4j.xml
+          if-no-files-found: warn
+          retention-days: 1

--- a/.sdlc/increment_1c_recovery_qualify.py
+++ b/.sdlc/increment_1c_recovery_qualify.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def replace_exact(path: str, old: str, new: str) -> None:
+    target = Path(path)
+    text = target.read_text(encoding="utf-8")
+    if text.count(old) != 1 or new in text:
+        raise SystemExit(f"qualifier source mismatch in {path}: {old[:120]}")
+    target.write_text(text.replace(old, new), encoding="utf-8")
+
+
+def main() -> None:
+    store_path = "newsroom/authority/_integrated_store.py"
+    replace_exact(
+        store_path,
+        '''        if (
+            not versions
+            or int(versions[0]["version_number"]) != 1''',
+        '''        if (
+            len(versions) != 1
+            or int(versions[0]["version_number"]) != 1''',
+    )
+    replace_exact(
+        store_path,
+        '''        version = conn.execute(
+            "SELECT candidate_id,fixture_id,route,retrieval_context_id,"
+            "manifest_digest FROM story_candidate_versions "
+            "WHERE candidate_version_id=?",
+            (str(row["candidate_version_id"]),),
+        ).fetchone()
+        context = conn.execute(
+            "SELECT context_digest FROM integrated_retrieval_contexts "
+            "WHERE context_id=?",
+            (str(row["retrieval_context_id"]),),
+        ).fetchone()
+        if (
+            candidate is None
+            or version is None
+            or context is None
+            or str(candidate["semantic_collision_digest"])
+            != str(row["semantic_collision_digest"])
+            or str(version["candidate_id"]) != str(row["candidate_id"])
+            or str(version["fixture_id"]) != str(row["fixture_id"])
+            or str(version["route"]) != str(row["route"])
+            or str(version["retrieval_context_id"])
+            != str(row["retrieval_context_id"])
+            or str(version["manifest_digest"])
+            != str(row["manifest_digest"])
+            or str(context["context_digest"])
+            != str(row["retrieval_context_digest"])
+        ):
+            raise AuthorityPersistenceError(
+                "candidate admission decision cross-record identity is inconsistent"
+            )''',
+        '''        version = conn.execute(
+            "SELECT candidate_id,fixture_id,signal_id,lead_id,"
+            "hypothesis_version_id,route,retrieval_context_id,"
+            "manifest_digest FROM story_candidate_versions "
+            "WHERE candidate_version_id=?",
+            (str(row["candidate_version_id"]),),
+        ).fetchone()
+        context = conn.execute(
+            "SELECT fixture_id,fixture_event_id,context_digest,manifest_digest "
+            "FROM integrated_retrieval_contexts WHERE context_id=?",
+            (str(row["retrieval_context_id"]),),
+        ).fetchone()
+        outcome = CandidateAdmissionOutcome(str(row["outcome"]))
+        expected_collision = (
+            None
+            if version is None or context is None
+            else digest_canonical(
+                {
+                    "contract": _COLLISION_CONTRACT,
+                    "fixture_id": str(context["fixture_id"]),
+                    "fixture_event_id": str(context["fixture_event_id"]),
+                    "signal_id": str(version["signal_id"]),
+                    "lead_id": str(version["lead_id"]),
+                    "hypothesis_version_id": str(
+                        version["hypothesis_version_id"]
+                    ),
+                    "route": str(version["route"]),
+                    "manifest_digest": str(context["manifest_digest"]),
+                }
+            )
+        )
+        if (
+            candidate is None
+            or version is None
+            or context is None
+            or str(candidate["semantic_collision_digest"])
+            != str(row["semantic_collision_digest"])
+            or str(version["candidate_id"]) != str(row["candidate_id"])
+            or str(version["fixture_id"]) != str(row["fixture_id"])
+            or str(version["route"]) != str(row["route"])
+            or str(version["manifest_digest"])
+            != str(row["manifest_digest"])
+            or str(context["fixture_id"]) != str(row["fixture_id"])
+            or str(context["manifest_digest"])
+            != str(row["manifest_digest"])
+            or str(context["context_digest"])
+            != str(row["retrieval_context_digest"])
+            or expected_collision != str(row["semantic_collision_digest"])
+            or (
+                outcome is CandidateAdmissionOutcome.ADMITTED
+                and str(version["retrieval_context_id"])
+                != str(row["retrieval_context_id"])
+            )
+        ):
+            raise AuthorityPersistenceError(
+                "candidate admission decision cross-record identity is inconsistent"
+            )''',
+    )
+    replace_exact(
+        store_path,
+        '''            "payload_digest,object_admission_id,trust_scope,security_scope,"
+            "retention_scope FROM ledger_events WHERE event_id=?",''',
+        '''            "payload_digest,object_admission_id,trust_scope,security_scope,"
+            "retention_scope,recorded_at FROM ledger_events WHERE event_id=?",''',
+    )
+    replace_exact(
+        store_path,
+        '''            or str(event["retention_scope"]) != "authority.audit"
+        ):''',
+        '''            or str(event["retention_scope"]) != "authority.audit"
+            or str(event["recorded_at"]) != str(row["recorded_at"])
+        ):''',
+    )
+
+    test_path = Path("newsroom/tests/test_integrated_c1_recovery_integrity.py")
+    if test_path.exists():
+        raise SystemExit(f"qualifier test path already exists: {test_path}")
+    test_path.write_text(
+        '''from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+import json
+import sqlite3
+
+import pytest
+
+from newsroom.authority import (
+    AuthorityPersistenceError,
+    UtcTimestamp,
+    canonical_json_bytes,
+    digest_bytes,
+)
+from newsroom.integrated import (
+    CandidateAdmissionOutcome,
+    IntegratedRetrievalContextId,
+    StoryCandidateVersionId,
+)
+
+from .integrated_c1_helpers import (
+    SECOND_PROPOSAL_ID,
+    candidate_request,
+    proof,
+)
+from .test_integrated_c1_candidate_authority import (
+    _open_candidate_system,
+    _seed,
+)
+
+
+def _disable_trigger(conn: sqlite3.Connection, name: str) -> str:
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='trigger' AND name=?",
+        (name,),
+    ).fetchone()
+    assert row is not None and row[0]
+    sql = str(row[0])
+    conn.execute(f'DROP TRIGGER "{name}"')
+    return sql
+
+
+def test_recovery_equivalent_context_dedup_reopens_exactly(
+    tmp_path: Path,
+) -> None:
+    database, state, graph = _seed(tmp_path)
+    recovered_context = replace(
+        graph.context,
+        context_id=IntegratedRetrievalContextId.new(),
+    )
+    system = _open_candidate_system(database, state, graph)
+    try:
+        admitted = system.candidates.admit(
+            candidate_request(graph.context),
+            context=graph.context,
+            manifest=state.manifest,
+            proof=proof(),
+        )
+        deduplicated = system.candidates.admit(
+            candidate_request(
+                recovered_context,
+                proposal_id=SECOND_PROPOSAL_ID,
+                key="integrated-recovery-context-deduplicate",
+            ),
+            context=recovered_context,
+            manifest=state.manifest,
+            proof=proof(),
+        )
+        assert admitted.outcome is CandidateAdmissionOutcome.ADMITTED
+        assert deduplicated.outcome is CandidateAdmissionOutcome.DEDUPLICATED
+        assert deduplicated.candidate_id == admitted.candidate_id
+        assert deduplicated.candidate_version_id == admitted.candidate_version_id
+        assert deduplicated.retrieval_context_id == recovered_context.context_id
+    finally:
+        system.close()
+
+    reopened = _open_candidate_system(database, state, graph)
+    try:
+        assert reopened.candidates.context(
+            recovered_context.context_id,
+            proof=proof(),
+        ) == recovered_context
+    finally:
+        reopened.close()
+
+
+def test_schema_v5_rejects_candidate_version_without_creation_authority(
+    tmp_path: Path,
+) -> None:
+    database, state, graph = _seed(tmp_path)
+    system = _open_candidate_system(database, state, graph)
+    try:
+        system.candidates.admit(
+            candidate_request(graph.context),
+            context=graph.context,
+            manifest=state.manifest,
+            proof=proof(),
+        )
+    finally:
+        system.close()
+
+    conn = sqlite3.connect(database)
+    conn.row_factory = sqlite3.Row
+    try:
+        row = conn.execute(
+            "SELECT * FROM story_candidate_versions"
+        ).fetchone()
+        assert row is not None
+        value = json.loads(bytes(row["canonical_bytes"]).decode("utf-8"))
+        new_version_id = StoryCandidateVersionId.new()
+        value["candidate_version_id"] = str(new_version_id)
+        value["version_number"] = 2
+        canonical = canonical_json_bytes(value)
+        conn.execute(
+            "INSERT INTO story_candidate_versions("
+            "candidate_version_id,candidate_id,version_number,fixture_id,"
+            "signal_id,lead_id,hypothesis_version_id,route,"
+            "hypothesis_trust_scope,retrieval_context_id,manifest_digest,"
+            "canonical_bytes,canonical_digest,recorded_at) "
+            "VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+            (
+                str(new_version_id),
+                str(row["candidate_id"]),
+                2,
+                str(row["fixture_id"]),
+                str(row["signal_id"]),
+                str(row["lead_id"]),
+                str(row["hypothesis_version_id"]),
+                str(row["route"]),
+                str(row["hypothesis_trust_scope"]),
+                str(row["retrieval_context_id"]),
+                str(row["manifest_digest"]),
+                canonical,
+                digest_bytes(canonical),
+                str(row["recorded_at"]),
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    with pytest.raises(
+        AuthorityPersistenceError,
+        match="one exact ADMITTED immutable version",
+    ):
+        _open_candidate_system(database, state, graph)
+
+
+def test_decision_time_must_equal_authority_event_time(
+    tmp_path: Path,
+) -> None:
+    database, state, graph = _seed(tmp_path)
+    system = _open_candidate_system(database, state, graph)
+    try:
+        system.candidates.admit(
+            candidate_request(graph.context),
+            context=graph.context,
+            manifest=state.manifest,
+            proof=proof(),
+        )
+    finally:
+        system.close()
+
+    rewritten_time = UtcTimestamp.parse(
+        "2030-01-01T00:00:00.000000Z"
+    ).to_text()
+    conn = sqlite3.connect(database)
+    try:
+        triggers = tuple(
+            _disable_trigger(conn, name)
+            for name in (
+                "immutable_story_candidate_update",
+                "immutable_story_candidate_version_update",
+                "immutable_candidate_admission_decision_update",
+            )
+        )
+        conn.execute(
+            "UPDATE story_candidates SET created_at=?",
+            (rewritten_time,),
+        )
+        conn.execute(
+            "UPDATE story_candidate_versions SET recorded_at=?",
+            (rewritten_time,),
+        )
+        conn.execute(
+            "UPDATE candidate_admission_decisions SET recorded_at=?",
+            (rewritten_time,),
+        )
+        for trigger in triggers:
+            conn.execute(trigger)
+        conn.commit()
+    finally:
+        conn.close()
+
+    with pytest.raises(
+        AuthorityPersistenceError,
+        match="exact authority event|recorded_at",
+    ):
+        _open_candidate_system(database, state, graph)
+''',
+        encoding="utf-8",
+    )
+
+    service_path = "newsroom/tests/test_integrated_c1_neo4j_service.py"
+    replace_exact(
+        service_path,
+        '''        assert deduplicated.candidate_id == initial.candidate.candidate_id
+        assert recovered_context.metadata.generation_id == recovery_generation
+
+        rights, hydration, admissions = _policy_registries()''',
+        '''        assert deduplicated.candidate_id == initial.candidate.candidate_id
+        assert recovered_context.metadata.generation_id == recovery_generation
+        assert controller.retained_context(
+            recovered_context.context_id,
+            proof=proof(),
+        ) == recovered_context
+
+        rights, hydration, admissions = _policy_registries()''',
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Closed without merge — temporary recovery-integrity qualification only

This Draft PR was temporary transport infrastructure and **must never be merged**.

Authority A2b run `30110976527` qualified exact target head `e1e3ed2bc090e92989c438a76f1c1019024b1626` and published:

`946eee62849103d707f4a271f23836a6db8521d3` — `fix(integrated): preserve recovery dedup authority`

The publisher passed locked compile, focused tests, the full repository suite, clustering regression and an actual Neo4j C1 recovery case. The source unit makes recovery dedup startup validation outcome-sensitive, rejects orphan schema-v5 Candidate versions, binds decision time to the authority event, and reopens the Candidate system after replacement-generation deduplication.

This PR is closed unmerged. Its branch is reset to current `main`, removing the temporary workflow and patch script.

No live source access, Graphiti/model/embedding execution, publication, shadow, canary, production activation, spending or public effect occurred.