### PR TITLE
chore(integrated): qualify bounded graph completeness

### DIFF
--- a/.github/workflows/authority-a2b.yml
+++ b/.github/workflows/authority-a2b.yml
@@ -88,3 +88,183 @@ jobs:
           test "$FOCUSED_OUTCOME" = success
           test "$REGRESSION_OUTCOME" = success
           test "$FAULT_OUTCOME" = success
+
+  increment-1c-read-completeness-publish:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.head_ref == 'agent/increment-1c-read-completeness-qualify' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.repository == 'fol2/newsroom'
+    needs: governed-object-authority
+    permissions:
+      contents: write
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+    steps:
+      - name: Checkout qualification branch
+        uses: actions/checkout@v4
+        with:
+          ref: agent/increment-1c-read-completeness-qualify
+          path: .qualifier
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Checkout exact Increment 1C target
+        uses: actions/checkout@v4
+        with:
+          ref: agent/increment-1c-integrated-foundation
+          path: .target
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up exact uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.8.0"
+          enable-cache: true
+          cache-dependency-glob: .target/uv.lock
+
+      - name: Correct, qualify and publish read completeness
+        shell: bash
+        working-directory: .target
+        run: |
+          set -euxo pipefail
+          diagnostic="${RUNNER_TEMP}/increment-1c-read-completeness.log"
+          exec > >(tee "${diagnostic}") 2>&1
+          expected_head="7abc652d09e5b2fa622ba3bee9537e7f16e64788"
+          test "$(git rev-parse HEAD)" = "${expected_head}"
+          python ../.qualifier/.sdlc/increment_1c_read_completeness_qualify.py
+
+          actual_files="$({
+            git diff --name-only
+            git ls-files --others --exclude-standard
+          } | sort)"
+          expected_files="$(printf '%s\n' \
+            newsroom/authority/_integrated_system.py \
+            newsroom/tests/test_integrated_c1_read_completeness.py | sort)"
+          test "${actual_files}" = "${expected_files}"
+          git diff --check
+          uv lock --check
+          uv sync --dev --locked
+          uv run --no-sync python -m compileall -q newsroom scripts
+          uv run --no-sync python -m pytest -q \
+            newsroom/tests/test_integrated_c1_read_completeness.py \
+            newsroom/tests/test_integrated_c1_context_semantics.py \
+            newsroom/tests/test_integrated_c1_candidate_authority.py \
+            newsroom/tests/test_integrated_c1_recovery_integrity.py \
+            newsroom/tests/test_integrated_c1_temporal_authority.py
+          uv run --no-sync python -m pytest -q newsroom/tests
+          uv run --no-sync python scripts/eval_clustering_metrics.py \
+            --dataset newsroom/evals/clustering_eval_dataset_v1.jsonl \
+            --baseline newsroom/evals/clustering_eval_metrics_baseline_v1.json \
+            --fail-on-regression
+
+          NEO4J_ADMIN_PASSWORD="$(python - <<'PY'
+          import secrets
+          print(secrets.token_urlsafe(32))
+          PY
+          )"
+          NEWSROOM_NEO4J_PROJECTOR_PASSWORD="$(python - <<'PY'
+          import secrets
+          print(secrets.token_urlsafe(32))
+          PY
+          )"
+          export NEO4J_ADMIN_PASSWORD NEWSROOM_NEO4J_PROJECTOR_PASSWORD
+          export NEWSROOM_NEO4J_URI="bolt://localhost:7687"
+          export NEWSROOM_NEO4J_DATABASE="neo4j"
+          export NEWSROOM_NEO4J_PROJECTOR_USERNAME="newsroom_projector"
+          export NEWSROOM_NEO4J_SERVICE_REQUIRED="1"
+          echo "::add-mask::${NEO4J_ADMIN_PASSWORD}"
+          echo "::add-mask::${NEWSROOM_NEO4J_PROJECTOR_PASSWORD}"
+          docker run --detach \
+            --name newsroom-c1-read-neo4j \
+            --publish 127.0.0.1:7687:7687 \
+            --env "NEO4J_AUTH=neo4j/${NEO4J_ADMIN_PASSWORD}" \
+            neo4j:2026.06.0-community-trixie
+          trap 'docker rm --force newsroom-c1-read-neo4j || true' EXIT
+          uv run --no-sync python - <<'PY'
+          import os
+          import time
+          from neo4j import GraphDatabase
+
+          uri = os.environ["NEWSROOM_NEO4J_URI"]
+          admin = ("neo4j", os.environ["NEO4J_ADMIN_PASSWORD"])
+          last_error = None
+          for _ in range(120):
+              driver = None
+              try:
+                  driver = GraphDatabase.driver(uri, auth=admin)
+                  driver.verify_connectivity()
+                  break
+              except Exception as exc:
+                  last_error = exc
+                  if driver is not None:
+                      driver.close()
+                  time.sleep(2)
+          else:
+              raise RuntimeError("authenticated Neo4j readiness timed out") from last_error
+          try:
+              with driver.session(database="system") as session:
+                  session.run(
+                      "CREATE USER newsroom_projector IF NOT EXISTS "
+                      "SET PLAINTEXT PASSWORD $password CHANGE NOT REQUIRED",
+                      password=os.environ["NEWSROOM_NEO4J_PROJECTOR_PASSWORD"],
+                  ).consume()
+          finally:
+              driver.close()
+          projector = GraphDatabase.driver(
+              uri,
+              auth=(
+                  os.environ["NEWSROOM_NEO4J_PROJECTOR_USERNAME"],
+                  os.environ["NEWSROOM_NEO4J_PROJECTOR_PASSWORD"],
+              ),
+          )
+          try:
+              projector.verify_connectivity()
+          finally:
+              projector.close()
+          PY
+          uv run --no-sync python -m pytest -q \
+            newsroom/tests/test_integrated_c1_neo4j_service.py::test_actual_service_integrated_foundation_replay_recovery_and_tombstone \
+            --junitxml=increment-1c-read-neo4j.xml
+          uv run --no-sync python - <<'PY'
+          import xml.etree.ElementTree as ET
+          root = ET.parse("increment-1c-read-neo4j.xml").getroot()
+          cases = root.findall(".//testcase")
+          if len(cases) != 1:
+              raise SystemExit(f"expected one C1 read case, found {len(cases)}")
+          case = cases[0]
+          if case.find("skipped") is not None:
+              raise SystemExit("C1 read case was skipped")
+          if case.find("failure") is not None or case.find("error") is not None:
+              raise SystemExit("C1 read case failed")
+          PY
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add \
+            newsroom/authority/_integrated_system.py \
+            newsroom/tests/test_integrated_c1_read_completeness.py
+          git commit -m 'fix(integrated): prevent bounded graph truncation'
+
+          remote_head="$(git ls-remote origin refs/heads/agent/increment-1c-integrated-foundation | cut -f1)"
+          test "${remote_head}" = "${expected_head}"
+          git push \
+            --force-with-lease=refs/heads/agent/increment-1c-integrated-foundation:${expected_head} \
+            origin HEAD:agent/increment-1c-integrated-foundation
+
+      - name: Upload read-completeness qualifier diagnostic
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: increment-1c-read-completeness-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/increment-1c-read-completeness.log
+            .target/increment-1c-read-neo4j.xml
+          if-no-files-found: warn
+          retention-days: 1

--- a/.sdlc/increment_1c_read_completeness_qualify.py
+++ b/.sdlc/increment_1c_read_completeness_qualify.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def replace_exact(path: str, old: str, new: str) -> None:
+    target = Path(path)
+    text = target.read_text(encoding="utf-8")
+    if text.count(old) != 1 or new in text:
+        raise SystemExit(f"qualifier source mismatch in {path}: {old[:120]}")
+    target.write_text(text.replace(old, new), encoding="utf-8")
+
+
+def main() -> None:
+    system = "newsroom/authority/_integrated_system.py"
+    replace_exact(
+        system,
+        '''        canonical_ids = tuple(item.canonical_id for item in context.nodes)
+        actual = self._adapter.read(
+            generation_id=str(context.metadata.generation_id),
+            canonical_ids=canonical_ids,
+            maximum_ledger_seq=context.metadata.contiguous_ledger_seq,
+            limit=max(len(context.nodes), len(context.relations), 1),
+        )''',
+        '''        canonical_ids = expected_canonical_ids
+        selected_ids = set(canonical_ids)
+        relevant_relation_upper_bound = len(
+            {
+                relation.relation_key
+                for batch in batches
+                for relation in batch.relations
+                if relation.source_canonical_id in selected_ids
+                or relation.target_canonical_id in selected_ids
+            }
+        )
+        read_limit = self._projection_read_policy.max_results
+        if (
+            len(canonical_ids) >= read_limit
+            or relevant_relation_upper_bound >= read_limit
+        ):
+            raise IntegratedStateError(
+                "integrated fixture graph exceeds the bounded read policy"
+            )
+        actual = self._adapter.read(
+            generation_id=str(context.metadata.generation_id),
+            canonical_ids=canonical_ids,
+            maximum_ledger_seq=context.metadata.contiguous_ledger_seq,
+            limit=read_limit,
+        )''',
+    )
+
+    test_path = Path("newsroom/tests/test_integrated_c1_read_completeness.py")
+    if test_path.exists():
+        raise SystemExit(f"qualifier test path already exists: {test_path}")
+    test_path.write_text(
+        '''from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from newsroom.integrated import IntegratedRetrievalContextId
+from newsroom.projection.neo4j import Neo4jIdentityConflict
+
+from .integrated_c1_helpers import candidate_request, proof
+from .test_integrated_c1_candidate_authority import (
+    _open_candidate_system,
+    _seed,
+)
+
+
+def test_caller_cannot_truncate_fixture_relations_with_a_smaller_read_limit(
+    tmp_path: Path,
+) -> None:
+    database, state, graph = _seed(tmp_path)
+    assert len(graph.context.relations) > len(graph.context.nodes)
+    retained_relations = graph.context.relations[: len(graph.context.nodes)]
+    assert len(retained_relations) < len(graph.context.relations)
+    assert any(
+        relation.source_event_id == str(graph.context.fixture_event_id)
+        and relation.object_admission_id == str(graph.context.admission_id)
+        for relation in retained_relations
+    )
+    truncated = replace(
+        graph.context,
+        context_id=IntegratedRetrievalContextId.new(),
+        relations=retained_relations,
+    )
+
+    system = _open_candidate_system(database, state, graph)
+    try:
+        before = system.events.after(0, limit=1000, proof=proof())
+        with pytest.raises(
+            Neo4jIdentityConflict,
+            match="current Neo4j read differs",
+        ):
+            system.candidates.admit(
+                candidate_request(
+                    truncated,
+                    key="integrated-truncated-relations",
+                ),
+                context=truncated,
+                manifest=state.manifest,
+                proof=proof(),
+            )
+        assert system.events.after(0, limit=1000, proof=proof()) == before
+    finally:
+        system.close()
+''',
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Closed without merge — temporary bounded-read qualification only

This Draft PR was temporary transport infrastructure and **must never be merged**.

Authority A2b run `30112806376` qualified exact target head `7abc652d09e5b2fa622ba3bee9537e7f16e64788` and published:

`75689474aaeb615d269217849fb3481b2e453e7e` — `fix(integrated): prevent bounded graph truncation`

The publisher passed locked compile, focused tests, the full repository suite, clustering regression and the actual Neo4j C1 proof. Candidate admission now uses a trusted policy-bound read limit and requires the complete bounded fixture neighbourhood, so a caller cannot omit the final fixture relation by shrinking the retained context.

This PR is closed unmerged. Its branch is reset to current `main`, removing the temporary workflow and patch script.

No live source access, Graphiti/model/embedding execution, publication, shadow, canary, production activation, spending or public effect occurred.