### PR TITLE
chore: temporary Increment 4E current-source export

### DIFF
--- a/.github/workflows/export-increment-4e-current-source.yml
+++ b/.github/workflows/export-increment-4e-current-source.yml
@@ -1,6 +1,8 @@
 name: Export exact Increment 4E current source
 
 on:
+  pull_request:
+    types: [opened, reopened, synchronize]
   push:
     branches:
       - agent/increment-4e-current-source-export
@@ -10,6 +12,7 @@ permissions:
 
 jobs:
   export-source:
+    if: github.event_name == 'push' || github.event.pull_request.head.ref == 'agent/increment-4e-current-source-export'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:

--- a/.github/workflows/export-increment-4e-current-source.yml
+++ b/.github/workflows/export-increment-4e-current-source.yml
@@ -1,0 +1,62 @@
+name: Export exact Increment 4E current source
+
+on:
+  push:
+    branches:
+      - agent/increment-4e-current-source-export
+
+permissions:
+  contents: read
+
+jobs:
+  export-source:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Check out exporter branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          show-progress: false
+          persist-credentials: false
+
+      - name: Build exact content-addressed source archive
+        shell: bash
+        env:
+          SOURCE_SHA: cbbdab785bfa7bb8b1b2c6342b7a058f35522d84
+          SOURCE_TREE: a6c069a61ca6c1adfff7ba0e7587111bc16a1015
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse "$SOURCE_SHA^{tree}")" = "$SOURCE_TREE"
+          git archive --format=tar --prefix=newsroom/ "$SOURCE_SHA" \
+            | gzip -n -9 > newsroom-increment-4e-current.tar.gz
+          archive_sha="$(sha256sum newsroom-increment-4e-current.tar.gz | awk '{print $1}')"
+          archive_bytes="$(wc -c < newsroom-increment-4e-current.tar.gz)"
+          python - <<PY
+          import json
+          from pathlib import Path
+          metadata = {
+              "schema_version": "newsroom.increment-4e.current-source-export.v1",
+              "commit_sha": "${SOURCE_SHA}",
+              "tree_sha": "${SOURCE_TREE}",
+              "archive_sha256": "sha256:${archive_sha}",
+              "archive_bytes": int("${archive_bytes}"),
+          }
+          Path("increment-4e-current-metadata.json").write_text(
+              json.dumps(metadata, sort_keys=True, separators=(",", ":")) + "\n",
+              encoding="utf-8",
+          )
+          PY
+          cat increment-4e-current-metadata.json
+
+      - name: Upload exact source archive
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4.6.2
+        with:
+          name: increment-4e-current-cbbdab7
+          path: |
+            newsroom-increment-4e-current.tar.gz
+            increment-4e-current-metadata.json
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+          overwrite: false

--- a/newsroom/increment4/__init__.py
+++ b/newsroom/increment4/__init__.py
@@ -1,0 +1,45 @@
+"""Deterministic Increment 4 admitted entity/relation proof contracts."""
+
+from .contracts import (
+    INCREMENT4_ADMITTED_FAMILY_AGGREGATE_ID,
+    INCREMENT4_ADMITTED_FAMILY_ID,
+    INCREMENT4_ADMITTED_FAMILY_VERSION,
+    INCREMENT4_ADMITTED_MAPPING_ID,
+    INCREMENT4_ADMITTED_MAPPING_VERSION,
+    INCREMENT4_ADMITTED_ONTOLOGY_ID,
+    INCREMENT4_ADMITTED_ONTOLOGY_VERSION,
+    INCREMENT4_ADMITTED_PROJECTOR_VERSION,
+    increment4_admitted_contract_registry,
+    increment4_admitted_family_v1,
+    increment4_admitted_mapping_v1,
+    increment4_admitted_ontology_v1,
+)
+from .models import (
+    Increment4AdmittedProjectionSnapshot,
+    Increment4EntityProjectionState,
+    Increment4ProofContractError,
+    Increment4RelationProjectionState,
+    sorted_snapshot,
+)
+from .projection import build_increment4_admitted_batches
+
+__all__ = [
+    "INCREMENT4_ADMITTED_FAMILY_AGGREGATE_ID",
+    "INCREMENT4_ADMITTED_FAMILY_ID",
+    "INCREMENT4_ADMITTED_FAMILY_VERSION",
+    "INCREMENT4_ADMITTED_MAPPING_ID",
+    "INCREMENT4_ADMITTED_MAPPING_VERSION",
+    "INCREMENT4_ADMITTED_ONTOLOGY_ID",
+    "INCREMENT4_ADMITTED_ONTOLOGY_VERSION",
+    "INCREMENT4_ADMITTED_PROJECTOR_VERSION",
+    "Increment4AdmittedProjectionSnapshot",
+    "Increment4EntityProjectionState",
+    "Increment4ProofContractError",
+    "Increment4RelationProjectionState",
+    "build_increment4_admitted_batches",
+    "increment4_admitted_contract_registry",
+    "increment4_admitted_family_v1",
+    "increment4_admitted_mapping_v1",
+    "increment4_admitted_ontology_v1",
+    "sorted_snapshot",
+]

--- a/newsroom/increment4/contracts.py
+++ b/newsroom/increment4/contracts.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+from newsroom.authority import AggregateId
+from newsroom.projection.mapping import (
+    ProjectionIdentitySource,
+    StructuralEventMapping,
+    StructuralMappingContract,
+    StructuralMappingRegistry,
+    StructuralNodeBinding,
+    StructuralRelationBinding,
+)
+from newsroom.projection.models import ProjectionFamilyDefinition, ProjectionFamilyKind
+from newsroom.projection.ontology import (
+    OntologyContract,
+    OntologyNodeDefinition,
+    OntologyRegistry,
+    OntologyRelationDefinition,
+    ProjectionNodeType,
+    ProjectionRelationType,
+)
+from newsroom.projection.policy import ProjectionContractRegistry
+from newsroom.projection.registry import ProjectionFamilyRegistry
+
+
+INCREMENT4_ADMITTED_FAMILY_ID = "graph.increment4.admitted"
+INCREMENT4_ADMITTED_FAMILY_VERSION = "increment4-admitted-family-v1"
+INCREMENT4_ADMITTED_ONTOLOGY_ID = "newsroom.increment4.admitted"
+INCREMENT4_ADMITTED_ONTOLOGY_VERSION = "increment4-admitted-ontology-v1"
+INCREMENT4_ADMITTED_MAPPING_ID = "newsroom.increment4.admitted"
+INCREMENT4_ADMITTED_MAPPING_VERSION = "increment4-admitted-mapping-v1"
+INCREMENT4_ADMITTED_PROJECTOR_VERSION = "increment4-admitted-snapshot-projector-v1"
+INCREMENT4_ADMITTED_FAMILY_AGGREGATE_ID = AggregateId.parse(
+    "44444444-4444-4444-8444-444444444444"
+)
+
+_INCREMENT4_NODE_TYPES = frozenset(
+    {
+        ProjectionNodeType.AUTHORITY_AGGREGATE,
+        ProjectionNodeType.AUTHORITY_VERSION,
+        ProjectionNodeType.PAYLOAD,
+        ProjectionNodeType.LEDGER_EVENT,
+    }
+)
+
+_INCREMENT4_EVENT_TYPES = (
+    "entity.merge.decided",
+    "entity.resolution.decided",
+    "entity.reversal.decided",
+    "entity.split.decided",
+    "editorial.relation.decided",
+)
+
+
+def increment4_admitted_ontology_v1() -> OntologyContract:
+    common_identity = frozenset({"canonical_id", "entity_type"})
+    provenance = frozenset({"authority_event_id", "ledger_seq"})
+    nodes = tuple(
+        OntologyNodeDefinition(item, common_identity)
+        for item in sorted(_INCREMENT4_NODE_TYPES, key=lambda value: value.value)
+    )
+    relations = (
+        OntologyRelationDefinition(
+            ProjectionRelationType.HAS_VERSION,
+            frozenset({ProjectionNodeType.AUTHORITY_AGGREGATE}),
+            frozenset({ProjectionNodeType.AUTHORITY_VERSION}),
+            provenance,
+        ),
+        OntologyRelationDefinition(
+            ProjectionRelationType.CONTAINS_PAYLOAD,
+            frozenset({ProjectionNodeType.AUTHORITY_VERSION}),
+            frozenset({ProjectionNodeType.PAYLOAD}),
+            provenance,
+        ),
+        OntologyRelationDefinition(
+            ProjectionRelationType.DERIVED_FROM,
+            frozenset({ProjectionNodeType.AUTHORITY_VERSION}),
+            frozenset({ProjectionNodeType.AUTHORITY_AGGREGATE, ProjectionNodeType.AUTHORITY_VERSION}),
+            provenance,
+        ),
+        OntologyRelationDefinition(
+            ProjectionRelationType.PROJECTED_FROM_EVENT,
+            frozenset(
+                item
+                for item in _INCREMENT4_NODE_TYPES
+                if item is not ProjectionNodeType.LEDGER_EVENT
+            ),
+            frozenset({ProjectionNodeType.LEDGER_EVENT}),
+            provenance,
+        ),
+    )
+    return OntologyContract(
+        ontology_id=INCREMENT4_ADMITTED_ONTOLOGY_ID,
+        ontology_version=INCREMENT4_ADMITTED_ONTOLOGY_VERSION,
+        implementation_version="increment4-admitted-ontology-python-v1",
+        nodes=nodes,
+        relations=relations,
+    )
+
+
+def increment4_admitted_mapping_v1(
+    ontology: OntologyContract,
+) -> StructuralMappingContract:
+    mappings = tuple(
+        StructuralEventMapping(
+            event_type=event_type,
+            required=False,
+            nodes=(
+                StructuralNodeBinding(
+                    alias="authority",
+                    node_type=ProjectionNodeType.AUTHORITY_AGGREGATE,
+                    identity_source=ProjectionIdentitySource.AGGREGATE,
+                ),
+                StructuralNodeBinding(
+                    alias="event",
+                    node_type=ProjectionNodeType.LEDGER_EVENT,
+                    identity_source=ProjectionIdentitySource.EVENT,
+                ),
+            ),
+            relations=(
+                StructuralRelationBinding(
+                    relation_type=ProjectionRelationType.PROJECTED_FROM_EVENT,
+                    source_alias="authority",
+                    target_alias="event",
+                ),
+            ),
+        )
+        for event_type in _INCREMENT4_EVENT_TYPES
+    )
+    contract = StructuralMappingContract(
+        mapping_id=INCREMENT4_ADMITTED_MAPPING_ID,
+        mapping_version=INCREMENT4_ADMITTED_MAPPING_VERSION,
+        implementation_version=INCREMENT4_ADMITTED_PROJECTOR_VERSION,
+        ontology_contract_digest=ontology.contract_digest,
+        mappings=mappings,
+    )
+    contract.validate_against(ontology)
+    return contract
+
+
+def increment4_admitted_family_v1(
+    ontology: OntologyContract,
+    mapping: StructuralMappingContract,
+) -> ProjectionFamilyDefinition:
+    return ProjectionFamilyDefinition(
+        family_id=INCREMENT4_ADMITTED_FAMILY_ID,
+        authority_aggregate_id=INCREMENT4_ADMITTED_FAMILY_AGGREGATE_ID,
+        family_kind=ProjectionFamilyKind.GRAPH,
+        definition_version=INCREMENT4_ADMITTED_FAMILY_VERSION,
+        projector_version=INCREMENT4_ADMITTED_PROJECTOR_VERSION,
+        ontology_contract_digest=ontology.contract_digest,
+        mapping_contract_digest=mapping.contract_digest,
+        max_delivery_attempts=3,
+        max_gap_span=10_000,
+        required_manage_scope="authority.projection.manage",
+        required_write_scope="authority.projection.write",
+        required_read_scope="authority.projection.read",
+        security_scope="authority.projection",
+        retention_scope="authority.default",
+    )
+
+
+def increment4_admitted_contract_registry() -> ProjectionContractRegistry:
+    ontology = increment4_admitted_ontology_v1()
+    mapping = increment4_admitted_mapping_v1(ontology)
+    family = increment4_admitted_family_v1(ontology, mapping)
+    ontologies = OntologyRegistry((ontology,))
+    mappings = StructuralMappingRegistry((mapping,))
+    families = ProjectionFamilyRegistry(
+        (family,), ontologies=ontologies, mappings=mappings
+    )
+    return ProjectionContractRegistry(
+        ontologies=ontologies,
+        mappings=mappings,
+        families=families,
+    )
+
+
+__all__ = [
+    "INCREMENT4_ADMITTED_FAMILY_AGGREGATE_ID",
+    "INCREMENT4_ADMITTED_FAMILY_ID",
+    "INCREMENT4_ADMITTED_FAMILY_VERSION",
+    "INCREMENT4_ADMITTED_MAPPING_ID",
+    "INCREMENT4_ADMITTED_MAPPING_VERSION",
+    "INCREMENT4_ADMITTED_ONTOLOGY_ID",
+    "INCREMENT4_ADMITTED_ONTOLOGY_VERSION",
+    "INCREMENT4_ADMITTED_PROJECTOR_VERSION",
+    "increment4_admitted_contract_registry",
+    "increment4_admitted_family_v1",
+    "increment4_admitted_mapping_v1",
+    "increment4_admitted_ontology_v1",
+]

--- a/newsroom/increment4/models.py
+++ b/newsroom/increment4/models.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Iterable
+
+from newsroom.authority.canonical import digest_canonical
+from newsroom.authority.persistence import LedgerEventRecord
+from newsroom.authority.types import TrustScope
+from newsroom.entities.models import (
+    CanonicalEntity,
+    CanonicalEntityVersion,
+    EntityAlias,
+    EntityPreferredIdentity,
+    EntityProjectionEvent,
+)
+from newsroom.entities.types import EntityProjectionAction
+from newsroom.relations.editorial_models import (
+    CanonicalEntityRelationEndpoint,
+    EditorialRelationCurrentView,
+    EditorialRelationProjectionEvent,
+)
+from newsroom.relations.editorial_types import (
+    EditorialRelationAssertionLifecycle,
+    EditorialRelationProjectionAction,
+)
+
+
+class Increment4ProofContractError(ValueError):
+    """Raised when Increment 4 proof inputs are not exact admitted authority."""
+
+
+def _event_digest(event: LedgerEventRecord) -> str:
+    if not isinstance(event, LedgerEventRecord):
+        raise Increment4ProofContractError("proof event must be a retained ledger event")
+    return digest_canonical(asdict(event))
+
+
+@dataclass(frozen=True, slots=True)
+class Increment4EntityProjectionState:
+    entity: CanonicalEntity
+    version: CanonicalEntityVersion
+    preferred: EntityPreferredIdentity
+    aliases: tuple[EntityAlias, ...]
+    projection_event: EntityProjectionEvent
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.entity, CanonicalEntity):
+            raise Increment4ProofContractError("entity state requires a canonical entity")
+        if not isinstance(self.version, CanonicalEntityVersion):
+            raise Increment4ProofContractError("entity state requires a canonical version")
+        if not isinstance(self.preferred, EntityPreferredIdentity):
+            raise Increment4ProofContractError("entity state requires preferred authority")
+        if not isinstance(self.projection_event, EntityProjectionEvent):
+            raise Increment4ProofContractError("entity state requires a projection event")
+        if self.projection_event.action is not EntityProjectionAction.UPSERT:
+            raise Increment4ProofContractError("only admitted current entity UPSERT state can project")
+        if (
+            self.entity.entity_id != self.version.entity_id
+            or self.entity.entity_id != self.preferred.entity_id
+            or self.version.entity_version_id
+            != self.preferred.current_entity_version_id
+            or self.projection_event.entity_id != self.entity.entity_id
+            or self.projection_event.entity_version_id != self.version.entity_version_id
+            or self.projection_event.preferred_entity_id != self.preferred.preferred_entity_id
+            or self.projection_event.lifecycle != self.version.lifecycle
+            or self.preferred.lifecycle != self.version.lifecycle
+        ):
+            raise Increment4ProofContractError("entity current, version and projection identities differ")
+        if not isinstance(self.aliases, tuple):
+            raise Increment4ProofContractError("entity aliases must be an immutable tuple")
+        alias_ids = tuple(str(item.alias_id) for item in self.aliases)
+        if alias_ids != tuple(sorted(set(alias_ids))):
+            raise Increment4ProofContractError("entity aliases must be sorted and unique")
+        for alias in self.aliases:
+            if not isinstance(alias, EntityAlias):
+                raise Increment4ProofContractError("entity alias must be typed")
+            if (
+                alias.entity_id != self.entity.entity_id
+                or alias.entity_version_id != self.version.entity_version_id
+            ):
+                raise Increment4ProofContractError("entity alias targets another entity version")
+
+    @property
+    def canonical_digest(self) -> str:
+        return digest_canonical(
+            {
+                "entity": self.entity.canonical_value(),
+                "version": self.version.canonical_value(),
+                "preferred": {
+                    "entity_id": str(self.preferred.entity_id),
+                    "current_entity_version_id": str(
+                        self.preferred.current_entity_version_id
+                    ),
+                    "preferred_entity_id": str(self.preferred.preferred_entity_id),
+                    "lifecycle": self.preferred.lifecycle.value,
+                    "decided_by_kind": (
+                        None
+                        if self.preferred.decided_by_kind is None
+                        else self.preferred.decided_by_kind.value
+                    ),
+                    "decided_by_id": self.preferred.decided_by_id,
+                    "projected_through_ledger_seq": (
+                        self.preferred.projected_through_ledger_seq
+                    ),
+                },
+                "aliases": [
+                    {
+                        "alias_id": str(item.alias_id),
+                        "entity_id": str(item.entity_id),
+                        "entity_version_id": str(item.entity_version_id),
+                        "normalization_contract_digest": (
+                            item.normalization_contract_digest
+                        ),
+                        "language": item.language,
+                        "script": item.script.value,
+                        "alias_kind": item.alias_kind.value,
+                        "valid_from": (
+                            None if item.valid_from is None else item.valid_from.to_text()
+                        ),
+                        "valid_until": (
+                            None if item.valid_until is None else item.valid_until.to_text()
+                        ),
+                        "provenance_mention_id": str(item.provenance_mention_id),
+                        "resolution_decision_id": str(item.resolution_decision_id),
+                        "uncertainty_codes": list(item.uncertainty_codes),
+                    }
+                    for item in self.aliases
+                ],
+                "projection_event": self.projection_event.canonical_value(),
+            }
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class Increment4RelationProjectionState:
+    current: EditorialRelationCurrentView
+    projection_event: EditorialRelationProjectionEvent
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.current, EditorialRelationCurrentView):
+            raise Increment4ProofContractError("relation state requires a current view")
+        if not isinstance(self.projection_event, EditorialRelationProjectionEvent):
+            raise Increment4ProofContractError("relation state requires a projection event")
+        assertion = self.current.assertion
+        if not isinstance(assertion.subject, CanonicalEntityRelationEndpoint) or not isinstance(
+            assertion.object, CanonicalEntityRelationEndpoint
+        ):
+            raise Increment4ProofContractError(
+                "Increment 4 admitted proof supports canonical entity relation endpoints"
+            )
+        if (
+            self.current.lifecycle is not EditorialRelationAssertionLifecycle.ACTIVE
+            or self.projection_event.action
+            is not EditorialRelationProjectionAction.UPSERT
+            or self.projection_event.lifecycle
+            is not EditorialRelationAssertionLifecycle.ACTIVE
+            or self.projection_event.assertion_id != assertion.assertion_id
+            or self.projection_event.assertion != assertion
+        ):
+            raise Increment4ProofContractError("relation current and projection authority differ")
+        if assertion.trust_scope is not TrustScope.ADMITTED:
+            raise Increment4ProofContractError("only admitted relation assertions can project")
+
+    @property
+    def canonical_digest(self) -> str:
+        assertion = self.current.assertion
+        return digest_canonical(
+            {
+                "assertion_id": str(assertion.assertion_id),
+                "assertion_digest": assertion.canonical_digest,
+                "relation_key": assertion.relation_key,
+                "lifecycle": self.current.lifecycle.value,
+                "current_decision_id": str(self.current.current_decision_id),
+                "current_decision_version": self.current.current_decision_version,
+                "projection_event_id": str(self.projection_event.projection_event_id),
+                "projection_event_digest": self.projection_event.canonical_digest,
+            }
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class Increment4AdmittedProjectionSnapshot:
+    entities: tuple[Increment4EntityProjectionState, ...]
+    relations: tuple[Increment4RelationProjectionState, ...]
+    events: tuple[LedgerEventRecord, ...]
+    through_ledger_seq: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.entities, tuple) or not self.entities:
+            raise Increment4ProofContractError("proof snapshot requires admitted entities")
+        if not isinstance(self.relations, tuple):
+            raise Increment4ProofContractError("proof relations must be an immutable tuple")
+        if not isinstance(self.events, tuple) or not self.events:
+            raise Increment4ProofContractError("proof snapshot requires retained ledger events")
+        entity_ids = tuple(str(item.entity.entity_id) for item in self.entities)
+        if entity_ids != tuple(sorted(set(entity_ids))):
+            raise Increment4ProofContractError("proof entities must be sorted and unique")
+        assertion_ids = tuple(
+            str(item.current.assertion.assertion_id) for item in self.relations
+        )
+        if assertion_ids != tuple(sorted(set(assertion_ids))):
+            raise Increment4ProofContractError("proof relations must be sorted and unique")
+        event_sequences = tuple(item.ledger_seq for item in self.events)
+        if event_sequences != tuple(sorted(set(event_sequences))):
+            raise Increment4ProofContractError("proof events must be sequence-sorted and unique")
+        event_ids = {item.event_id for item in self.events}
+        required_event_ids: set[str] = set()
+        for state in self.entities:
+            required_event_ids.update(
+                {
+                    str(state.entity.authority_event_id),
+                    str(state.version.authority_event_id),
+                    str(state.projection_event.source_event_id),
+                }
+            )
+            required_event_ids.update(str(alias.authority_event_id) for alias in state.aliases)
+        for state in self.relations:
+            required_event_ids.add(str(state.projection_event.source_event_id))
+        missing = required_event_ids - event_ids
+        if missing:
+            raise Increment4ProofContractError(
+                "proof snapshot lacks exact retained event provenance: "
+                + ",".join(sorted(missing))
+            )
+        if (
+            isinstance(self.through_ledger_seq, bool)
+            or not isinstance(self.through_ledger_seq, int)
+            or self.through_ledger_seq <= 0
+            or self.through_ledger_seq < max(event_sequences)
+        ):
+            raise Increment4ProofContractError("proof cutoff must cover all retained events")
+        current_versions = {
+            str(item.version.entity_version_id): item for item in self.entities
+        }
+        current_entities = {str(item.entity.entity_id) for item in self.entities}
+        for state in self.entities:
+            preferred = str(state.preferred.preferred_entity_id)
+            if preferred not in current_entities:
+                raise Increment4ProofContractError(
+                    "preferred entity is absent from the admitted projection snapshot"
+                )
+        for state in self.relations:
+            assertion = state.current.assertion
+            subject = str(assertion.subject.entity_version_id)
+            object_ = str(assertion.object.entity_version_id)
+            if subject not in current_versions or object_ not in current_versions:
+                raise Increment4ProofContractError(
+                    "admitted relation endpoint is absent from current entity authority"
+                )
+
+    @property
+    def event_by_id(self) -> dict[str, LedgerEventRecord]:
+        return {item.event_id: item for item in self.events}
+
+    @property
+    def canonical_digest(self) -> str:
+        return digest_canonical(
+            {
+                "contract": "newsroom.increment4.admitted-snapshot.v1",
+                "through_ledger_seq": self.through_ledger_seq,
+                "entities": [item.canonical_digest for item in self.entities],
+                "relations": [item.canonical_digest for item in self.relations],
+                "events": [_event_digest(item) for item in self.events],
+            }
+        )
+
+
+def sorted_snapshot(
+    *,
+    entities: Iterable[Increment4EntityProjectionState],
+    relations: Iterable[Increment4RelationProjectionState],
+    events: Iterable[LedgerEventRecord],
+    through_ledger_seq: int,
+) -> Increment4AdmittedProjectionSnapshot:
+    return Increment4AdmittedProjectionSnapshot(
+        entities=tuple(sorted(entities, key=lambda item: str(item.entity.entity_id))),
+        relations=tuple(
+            sorted(relations, key=lambda item: str(item.current.assertion.assertion_id))
+        ),
+        events=tuple(sorted(events, key=lambda item: item.ledger_seq)),
+        through_ledger_seq=through_ledger_seq,
+    )
+
+
+__all__ = [
+    "Increment4AdmittedProjectionSnapshot",
+    "Increment4EntityProjectionState",
+    "Increment4ProofContractError",
+    "Increment4RelationProjectionState",
+    "sorted_snapshot",
+]

--- a/newsroom/increment4/projection.py
+++ b/newsroom/increment4/projection.py
@@ -1,0 +1,383 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import asdict
+
+from newsroom.authority.canonical import digest_canonical
+from newsroom.authority.persistence import LedgerEventRecord
+from newsroom.authority.types import TrustScope, UtcTimestamp
+from newsroom.entities.models import EntityAlias
+from newsroom.projection.mapping import (
+    canonical_governed_node_id,
+    governed_identity_reference,
+)
+from newsroom.projection.models import ProjectionFamilyDefinition, ProjectionGenerationId
+from newsroom.projection.neo4j.models import StructuralBatch, StructuralNode, StructuralRelation
+from newsroom.projection.ontology import ProjectionNodeType, ProjectionRelationType
+from newsroom.relations.editorial_models import CanonicalEntityRelationEndpoint
+
+from .contracts import INCREMENT4_ADMITTED_FAMILY_ID
+from .models import (
+    Increment4AdmittedProjectionSnapshot,
+    Increment4EntityProjectionState,
+    Increment4ProofContractError,
+    Increment4RelationProjectionState,
+)
+
+
+_ENTITY_NAMESPACE = "canonical_entity_id"
+_ENTITY_VERSION_NAMESPACE = "canonical_entity_version_id"
+_ALIAS_NAMESPACE = "entity_alias_id"
+_ASSERTION_NAMESPACE = "editorial_relation_assertion_id"
+_EVENT_NAMESPACE = "authority_event_id"
+
+
+def _event_digest(event: LedgerEventRecord) -> str:
+    return digest_canonical(asdict(event))
+
+
+def _node(
+    *,
+    node_type: ProjectionNodeType,
+    namespace: str,
+    value: str,
+    event: LedgerEventRecord,
+) -> StructuralNode:
+    reference = governed_identity_reference(node_type, namespace, value)
+    return StructuralNode(
+        canonical_id=canonical_governed_node_id(node_type, namespace, value),
+        node_type=node_type,
+        identity_source=namespace.upper(),
+        identity_reference_digest=digest_canonical(reference),
+        first_ledger_seq=event.ledger_seq,
+        first_source_event_id=event.event_id,
+        first_source_event_digest=_event_digest(event),
+    )
+
+
+def _relation(
+    *,
+    generation_id: ProjectionGenerationId,
+    relation_type: ProjectionRelationType,
+    source: StructuralNode,
+    target: StructuralNode,
+    event: LedgerEventRecord,
+    semantic_digest: str,
+    semantic_id: str,
+) -> StructuralRelation:
+    event_digest = _event_digest(event)
+    relation_key = digest_canonical(
+        {
+            "relation_contract": "newsroom.increment4.admitted-relation.v1",
+            "generation_id": str(generation_id),
+            "relation_type": relation_type.value,
+            "source_canonical_id": source.canonical_id,
+            "target_canonical_id": target.canonical_id,
+            "source_event_id": event.event_id,
+            "source_event_digest": event_digest,
+            "semantic_id": semantic_id,
+            "semantic_digest": semantic_digest,
+        }
+    )
+    return StructuralRelation(
+        relation_key=relation_key,
+        relation_type=relation_type,
+        source_canonical_id=source.canonical_id,
+        target_canonical_id=target.canonical_id,
+        ledger_seq=event.ledger_seq,
+        source_event_id=event.event_id,
+        source_event_type=event.event_type,
+        source_event_digest=event_digest,
+        aggregate_type=event.aggregate_type,
+        aggregate_id=event.aggregate_id,
+        aggregate_version=event.aggregate_version,
+        payload_id=semantic_id,
+        payload_digest=semantic_digest,
+        object_admission_id=event.object_admission_id,
+        principal_id=event.principal_id,
+        trust_scope=TrustScope(event.trust_scope),
+        security_scope=event.security_scope,
+        retention_scope=event.retention_scope,
+        recorded_at=UtcTimestamp.parse(event.recorded_at),
+    )
+
+
+def _event_node(event: LedgerEventRecord) -> StructuralNode:
+    return _node(
+        node_type=ProjectionNodeType.LEDGER_EVENT,
+        namespace=_EVENT_NAMESPACE,
+        value=event.event_id,
+        event=event,
+    )
+
+
+def _entity_nodes(
+    state: Increment4EntityProjectionState,
+    events: dict[str, LedgerEventRecord],
+) -> tuple[StructuralNode, StructuralNode, tuple[tuple[EntityAlias, StructuralNode], ...]]:
+    entity_event = events[str(state.entity.authority_event_id)]
+    version_event = events[str(state.version.authority_event_id)]
+    entity = _node(
+        node_type=ProjectionNodeType.AUTHORITY_AGGREGATE,
+        namespace=_ENTITY_NAMESPACE,
+        value=str(state.entity.entity_id),
+        event=entity_event,
+    )
+    version = _node(
+        node_type=ProjectionNodeType.AUTHORITY_VERSION,
+        namespace=_ENTITY_VERSION_NAMESPACE,
+        value=str(state.version.entity_version_id),
+        event=version_event,
+    )
+    aliases = tuple(
+        (
+            alias,
+            _node(
+                node_type=ProjectionNodeType.PAYLOAD,
+                namespace=_ALIAS_NAMESPACE,
+                value=str(alias.alias_id),
+                event=events[str(alias.authority_event_id)],
+            ),
+        )
+        for alias in state.aliases
+    )
+    return entity, version, aliases
+
+
+def _entity_batch_parts(
+    state: Increment4EntityProjectionState,
+    *,
+    generation_id: ProjectionGenerationId,
+    events: dict[str, LedgerEventRecord],
+    nodes: dict[str, StructuralNode],
+    relations: list[StructuralRelation],
+) -> None:
+    source_event = events[str(state.projection_event.source_event_id)]
+    event_node = _event_node(source_event)
+    entity_node, version_node, alias_nodes = _entity_nodes(state, events)
+    for node in (event_node, entity_node, version_node, *(item[1] for item in alias_nodes)):
+        existing = nodes.get(node.canonical_id)
+        if existing is not None and existing != node:
+            raise Increment4ProofContractError("canonical graph node has conflicting provenance")
+        nodes[node.canonical_id] = node
+    relations.extend(
+        (
+            _relation(
+                generation_id=generation_id,
+                relation_type=ProjectionRelationType.HAS_VERSION,
+                source=entity_node,
+                target=version_node,
+                event=source_event,
+                semantic_digest=state.version.canonical_digest,
+                semantic_id=str(state.version.entity_version_id),
+            ),
+            _relation(
+                generation_id=generation_id,
+                relation_type=ProjectionRelationType.PROJECTED_FROM_EVENT,
+                source=version_node,
+                target=event_node,
+                event=source_event,
+                semantic_digest=state.projection_event.canonical_digest,
+                semantic_id=str(state.projection_event.projection_event_id),
+            ),
+        )
+    )
+    for alias, alias_node in alias_nodes:
+        relations.append(
+            _relation(
+                generation_id=generation_id,
+                relation_type=ProjectionRelationType.CONTAINS_PAYLOAD,
+                source=version_node,
+                target=alias_node,
+                event=source_event,
+                semantic_digest=alias.canonical_digest,
+                semantic_id=str(alias.alias_id),
+            )
+        )
+    preferred = state.preferred.preferred_entity_id
+    if preferred != state.entity.entity_id:
+        # The target node is inserted by its own state in the same grouped batch
+        # or a prior batch. StructuralBatch nevertheless requires it locally, so
+        # add an identity-stable reference using the current source event.
+        target_node = _node(
+            node_type=ProjectionNodeType.AUTHORITY_AGGREGATE,
+            namespace=_ENTITY_NAMESPACE,
+            value=str(preferred),
+            event=source_event,
+        )
+        nodes.setdefault(target_node.canonical_id, target_node)
+        relations.append(
+            _relation(
+                generation_id=generation_id,
+                relation_type=ProjectionRelationType.DERIVED_FROM,
+                source=version_node,
+                target=target_node,
+                event=source_event,
+                semantic_digest=state.canonical_digest,
+                semantic_id=str(preferred),
+            )
+        )
+
+
+def _relation_batch_parts(
+    state: Increment4RelationProjectionState,
+    *,
+    generation_id: ProjectionGenerationId,
+    events: dict[str, LedgerEventRecord],
+    entity_by_version: dict[str, Increment4EntityProjectionState],
+    nodes: dict[str, StructuralNode],
+    relations: list[StructuralRelation],
+) -> None:
+    source_event = events[str(state.projection_event.source_event_id)]
+    event_node = _event_node(source_event)
+    assertion = state.current.assertion
+    assertion_node = _node(
+        node_type=ProjectionNodeType.AUTHORITY_VERSION,
+        namespace=_ASSERTION_NAMESPACE,
+        value=str(assertion.assertion_id),
+        event=source_event,
+    )
+    subject = assertion.subject
+    object_ = assertion.object
+    if not isinstance(subject, CanonicalEntityRelationEndpoint) or not isinstance(
+        object_, CanonicalEntityRelationEndpoint
+    ):
+        raise Increment4ProofContractError("relation endpoints are not canonical entities")
+    subject_state = entity_by_version[str(subject.entity_version_id)]
+    object_state = entity_by_version[str(object_.entity_version_id)]
+    subject_node = _node(
+        node_type=ProjectionNodeType.AUTHORITY_VERSION,
+        namespace=_ENTITY_VERSION_NAMESPACE,
+        value=str(subject.entity_version_id),
+        event=events[str(subject_state.version.authority_event_id)],
+    )
+    object_node = _node(
+        node_type=ProjectionNodeType.AUTHORITY_VERSION,
+        namespace=_ENTITY_VERSION_NAMESPACE,
+        value=str(object_.entity_version_id),
+        event=events[str(object_state.version.authority_event_id)],
+    )
+    for node in (event_node, assertion_node, subject_node, object_node):
+        existing = nodes.get(node.canonical_id)
+        if existing is not None and existing != node:
+            raise Increment4ProofContractError("canonical relation endpoint has conflicting provenance")
+        nodes[node.canonical_id] = node
+    for relation_type, target, role in (
+        (ProjectionRelationType.DERIVED_FROM, subject_node, "subject"),
+        (ProjectionRelationType.DERIVED_FROM, object_node, "object"),
+    ):
+        relations.append(
+            _relation(
+                generation_id=generation_id,
+                relation_type=relation_type,
+                source=assertion_node,
+                target=target,
+                event=source_event,
+                semantic_digest=assertion.canonical_digest,
+                semantic_id=f"{assertion.assertion_id}:{role}",
+            )
+        )
+    relations.append(
+        _relation(
+            generation_id=generation_id,
+            relation_type=ProjectionRelationType.PROJECTED_FROM_EVENT,
+            source=assertion_node,
+            target=event_node,
+            event=source_event,
+            semantic_digest=state.projection_event.canonical_digest,
+            semantic_id=str(state.projection_event.projection_event_id),
+        )
+    )
+
+
+def build_increment4_admitted_batches(
+    snapshot: Increment4AdmittedProjectionSnapshot,
+    *,
+    generation_id: ProjectionGenerationId,
+    family: ProjectionFamilyDefinition,
+) -> tuple[StructuralBatch, ...]:
+    if not isinstance(snapshot, Increment4AdmittedProjectionSnapshot):
+        raise TypeError("Increment 4 mapper requires a typed admitted snapshot")
+    if not isinstance(generation_id, ProjectionGenerationId):
+        raise TypeError("Increment 4 mapper requires a typed generation")
+    if not isinstance(family, ProjectionFamilyDefinition):
+        raise TypeError("Increment 4 mapper requires a typed family")
+    if family.family_id != INCREMENT4_ADMITTED_FAMILY_ID:
+        raise Increment4ProofContractError("projection family is not the Increment 4 admitted family")
+
+    events = snapshot.event_by_id
+    entity_by_version = {
+        str(item.version.entity_version_id): item for item in snapshot.entities
+    }
+    entities_by_seq: dict[int, list[Increment4EntityProjectionState]] = defaultdict(list)
+    relations_by_seq: dict[int, list[Increment4RelationProjectionState]] = defaultdict(list)
+    for state in snapshot.entities:
+        entities_by_seq[state.projection_event.source_ledger_seq].append(state)
+    for state in snapshot.relations:
+        relations_by_seq[state.projection_event.source_ledger_seq].append(state)
+
+    batches: list[StructuralBatch] = []
+    all_sequences = sorted(set(entities_by_seq) | set(relations_by_seq))
+    for ledger_seq in all_sequences:
+        source_ids = {
+            str(item.projection_event.source_event_id)
+            for item in (*entities_by_seq[ledger_seq], *relations_by_seq[ledger_seq])
+        }
+        if len(source_ids) != 1:
+            raise Increment4ProofContractError(
+                "one projection sequence must bind one exact authority event"
+            )
+        source_event = events[next(iter(source_ids))]
+        if source_event.ledger_seq != ledger_seq:
+            raise Increment4ProofContractError("projection sequence differs from retained event")
+        if source_event.trust_scope != TrustScope.ADMITTED.value:
+            raise Increment4ProofContractError("only ADMITTED source events may project")
+        nodes: dict[str, StructuralNode] = {}
+        relations: list[StructuralRelation] = []
+        for state in sorted(
+            entities_by_seq[ledger_seq], key=lambda item: str(item.entity.entity_id)
+        ):
+            _entity_batch_parts(
+                state,
+                generation_id=generation_id,
+                events=events,
+                nodes=nodes,
+                relations=relations,
+            )
+        for state in sorted(
+            relations_by_seq[ledger_seq],
+            key=lambda item: str(item.current.assertion.assertion_id),
+        ):
+            _relation_batch_parts(
+                state,
+                generation_id=generation_id,
+                events=events,
+                entity_by_version=entity_by_version,
+                nodes=nodes,
+                relations=relations,
+            )
+        if not relations:
+            raise Increment4ProofContractError("projection batch has no admitted relation state")
+        relation_keys = [item.relation_key for item in relations]
+        if len(relation_keys) != len(set(relation_keys)):
+            raise Increment4ProofContractError("projection relation keys are not unique")
+        batches.append(
+            StructuralBatch(
+                generation_id=generation_id,
+                family_id=family.family_id,
+                family_definition_version=family.definition_version,
+                projector_version=family.projector_version,
+                ontology_contract_digest=family.ontology_contract_digest,
+                mapping_contract_digest=family.mapping_contract_digest,
+                ledger_seq=source_event.ledger_seq,
+                source_event_id=source_event.event_id,
+                source_event_type=source_event.event_type,
+                source_event_digest=_event_digest(source_event),
+                nodes=tuple(nodes[key] for key in sorted(nodes)),
+                relations=tuple(sorted(relations, key=lambda item: item.relation_key)),
+            )
+        )
+    return tuple(batches)
+
+
+__all__ = ["build_increment4_admitted_batches"]

--- a/newsroom/tests/test_increment4e_projection_contracts.py
+++ b/newsroom/tests/test_increment4e_projection_contracts.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from newsroom.authority.persistence import LedgerEventRecord
+from newsroom.authority.types import TrustScope
+from newsroom.increment4 import (
+    INCREMENT4_ADMITTED_FAMILY_ID,
+    Increment4EntityProjectionState,
+    Increment4RelationProjectionState,
+    build_increment4_admitted_batches,
+    increment4_admitted_contract_registry,
+    sorted_snapshot,
+)
+from newsroom.projection import ProjectionGenerationId, ProjectionNodeType, ProjectionRelationType
+from newsroom.relations import EditorialRelationDecisionAction
+
+from .editorial_relation_4c_helpers import (
+    ENTITY_ID,
+    ENTITY_VERSION_ID,
+    RELATION_ACCEPT_DECISION_ID,
+    RELATION_ASSERTION_ID,
+    ZH_ENTITY_ID,
+    ZH_ENTITY_VERSION_ID,
+    open_entity_system_after_relation,
+    open_relation_system,
+    relation_decision_request,
+    relation_proposal_request,
+    seed_relation_fixture,
+)
+from .extraction_4a_helpers import extraction_proof
+
+
+def _ledger_events(path: Path) -> tuple[LedgerEventRecord, ...]:
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute("SELECT * FROM ledger_events ORDER BY ledger_seq").fetchall()
+    finally:
+        conn.close()
+    return tuple(
+        LedgerEventRecord(
+            ledger_seq=int(row["ledger_seq"]),
+            event_id=str(row["event_id"]),
+            event_type=str(row["event_type"]),
+            event_schema_version=int(row["event_schema_version"]),
+            aggregate_type=str(row["aggregate_type"]),
+            aggregate_id=str(row["aggregate_id"]),
+            aggregate_version=int(row["aggregate_version"]),
+            recorded_at=str(row["recorded_at"]),
+            command_id=str(row["command_id"]),
+            producer_version=str(row["producer_version"]),
+            command_definition_version=str(row["command_definition_version"]),
+            command_definition_digest=str(row["command_definition_digest"]),
+            payload_id=str(row["payload_id"]),
+            payload_mode=str(row["payload_mode"]),
+            payload_schema_version=str(row["payload_schema_version"]),
+            payload_schema_contract_version=str(row["payload_schema_contract_version"]),
+            payload_schema_contract_digest=str(row["payload_schema_contract_digest"]),
+            payload_canonicalizer_version=str(row["payload_canonicalizer_version"]),
+            payload_digest=str(row["payload_digest"]),
+            object_admission_id=(
+                None if row["object_admission_id"] is None else str(row["object_admission_id"])
+            ),
+            principal_id=str(row["principal_id"]),
+            authentication_context_id=str(row["authentication_context_id"]),
+            authorization_request_digest=str(row["authorization_request_digest"]),
+            authorization_decision_id=str(row["authorization_decision_id"]),
+            correlation_id=None if row["correlation_id"] is None else str(row["correlation_id"]),
+            causation_kind=None if row["causation_kind"] is None else str(row["causation_kind"]),
+            causation_identifier=(
+                None if row["causation_identifier"] is None else str(row["causation_identifier"])
+            ),
+            causation_external_system=(
+                None
+                if row["causation_external_system"] is None
+                else str(row["causation_external_system"])
+            ),
+            security_scope=str(row["security_scope"]),
+            retention_scope=str(row["retention_scope"]),
+            trust_scope=str(row["trust_scope"]),
+        )
+        for row in rows
+    )
+
+
+def _entity_state(system, entity_id, version_id):
+    projection = [
+        item
+        for item in system.entities.projection_events_after(
+            0, limit=100, proof=extraction_proof()
+        )
+        if item.entity_id == entity_id and item.preferred_entity_id is not None
+    ][-1]
+    return Increment4EntityProjectionState(
+        entity=system.entities.entity(entity_id, proof=extraction_proof()),
+        version=system.entities.entity_version(version_id, proof=extraction_proof()),
+        preferred=system.entities.preferred(entity_id, proof=extraction_proof()),
+        aliases=tuple(
+            sorted(
+                system.entities.aliases(entity_id, limit=100, proof=extraction_proof()),
+                key=lambda item: str(item.alias_id),
+            )
+        ),
+        projection_event=projection,
+    )
+
+
+def _admitted_fixture(tmp_path: Path):
+    state = seed_relation_fixture(tmp_path)
+    with open_relation_system(state) as system:
+        proposal = system.relations.propose(
+            relation_proposal_request(state), proof=extraction_proof()
+        )
+        system.relations.decide(
+            relation_decision_request(
+                proposal,
+                action=EditorialRelationDecisionAction.ACCEPT,
+                decision_id=RELATION_ACCEPT_DECISION_ID,
+                assertion_id=RELATION_ASSERTION_ID,
+                key="increment-4e-relation-accept-v1",
+            ),
+            proof=extraction_proof(),
+        )
+        current = system.relations.current(
+            RELATION_ASSERTION_ID, proof=extraction_proof()
+        )
+        relation_event = [
+            item
+            for item in system.relations.projection_events_after(
+                after_ledger_seq=0, limit=100, proof=extraction_proof()
+            )
+            if item.assertion_id == RELATION_ASSERTION_ID and item.assertion is not None
+        ][-1]
+    with open_entity_system_after_relation(state) as system:
+        entities = (
+            _entity_state(system, ENTITY_ID, ENTITY_VERSION_ID),
+            _entity_state(system, ZH_ENTITY_ID, ZH_ENTITY_VERSION_ID),
+        )
+    events = _ledger_events(state.entity.extraction.database)
+    snapshot = sorted_snapshot(
+        entities=entities,
+        relations=(Increment4RelationProjectionState(current, relation_event),),
+        events=events,
+        through_ledger_seq=events[-1].ledger_seq,
+    )
+    return state, snapshot
+
+
+def test_increment4_admitted_contract_is_versioned_and_closed() -> None:
+    contracts = increment4_admitted_contract_registry()
+    family = contracts.family(INCREMENT4_ADMITTED_FAMILY_ID)
+    ontology = contracts.ontologies.resolve_digest(family.ontology_contract_digest)
+    mapping = contracts.mappings.resolve_digest(family.mapping_contract_digest)
+
+    assert family.family_id == INCREMENT4_ADMITTED_FAMILY_ID
+    assert ontology.node_types == frozenset(
+        {
+            ProjectionNodeType.AUTHORITY_AGGREGATE,
+            ProjectionNodeType.AUTHORITY_VERSION,
+            ProjectionNodeType.PAYLOAD,
+            ProjectionNodeType.LEDGER_EVENT,
+        }
+    )
+    assert ontology.relation_types == frozenset(
+        {
+            ProjectionRelationType.HAS_VERSION,
+            ProjectionRelationType.CONTAINS_PAYLOAD,
+            ProjectionRelationType.DERIVED_FROM,
+            ProjectionRelationType.PROJECTED_FROM_EVENT,
+        }
+    )
+    assert {item.event_type for item in mapping.mappings} == {
+        "entity.merge.decided",
+        "entity.resolution.decided",
+        "entity.reversal.decided",
+        "entity.split.decided",
+        "editorial.relation.decided",
+    }
+    assert not any(item.required for item in mapping.mappings)
+
+
+def test_increment4_mapper_projects_only_admitted_bilingual_current_state(tmp_path: Path) -> None:
+    _, snapshot = _admitted_fixture(tmp_path)
+    contracts = increment4_admitted_contract_registry()
+    family = contracts.family(INCREMENT4_ADMITTED_FAMILY_ID)
+    generation = ProjectionGenerationId.parse("00000000-0000-4000-8000-000000004901")
+
+    batches = build_increment4_admitted_batches(
+        snapshot, generation_id=generation, family=family
+    )
+
+    assert batches
+    assert tuple(item.ledger_seq for item in batches) == tuple(
+        sorted(item.ledger_seq for item in batches)
+    )
+    nodes = {node.canonical_id: node for batch in batches for node in batch.nodes}
+    relations = [relation for batch in batches for relation in batch.relations]
+    node_types = {item.node_type for item in nodes.values()}
+    assert ProjectionNodeType.AUTHORITY_AGGREGATE in node_types
+    assert ProjectionNodeType.AUTHORITY_VERSION in node_types
+    assert ProjectionNodeType.PAYLOAD in node_types
+    assert len(
+        [item for item in nodes.values() if item.identity_source == "CANONICAL_ENTITY_ID"]
+    ) == 2
+    assert len(
+        [item for item in nodes.values() if item.identity_source == "ENTITY_ALIAS_ID"]
+    ) == 2
+    assert len(
+        [
+            item
+            for item in nodes.values()
+            if item.identity_source == "EDITORIAL_RELATION_ASSERTION_ID"
+        ]
+    ) == 1
+    relation_types = {item.relation_type for item in relations}
+    assert ProjectionRelationType.HAS_VERSION in relation_types
+    assert ProjectionRelationType.CONTAINS_PAYLOAD in relation_types
+    assert ProjectionRelationType.DERIVED_FROM in relation_types
+    assert all(item.trust_scope is TrustScope.ADMITTED for item in relations)
+    assert all(item.generation_id == generation for item in batches)
+
+
+def test_increment4_relation_is_reified_and_false_merge_entities_stay_distinct(tmp_path: Path) -> None:
+    _, snapshot = _admitted_fixture(tmp_path)
+    family = increment4_admitted_contract_registry().family(
+        INCREMENT4_ADMITTED_FAMILY_ID
+    )
+    generation = ProjectionGenerationId.parse("00000000-0000-4000-8000-000000004902")
+    batches = build_increment4_admitted_batches(
+        snapshot, generation_id=generation, family=family
+    )
+
+    nodes = [node for batch in batches for node in batch.nodes]
+    entity_nodes = {
+        node.canonical_id
+        for node in nodes
+        if node.identity_source == "CANONICAL_ENTITY_ID"
+    }
+    assert len(entity_nodes) == 2
+    assertion_nodes = {
+        node.canonical_id
+        for node in nodes
+        if node.identity_source == "EDITORIAL_RELATION_ASSERTION_ID"
+    }
+    assert len(assertion_nodes) == 1
+    relations = [relation for batch in batches for relation in batch.relations]
+    subject = [
+        item for item in relations if item.relation_type is ProjectionRelationType.DERIVED_FROM and item.payload_id.endswith(":subject")
+    ]
+    object_ = [
+        item for item in relations if item.relation_type is ProjectionRelationType.DERIVED_FROM and item.payload_id.endswith(":object")
+    ]
+    assert len(subject) == 1
+    assert len(object_) == 1
+    assert subject[0].source_canonical_id == object_[0].source_canonical_id
+    assert subject[0].target_canonical_id != object_[0].target_canonical_id
+    assert subject[0].source_canonical_id in assertion_nodes


### PR DESCRIPTION
Temporary Increment 4E current-source recovery is complete. Workflow artifact `8796207184` exported exact clean checkpoint `cbbdab785bfa7bb8b1b2c6342b7a058f35522d84`, tree `a6c069a61ca6c1adfff7ba0e7587111bc16a1015`. The archive digest was independently verified as `sha256:69d342fa33d0fa859a26f04fbd4a6072ba564c8541d553662ae180a9c171519d`, and the recovered Git tree matched exactly. This temporary PR is closed unmerged.