### PR TITLE
chore: temporary Increment 4A Python toolchain export

### DIFF
--- a/.github/workflows/export-increment-4a-python-toolchain.yml
+++ b/.github/workflows/export-increment-4a-python-toolchain.yml
@@ -1,0 +1,60 @@
+name: Export Increment 4A Python toolchain subset
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  export-toolchain:
+    if: github.event.pull_request.head.ref == 'agent/increment-4a-python-toolchain-export'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Check out exact authorised source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: agent/increment-4a-python-toolchain-export
+          fetch-depth: 0
+          show-progress: false
+          persist-credentials: false
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.12'
+
+      - name: Set up exact uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: '0.8.0'
+          github-token: ''
+          enable-cache: false
+
+      - name: Sync and archive pure-Python test dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv lock --check
+          uv sync --dev --locked
+          root='.venv/lib/python3.12/site-packages'
+          test -d "$root/neo4j"
+          test -d "$root/xdist"
+          test -d "$root/execnet"
+          mkdir -p "$RUNNER_TEMP/increment-4a-toolchain"
+          tar -C "$root" -czf "$RUNNER_TEMP/increment-4a-toolchain/pure-python-site-packages.tar.gz" \
+            neo4j neo4j-*.dist-info \
+            xdist pytest_xdist-*.dist-info \
+            execnet execnet-*.dist-info
+          sha256sum "$RUNNER_TEMP/increment-4a-toolchain/pure-python-site-packages.tar.gz" \
+            > "$RUNNER_TEMP/increment-4a-toolchain/manifest.txt"
+
+      - name: Upload exact toolchain subset
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4.6.2
+        with:
+          name: increment-4a-python-toolchain
+          path: ${{ runner.temp }}/increment-4a-toolchain
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/export-increment-4a-python-toolchain.yml
+++ b/.github/workflows/export-increment-4a-python-toolchain.yml
@@ -1,4 +1,4 @@
-name: Export Increment 4A Python toolchain subset
+name: Benchmark exact Increment 4A core topology
 
 on:
   pull_request:
@@ -8,15 +8,67 @@ permissions:
   contents: read
 
 jobs:
-  export-toolchain:
+  benchmark-core:
     if: github.event.pull_request.head.ref == 'agent/increment-4a-python-toolchain-export'
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - profile: loadfile5
+            workers: 5
+            distribution: loadfile
+            explicit: '0'
+            no_warnings: '0'
+            no_bytecode: '0'
+          - profile: loadfile5-no-warnings
+            workers: 5
+            distribution: loadfile
+            explicit: '0'
+            no_warnings: '1'
+            no_bytecode: '0'
+          - profile: loadfile5-explicit
+            workers: 5
+            distribution: loadfile
+            explicit: '1'
+            no_warnings: '0'
+            no_bytecode: '0'
+          - profile: loadfile5-explicit-no-warnings
+            workers: 5
+            distribution: loadfile
+            explicit: '1'
+            no_warnings: '1'
+            no_bytecode: '0'
+          - profile: worksteal4
+            workers: 4
+            distribution: worksteal
+            explicit: '0'
+            no_warnings: '0'
+            no_bytecode: '0'
+          - profile: worksteal4-no-warnings
+            workers: 4
+            distribution: worksteal
+            explicit: '0'
+            no_warnings: '1'
+            no_bytecode: '0'
+          - profile: loadfile5-no-bytecode
+            workers: 5
+            distribution: loadfile
+            explicit: '0'
+            no_warnings: '0'
+            no_bytecode: '1'
+          - profile: worksteal4-no-bytecode
+            workers: 4
+            distribution: worksteal
+            explicit: '0'
+            no_warnings: '0'
+            no_bytecode: '1'
     steps:
-      - name: Check out exact authorised source
+      - name: Check out exact clean Increment 4A head
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: agent/increment-4a-python-toolchain-export
+          ref: a220e7f8eaa924e99696ba1972aced5885f39b58
           fetch-depth: 0
           show-progress: false
           persist-credentials: false
@@ -31,38 +83,65 @@ jobs:
         with:
           version: '0.8.0'
           github-token: ''
-          enable-cache: false
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+          restore-cache: true
+          save-cache: false
+          cache-suffix: newsroom-py312
+          prune-cache: false
+          cache-python: false
 
-      - name: Sync and archive pure-Python test dependencies
+      - name: Verify exact source and sync locked environment
         shell: bash
         run: |
           set -euo pipefail
+          test "$(git rev-parse HEAD)" = 'a220e7f8eaa924e99696ba1972aced5885f39b58'
+          test "$(git rev-parse HEAD^{tree})" = '372bbf76dccd032d852456eaa3bf1fb7349b5631'
+          git diff --check
           uv lock --check
           uv sync --dev --locked
-          root='.venv/lib/python3.12/site-packages'
-          test -d "$root/neo4j"
-          test -d "$root/xdist"
-          test -d "$root/execnet"
-          mkdir -p "$RUNNER_TEMP/increment-4a-toolchain"
-          (
-            cd "$root"
-            shopt -s nullglob
-            entries=(
-              neo4j neo4j-*.dist-info
-              xdist pytest_xdist-*.dist-info
-              execnet execnet-*.dist-info
-            )
-            test "${#entries[@]}" -ge 6
-            tar -czf "$RUNNER_TEMP/increment-4a-toolchain/pure-python-site-packages.tar.gz" \
-              "${entries[@]}"
-          )
-          sha256sum "$RUNNER_TEMP/increment-4a-toolchain/pure-python-site-packages.tar.gz" \
-            > "$RUNNER_TEMP/increment-4a-toolchain/manifest.txt"
 
-      - name: Upload exact toolchain subset
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4.6.2
-        with:
-          name: increment-4a-python-toolchain
-          path: ${{ runner.temp }}/increment-4a-toolchain
-          if-no-files-found: error
-          retention-days: 1
+      - name: Benchmark complete deterministic inventory
+        shell: bash
+        env:
+          PROFILE: ${{ matrix.profile }}
+          WORKERS: ${{ matrix.workers }}
+          DISTRIBUTION: ${{ matrix.distribution }}
+          EXPLICIT: ${{ matrix.explicit }}
+          NO_WARNINGS: ${{ matrix.no_warnings }}
+          NO_BYTECODE: ${{ matrix.no_bytecode }}
+          PYTEST_DISABLE_PLUGIN_AUTOLOAD: '1'
+          PYTHONHASHSEED: '0'
+          PYTHONUTF8: '1'
+        run: |
+          set -euo pipefail
+          args=(
+            -q --assert=plain
+            -p no:cacheprovider
+            -p xdist.plugin
+            -n "$WORKERS"
+            --dist="$DISTRIBUTION"
+            --max-worker-restart=0
+          )
+          if test "$NO_WARNINGS" = '1'; then
+            args+=( -p no:warnings )
+          fi
+          if test "$EXPLICIT" = '1'; then
+            mapfile -t test_files < <(find newsroom/tests -type f -name 'test_*.py' -print | LC_ALL=C sort)
+            test "${#test_files[@]}" -eq 194
+            args+=( "${test_files[@]}" )
+          else
+            args+=( newsroom/tests )
+          fi
+          if test "$NO_BYTECODE" = '1'; then
+            export PYTHONDONTWRITEBYTECODE=1
+          fi
+          rm -rf "$RUNNER_TEMP/core-$PROFILE"
+          printf 'BENCHMARK profile=%s workers=%s distribution=%s explicit=%s no_warnings=%s no_bytecode=%s nproc=%s\n' \
+            "$PROFILE" "$WORKERS" "$DISTRIBUTION" "$EXPLICIT" \
+            "$NO_WARNINGS" "$NO_BYTECODE" "$(nproc)"
+          /usr/bin/time -f 'BENCHMARK elapsed_seconds=%e user_seconds=%U system_seconds=%S max_rss_kb=%M' \
+            timeout --signal=TERM --kill-after=5s 80s \
+            uv run --no-sync python -m pytest "${args[@]}" \
+              --basetemp="$RUNNER_TEMP/core-$PROFILE" \
+              --junitxml="$RUNNER_TEMP/core-$PROFILE.xml"

--- a/.github/workflows/export-increment-4a-python-toolchain.yml
+++ b/.github/workflows/export-increment-4a-python-toolchain.yml
@@ -44,10 +44,18 @@ jobs:
           test -d "$root/xdist"
           test -d "$root/execnet"
           mkdir -p "$RUNNER_TEMP/increment-4a-toolchain"
-          tar -C "$root" -czf "$RUNNER_TEMP/increment-4a-toolchain/pure-python-site-packages.tar.gz" \
-            neo4j neo4j-*.dist-info \
-            xdist pytest_xdist-*.dist-info \
-            execnet execnet-*.dist-info
+          (
+            cd "$root"
+            shopt -s nullglob
+            entries=(
+              neo4j neo4j-*.dist-info
+              xdist pytest_xdist-*.dist-info
+              execnet execnet-*.dist-info
+            )
+            test "${#entries[@]}" -ge 6
+            tar -czf "$RUNNER_TEMP/increment-4a-toolchain/pure-python-site-packages.tar.gz" \
+              "${entries[@]}"
+          )
           sha256sum "$RUNNER_TEMP/increment-4a-toolchain/pure-python-site-packages.tar.gz" \
             > "$RUNNER_TEMP/increment-4a-toolchain/manifest.txt"
 

--- a/.github/workflows/export-increment-4a-python-toolchain.yml
+++ b/.github/workflows/export-increment-4a-python-toolchain.yml
@@ -1,4 +1,4 @@
-name: Benchmark exact Increment 4A core topology
+name: Export exact Increment 4A core timings
 
 on:
   pull_request:
@@ -8,62 +8,10 @@ permissions:
   contents: read
 
 jobs:
-  benchmark-core:
+  export-core-timings:
     if: github.event.pull_request.head.ref == 'agent/increment-4a-python-toolchain-export'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - profile: loadfile5
-            workers: 5
-            distribution: loadfile
-            explicit: '0'
-            no_warnings: '0'
-            no_bytecode: '0'
-          - profile: loadfile5-no-warnings
-            workers: 5
-            distribution: loadfile
-            explicit: '0'
-            no_warnings: '1'
-            no_bytecode: '0'
-          - profile: loadfile5-explicit
-            workers: 5
-            distribution: loadfile
-            explicit: '1'
-            no_warnings: '0'
-            no_bytecode: '0'
-          - profile: loadfile5-explicit-no-warnings
-            workers: 5
-            distribution: loadfile
-            explicit: '1'
-            no_warnings: '1'
-            no_bytecode: '0'
-          - profile: worksteal4
-            workers: 4
-            distribution: worksteal
-            explicit: '0'
-            no_warnings: '0'
-            no_bytecode: '0'
-          - profile: worksteal4-no-warnings
-            workers: 4
-            distribution: worksteal
-            explicit: '0'
-            no_warnings: '1'
-            no_bytecode: '0'
-          - profile: loadfile5-no-bytecode
-            workers: 5
-            distribution: loadfile
-            explicit: '0'
-            no_warnings: '0'
-            no_bytecode: '1'
-          - profile: worksteal4-no-bytecode
-            workers: 4
-            distribution: worksteal
-            explicit: '0'
-            no_warnings: '0'
-            no_bytecode: '1'
     steps:
       - name: Check out exact clean Increment 4A head
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -91,8 +39,12 @@ jobs:
           prune-cache: false
           cache-python: false
 
-      - name: Verify exact source and sync locked environment
+      - name: Verify source and execute complete timing inventory
         shell: bash
+        env:
+          PYTEST_DISABLE_PLUGIN_AUTOLOAD: '1'
+          PYTHONHASHSEED: '0'
+          PYTHONUTF8: '1'
         run: |
           set -euo pipefail
           test "$(git rev-parse HEAD)" = 'a220e7f8eaa924e99696ba1972aced5885f39b58'
@@ -100,48 +52,64 @@ jobs:
           git diff --check
           uv lock --check
           uv sync --dev --locked
+          mkdir -p "$RUNNER_TEMP/increment-4a-core-timings"
+          /usr/bin/time -f 'elapsed_seconds=%e user_seconds=%U system_seconds=%S max_rss_kb=%M' \
+            -o "$RUNNER_TEMP/increment-4a-core-timings/process-metrics.txt" \
+            uv run --no-sync python -m pytest \
+              -q --assert=plain \
+              -p no:cacheprovider \
+              -p xdist.plugin \
+              -n 4 --dist=worksteal --max-worker-restart=0 \
+              newsroom/tests \
+              --basetemp="$RUNNER_TEMP/timing-pytest" \
+              --junitxml="$RUNNER_TEMP/increment-4a-core-timings/pytest.xml"
+          python - <<'PY'
+          from pathlib import Path
+          from xml.etree import ElementTree as ET
+          import hashlib
+          import json
 
-      - name: Benchmark complete deterministic inventory
-        shell: bash
-        env:
-          PROFILE: ${{ matrix.profile }}
-          WORKERS: ${{ matrix.workers }}
-          DISTRIBUTION: ${{ matrix.distribution }}
-          EXPLICIT: ${{ matrix.explicit }}
-          NO_WARNINGS: ${{ matrix.no_warnings }}
-          NO_BYTECODE: ${{ matrix.no_bytecode }}
-          PYTEST_DISABLE_PLUGIN_AUTOLOAD: '1'
-          PYTHONHASHSEED: '0'
-          PYTHONUTF8: '1'
-        run: |
-          set -euo pipefail
-          args=(
-            -q --assert=plain
-            -p no:cacheprovider
-            -p xdist.plugin
-            -n "$WORKERS"
-            --dist="$DISTRIBUTION"
-            --max-worker-restart=0
+          root = Path("$RUNNER_TEMP/increment-4a-core-timings")
+          report = root / "pytest.xml"
+          document = ET.parse(report).getroot()
+          cases = list(document.iter("testcase"))
+          by_module: dict[str, dict[str, float | int]] = {}
+          for case in cases:
+              classname = case.attrib.get("classname", "")
+              parts = classname.split(".")
+              module = ".".join(parts[:3])
+              entry = by_module.setdefault(module, {"seconds": 0.0, "test_count": 0})
+              entry["seconds"] = round(float(entry["seconds"]) + float(case.attrib.get("time", "0")), 6)
+              entry["test_count"] = int(entry["test_count"]) + 1
+          inventory = sorted(
+              path.as_posix()
+              for path in Path("newsroom/tests").glob("test_*.py")
           )
-          if test "$NO_WARNINGS" = '1'; then
-            args+=( -p no:warnings )
-          fi
-          if test "$EXPLICIT" = '1'; then
-            mapfile -t test_files < <(find newsroom/tests -type f -name 'test_*.py' -print | LC_ALL=C sort)
-            test "${#test_files[@]}" -eq 194
-            args+=( "${test_files[@]}" )
-          else
-            args+=( newsroom/tests )
-          fi
-          if test "$NO_BYTECODE" = '1'; then
-            export PYTHONDONTWRITEBYTECODE=1
-          fi
-          rm -rf "$RUNNER_TEMP/core-$PROFILE"
-          printf 'BENCHMARK profile=%s workers=%s distribution=%s explicit=%s no_warnings=%s no_bytecode=%s nproc=%s\n' \
-            "$PROFILE" "$WORKERS" "$DISTRIBUTION" "$EXPLICIT" \
-            "$NO_WARNINGS" "$NO_BYTECODE" "$(nproc)"
-          /usr/bin/time -f 'BENCHMARK elapsed_seconds=%e user_seconds=%U system_seconds=%S max_rss_kb=%M' \
-            timeout --signal=TERM --kill-after=5s 80s \
-            uv run --no-sync python -m pytest "${args[@]}" \
-              --basetemp="$RUNNER_TEMP/core-$PROFILE" \
-              --junitxml="$RUNNER_TEMP/core-$PROFILE.xml"
+          payload = {
+              "schema_version": "newsroom.sdlc.core-timings.v1",
+              "head_sha": "a220e7f8eaa924e99696ba1972aced5885f39b58",
+              "tree_sha": "372bbf76dccd032d852456eaa3bf1fb7349b5631",
+              "inventory_count": len(inventory),
+              "inventory_digest": "sha256:" + hashlib.sha256(("\n".join(inventory) + "\n").encode()).hexdigest(),
+              "testcase_count": len(cases),
+              "modules": dict(sorted(by_module.items())),
+          }
+          (root / "timings.json").write_text(
+              json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n",
+              encoding="utf-8",
+          )
+          with (root / "manifest.txt").open("w", encoding="utf-8") as stream:
+              for path in sorted(root.iterdir()):
+                  if path.name == "manifest.txt":
+                      continue
+                  stream.write(f"{hashlib.sha256(path.read_bytes()).hexdigest()}  {path.name}\n")
+          PY
+
+      - name: Upload exact timing evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4.6.2
+        with:
+          name: increment-4a-core-timings-a220e7f8
+          path: ${{ runner.temp }}/increment-4a-core-timings
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0

--- a/.github/workflows/export-increment-4a-python-toolchain.yml
+++ b/.github/workflows/export-increment-4a-python-toolchain.yml
@@ -68,8 +68,9 @@ jobs:
           from xml.etree import ElementTree as ET
           import hashlib
           import json
+          import os
 
-          root = Path("$RUNNER_TEMP/increment-4a-core-timings")
+          root = Path(os.environ["RUNNER_TEMP"]) / "increment-4a-core-timings"
           report = root / "pytest.xml"
           document = ET.parse(report).getroot()
           cases = list(document.iter("testcase"))


### PR DESCRIPTION
Temporary recovery and benchmark work is complete. The branch was used only to export locked Python test dependencies and exact timing evidence after an execution-sandbox reset, and to compare complete deterministic-suite scheduling variants without reducing coverage or changing authority.

Retained evidence includes:
- toolchain export run `30497079136`, artifact `8742008870`, digest `sha256:fa7c698e8eecc5676704056f979bc2e4cab142a85cc70664db1f616e5906b0b2`;
- exact core-timing export run `30498686017`, artifact `8742625529`, digest `sha256:eba8962c30509a70d2a0bcf5212cbf95d94b05b61f7d075735b42d97080b88a4`.

The production PR now carries the clean reviewed implementation and owner-approved `sdlc-v2.3` amendment. This temporary PR is closed unmerged; none of its exporter or benchmark workflow enters Increment 4A.