### PR TITLE
chore: export Increment 2B authorised base

### DIFF
--- a/.github/workflows/agent-increment2b-source-export.yml
+++ b/.github/workflows/agent-increment2b-source-export.yml
@@ -1,0 +1,24 @@
+name: agent-increment2b-source-export
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  export:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Upload exact source tree
+        uses: actions/upload-artifact@v4
+        with:
+          name: increment2b-source
+          path: |
+            .
+            !.git/**
+          include-hidden-files: true
+          retention-days: 1


### PR DESCRIPTION
Temporary draft PR used only to export the exact `main@819883fb77eeabfb76d91aca531003d07932d5a7` source tree for owner-authorised Increment 2B implementation. It contains no product change and will be closed without merge after the artifact is downloaded.