### PR TITLE
chore(docs): qualify readiness branch refresh

### DIFF
--- a/.github/workflows/increments-readiness-qualify.yml
+++ b/.github/workflows/increments-readiness-qualify.yml
@@ -1,0 +1,74 @@
+name: Temporary Increments Readiness Qualifier
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    if: >-
+      github.head_ref == 'agent/increments-readiness-qualify' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.repository == 'fol2/newsroom'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout exact readiness branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: agent/increments-2-11-readiness
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Merge current main, correct review facts and publish
+        shell: bash
+        run: |
+          set -euxo pipefail
+          expected_head="e412c1e5a8404b458e33a55bea8f5142f6f70440"
+          expected_main="5fcd8bc862e552961b6b147572879e79c7266931"
+          test "$(git rev-parse HEAD)" = "${expected_head}"
+          git fetch --no-tags origin main
+          test "$(git rev-parse origin/main)" = "${expected_main}"
+          git merge --no-ff --no-commit origin/main
+
+          python - <<'PY'
+          from pathlib import Path
+
+          replacements = {
+              Path("docs/plans/2026-07-24-008-increment-2-complete-fixture-readiness.md"): (
+                  "**Base:** `main@843f6baddd3bf44a0f993c3f2e54df6d4746a059`  ",
+                  "**Review base:** `main@5fcd8bc862e552961b6b147572879e79c7266931`  ",
+              ),
+              Path("docs/plans/2026-07-24-009-increments-3-11-readiness-ladder.md"): (
+                  "**Base:** `main@843f6baddd3bf44a0f993c3f2e54df6d4746a059`  ",
+                  "**Review base:** `main@5fcd8bc862e552961b6b147572879e79c7266931`  ",
+              ),
+              Path("docs/README.md"): (
+                  "- Issue #98 and PR #99 are the acceptance boundary. Existing required workflows remain unchanged until reversible Phase 1/2 shadow controls are merged; B3 product expansion remains preserved on Draft PR #97 until those minimum controls exist.",
+                  "- Issue #98 is closed completed. PR #99 accepted the SDLC v2 specification and PR #119 merged the reversible Phase 1/2 **SDLC Evidence Shadow** implementation. Legacy required workflows remain during burn-in; evidence remains regression evidence rather than owner approval.",
+              ),
+          }
+
+          for path, (old, new) in replacements.items():
+              text = path.read_text(encoding="utf-8")
+              if text.count(old) != 1 or new in text:
+                  raise SystemExit(f"readiness source mismatch: {path}")
+              path.write_text(text.replace(old, new), encoding="utf-8")
+          PY
+
+          git diff --check
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add \
+            docs/README.md \
+            docs/plans/2026-07-24-008-increment-2-complete-fixture-readiness.md \
+            docs/plans/2026-07-24-009-increments-3-11-readiness-ladder.md
+          git commit -m 'docs: refresh readiness review base'
+
+          remote_head="$(git ls-remote origin refs/heads/agent/increments-2-11-readiness | cut -f1)"
+          test "${remote_head}" = "${expected_head}"
+          git push \
+            --force-with-lease=refs/heads/agent/increments-2-11-readiness:${expected_head} \
+            origin HEAD:agent/increments-2-11-readiness

--- a/.github/workflows/increments-readiness-qualify.yml
+++ b/.github/workflows/increments-readiness-qualify.yml
@@ -39,11 +39,11 @@ jobs:
           replacements = {
               Path("docs/plans/2026-07-24-008-increment-2-complete-fixture-readiness.md"): (
                   "**Base:** `main@843f6baddd3bf44a0f993c3f2e54df6d4746a059`  ",
-                  "**Review base:** `main@5fcd8bc862e552961b6b147572879e79c7266931`  ",
+                  "**Review base:** `main@5fcd8bc862e552961b6b147572879e79c7266931`",
               ),
               Path("docs/plans/2026-07-24-009-increments-3-11-readiness-ladder.md"): (
                   "**Base:** `main@843f6baddd3bf44a0f993c3f2e54df6d4746a059`  ",
-                  "**Review base:** `main@5fcd8bc862e552961b6b147572879e79c7266931`  ",
+                  "**Review base:** `main@5fcd8bc862e552961b6b147572879e79c7266931`",
               ),
               Path("docs/README.md"): (
                   "- Issue #98 and PR #99 are the acceptance boundary. Existing required workflows remain unchanged until reversible Phase 1/2 shadow controls are merged; B3 product expansion remains preserved on Draft PR #97 until those minimum controls exist.",

--- a/.github/workflows/increments-readiness-qualify.yml
+++ b/.github/workflows/increments-readiness-qualify.yml
@@ -26,6 +26,8 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
+          diagnostic="${RUNNER_TEMP}/increments-readiness-qualifier.log"
+          exec > >(tee "${diagnostic}") 2>&1
           expected_head="e412c1e5a8404b458e33a55bea8f5142f6f70440"
           expected_main="5fcd8bc862e552961b6b147572879e79c7266931"
           test "$(git rev-parse HEAD)" = "${expected_head}"
@@ -72,3 +74,16 @@ jobs:
           git push \
             --force-with-lease=refs/heads/agent/increments-2-11-readiness:${expected_head} \
             origin HEAD:agent/increments-2-11-readiness
+
+      - name: Upload qualifier diagnostic
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: increments-readiness-qualifier-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/increments-readiness-qualifier.log
+          if-no-files-found: warn
+          retention-days: 1
+          compression-level: 0
+          overwrite: false
+          include-hidden-files: false
+          archive: true

--- a/.github/workflows/increments-readiness-qualify.yml
+++ b/.github/workflows/increments-readiness-qualify.yml
@@ -33,6 +33,8 @@ jobs:
           test "$(git rev-parse HEAD)" = "${expected_head}"
           git fetch --no-tags origin main
           test "$(git rev-parse origin/main)" = "${expected_main}"
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git merge --no-ff --no-commit origin/main
 
           python - <<'PY'
@@ -61,8 +63,6 @@ jobs:
           PY
 
           git diff --check
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add \
             docs/README.md \
             docs/plans/2026-07-24-008-increment-2-complete-fixture-readiness.md \


### PR DESCRIPTION
## Closed without merge — temporary readiness refresh transport only

This Draft PR was temporary transport infrastructure and **must never be merged**.

Run `30125046828` used exact target head `e412c1e5a8404b458e33a55bea8f5142f6f70440`, exact `main@5fcd8bc862e552961b6b147572879e79c7266931` and force-with-lease to publish target head:

`83364576a8caa64483c33647724020e22f20c4cc` — `docs: refresh readiness review base`

The target branch now includes current `main`, records that review base in both Proposed plans, and updates `docs/README.md` to reflect the completed SDLC Phase 1/2 merge. Plan status and implementation authority were not changed.

The first diagnostics found Markdown trailing-space and pre-merge committer-identity issues in this temporary workflow; both failed before any target push. The retained one-day diagnostic artifact is `8608849350`, digest `sha256:b1f52de78d9c7bf7fc530035869f7f9b2dc1990ce3c7e8e0c56f8866108e5f46`.

This PR is closed unmerged and its branch is reset to current `main`, removing the temporary workflow.

No implementation, source access, Neo4j mutation, Graphiti/model/embedding call, search, spending, shadow, canary, publication, activation or retirement occurred.