### PR TITLE
Support: materialize final Increment 5A receipt-document consistency

### DIFF
--- a/scripts/sdlc/_staging_increment5_final_doc_consistency_trigger.txt
+++ b/scripts/sdlc/_staging_increment5_final_doc_consistency_trigger.txt
@@ -1,0 +1,1 @@
+trigger-v1

--- a/scripts/sdlc/_staging_increment5_final_doc_consistency_trigger.txt
+++ b/scripts/sdlc/_staging_increment5_final_doc_consistency_trigger.txt
@@ -1,1 +1,1 @@
-trigger-v1
+trigger-v2


### PR DESCRIPTION
Disposable support PR for PR #255 only.

This PR exists solely to trigger the isolated documentation-consistency materializer on base branch `staging/increment-5a-final-doc-consistency-20260804`.

The support workflow will:

- update the Evaluation Plan from receipt v5 to receipt v7 and record the prewrite-snapshot semantics;
- narrow the decision document's drift guarantee to the final prewrite snapshot;
- add one regression pinning both reviewed documents;
- run focused Increment 5A tests, the complete deterministic suite, and source-integrity checks; and
- push the verified generated candidate back to the support base.

The helper, workflow, trigger, and scratch manifest are disposable support machinery. They must not enter PR #255 or `main`. The final product branch will remain exactly one commit over fixed base `3ea1874de5e1bd6c622a3760eabb74adfe75d169`.

Do not merge this PR.