### PR TITLE
chore: export exact Increment 2C base

### DIFF
--- a/.github/workflows/agent-increment2c-source-export.yml
+++ b/.github/workflows/agent-increment2c-source-export.yml
@@ -1,0 +1,26 @@
+name: agent-increment2c-source-export
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  export:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Upload exact Increment 2C base source tree
+        uses: actions/upload-artifact@v4
+        with:
+          name: increment2c-base-source
+          path: |
+            .
+            !.git/**
+          include-hidden-files: true
+          retention-days: 1


### PR DESCRIPTION
Temporary draft PR used only to export the exact `main@cc9053e80a0198af33ed862df118dbdac625f58f` source tree for local Increment 2C implementation. It contains no product change and will be closed without merge after the artifact is downloaded.