### PR TITLE
Support: verify shallow-independent Increment 5A HEAD race

### DIFF
--- a/scripts/sdlc/_staging_increment5_shallow_ci_regression_trigger.txt
+++ b/scripts/sdlc/_staging_increment5_shallow_ci_regression_trigger.txt
@@ -1,1 +1,1 @@
-trigger-v2
+trigger-v3

--- a/scripts/sdlc/_staging_increment5_shallow_ci_regression_trigger.txt
+++ b/scripts/sdlc/_staging_increment5_shallow_ci_regression_trigger.txt
@@ -1,1 +1,1 @@
-trigger-v3
+trigger-v4

--- a/scripts/sdlc/_staging_increment5_shallow_ci_regression_trigger.txt
+++ b/scripts/sdlc/_staging_increment5_shallow_ci_regression_trigger.txt
@@ -1,0 +1,1 @@
+trigger-v1

--- a/scripts/sdlc/_staging_increment5_shallow_ci_regression_trigger.txt
+++ b/scripts/sdlc/_staging_increment5_shallow_ci_regression_trigger.txt
@@ -1,1 +1,1 @@
-trigger-v1
+trigger-v2


### PR DESCRIPTION
Disposable support PR for PR #255 only.

This PR triggers a shallow-checkout verification of the final Increment 5A race regression. The generated product change replaces the `HEAD^` dependency with a synthetic different commit over the exact same tree, so the HEAD-race test measures the validator invariant without assuming parent history exists.

The workflow uses `fetch-depth: 1`, runs the focused Increment 5A suite, the complete deterministic suite, and source-integrity checks, then publishes the verified materialization to the support base.

The helper, workflow, trigger, and scratch manifest are disposable support machinery. They must not enter PR #255 or `main`. Do not merge this PR.