### PR TITLE
chore(integrated): qualify hydration commit parity

### DIFF
--- a/.github/workflows/authority-a2b.yml
+++ b/.github/workflows/authority-a2b.yml
@@ -9,22 +9,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-
       - name: Install uv
         run: |
           python -m pip install --upgrade pip
           python -m pip install uv
-
       - name: Lockfile Check
         run: uv lock --check
-
       - name: Sync (Dev)
         run: uv sync --dev --locked
-
       - name: Focused A2b Tests
         id: focused
         continue-on-error: true
@@ -32,7 +27,6 @@ jobs:
           uv run python -m pytest -q \
             newsroom/tests/test_authority_a2b_*.py \
             --junitxml=a2b-focused-results.xml
-
       - name: Upload Focused A2b Evidence
         if: always()
         uses: actions/upload-artifact@v4
@@ -40,7 +34,6 @@ jobs:
           name: authority-a2b-focused-evidence
           path: a2b-focused-results.xml
           if-no-files-found: error
-
       - name: A1 and A2a Regression Tests
         id: regression
         continue-on-error: true
@@ -52,7 +45,6 @@ jobs:
           )
           uv run python -m pytest -q "${files[@]}" \
             --junitxml=a2b-regression-results.xml
-
       - name: Upload A1 and A2a Regression Evidence
         if: always()
         uses: actions/upload-artifact@v4
@@ -60,7 +52,6 @@ jobs:
           name: authority-a2b-regression-evidence
           path: a2b-regression-results.xml
           if-no-files-found: error
-
       - name: Independent A2b Fault Matrix
         id: faults
         continue-on-error: true
@@ -69,7 +60,6 @@ jobs:
             newsroom/tests/test_authority_a2b_integrity_faults.py \
             newsroom/tests/test_authority_a2b_fault_matrix.py \
             --junitxml=a2b-fault-matrix-results.xml
-
       - name: Upload A2b Fault Matrix Evidence
         if: always()
         uses: actions/upload-artifact@v4
@@ -77,7 +67,6 @@ jobs:
           name: authority-a2b-fault-matrix-evidence
           path: a2b-fault-matrix-results.xml
           if-no-files-found: error
-
       - name: Enforce A2b Gates
         if: always()
         env:
@@ -88,3 +77,166 @@ jobs:
           test "$FOCUSED_OUTCOME" = success
           test "$REGRESSION_OUTCOME" = success
           test "$FAULT_OUTCOME" = success
+
+  increment-1c-hydration-parity-publish:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.head_ref == 'agent/increment-1c-hydration-parity-qualify' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.repository == 'fol2/newsroom'
+    needs: governed-object-authority
+    permissions:
+      contents: write
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+    steps:
+      - name: Checkout qualification branch
+        uses: actions/checkout@v4
+        with:
+          ref: agent/increment-1c-hydration-parity-qualify
+          path: .qualifier
+          fetch-depth: 1
+          persist-credentials: false
+      - name: Checkout exact Increment 1C target
+        uses: actions/checkout@v4
+        with:
+          ref: agent/increment-1c-integrated-foundation
+          path: .target
+          fetch-depth: 0
+          persist-credentials: true
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Set up exact uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.8.0"
+          enable-cache: true
+          cache-dependency-glob: .target/uv.lock
+      - name: Correct, qualify and publish hydration parity
+        shell: bash
+        working-directory: .target
+        run: |
+          set -euxo pipefail
+          diagnostic="${RUNNER_TEMP}/increment-1c-hydration-parity.log"
+          exec > >(tee "${diagnostic}") 2>&1
+          expected_head="75689474aaeb615d269217849fb3481b2e453e7e"
+          test "$(git rev-parse HEAD)" = "${expected_head}"
+          python ../.qualifier/.sdlc/increment_1c_hydration_parity_qualify.py
+
+          actual_files="$({
+            git diff --name-only
+            git ls-files --others --exclude-standard
+          } | sort)"
+          expected_files="$(printf '%s\n' \
+            newsroom/authority/_integrated_store.py \
+            newsroom/tests/test_integrated_c1_hydration_commit.py | sort)"
+          test "${actual_files}" = "${expected_files}"
+          git diff --check
+          uv lock --check
+          uv sync --dev --locked
+          uv run --no-sync python -m compileall -q newsroom scripts
+          uv run --no-sync python -m pytest -q \
+            newsroom/tests/test_integrated_c1_hydration_commit.py \
+            newsroom/tests/test_integrated_c1_candidate_authority.py \
+            newsroom/tests/test_integrated_c1_context_semantics.py \
+            newsroom/tests/test_integrated_c1_temporal_authority.py \
+            newsroom/tests/test_integrated_c1_recovery_integrity.py
+          uv run --no-sync python -m pytest -q newsroom/tests
+          uv run --no-sync python scripts/eval_clustering_metrics.py \
+            --dataset newsroom/evals/clustering_eval_dataset_v1.jsonl \
+            --baseline newsroom/evals/clustering_eval_metrics_baseline_v1.json \
+            --fail-on-regression
+
+          NEO4J_ADMIN_PASSWORD="$(python - <<'PY'
+          import secrets
+          print(secrets.token_urlsafe(32))
+          PY
+          )"
+          NEWSROOM_NEO4J_PROJECTOR_PASSWORD="$(python - <<'PY'
+          import secrets
+          print(secrets.token_urlsafe(32))
+          PY
+          )"
+          export NEO4J_ADMIN_PASSWORD NEWSROOM_NEO4J_PROJECTOR_PASSWORD
+          export NEWSROOM_NEO4J_URI="bolt://localhost:7687"
+          export NEWSROOM_NEO4J_DATABASE="neo4j"
+          export NEWSROOM_NEO4J_PROJECTOR_USERNAME="newsroom_projector"
+          export NEWSROOM_NEO4J_SERVICE_REQUIRED="1"
+          echo "::add-mask::${NEO4J_ADMIN_PASSWORD}"
+          echo "::add-mask::${NEWSROOM_NEO4J_PROJECTOR_PASSWORD}"
+          docker run --detach \
+            --name newsroom-c1-hydration-neo4j \
+            --publish 127.0.0.1:7687:7687 \
+            --env "NEO4J_AUTH=neo4j/${NEO4J_ADMIN_PASSWORD}" \
+            neo4j:2026.06.0-community-trixie
+          trap 'docker rm --force newsroom-c1-hydration-neo4j || true' EXIT
+          uv run --no-sync python - <<'PY'
+          import os
+          import time
+          from neo4j import GraphDatabase
+
+          uri = os.environ["NEWSROOM_NEO4J_URI"]
+          admin = ("neo4j", os.environ["NEO4J_ADMIN_PASSWORD"])
+          last_error = None
+          for _ in range(120):
+              driver = None
+              try:
+                  driver = GraphDatabase.driver(uri, auth=admin)
+                  driver.verify_connectivity()
+                  break
+              except Exception as exc:
+                  last_error = exc
+                  if driver is not None:
+                      driver.close()
+                  time.sleep(2)
+          else:
+              raise RuntimeError("authenticated Neo4j readiness timed out") from last_error
+          try:
+              with driver.session(database="system") as session:
+                  session.run(
+                      "CREATE USER newsroom_projector IF NOT EXISTS "
+                      "SET PLAINTEXT PASSWORD $password CHANGE NOT REQUIRED",
+                      password=os.environ["NEWSROOM_NEO4J_PROJECTOR_PASSWORD"],
+                  ).consume()
+          finally:
+              driver.close()
+          projector = GraphDatabase.driver(
+              uri,
+              auth=(
+                  os.environ["NEWSROOM_NEO4J_PROJECTOR_USERNAME"],
+                  os.environ["NEWSROOM_NEO4J_PROJECTOR_PASSWORD"],
+              ),
+          )
+          try:
+              projector.verify_connectivity()
+          finally:
+              projector.close()
+          PY
+          uv run --no-sync python -m pytest -q \
+            newsroom/tests/test_integrated_c1_neo4j_service.py::test_actual_service_integrated_foundation_replay_recovery_and_tombstone \
+            --junitxml=increment-1c-hydration-neo4j.xml
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add \
+            newsroom/authority/_integrated_store.py \
+            newsroom/tests/test_integrated_c1_hydration_commit.py
+          git commit -m 'fix(integrated): require full hydration before Candidate commit'
+
+          remote_head="$(git ls-remote origin refs/heads/agent/increment-1c-integrated-foundation | cut -f1)"
+          test "${remote_head}" = "${expected_head}"
+          git push \
+            --force-with-lease=refs/heads/agent/increment-1c-integrated-foundation:${expected_head} \
+            origin HEAD:agent/increment-1c-integrated-foundation
+      - name: Upload hydration-parity qualifier diagnostic
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: increment-1c-hydration-parity-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/increment-1c-hydration-parity.log
+            .target/increment-1c-hydration-neo4j.xml
+          if-no-files-found: warn
+          retention-days: 1

--- a/.sdlc/increment_1c_hydration_parity_qualify.py
+++ b/.sdlc/increment_1c_hydration_parity_qualify.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def replace_exact(path: str, old: str, new: str) -> None:
+    target = Path(path)
+    text = target.read_text(encoding="utf-8")
+    if text.count(old) != 1 or new in text:
+        raise SystemExit(f"qualifier source mismatch in {path}: {old[:120]}")
+    target.write_text(text.replace(old, new), encoding="utf-8")
+
+
+def main() -> None:
+    store = "newsroom/authority/_integrated_store.py"
+    replace_exact(
+        store,
+        '''        admission = conn.execute(
+            "SELECT a.blob_digest,a.valid_from,a.valid_until,"
+            "v.state AS admission_state,bv.state AS blob_state,"
+            "bv.integrity_state,r.allowed AS rights_allowed,"
+            "r.valid_from AS rights_valid_from,r.valid_until AS rights_valid_until "
+            "FROM object_admissions a "
+            "JOIN object_admission_heads h ON h.admission_id=a.admission_id "''',
+        '''        admission = conn.execute(
+            "SELECT a.blob_digest,b.size_bytes AS blob_size_bytes,"
+            "a.valid_from,a.valid_until,"
+            "v.state AS admission_state,bv.state AS blob_state,"
+            "bv.integrity_state,r.allowed AS rights_allowed,"
+            "r.valid_from AS rights_valid_from,r.valid_until AS rights_valid_until "
+            "FROM object_admissions a "
+            "JOIN blob_identities b ON b.blob_digest=a.blob_digest "
+            "JOIN object_admission_heads h ON h.admission_id=a.admission_id "''',
+    )
+    replace_exact(
+        store,
+        '''            or int(access["byte_offset"]) != 0
+            or int(access["allowed_bytes"]) <= 0
+            or access_value.get("admission_id") != str(context.admission_id)''',
+        '''            or int(access["byte_offset"]) != 0
+            or int(access["allowed_bytes"])
+            != int(admission["blob_size_bytes"])
+            or str(access["decided_at"]) != context.recorded_at.to_text()
+            or access_value.get("decided_at")
+            != context.recorded_at.to_text()
+            or access_value.get("admission_id") != str(context.admission_id)''',
+    )
+
+    test_path = Path("newsroom/tests/test_integrated_c1_hydration_commit.py")
+    if test_path.exists():
+        raise SystemExit(f"qualifier test path already exists: {test_path}")
+    test_path.write_text(
+        '''from __future__ import annotations
+
+from dataclasses import replace
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+
+from newsroom.authority import HydrationRequest, UtcTimestamp
+from newsroom.integrated import IntegratedStateError
+
+from .authority_a2b_helpers import _policy_registries, open_object_system
+from .authority_helpers import FIXED_NOW
+from .integrated_c1_helpers import (
+    authenticator,
+    authorizer,
+    candidate_request,
+    event_policy,
+    proof,
+    scopes,
+)
+from .projection_b1_helpers import projection_contracts, projection_read_policy
+from newsroom.authority._integrated_system import _open_candidate_with_adapter
+from .test_integrated_c1_candidate_authority import (
+    _open_candidate_system,
+    _seed,
+)
+
+
+def _partial_hydration(tmp_path: Path, database, state):
+    rights, hydration, admissions = _policy_registries()
+    system = open_object_system(
+        database,
+        object_root=tmp_path / "objects",
+        scopes=scopes(),
+        policy_registries=(rights, hydration, admissions),
+        authenticator=authenticator(),
+        authorizer=authorizer(),
+        clock=lambda: FIXED_NOW,
+        command_registry=state.commands,
+        payload_schema_registry=state.schemas,
+    )
+    try:
+        length = len(state.manifest.canonical_bytes) - 1
+        assert length > 0
+        hydrated = system.objects.hydrate(
+            HydrationRequest(
+                state.admission_id,
+                "project.discovery",
+                offset=0,
+                length=length,
+            ),
+            proof=proof(),
+        )
+        assert len(hydrated.data) == length
+        return hydrated
+    finally:
+        system.close()
+
+
+def test_partial_hydration_decision_cannot_commit_candidate_authority(
+    tmp_path: Path,
+) -> None:
+    database, state, graph = _seed(tmp_path)
+    partial = _partial_hydration(tmp_path, database, state)
+    changed = replace(
+        graph.context,
+        hydration_access_decision_id=(
+            partial.decision.access_decision_id
+        ),
+        recorded_at=partial.decision.decided_at,
+    )
+    system = _open_candidate_system(database, state, graph)
+    try:
+        before = system.events.after(0, limit=1000, proof=proof())
+        with pytest.raises(
+            IntegratedStateError,
+            match="hydration decision differs",
+        ):
+            system.candidates.admit(
+                candidate_request(
+                    changed,
+                    key="integrated-partial-hydration-candidate",
+                ),
+                context=changed,
+                manifest=state.manifest,
+                proof=proof(),
+            )
+        assert system.events.after(0, limit=1000, proof=proof()) == before
+    finally:
+        system.close()
+
+
+def test_hydration_decision_time_cannot_be_rebound_at_candidate_commit(
+    tmp_path: Path,
+) -> None:
+    database, state, graph = _seed(tmp_path)
+    later = UtcTimestamp(FIXED_NOW.value + timedelta(minutes=1))
+    changed = replace(graph.context, recorded_at=later)
+    system = _open_candidate_with_adapter(
+        path=database,
+        registry=state.commands,
+        payload_schemas=state.schemas,
+        contracts=projection_contracts(),
+        authenticator=authenticator(),
+        authorizer=authorizer(),
+        event_read_policy=event_policy(),
+        projection_read_policy=projection_read_policy(),
+        adapter=graph.adapter,
+        clock=lambda: later,
+    )
+    try:
+        before = system.events.after(0, limit=1000, proof=proof())
+        with pytest.raises(
+            IntegratedStateError,
+            match="hydration decision differs",
+        ):
+            system.candidates.admit(
+                candidate_request(
+                    changed,
+                    key="integrated-hydration-time-rebind",
+                ),
+                context=changed,
+                manifest=state.manifest,
+                proof=proof(),
+            )
+        assert system.events.after(0, limit=1000, proof=proof()) == before
+    finally:
+        system.close()
+''',
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Closed without merge — temporary hydration-parity qualification only

This Draft PR was temporary transport infrastructure and **must never be merged**.

Authority A2b run `30113534901` qualified exact target head `75689474aaeb615d269217849fb3481b2e453e7e` and published:

`8083c2f49e780850b1fb02c027e61300e06931ed` — `fix(integrated): require full hydration before Candidate commit`

The publisher passed locked compile, focused tests, the full repository suite, clustering regression and the actual Neo4j C1 proof. Candidate commit now enforces the same full-object hydration range and exact hydration-decision time as startup integrity, so partial access decisions or time rebinding fail before any Candidate authority mutation.

This PR is closed unmerged. Its branch is reset to current `main`, removing the temporary workflow and patch script.

No live source access, Graphiti/model/embedding execution, publication, shadow, canary, production activation, spending or public effect occurred.