### PR TITLE
SDLC v2.4: double CI hard budgets

### DIFF
--- a/.github/workflows/evidence.yml
+++ b/.github/workflows/evidence.yml
@@ -23,7 +23,7 @@ jobs:
   route:
     name: route
     runs-on: ubuntu-24.04
-    timeout-minutes: 3
+    timeout-minutes: 6
     outputs:
       service_required: ${{ steps.route_output.outputs.service_required }}
     steps:
@@ -91,7 +91,7 @@ jobs:
       - route
     if: needs.route.result == 'success'
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Checkout evaluated head
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -191,7 +191,7 @@ jobs:
       - route
     if: needs.route.result == 'success' && needs.route.outputs.service_required == 'true'
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 10
     env:
       NEO4J_B2_IMAGE: neo4j:2026.06.0-community-trixie
       NEO4J_URI: bolt://localhost:7687
@@ -275,7 +275,7 @@ jobs:
           printf 'NEO4J_ADMIN_PASSWORD=%s\n' "${NEO4J_ADMIN_PASSWORD}" > "${admin_file}"
           printf 'NEWSROOM_NEO4J_PROJECTOR_PASSWORD=%s\n' "${NEWSROOM_NEO4J_PROJECTOR_PASSWORD}" > "${projector_file}"
           chmod 600 "${admin_file}" "${projector_file}"
-          timeout --signal=TERM --kill-after=5s 110s \
+          timeout --signal=TERM --kill-after=5s 220s \
             docker pull "${NEO4J_B2_IMAGE}"
           timeout --signal=TERM --kill-after=2s 20s \
             docker run --detach --pull=never \
@@ -419,7 +419,7 @@ jobs:
       - service
     if: always()
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 10
     permissions:
       actions: read
       contents: read
@@ -448,7 +448,7 @@ jobs:
         run: |
           set -uo pipefail
           set +e
-          timeout --signal=TERM --kill-after=2s 110s \
+          timeout --signal=TERM --kill-after=2s 220s \
             python -m scripts.sdlc.workflow_orchestrator collect \
               --output-directory .sdlc-run/decision-input \
               > "${RUNNER_TEMP}/collection-result.json"

--- a/.sdlc/gates.toml
+++ b/.sdlc/gates.toml
@@ -1,16 +1,16 @@
 schema_version = "newsroom.sdlc.gates.v1"
-contract_version = "sdlc-v2.3"
+contract_version = "sdlc-v2.4"
 status = "accepted"
 owner = "fol2"
 canonical_language = "English"
 specification = "docs/specs/sdlc/high-performance-evidence-sdlc.md"
-acceptance_record = "docs/specs/sdlc/2026-07-30-sdlc-v2.3-owner-budget-amendment.md"
+acceptance_record = "docs/specs/sdlc/2026-08-02-sdlc-v2.4-owner-budget-amendment.md"
 issue = 98
 
 [global]
-gate_command_timeout_seconds = 110
-lane_execution_timeout_seconds = 110
-finalization_timeout_seconds = 10
+gate_command_timeout_seconds = 220
+lane_execution_timeout_seconds = 220
+finalization_timeout_seconds = 20
 pr_feedback_p50_target_seconds = 30
 pr_feedback_p95_target_seconds = 60
 runner_queue_p95_target_seconds = 5
@@ -27,7 +27,7 @@ rerun_can_overwrite_required_result = false
 id = "route"
 p50_target_seconds = 1
 p95_target_seconds = 2
-hard_timeout_seconds = 10
+hard_timeout_seconds = 20
 blocking = true
 lane = "core"
 
@@ -35,7 +35,7 @@ lane = "core"
 id = "source-integrity"
 p50_target_seconds = 3
 p95_target_seconds = 8
-hard_timeout_seconds = 30
+hard_timeout_seconds = 60
 blocking = true
 lane = "core"
 
@@ -43,7 +43,7 @@ lane = "core"
 id = "core-deterministic"
 p50_target_seconds = 15
 p95_target_seconds = 35
-hard_timeout_seconds = 110
+hard_timeout_seconds = 220
 blocking = true
 lane = "core"
 
@@ -51,7 +51,7 @@ lane = "core"
 id = "service-neo4j"
 p50_target_seconds = 25
 p95_target_seconds = 50
-hard_timeout_seconds = 110
+hard_timeout_seconds = 220
 blocking = true
 risk_triggered = true
 lane = "service"
@@ -60,7 +60,7 @@ lane = "service"
 id = "merge-exact"
 p50_target_seconds = 20
 p95_target_seconds = 50
-hard_timeout_seconds = 110
+hard_timeout_seconds = 220
 blocking = true
 lane = "merge_group"
 activation = "after_merge_queue_adoption"
@@ -69,7 +69,7 @@ activation = "after_merge_queue_adoption"
 id = "science-*"
 p50_target_seconds = 20
 p95_target_seconds = 50
-hard_timeout_seconds = 110
+hard_timeout_seconds = 220
 blocking = false
 lane = "science"
 
@@ -77,7 +77,7 @@ lane = "science"
 id = "evidence-finalize"
 p50_target_seconds = 1
 p95_target_seconds = 3
-hard_timeout_seconds = 10
+hard_timeout_seconds = 20
 blocking = true
 lane = "decision"
 
@@ -191,7 +191,7 @@ clustering = [
 [lanes.core]
 bootstrap_once = true
 run_full_suite_when_p95_below_seconds = 35
-hard_timeout_seconds = 110
+hard_timeout_seconds = 220
 required = true
 
 [lanes.service]
@@ -200,21 +200,21 @@ parallel_with = "core"
 condition = "risk.service == true"
 actual_service_required = true
 fake_or_noop_satisfies = false
-hard_timeout_seconds = 110
+hard_timeout_seconds = 220
 
 [lanes.merge_group]
 exact_tree_required = true
 reuse_requires_exact_evidence_identity = true
-hard_timeout_seconds = 110
+hard_timeout_seconds = 220
 
 [lanes.science]
 parallel_shards = true
-per_shard_hard_timeout_seconds = 110
+per_shard_hard_timeout_seconds = 220
 pr_blocking = false
 
 [lanes.decision]
 always_reports = true
-hard_timeout_seconds = 10
+hard_timeout_seconds = 20
 
 [test_strategy]
 full_suite_blocking_default = true
@@ -241,7 +241,7 @@ individual_test_or_file_p95_seconds = 1.0
 individual_test_p95_seconds = 5.0
 
 [test_sizes.science]
-shard_hard_timeout_seconds = 110
+shard_hard_timeout_seconds = 220
 
 [sentinels]
 execution_p95_target_seconds = 5
@@ -307,7 +307,7 @@ decomposition_note_required_above_trigger = true
 
 [slo_error_budget]
 window_days = 7
-execution_p95_max_seconds = 110
+execution_p95_max_seconds = 220
 budget_exceeded_fraction_max = 0.01
 flake_fraction_max = 0.005
 evidence_mismatch_fraction_max = 0.001
@@ -327,8 +327,8 @@ allowed = [
 
 [owner_decisions]
 accepted_at = "2026-07-22"
-budget_amended_at = "2026-07-30"
-predecessor_contract_version = "sdlc-v2.2"
+budget_amended_at = "2026-08-02"
+predecessor_contract_version = "sdlc-v2.3"
 hard_budget_multiplier = 2
 review_net_executable_lines_trigger = 400
 review_changed_files_trigger = 12

--- a/docs/specs/sdlc/2026-08-02-sdlc-v2.4-owner-budget-amendment.md
+++ b/docs/specs/sdlc/2026-08-02-sdlc-v2.4-owner-budget-amendment.md
@@ -1,0 +1,58 @@
+# SDLC-V2.4 owner hard-budget amendment
+
+- Role: Normative owner amendment record
+- Status: Accepted
+- Owner: fol2
+- Canonical language: English
+- Date: 2026-08-02
+- Specification: `docs/specs/sdlc/high-performance-evidence-sdlc.md`
+- Predecessor acceptance: `docs/specs/sdlc/2026-07-30-sdlc-v2.3-owner-budget-amendment.md`
+- Predecessor contract: `sdlc-v2.3`
+- Contract version: `sdlc-v2.4`
+- Active implementation context: Increment 5A / issue #250 / PR #255
+
+## Owner decision
+
+The owner explicitly authorises the SDLC hard budgets to be doubled from the accepted `sdlc-v2.3` values for all tiers. Newsroom risk tiers R0 through R4 continue to share the same gate and lane hard ceilings, so this amendment applies uniformly without changing risk classification, required lanes, exact test inventory or evidence escalation.
+
+The accepted hard ceilings are amended as follows:
+
+| Boundary | `sdlc-v2.3` | `sdlc-v2.4` |
+|---|---:|---:|
+| Global gate command | 110 s | 220 s |
+| Global interactive lane | 110 s | 220 s |
+| Finalisation | 10 s | 20 s |
+| Route command | 10 s | 20 s |
+| Source-integrity command | 30 s | 60 s |
+| Core deterministic command | 110 s | 220 s |
+| Authenticated Neo4j service command | 110 s | 220 s |
+| Merge-exact command and lane | 110 s | 220 s |
+| Science shard | 110 s | 220 s |
+| Evidence-finalize command and lane | 10 s | 20 s |
+
+The contract and watchdog retain a strict upper bound below 240 seconds. Any later increase still requires another explicit owner amendment and a new contract version.
+
+## Preserved controls
+
+This amendment changes hard enforcement ceilings only. It does not:
+
+- change the p50 or p95 performance targets;
+- remove, select away, skip or reclassify any required test;
+- weaken exact-tree, exact-lock, exact-toolchain, first-result or evidence-identity checks;
+- permit a fake or no-op service to satisfy authenticated Neo4j evidence;
+- change SQLite, governed-object, projection, retrieval, Candidate or publication authority;
+- authorise Graphiti, a model, embeddings, live sources, credentials, spending, publication, canary, shadow product execution or production activation;
+- authorise Increment 5B before the separately admitted post-merge 5A implementation record exists; or
+- allow a rerun to overwrite the first required result.
+
+A command that exceeds its amended ceiling remains `BUDGET_EXCEEDED`. Unknown paths and contract-control changes continue to escalate to R3.
+
+## Implementation authority
+
+The owner authorises one independently reviewed SDLC support change to update the machine contract, contract-version binding, watchdog validation, signed workflow operational caps, tests and specification. The change must remain separate from PR #255 and must pass every applicable repository, Authority, Projection, authenticated Neo4j and signed SDLC gate on its exact reviewed head before merge.
+
+After this amendment is merged to `main`, PR #255 must be updated onto that exact main contract and requalified. This amendment does not itself approve the Increment 5A owner statement, materialise an approval record, create the post-merge implementation-admission record, close issue #250 or begin issue #251.
+
+## Rollback
+
+Rollback is one reviewed revert of the `sdlc-v2.4` amendment commit. That restores `sdlc-v2.3` and the previous hard ceilings. Evidence produced under one contract version cannot satisfy another because the contract version and contract-controlled source tree are bound into routing and evidence identities.

--- a/docs/specs/sdlc/high-performance-evidence-sdlc.md
+++ b/docs/specs/sdlc/high-performance-evidence-sdlc.md
@@ -1,15 +1,15 @@
 # High-performance evidence SDLC
 
 - Role: Normative target specification
-- Status: Accepted — amended by the owner on 2026-07-30
+- Status: Accepted — amended by the owner on 2026-08-02
 - Owner: fol2
 - Canonical language: English
 - Date: 2026-07-21
 - Specification ID: `SDLC-V2`
-- Contract version: `sdlc-v2.3`
+- Contract version: `sdlc-v2.4`
 - Related issue: #98
 - Related active product work: #96 / PR #97
-- Current owner amendment: `docs/specs/sdlc/2026-07-30-sdlc-v2.3-owner-budget-amendment.md`
+- Current owner amendment: `docs/specs/sdlc/2026-08-02-sdlc-v2.4-owner-budget-amendment.md`
 
 ## 1. Decision
 
@@ -24,14 +24,14 @@ The normal pull-request path has one always-reporting decision workflow with two
 
 The measured exact-head test selections are currently small: the recorded JUnit suites range from 1.134 to 7.401 seconds. The exact full-repository pytest p95 has not yet been recorded. Full deterministic tests remain the blocking default until measurement proves that their p95 no longer fits the core-lane budget. Test-impact analysis begins in observe mode and cannot replace full evidence until repository-specific shadow controls demonstrate that it preserves defect detection.
 
-Deep mutation, fuzz, compatibility, flake, performance and recovery work runs as independent scientific shards outside the interactive path. Each shard has its own sub-120-second budget; a large experiment is many content-addressed shards, not one unbounded job.
+Deep mutation, fuzz, compatibility, flake, performance and recovery work runs as independent scientific shards outside the interactive path. Each shard has its own 220-second hard budget; a large experiment is many content-addressed shards, not one unbounded job.
 
 ## 2. Goals
 
 `SDLC-V2` must:
 
 - preserve or improve regression, authority, security, deletion and production-profile confidence;
-- give developers a correct blocking machine decision within a 110-second repository-owned execution envelope;
+- give developers a correct blocking machine decision within a 220-second repository-owned execution envelope;
 - target less than 60 seconds p95 from GitHub event to decision once queue and provisioning are measured and controlled;
 - prevent obsolete commits from consuming runner capacity;
 - remove repeated checkout, Python setup, uv installation, dependency sync and overlapping tests;
@@ -135,26 +135,26 @@ A deterministic classification of changed paths and semantic surfaces that contr
 
 All gate and lane durations below start after runner allocation.
 
-The 2026-07-30 owner amendment doubles every hard command, lane, shard and finalisation ceiling for all risk tiers. It does not double the p50/p95 performance targets, relax required evidence, reduce test coverage or alter risk routing. The unchanged targets continue to expose performance regression; the doubled values control only typed `BUDGET_EXCEEDED` enforcement.
+The 2026-08-02 owner amendment doubles every `sdlc-v2.3` hard command, lane, shard and finalisation ceiling for all risk tiers. It does not double the p50/p95 performance targets, relax required evidence, reduce test coverage or alter risk routing. The unchanged targets continue to expose performance regression; the doubled values control only typed `BUDGET_EXCEEDED` enforcement. The watchdog retains a strict upper bound below 240 seconds.
 
 | Gate | p50 | p95 | hard command timeout | Lane |
 |---|---:|---:|---:|---|
-| `route` | 1 s | 2 s | 10 s | core |
-| `source-integrity` | 3 s | 8 s | 30 s | core |
-| `core-deterministic` | 15 s | 35 s | 110 s | core |
-| `service-neo4j` | 25 s | 50 s | 110 s | service |
-| `merge-exact` | 20 s | 50 s | 110 s | merge group |
-| each `science-*` shard | 20 s | 50 s | 110 s | science |
-| `evidence-finalize` | 1 s | 3 s | 10 s | decision |
+| `route` | 1 s | 2 s | 20 s | core |
+| `source-integrity` | 3 s | 8 s | 60 s | core |
+| `core-deterministic` | 15 s | 35 s | 220 s | core |
+| `service-neo4j` | 25 s | 50 s | 220 s | service |
+| `merge-exact` | 20 s | 50 s | 220 s | merge group |
+| each `science-*` shard | 20 s | 50 s | 220 s | science |
+| `evidence-finalize` | 1 s | 3 s | 20 s | decision |
 
 Aggregate execution rules:
 
-- core-lane repository-owned execution hard deadline: 110 seconds;
-- service-lane repository-owned execution hard deadline: 110 seconds;
-- merge-lane repository-owned execution hard deadline: 110 seconds;
-- finalisation hard deadline: 10 seconds;
+- core-lane repository-owned execution hard deadline: 220 seconds;
+- service-lane repository-owned execution hard deadline: 220 seconds;
+- merge-lane repository-owned execution hard deadline: 220 seconds;
+- finalisation hard deadline: 20 seconds;
 - an internal command's timeout is capped by the lane's remaining deadline;
-- a GitHub job may use a two-minute timeout where supported, but the repository-owned lane watchdog is authoritative and reserves finalisation time.
+- a GitHub job may use a four-minute or larger operational timeout where supported, but the repository-owned lane watchdog is authoritative and reserves finalisation time.
 
 Global objectives:
 
@@ -336,13 +336,13 @@ It:
 
 Purpose: catch repository interactions without delaying every edit.
 
-It runs bounded shards for clean full deterministic evidence, package smoke, migration matrices, actual-service recovery, dependency/workflow integrity and clustering. If a full category exceeds 110 seconds, it is partitioned into deterministic content-addressed shards; no shard exceeds the budget.
+It runs bounded shards for clean full deterministic evidence, package smoke, migration matrices, actual-service recovery, dependency/workflow integrity and clustering. If a full category exceeds 220 seconds, it is partitioned into deterministic content-addressed shards; no shard exceeds the budget.
 
 A critical failure creates a revert/fix-forward incident and follows the owner-selected merge-pause policy. It never rewrites PR evidence.
 
 ### 8.7 `G6` scientific verification
 
-Independent sub-110-second shards include:
+Independent sub-220-second shards include:
 
 - mutation testing by target slice;
 - deterministic fault injection;
@@ -379,7 +379,7 @@ Canonical output shape:
 ```json
 {
   "schema_version": "newsroom.sdlc.route.v1",
-  "contract_version": "sdlc-v2.3",
+  "contract_version": "sdlc-v2.4",
   "base_sha": "0000000000000000000000000000000000000000",
   "head_sha": "1111111111111111111111111111111111111111",
   "base_tree_sha": "2222222222222222222222222222222222222222",
@@ -407,7 +407,7 @@ The complete deterministic suite remains blocking while all are true:
 
 - measured p95 test execution is at most 35 seconds;
 - measured warm bootstrap p95 is at most 10 seconds;
-- lane execution remains below 110 seconds;
+- lane execution remains below 220 seconds;
 - flake rate is below 0.1%;
 - no test requires an unauthorised external effect.
 
@@ -418,7 +418,7 @@ Current component selections are well below the test threshold, but the exact fu
 - `micro`: individual p95 below 100 ms;
 - `small`: hermetic test/file p95 below 1 second;
 - `service`: disposable actual-service individual p95 below 5 seconds;
-- `science`: shard below 110 seconds.
+- `science`: shard below 220 seconds.
 
 A target above its size budget is split, redesigned, moved to the correct lane or granted a documented temporary exception.
 
@@ -494,7 +494,7 @@ If execution conforms but feedback p95 remains above 60 seconds because queue/pr
 
 ### 11.4 Build-system graduation
 
-Do not adopt Bazel/Pants for appearance. Evaluate a hermetic action graph/remote cache only when simpler optimisation cannot keep the deterministic lane below 110 seconds, the repository becomes multi-package/multi-language, generated dependency inference is unreliable, remote-cache modelling predicts material improvement, or environment drift becomes recurring.
+Do not adopt Bazel/Pants for appearance. Evaluate a hermetic action graph/remote cache only when simpler optimisation cannot keep the deterministic lane below 220 seconds, the repository becomes multi-package/multi-language, generated dependency inference is unreliable, remote-cache modelling predicts material improvement, or environment drift becomes recurring.
 
 Any adoption must prove lower p95 and no reproducibility loss in shadow.
 
@@ -621,7 +621,7 @@ Method:
 - stop/rollback on quality regression;
 - review monthly and after every escaped defect.
 
-A lane is non-conformant over seven days when p95 execution exceeds 110 seconds, more than 1% hit `BUDGET_EXCEEDED`, flake exceeds 0.5%, evidence mismatch exceeds 0.1%, or routing/selection misses a known regression. It accepts no additional scope until fixed or split.
+A lane is non-conformant over seven days when p95 execution exceeds 220 seconds, more than 1% hit `BUDGET_EXCEEDED`, flake exceeds 0.5%, evidence mismatch exceeds 0.1%, or routing/selection misses a known regression. It accepts no additional scope until fixed or split.
 
 ## 15. Security and supply chain
 

--- a/newsroom/tests/test_sdlc_contract.py
+++ b/newsroom/tests/test_sdlc_contract.py
@@ -19,27 +19,27 @@ REPO_ROOT = Path(__file__).parents[2]
 def test_accepted_contract_loads_and_references_exact_source_files() -> None:
     contract = load_contract(REPO_ROOT)
 
-    assert contract.contract_version == "sdlc-v2.3"
+    assert contract.contract_version == "sdlc-v2.4"
     assert contract.classifier_version == "sdlc-risk-v1"
     assert contract.data["status"] == "accepted"
     assert contract.source_path == REPO_ROOT / ".sdlc" / "gates.toml"
     assert contract.data["acceptance_record"] == (
-        "docs/specs/sdlc/2026-07-30-sdlc-v2.3-owner-budget-amendment.md"
+        "docs/specs/sdlc/2026-08-02-sdlc-v2.4-owner-budget-amendment.md"
     )
     assert contract.unknown_path_risk == "R3_EXTERNAL_SERVICE_SECURITY"
 
 
-def test_every_gate_lane_resolves_and_all_hard_timeouts_are_below_two_minutes() -> None:
+def test_every_gate_lane_resolves_and_all_hard_timeouts_are_below_four_minutes() -> None:
     contract = load_contract(REPO_ROOT)
     lanes = contract.data["lanes"]
 
     for gate in contract.data["gate"].values():
         assert gate["lane"] in lanes
-        assert 0 < gate["hard_timeout_seconds"] < 120
+        assert 0 < gate["hard_timeout_seconds"] < 240
     assert contract.data["global"] == {
-        "gate_command_timeout_seconds": 110,
-        "lane_execution_timeout_seconds": 110,
-        "finalization_timeout_seconds": 10,
+        "gate_command_timeout_seconds": 220,
+        "lane_execution_timeout_seconds": 220,
+        "finalization_timeout_seconds": 20,
         "pr_feedback_p50_target_seconds": 30,
         "pr_feedback_p95_target_seconds": 60,
         "runner_queue_p95_target_seconds": 5,
@@ -56,27 +56,27 @@ def test_every_gate_lane_resolves_and_all_hard_timeouts_are_below_two_minutes() 
         name: value["hard_timeout_seconds"]
         for name, value in contract.data["gate"].items()
     } == {
-        "route": 10,
-        "source-integrity": 30,
-        "core-deterministic": 110,
-        "service-neo4j": 110,
-        "merge-exact": 110,
-        "science-shard": 110,
-        "evidence-finalize": 10,
+        "route": 20,
+        "source-integrity": 60,
+        "core-deterministic": 220,
+        "service-neo4j": 220,
+        "merge-exact": 220,
+        "science-shard": 220,
+        "evidence-finalize": 20,
     }
-    assert lanes["decision"] == {"always_reports": True, "hard_timeout_seconds": 10}
-    assert lanes["core"]["hard_timeout_seconds"] == 110
-    assert lanes["service"]["hard_timeout_seconds"] == 110
-    assert lanes["merge_group"]["hard_timeout_seconds"] == 110
-    assert lanes["science"]["per_shard_hard_timeout_seconds"] == 110
+    assert lanes["decision"] == {"always_reports": True, "hard_timeout_seconds": 20}
+    assert lanes["core"]["hard_timeout_seconds"] == 220
+    assert lanes["service"]["hard_timeout_seconds"] == 220
+    assert lanes["merge_group"]["hard_timeout_seconds"] == 220
+    assert lanes["science"]["per_shard_hard_timeout_seconds"] == 220
 
 
-def test_two_minute_ceiling_and_owner_multiplier_are_fail_closed() -> None:
+def test_four_minute_ceiling_and_owner_multiplier_are_fail_closed() -> None:
     contract = load_contract(REPO_ROOT)
 
     oversized = deepcopy(contract.data)
-    oversized["gate"]["core-deterministic"]["hard_timeout_seconds"] = 120
-    with pytest.raises(ContractError, match="below 120"):
+    oversized["gate"]["core-deterministic"]["hard_timeout_seconds"] = 240
+    with pytest.raises(ContractError, match="below 240"):
         validate_contract_data(oversized)
 
     wrong_owner_multiplier = deepcopy(contract.data)
@@ -140,8 +140,8 @@ def test_owner_values_match_review_and_selector_policy() -> None:
 
     assert owner == {
         "accepted_at": "2026-07-22",
-        "budget_amended_at": "2026-07-30",
-        "predecessor_contract_version": "sdlc-v2.2",
+        "budget_amended_at": "2026-08-02",
+        "predecessor_contract_version": "sdlc-v2.3",
         "hard_budget_multiplier": 2,
         "review_net_executable_lines_trigger": 400,
         "review_changed_files_trigger": 12,
@@ -172,5 +172,5 @@ def test_contract_validation_cli_emits_a_small_typed_summary(
     output = capsys.readouterr().out
 
     assert '"status":"PASS"' in output
-    assert '"contract_version":"sdlc-v2.3"' in output
+    assert '"contract_version":"sdlc-v2.4"' in output
     assert "R4_RELEASE_OPERATIONAL" in output

--- a/newsroom/tests/test_sdlc_evidence.py
+++ b/newsroom/tests/test_sdlc_evidence.py
@@ -53,6 +53,7 @@ def _copy_contract(root: Path) -> None:
         "docs/specs/sdlc/high-performance-evidence-sdlc.md",
         "docs/specs/sdlc/2026-07-22-sdlc-v2-owner-acceptance.md",
         "docs/specs/sdlc/2026-07-30-sdlc-v2.3-owner-budget-amendment.md",
+        "docs/specs/sdlc/2026-08-02-sdlc-v2.4-owner-budget-amendment.md",
     )
     for relative in paths:
         target = root / relative

--- a/newsroom/tests/test_sdlc_evidence_workflow.py
+++ b/newsroom/tests/test_sdlc_evidence_workflow.py
@@ -124,7 +124,14 @@ def test_job_graph_is_exact_and_decision_always_reports() -> None:
     assert jobs["route"]["outputs"] == {
         "service_required": "${{ steps.route_output.outputs.service_required }}"
     }
-    assert all(int(job["timeout-minutes"]) <= 5 for job in jobs.values())
+    assert {
+        job_id: job["timeout-minutes"] for job_id, job in jobs.items()
+    } == {
+        "route": "6",
+        "core": "10",
+        "service": "10",
+        "decision": "10",
+    }
 
 
 def test_every_action_is_release_pinned_to_an_exact_sha() -> None:
@@ -324,7 +331,7 @@ def test_service_boundary_is_exact_authenticated_loopback_and_bounded() -> None:
         'chmod 600 "${admin_file}" "${projector_file}"',
         "--publish 127.0.0.1:7687:7687",
         "--pull=never",
-        "timeout --signal=TERM --kill-after=5s 110s",
+        "timeout --signal=TERM --kill-after=5s 220s",
         "timeout --signal=TERM --kill-after=2s 20s",
     ):
         assert required in start
@@ -377,7 +384,7 @@ def test_repository_owned_gate_budgets_drive_route_lane_and_decision() -> None:
 
     collect = _step("decision", "Collect exact lane evidence")
     assert collect["env"] == {"GITHUB_TOKEN": "${{ github.token }}"}
-    assert "timeout --signal=TERM --kill-after=2s 110s" in collect["run"]
+    assert "timeout --signal=TERM --kill-after=2s 220s" in collect["run"]
     assert "scripts.sdlc.workflow_orchestrator collect" in collect["run"]
     finalize = _step("decision", "Finalize decision")
     assert finalize["if"] == "always()"

--- a/newsroom/tests/test_sdlc_shadow_decision.py
+++ b/newsroom/tests/test_sdlc_shadow_decision.py
@@ -403,7 +403,7 @@ def test_gate_failure_required_skip_and_budget_precedence(
         route,
         gates=(
             _gate("source-integrity", "source", result="FAIL"),
-            _gate("core-deterministic", "tests", execution_ms=111_000),
+            _gate("core-deterministic", "tests", execution_ms=221_000),
         ),
     )
     _patch_lane_validator(monkeypatch, over_budget)

--- a/newsroom/tests/test_sdlc_shadow_lane.py
+++ b/newsroom/tests/test_sdlc_shadow_lane.py
@@ -42,7 +42,7 @@ class _Metadata:
 
 @dataclass(frozen=True)
 class _Route:
-    contract_version: str = "sdlc-v2.3"
+    contract_version: str = "sdlc-v2.4"
     risk_classifier_version: str = "sdlc-risk-v1"
     risk_tier: str = "R1_LOCAL_CODE"
     service_required: bool = False
@@ -349,7 +349,6 @@ def test_cross_record_identity_mismatch_fails_closed(
         )
 
 
-
 def test_route_and_lane_gate_semantics_fail_closed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -430,7 +429,6 @@ def test_record_rejects_shape_policy_and_identity_tampering(
     changed["lane_identity"] = "sha256:" + "0" * 64
     with pytest.raises(ShadowLaneError, match="lane_identity"):
         validate_shadow_lane_record(changed)
-
 
 
 def test_direct_record_rejects_validator_substitution(

--- a/newsroom/tests/test_sdlc_watchdog.py
+++ b/newsroom/tests/test_sdlc_watchdog.py
@@ -232,23 +232,23 @@ def test_environment_error_does_not_echo_command_or_exception_message() -> None:
 
 def test_deadline_and_configured_budget_cannot_be_raised() -> None:
     contract = load_contract(REPO_ROOT)
-    assert start_lane_deadline(contract, "route").timeout_ms == 110_000
+    assert start_lane_deadline(contract, "route").timeout_ms == 220_000
 
-    with pytest.raises(GateRunError, match="below 120"):
-        LaneDeadline(0, 120_000)
+    with pytest.raises(GateRunError, match="below 240"):
+        LaneDeadline(0, 240_000)
     with pytest.raises(GateRunError, match="accepted lane timeout"):
         run_configured_gate(
             contract=contract,
             gate_id="route",
             phase="oversized",
             argv=_python("pass"),
-            deadline=LaneDeadline.start(119),
+            deadline=LaneDeadline.start(239),
         )
 
 
 def test_invalid_budget_identifier_and_output_limit_are_rejected() -> None:
-    with pytest.raises(GateRunError, match="below 120"):
-        LaneDeadline.start(120)
+    with pytest.raises(GateRunError, match="below 240"):
+        LaneDeadline.start(240)
     with pytest.raises(GateRunError, match="unsupported characters"):
         _run_gate_command(
             gate_id="bad:gate",

--- a/scripts/sdlc/contracts.py
+++ b/scripts/sdlc/contracts.py
@@ -30,7 +30,7 @@ _REQUIRED_RISKS = (
     "R4_RELEASE_OPERATIONAL",
 )
 _INTERACTIVE_LANES = frozenset({"core", "service", "merge_group"})
-_MAX_HARD_TIMEOUT_SECONDS = 120
+_MAX_HARD_TIMEOUT_SECONDS = 240
 
 
 def _mapping(value: object, name: str) -> Mapping[str, Any]:
@@ -282,9 +282,9 @@ def validate_contract_data(
         owner.get("selector_mutation_recall_minimum"),
         "owner mutation recall",
     )
-    if owner.get("predecessor_contract_version") != "sdlc-v2.2":
+    if owner.get("predecessor_contract_version") != "sdlc-v2.3":
         raise ContractError("accepted predecessor contract version is missing")
-    if owner.get("budget_amended_at") != "2026-07-30":
+    if owner.get("budget_amended_at") != "2026-08-02":
         raise ContractError("accepted budget amendment date is missing")
     if owner.get("hard_budget_multiplier") != 2:
         raise ContractError("accepted hard-budget multiplier must be two")

--- a/scripts/sdlc/run_gate.py
+++ b/scripts/sdlc/run_gate.py
@@ -20,7 +20,7 @@ SCHEMA_VERSION = "newsroom.sdlc.gate-run.v1"
 _SECRET_NAME = re.compile(r"(?:AUTH|CREDENTIAL|KEY|PASSWORD|SECRET|TOKEN)", re.IGNORECASE)
 _SAFE_ID = re.compile(r"[A-Za-z0-9_.*-]{1,128}")
 _MAX_OUTPUT_BYTES = 1_048_576
-_MAX_TIMEOUT_SECONDS = 120
+_MAX_TIMEOUT_SECONDS = 240
 _SCHEDULER_MARGIN_SECONDS = 0.05
 
 
@@ -45,7 +45,7 @@ class LaneDeadline:
             or not isinstance(self.timeout_ms, int)
             or not 0 < self.timeout_ms < _MAX_TIMEOUT_SECONDS * 1000
         ):
-            raise GateRunError("lane timeout must be positive and below 120 seconds")
+            raise GateRunError("lane timeout must be positive and below 240 seconds")
 
     @classmethod
     def start(cls, timeout_seconds: float) -> "LaneDeadline":
@@ -132,7 +132,7 @@ def _timeout_seconds(value: object, name: str) -> float:
         raise GateRunError(f"{name} must be numeric")
     timeout = float(value)
     if timeout <= 0 or timeout >= _MAX_TIMEOUT_SECONDS:
-        raise GateRunError(f"{name} must be positive and below 120 seconds")
+        raise GateRunError(f"{name} must be positive and below 240 seconds")
     return timeout
 
 

--- a/scripts/sdlc/shadow_lane.py
+++ b/scripts/sdlc/shadow_lane.py
@@ -31,7 +31,7 @@ from .workflow_event import (
 
 SCHEMA_VERSION = "newsroom.sdlc.shadow-lane.v1"
 POLICY_VERSION = "sdlc-shadow-lane-v1"
-CONTRACT_VERSION = "sdlc-v2.3"
+CONTRACT_VERSION = "sdlc-v2.4"
 CLASSIFIER_VERSION = "sdlc-risk-v1"
 _SERVICE_RISKS = frozenset({"R3_EXTERNAL_SERVICE_SECURITY", "R4_RELEASE_OPERATIONAL"})
 _OWNER_RISKS = frozenset({"R4_RELEASE_OPERATIONAL"})


### PR DESCRIPTION
## Scope

Implements owner-authorised issue #257 as a narrow SDLC support change, independent of Increment 5A / PR #255.

The accepted contract advances from `sdlc-v2.3` to `sdlc-v2.4` and doubles every v2.3 hard enforcement ceiling for all risk tiers:

- global command and interactive lane: 110 → 220 seconds;
- finalisation: 10 → 20 seconds;
- route: 10 → 20 seconds;
- source integrity: 30 → 60 seconds;
- core, authenticated Neo4j, merge-exact and science: 110 → 220 seconds;
- workflow job operational caps: route 3 → 6 minutes; core/service/decision 5 → 10 minutes;
- watchdog maximum: below 120 → below 240 seconds.

## Preserved controls

This PR does not change p50/p95 targets, risk routing, test inventory, xdist scheduling, required skips, actual-Neo4j requirements, exact tree/lock/toolchain binding, evidence schemas, first-result immutability or fail-closed result semantics.

It does not authorize Graphiti, a model, embeddings, live sources, credentials, spending, publication, product shadow/canary/production, the Increment 5A owner statement, either 5A authority record or Increment 5B.

## Changed surfaces

- new normative owner amendment for `sdlc-v2.4`;
- normative specification and machine contract;
- contract validator and shadow-lane contract binding;
- signed evidence workflow operational caps;
- exact contract, evidence, shadow-lane and workflow regressions.

## Required completion

- all permanent workflows green on the exact reviewed head;
- canonical signed SDLC `PASS` under v2.4;
- zero unresolved P1/P2 findings and review threads;
- squash merge to `main`;
- only then update PR #255 onto the merged v2.4 contract and requalify 5A.

Tracks #257. Unblocks continued qualification of #250; does not start #251.
