### PR TITLE
chore(discovery): temporary 3D store source export

### DIFF
--- a/.github/workflows/export-increment-3d-store-source.yml
+++ b/.github/workflows/export-increment-3d-store-source.yml
@@ -1,24 +1,21 @@
 name: Export Increment 3D store source
 
 on:
-  push:
-    branches:
-      - agent/increment-3d-store-export
-    paths:
-      - .github/workflows/export-increment-3d-store-source.yml
+  pull_request:
 
 permissions:
   contents: read
 
 jobs:
   export:
+    if: github.event.pull_request.head.ref == 'agent/increment-3d-store-export'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - name: Check out exact export head
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
           show-progress: false
 
@@ -40,7 +37,7 @@ jobs:
       - name: Upload exact source archive
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: newsroom-increment-3d-store-source-${{ github.sha }}
+          name: newsroom-increment-3d-store-source-${{ github.event.pull_request.head.sha }}
           path: |
             /tmp/newsroom-increment-3d-store-source.tgz
             /tmp/newsroom-increment-3d-store-source.sha256

--- a/.github/workflows/export-increment-3d-store-source.yml
+++ b/.github/workflows/export-increment-3d-store-source.yml
@@ -1,0 +1,51 @@
+name: Export Increment 3D store source
+
+on:
+  push:
+    branches:
+      - agent/increment-3d-store-export
+    paths:
+      - .github/workflows/export-increment-3d-store-source.yml
+
+permissions:
+  contents: read
+
+jobs:
+  export:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Check out exact export head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          show-progress: false
+
+      - name: Create deterministic source archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          tar \
+            --exclude=.git \
+            --sort=name \
+            --mtime='UTC 1970-01-01' \
+            --owner=0 \
+            --group=0 \
+            --numeric-owner \
+            -czf /tmp/newsroom-increment-3d-store-source.tgz .
+          sha256sum /tmp/newsroom-increment-3d-store-source.tgz \
+            > /tmp/newsroom-increment-3d-store-source.sha256
+
+      - name: Upload exact source archive
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: newsroom-increment-3d-store-source-${{ github.sha }}
+          path: |
+            /tmp/newsroom-increment-3d-store-source.tgz
+            /tmp/newsroom-increment-3d-store-source.sha256
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+          overwrite: false
+          include-hidden-files: false


### PR DESCRIPTION
Temporary transport-only PR used to export the exact current Increment 3D remote tree for deterministic local reconciliation. It will be closed without merge after the artifact is retrieved.