### PR TITLE
chore(integrated): qualify complete context semantics

### DIFF
--- a/.github/workflows/authority-a2b.yml
+++ b/.github/workflows/authority-a2b.yml
@@ -88,3 +88,198 @@ jobs:
           test "$FOCUSED_OUTCOME" = success
           test "$REGRESSION_OUTCOME" = success
           test "$FAULT_OUTCOME" = success
+
+  increment-1c-context-semantics-publish:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.head_ref == 'agent/increment-1c-context-semantics-qualify' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.repository == 'fol2/newsroom'
+    needs: governed-object-authority
+    permissions:
+      contents: write
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+    steps:
+      - name: Checkout qualification branch
+        uses: actions/checkout@v4
+        with:
+          ref: agent/increment-1c-context-semantics-qualify
+          path: .qualifier
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Checkout exact Increment 1C target
+        uses: actions/checkout@v4
+        with:
+          ref: agent/increment-1c-integrated-foundation
+          path: .target
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up exact uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.8.0"
+          enable-cache: true
+          cache-dependency-glob: .target/uv.lock
+
+      - name: Correct, qualify and publish context semantics
+        shell: bash
+        working-directory: .target
+        run: |
+          set -euxo pipefail
+          diagnostic="${RUNNER_TEMP}/increment-1c-context-semantics.log"
+          exec > >(tee "${diagnostic}") 2>&1
+          expected_head="946eee62849103d707f4a271f23836a6db8521d3"
+          test "$(git rev-parse HEAD)" = "${expected_head}"
+          python ../.qualifier/.sdlc/increment_1c_context_semantics_qualify.py
+
+          actual_files="$({
+            git diff --name-only
+            git ls-files --others --exclude-standard
+          } | sort)"
+          expected_files="$(printf '%s\n' \
+            newsroom/authority/_integrated_store.py \
+            newsroom/authority/_integrated_system.py \
+            newsroom/integrated/models.py \
+            newsroom/tests/integrated_c1_helpers.py \
+            newsroom/tests/test_integrated_c1_context_history.py \
+            newsroom/tests/test_integrated_c1_context_semantics.py \
+            newsroom/tests/test_integrated_c1_contracts.py \
+            newsroom/tests/test_integrated_c1_temporal_integrity.py | sort)"
+          test "${actual_files}" = "${expected_files}"
+          git diff --check
+          uv lock --check
+          uv sync --dev --locked
+          uv run --no-sync python -m compileall -q newsroom scripts
+          uv run --no-sync python -m pytest -q \
+            newsroom/tests/test_integrated_c1_context_semantics.py \
+            newsroom/tests/test_integrated_c1_contracts.py \
+            newsroom/tests/test_integrated_c1_context_history.py \
+            newsroom/tests/test_integrated_c1_temporal_integrity.py \
+            newsroom/tests/test_integrated_c1_candidate_authority.py \
+            newsroom/tests/test_integrated_c1_recovery_integrity.py \
+            newsroom/tests/test_integrated_c1_persisted_context.py \
+            newsroom/tests/test_integrated_c1_proof_integrity.py
+          uv run --no-sync python -m pytest -q newsroom/tests
+          uv run --no-sync python scripts/eval_clustering_metrics.py \
+            --dataset newsroom/evals/clustering_eval_dataset_v1.jsonl \
+            --baseline newsroom/evals/clustering_eval_metrics_baseline_v1.json \
+            --fail-on-regression
+
+          NEO4J_ADMIN_PASSWORD="$(python - <<'PY'
+          import secrets
+          print(secrets.token_urlsafe(32))
+          PY
+          )"
+          NEWSROOM_NEO4J_PROJECTOR_PASSWORD="$(python - <<'PY'
+          import secrets
+          print(secrets.token_urlsafe(32))
+          PY
+          )"
+          export NEO4J_ADMIN_PASSWORD NEWSROOM_NEO4J_PROJECTOR_PASSWORD
+          export NEWSROOM_NEO4J_URI="bolt://localhost:7687"
+          export NEWSROOM_NEO4J_DATABASE="neo4j"
+          export NEWSROOM_NEO4J_PROJECTOR_USERNAME="newsroom_projector"
+          export NEWSROOM_NEO4J_SERVICE_REQUIRED="1"
+          echo "::add-mask::${NEO4J_ADMIN_PASSWORD}"
+          echo "::add-mask::${NEWSROOM_NEO4J_PROJECTOR_PASSWORD}"
+          docker run --detach \
+            --name newsroom-c1-context-neo4j \
+            --publish 127.0.0.1:7687:7687 \
+            --env "NEO4J_AUTH=neo4j/${NEO4J_ADMIN_PASSWORD}" \
+            neo4j:2026.06.0-community-trixie
+          trap 'docker rm --force newsroom-c1-context-neo4j || true' EXIT
+          uv run --no-sync python - <<'PY'
+          import os
+          import time
+          from neo4j import GraphDatabase
+
+          uri = os.environ["NEWSROOM_NEO4J_URI"]
+          admin = ("neo4j", os.environ["NEO4J_ADMIN_PASSWORD"])
+          last_error = None
+          for _ in range(120):
+              driver = None
+              try:
+                  driver = GraphDatabase.driver(uri, auth=admin)
+                  driver.verify_connectivity()
+                  break
+              except Exception as exc:
+                  last_error = exc
+                  if driver is not None:
+                      driver.close()
+                  time.sleep(2)
+          else:
+              raise RuntimeError("authenticated Neo4j readiness timed out") from last_error
+          try:
+              with driver.session(database="system") as session:
+                  session.run(
+                      "CREATE USER newsroom_projector IF NOT EXISTS "
+                      "SET PLAINTEXT PASSWORD $password CHANGE NOT REQUIRED",
+                      password=os.environ["NEWSROOM_NEO4J_PROJECTOR_PASSWORD"],
+                  ).consume()
+          finally:
+              driver.close()
+          projector = GraphDatabase.driver(
+              uri,
+              auth=(
+                  os.environ["NEWSROOM_NEO4J_PROJECTOR_USERNAME"],
+                  os.environ["NEWSROOM_NEO4J_PROJECTOR_PASSWORD"],
+              ),
+          )
+          try:
+              projector.verify_connectivity()
+          finally:
+              projector.close()
+          PY
+          uv run --no-sync python -m pytest -q \
+            newsroom/tests/test_integrated_c1_neo4j_service.py::test_actual_service_integrated_foundation_replay_recovery_and_tombstone \
+            --junitxml=increment-1c-context-neo4j.xml
+          uv run --no-sync python - <<'PY'
+          import xml.etree.ElementTree as ET
+          root = ET.parse("increment-1c-context-neo4j.xml").getroot()
+          cases = root.findall(".//testcase")
+          if len(cases) != 1:
+              raise SystemExit(f"expected one C1 context case, found {len(cases)}")
+          case = cases[0]
+          if case.find("skipped") is not None:
+              raise SystemExit("C1 context case was skipped")
+          if case.find("failure") is not None or case.find("error") is not None:
+              raise SystemExit("C1 context case failed")
+          PY
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add \
+            newsroom/authority/_integrated_store.py \
+            newsroom/authority/_integrated_system.py \
+            newsroom/integrated/models.py \
+            newsroom/tests/integrated_c1_helpers.py \
+            newsroom/tests/test_integrated_c1_context_history.py \
+            newsroom/tests/test_integrated_c1_context_semantics.py \
+            newsroom/tests/test_integrated_c1_contracts.py \
+            newsroom/tests/test_integrated_c1_temporal_integrity.py
+          git commit -m 'fix(integrated): bind complete context semantics'
+
+          remote_head="$(git ls-remote origin refs/heads/agent/increment-1c-integrated-foundation | cut -f1)"
+          test "${remote_head}" = "${expected_head}"
+          git push \
+            --force-with-lease=refs/heads/agent/increment-1c-integrated-foundation:${expected_head} \
+            origin HEAD:agent/increment-1c-integrated-foundation
+
+      - name: Upload context-semantics qualifier diagnostic
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: increment-1c-context-semantics-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/increment-1c-context-semantics.log
+            .target/increment-1c-context-neo4j.xml
+          if-no-files-found: warn
+          retention-days: 1

--- a/.github/workflows/authority-a2b.yml
+++ b/.github/workflows/authority-a2b.yml
@@ -139,6 +139,7 @@ jobs:
           expected_head="946eee62849103d707f4a271f23836a6db8521d3"
           test "$(git rev-parse HEAD)" = "${expected_head}"
           python ../.qualifier/.sdlc/increment_1c_context_semantics_qualify.py
+          python ../.qualifier/.sdlc/increment_1c_context_semantics_test_align.py
 
           actual_files="$({
             git diff --name-only
@@ -152,6 +153,7 @@ jobs:
             newsroom/tests/test_integrated_c1_context_history.py \
             newsroom/tests/test_integrated_c1_context_semantics.py \
             newsroom/tests/test_integrated_c1_contracts.py \
+            newsroom/tests/test_integrated_c1_proof_integrity.py \
             newsroom/tests/test_integrated_c1_temporal_integrity.py | sort)"
           test "${actual_files}" = "${expected_files}"
           git diff --check
@@ -264,6 +266,7 @@ jobs:
             newsroom/tests/test_integrated_c1_context_history.py \
             newsroom/tests/test_integrated_c1_context_semantics.py \
             newsroom/tests/test_integrated_c1_contracts.py \
+            newsroom/tests/test_integrated_c1_proof_integrity.py \
             newsroom/tests/test_integrated_c1_temporal_integrity.py
           git commit -m 'fix(integrated): bind complete context semantics'
 

--- a/.sdlc/increment_1c_context_semantics_qualify.py
+++ b/.sdlc/increment_1c_context_semantics_qualify.py
@@ -1,0 +1,555 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def replace_exact(path: str, old: str, new: str) -> None:
+    target = Path(path)
+    text = target.read_text(encoding="utf-8")
+    if text.count(old) != 1 or new in text:
+        raise SystemExit(f"qualifier source mismatch in {path}: {old[:120]}")
+    target.write_text(text.replace(old, new), encoding="utf-8")
+
+
+def main() -> None:
+    models = "newsroom/integrated/models.py"
+    replace_exact(
+        models,
+        '''        if (
+            self.metadata.authoritative_system
+            != "sqlite-ledger-and-governed-objects"
+            or self.metadata.graph_role
+            != "non-authoritative-rebuildable-context"
+        ):
+            raise IntegratedStateError(
+                "integrated context must return to non-graph authority"
+            )
+        if not isinstance(self.nodes, tuple) or not self.nodes:''',
+        '''        if (
+            self.metadata.authoritative_system
+            != "sqlite-ledger-and-governed-objects"
+            or self.metadata.graph_role
+            != "non-authoritative-rebuildable-context"
+        ):
+            raise IntegratedStateError(
+                "integrated context must return to non-graph authority"
+            )
+        if (
+            self.metadata.query_valid_time.value
+            > self.metadata.serving_time.value
+        ):
+            raise IntegratedStateError(
+                "integrated query-valid time exceeds serving time"
+            )
+        if not isinstance(self.nodes, tuple) or not self.nodes:''',
+    )
+    replace_exact(
+        models,
+        '''        if any(
+            relation.source_canonical_id not in known_node_ids
+            or relation.target_canonical_id not in known_node_ids
+            for relation in self.relations
+        ):
+            raise IntegratedContractError(
+                "integrated graph relation endpoint is absent from returned nodes"
+            )
+        if not isinstance(self.exact_index, tuple) or not self.exact_index:''',
+        '''        if any(
+            relation.source_canonical_id not in known_node_ids
+            or relation.target_canonical_id not in known_node_ids
+            for relation in self.relations
+        ):
+            raise IntegratedContractError(
+                "integrated graph relation endpoint is absent from returned nodes"
+            )
+        if any(
+            relation.recorded_at.value
+            > self.metadata.query_valid_time.value
+            for relation in self.relations
+        ):
+            raise IntegratedStateError(
+                "integrated graph relation postdates query-valid time"
+            )
+        if not isinstance(self.exact_index, tuple) or not self.exact_index:''',
+    )
+    replace_exact(
+        models,
+        '''        if self.hydrated_blob_digest != self.manifest_digest:
+            raise IntegratedStateError(
+                "integrated hydrated blob must equal the canonical manifest"
+            )
+        if not isinstance(''',
+        '''        if self.hydrated_blob_digest != self.manifest_digest:
+            raise IntegratedStateError(
+                "integrated hydrated blob must equal the canonical manifest"
+            )
+        expected_query_digest = digest_canonical(
+            {
+                "contract": "newsroom-integrated-query-v1",
+                "family_id": self.metadata.family_id,
+                "generation_id": str(self.metadata.generation_id),
+                "canonical_ids": list(node_ids),
+                "query_valid_time": (
+                    self.metadata.query_valid_time.to_text()
+                ),
+                "authority_watermark": (
+                    self.metadata.contiguous_ledger_seq
+                ),
+            }
+        )
+        if self.query_digest != expected_query_digest:
+            raise IntegratedStateError(
+                "integrated query digest differs from exact graph request"
+            )
+        if not isinstance(''',
+    )
+    replace_exact(
+        models,
+        '''        object.__setattr__(
+            self,
+            "known_omissions",
+            _require_text_tuple(
+                self.known_omissions,
+                field="known_omissions",
+                allow_empty=True,
+            ),
+        )
+        if not isinstance(self.recorded_at, UtcTimestamp):
+            raise IntegratedContractError("retrieval context time must be typed")''',
+        '''        object.__setattr__(
+            self,
+            "known_omissions",
+            _require_text_tuple(
+                self.known_omissions,
+                field="known_omissions",
+                allow_empty=True,
+            ),
+        )
+        expected_omissions = (
+            "No vector, full-text, Graphiti, model, embedding or "
+            "live-source retrieval was executed.",
+        )
+        if self.known_omissions != expected_omissions:
+            raise IntegratedStateError(
+                "integrated context must retain exact negative execution evidence"
+            )
+        if not isinstance(self.recorded_at, UtcTimestamp):
+            raise IntegratedContractError("retrieval context time must be typed")
+        if self.metadata.serving_time.value > self.recorded_at.value:
+            raise IntegratedStateError(
+                "integrated context cannot be recorded before serving time"
+            )''',
+    )
+
+    store = "newsroom/authority/_integrated_store.py"
+    replace_exact(
+        store,
+        '''            "SELECT fixture_id,fixture_event_id,admission_id,context_digest,"
+            "manifest_digest FROM integrated_retrieval_contexts "''',
+        '''            "SELECT fixture_id,fixture_event_id,admission_id,context_digest,"
+            "manifest_digest,retrieval_version FROM integrated_retrieval_contexts "''',
+    )
+    replace_exact(
+        store,
+        '''            or manifest.get("hypothesis_trust_scope") != "PROPOSED"
+            or value.get("hypothesis_trust_scope") != "PROPOSED"
+        ):''',
+        '''            or manifest.get("hypothesis_trust_scope") != "PROPOSED"
+            or manifest.get("retrieval_version")
+            != str(context["retrieval_version"])
+            or value.get("hypothesis_trust_scope") != "PROPOSED"
+        ):''',
+    )
+    replace_exact(
+        store,
+        '''        if manifest.manifest_digest != context.manifest_digest:
+            raise IntegratedStateError(
+                "retrieval context belongs to another fixture manifest"
+            )
+        if context.hydrated_blob_digest != manifest.manifest_digest:''',
+        '''        if manifest.manifest_digest != context.manifest_digest:
+            raise IntegratedStateError(
+                "retrieval context belongs to another fixture manifest"
+            )
+        if context.retrieval_version != manifest.retrieval_version:
+            raise IntegratedStateError(
+                "retrieval context version differs from fixture manifest"
+            )
+        if context.hydrated_blob_digest != manifest.manifest_digest:''',
+    )
+
+    system = "newsroom/authority/_integrated_system.py"
+    replace_exact(
+        system,
+        '''    def context(
+        self,
+        context_id: IntegratedRetrievalContextId,
+        proof: AuthenticationProof,
+    ) -> IntegratedRetrievalContext:
+        if not isinstance(context_id, IntegratedRetrievalContextId):
+            raise TypeError("retrieval context identity must be typed")
+        authenticated = self._projection_boundary._authenticate_read(proof)
+        context = self._store.retrieval_context(context_id)
+        self._projection_boundary._authorize_read(
+            family_id=context.metadata.family_id,
+            operation="integrated-retained-context-read",
+            semantic_value={
+                "context_id": str(context.context_id),
+                "context_digest": context.context_digest,
+                "generation_id": str(context.metadata.generation_id),
+                "authority_watermark": (
+                    context.metadata.contiguous_ledger_seq
+                ),
+            },
+            authenticated=authenticated,
+        )
+        return context''',
+        '''    def context(
+        self,
+        context_id: IntegratedRetrievalContextId,
+        proof: AuthenticationProof,
+    ) -> IntegratedRetrievalContext:
+        if not isinstance(context_id, IntegratedRetrievalContextId):
+            raise TypeError("retrieval context identity must be typed")
+        family_ids = tuple(
+            sorted(self._projection_read_policy.allowed_family_ids)
+        )
+        if len(family_ids) != 1:
+            raise IntegratedStateError(
+                "retained context reads require one exact family policy"
+            )
+        family_id = family_ids[0]
+        authenticated = self._projection_boundary._authenticate_read(proof)
+        self._projection_boundary._authorize_read(
+            family_id=family_id,
+            operation="integrated-retained-context-read",
+            semantic_value={"context_id": str(context_id)},
+            authenticated=authenticated,
+        )
+        context = self._store.retrieval_context(context_id)
+        if context.metadata.family_id != family_id:
+            raise IntegratedStateError(
+                "retained context belongs to another projection family"
+            )
+        return context''',
+    )
+    replace_exact(
+        system,
+        '''        batches = self._expected_batches(
+            context.metadata.generation_id,
+            context.metadata.contiguous_ledger_seq,
+        )
+        state_digest = self._adapter.reconcile_generation(''',
+        '''        batches = self._expected_batches(
+            context.metadata.generation_id,
+            context.metadata.contiguous_ledger_seq,
+        )
+        fixture_batches = tuple(
+            batch
+            for batch in batches
+            if batch.source_event_id == str(context.fixture_event_id)
+        )
+        if len(fixture_batches) != 1:
+            raise IntegratedStateError(
+                "retrieval context lacks one exact fixture structural batch"
+            )
+        expected_canonical_ids = tuple(
+            sorted(node.canonical_id for node in fixture_batches[0].nodes)
+        )
+        retained_canonical_ids = tuple(
+            node.canonical_id for node in context.nodes
+        )
+        if retained_canonical_ids != expected_canonical_ids:
+            raise IntegratedStateError(
+                "retrieval context must cover the complete fixture structural mapping"
+            )
+        state_digest = self._adapter.reconcile_generation(''',
+    )
+
+    helpers = "newsroom/tests/integrated_c1_helpers.py"
+    replace_exact(
+        helpers,
+        '''        query_digest=digest_canonical(
+            {"canonical_ids": list(canonical_ids)}
+        ),
+        known_omissions=(
+            "No vector, full-text, model or live-source retrieval was executed.",
+        ),''',
+        '''        query_digest=digest_canonical(
+            {
+                "contract": "newsroom-integrated-query-v1",
+                "family_id": response.metadata.family_id,
+                "generation_id": str(response.metadata.generation_id),
+                "canonical_ids": list(canonical_ids),
+                "query_valid_time": (
+                    response.metadata.query_valid_time.to_text()
+                ),
+                "authority_watermark": (
+                    response.metadata.contiguous_ledger_seq
+                ),
+            }
+        ),
+        known_omissions=(
+            "No vector, full-text, Graphiti, model, embedding or "
+            "live-source retrieval was executed.",
+        ),''',
+    )
+
+    contracts = "newsroom/tests/test_integrated_c1_contracts.py"
+    replace_exact(
+        contracts,
+        '''QUERY_DIGEST = digest_canonical({"canonical_ids": ["aggregate", "event"]})''',
+        '''QUERY_DIGEST = digest_canonical(
+    {
+        "contract": "newsroom-integrated-query-v1",
+        "family_id": "native-structural",
+        "generation_id": str(GENERATION_ID),
+        "canonical_ids": [
+            "npid:v1:authority-aggregate:fixture",
+            "npid:v1:ledger-event:fixture",
+        ],
+        "query_valid_time": NOW.to_text(),
+        "authority_watermark": 1,
+    }
+)''',
+    )
+    replace_exact(
+        contracts,
+        '''        known_omissions=(
+            "No vector, full-text, model or live-source retrieval was executed.",
+        ),''',
+        '''        known_omissions=(
+            "No vector, full-text, Graphiti, model, embedding or "
+            "live-source retrieval was executed.",
+        ),''',
+    )
+
+    history = "newsroom/tests/test_integrated_c1_context_history.py"
+    replace_exact(
+        history,
+        '''        query_digest=digest_canonical(
+            {"canonical_ids": list(canonical_ids)}
+        ),''',
+        '''        query_digest=digest_canonical(
+            {
+                "contract": "newsroom-integrated-query-v1",
+                "family_id": response.metadata.family_id,
+                "generation_id": str(response.metadata.generation_id),
+                "canonical_ids": list(canonical_ids),
+                "query_valid_time": (
+                    response.metadata.query_valid_time.to_text()
+                ),
+                "authority_watermark": (
+                    response.metadata.contiguous_ledger_seq
+                ),
+            }
+        ),''',
+    )
+
+    temporal = "newsroom/tests/test_integrated_c1_temporal_integrity.py"
+    replace_exact(
+        temporal,
+        '''    future = replace(
+        graph.context,
+        metadata=replace(
+            graph.context.metadata,
+            serving_time=type(FIXED_NOW)(
+                FIXED_NOW.value + timedelta(minutes=1)
+            ),
+        ),
+    )''',
+        '''    future_time = type(FIXED_NOW)(
+        FIXED_NOW.value + timedelta(minutes=1)
+    )
+    future = replace(
+        graph.context,
+        metadata=replace(
+            graph.context.metadata,
+            serving_time=future_time,
+        ),
+        recorded_at=future_time,
+    )''',
+    )
+
+    test_path = Path("newsroom/tests/test_integrated_c1_context_semantics.py")
+    if test_path.exists():
+        raise SystemExit(f"qualifier test path already exists: {test_path}")
+    test_path.write_text(
+        '''from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from newsroom.authority import StaticAuthorizer, digest_canonical
+from newsroom.authority._integrated_system import _open_candidate_with_adapter
+from newsroom.integrated import (
+    IntegratedRetrievalContextId,
+    IntegratedStateError,
+)
+
+from .integrated_c1_helpers import (
+    authenticator,
+    candidate_request,
+    event_policy,
+    manifest,
+    proof,
+    scopes,
+)
+from .projection_b1_helpers import projection_contracts, projection_read_policy
+from .test_integrated_c1_candidate_authority import (
+    _open_candidate_system,
+    _seed,
+)
+from .test_integrated_c1_contracts import context as contract_context
+
+
+def _query_digest(context, nodes) -> str:
+    return digest_canonical(
+        {
+            "contract": "newsroom-integrated-query-v1",
+            "family_id": context.metadata.family_id,
+            "generation_id": str(context.metadata.generation_id),
+            "canonical_ids": [node.canonical_id for node in nodes],
+            "query_valid_time": context.metadata.query_valid_time.to_text(),
+            "authority_watermark": context.metadata.contiguous_ledger_seq,
+        }
+    )
+
+
+def test_query_digest_is_server_recomputable() -> None:
+    current = contract_context()
+    with pytest.raises(IntegratedStateError, match="query digest"):
+        replace(
+            current,
+            query_digest=digest_canonical({"caller": "asserted"}),
+        )
+
+
+def test_negative_execution_evidence_is_exact() -> None:
+    current = contract_context()
+    with pytest.raises(IntegratedStateError, match="negative execution evidence"):
+        replace(current, known_omissions=())
+
+
+def test_retrieval_version_must_match_fixture_manifest(
+    tmp_path: Path,
+) -> None:
+    database, state, graph = _seed(tmp_path)
+    changed = replace(
+        graph.context,
+        retrieval_version="integrated_retrieval_v2",
+    )
+    system = _open_candidate_system(database, state, graph)
+    try:
+        before = system.events.after(0, limit=1000, proof=proof())
+        with pytest.raises(IntegratedStateError, match="version.*manifest"):
+            system.candidates.admit(
+                candidate_request(
+                    changed,
+                    key="integrated-retrieval-version-mismatch",
+                ),
+                context=changed,
+                manifest=state.manifest,
+                proof=proof(),
+            )
+        assert system.events.after(0, limit=1000, proof=proof()) == before
+    finally:
+        system.close()
+
+
+def test_partial_fixture_graph_context_cannot_commit_candidate(
+    tmp_path: Path,
+) -> None:
+    database, state, graph = _seed(tmp_path)
+    relation = next(
+        item
+        for item in graph.context.relations
+        if item.source_event_id == str(graph.context.fixture_event_id)
+        and item.object_admission_id == str(graph.context.admission_id)
+    )
+    retained_ids = {
+        relation.source_canonical_id,
+        relation.target_canonical_id,
+    }
+    nodes = tuple(
+        node
+        for node in graph.context.nodes
+        if node.canonical_id in retained_ids
+    )
+    exact_index = tuple(
+        entry
+        for entry in graph.context.exact_index
+        if entry.canonical_id in retained_ids
+    )
+    partial = replace(
+        graph.context,
+        context_id=IntegratedRetrievalContextId.new(),
+        nodes=nodes,
+        relations=(relation,),
+        exact_index=exact_index,
+        query_digest=_query_digest(graph.context, nodes),
+    )
+    system = _open_candidate_system(database, state, graph)
+    try:
+        before = system.events.after(0, limit=1000, proof=proof())
+        with pytest.raises(
+            IntegratedStateError,
+            match="complete fixture structural mapping",
+        ):
+            system.candidates.admit(
+                candidate_request(
+                    partial,
+                    key="integrated-partial-context",
+                ),
+                context=partial,
+                manifest=state.manifest,
+                proof=proof(),
+            )
+        assert system.events.after(0, limit=1000, proof=proof()) == before
+    finally:
+        system.close()
+
+
+def test_retained_context_authorizes_before_identity_lookup(
+    tmp_path: Path,
+) -> None:
+    database, state, graph = _seed(tmp_path)
+    denied_scopes = frozenset(
+        scope for scope in scopes() if scope != "authority.projection.read"
+    )
+    system = _open_candidate_with_adapter(
+        path=database,
+        registry=state.commands,
+        payload_schemas=state.schemas,
+        contracts=projection_contracts(),
+        authenticator=authenticator(),
+        authorizer=StaticAuthorizer(
+            policy_version="authz-v1",
+            grants_by_principal={"principal.alpha": denied_scopes},
+        ),
+        event_read_policy=event_policy(),
+        projection_read_policy=projection_read_policy(),
+        adapter=graph.adapter,
+        clock=lambda: graph.context.recorded_at,
+    )
+    try:
+        failures = []
+        for context_id in (
+            graph.context.context_id,
+            IntegratedRetrievalContextId.new(),
+        ):
+            with pytest.raises(PermissionError) as exc_info:
+                system.candidates.context(context_id, proof=proof())
+            failures.append((type(exc_info.value), str(exc_info.value)))
+        assert failures[0] == failures[1]
+    finally:
+        system.close()
+''',
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.sdlc/increment_1c_context_semantics_test_align.py
+++ b/.sdlc/increment_1c_context_semantics_test_align.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 def replace_exact(path: Path, old: str, new: str, *, identity: str) -> None:
     text = path.read_text(encoding="utf-8")
-    if text.count(old) != 1 or new in text:
+    if text.count(old) != 1 or (new and new in text):
         raise SystemExit(f"{identity} source mismatch")
     path.write_text(text.replace(old, new), encoding="utf-8")
 

--- a/.sdlc/increment_1c_context_semantics_test_align.py
+++ b/.sdlc/increment_1c_context_semantics_test_align.py
@@ -3,10 +3,17 @@ from __future__ import annotations
 from pathlib import Path
 
 
-def main() -> None:
-    path = Path("newsroom/tests/test_integrated_c1_proof_integrity.py")
+def replace_exact(path: Path, old: str, new: str, *, identity: str) -> None:
     text = path.read_text(encoding="utf-8")
-    old = '''def test_context_digest_binds_authoritative_serving_time() -> None:
+    if text.count(old) != 1 or new in text:
+        raise SystemExit(f"{identity} source mismatch")
+    path.write_text(text.replace(old, new), encoding="utf-8")
+
+
+def main() -> None:
+    replace_exact(
+        Path("newsroom/tests/test_integrated_c1_proof_integrity.py"),
+        '''def test_context_digest_binds_authoritative_serving_time() -> None:
     current = context()
     changed = replace(
         current,
@@ -18,8 +25,8 @@ def main() -> None:
         ),
     )
     assert changed.context_digest != current.context_digest
-'''
-    new = '''def test_context_digest_binds_authoritative_serving_time() -> None:
+''',
+        '''def test_context_digest_binds_authoritative_serving_time() -> None:
     current = context()
     serving_time = UtcTimestamp.parse(
         "2026-07-24T08:01:00.000000Z"
@@ -33,10 +40,23 @@ def main() -> None:
         recorded_at=serving_time,
     )
     assert changed.context_digest != current.context_digest
-'''
-    if text.count(old) != 1 or new in text:
-        raise SystemExit("proof-integrity serving-time test source mismatch")
-    path.write_text(text.replace(old, new), encoding="utf-8")
+''',
+        identity="proof-integrity serving-time test",
+    )
+    replace_exact(
+        Path("newsroom/integrated/models.py"),
+        '''        if any(
+            relation.recorded_at.value
+            > self.metadata.query_valid_time.value
+            for relation in self.relations
+        ):
+            raise IntegratedStateError(
+                "integrated graph relation postdates query-valid time"
+            )
+''',
+        "",
+        identity="business-valid relation semantics",
+    )
 
 
 if __name__ == "__main__":

--- a/.sdlc/increment_1c_context_semantics_test_align.py
+++ b/.sdlc/increment_1c_context_semantics_test_align.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def main() -> None:
+    path = Path("newsroom/tests/test_integrated_c1_proof_integrity.py")
+    text = path.read_text(encoding="utf-8")
+    old = '''def test_context_digest_binds_authoritative_serving_time() -> None:
+    current = context()
+    changed = replace(
+        current,
+        metadata=replace(
+            current.metadata,
+            serving_time=UtcTimestamp.parse(
+                "2026-07-24T08:01:00.000000Z"
+            ),
+        ),
+    )
+    assert changed.context_digest != current.context_digest
+'''
+    new = '''def test_context_digest_binds_authoritative_serving_time() -> None:
+    current = context()
+    serving_time = UtcTimestamp.parse(
+        "2026-07-24T08:01:00.000000Z"
+    )
+    changed = replace(
+        current,
+        metadata=replace(
+            current.metadata,
+            serving_time=serving_time,
+        ),
+        recorded_at=serving_time,
+    )
+    assert changed.context_digest != current.context_digest
+'''
+    if text.count(old) != 1 or new in text:
+        raise SystemExit("proof-integrity serving-time test source mismatch")
+    path.write_text(text.replace(old, new), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Closed without merge — temporary context-semantics qualification only

This Draft PR was temporary transport infrastructure and **must never be merged**.

Authority A2b run `30112116121` qualified exact target head `946eee62849103d707f4a271f23836a6db8521d3` and published:

`299124e4b47f3d5ad51ede987386f66c3e8fab01` — `fix(integrated): bind complete context semantics`

The publisher passed 23 focused tests, 975 full-suite tests with only the expected actual-service skips, clustering regression and the actual Neo4j C1 proof. The source unit now requires server-recomputable query evidence, exact negative execution evidence, manifest-bound retrieval versions, complete fixture canonical-ID coverage, serving-before-recording integrity and retained-context authorization before SQLite identity lookup.

The qualifier deliberately preserves business-valid query semantics: a retroactive fact may be recorded after its query-valid time, while `query_valid_time <= serving_time` remains mandatory.

This PR is closed unmerged. Its branch is reset to current `main`, removing temporary workflow and patch scripts.

No live source access, Graphiti/model/embedding execution, publication, shadow, canary, production activation, spending or public effect occurred.