### PR TITLE
Increment 5B2: bounded bilingual full-text retriever and immutable receipts

### DIFF
--- a/docs/operations/increment-5b2-fulltext-retriever.md
+++ b/docs/operations/increment-5b2-fulltext-retriever.md
@@ -1,0 +1,138 @@
+# Increment 5B2 bilingual full-text retriever operating boundary
+
+- **Issue:** #292, child of #251
+- **Accepted base:** `main@4acc389e1a2709cdb09a96de937cb163ad6525ba`
+- **5A retrieval contract:** `sha256:51a3837ad9cdb70fe8aaa4242997b191c7e848bb1d391c6940cccc2bd45ba06c`
+- **Full-text component:** `sha256:ec859d0a25d7684f6c3a693b59dca96337946b07552eae6aa870910eaf24465a`
+- **Normalization component:** `sha256:0ed4fa41238d589933905cb3bf55b4dd9fe290c563ff07ee8676d776ad104070`
+- **Effect:** one independently attributable, non-authoritative, read-only branch
+
+## Scope
+
+This atom implements only the `FULL_TEXT` branch required by Increment 5B. It
+adds immutable request, hit, exclusion and receipt contracts; deterministic
+bilingual normalization; one repository-owned Lucene expression builder; one
+bounded authority-owned Neo4j read capability; and an immutable
+non-authoritative SQLite receipt journal.
+
+It does not implement the SQLite exact branch, vector retrieval, admitted-graph
+traversal, fusion, cross-mode score comparison, dependency-root deduplication,
+authoritative hydration, complete Retrieval Context assembly, Candidate
+creation or relation admission. It does not activate production.
+
+## Normalization and query construction
+
+The normalizer is deterministic and repository-owned:
+
+- CRLF and CR become LF before whitespace collapse;
+- Unicode normalization is NFKC;
+- Latin text is case-folded;
+- traditional Han is preserved without script conversion;
+- contiguous Han text emits exact bigrams;
+- retained formal identifiers remain exact tokens;
+- only typed current authority aliases valid at query-valid time contribute;
+- no free transliteration is performed; and
+- all Lucene metacharacters remain inside escaped, repository-built,
+  field-scoped clauses.
+
+The caller supplies bounded surface text and a typed language mode. It cannot
+supply Lucene syntax, an index name, node label, property, provider, analyzer,
+predicate, sort order or result limit. The retriever derives every graph-read
+control from the accepted contract and the authoritative projection snapshot.
+
+## Private Neo4j ownership
+
+The existing repository invariant remains unchanged:
+
+`newsroom/authority/_neo4j_projection_system.py` is the sole production
+importer of `newsroom.projection.neo4j._adapter`.
+
+The 5B2 retriever therefore never receives a driver, session, transaction,
+private adapter or generic query callback. It receives only a typed
+`Neo4jFullTextReader` capability. That capability exposes one phased `read`
+operation restricted to `COMPONENT`, `INDEX` and `QUERY`, plus the exact driver
+version; it exposes no driver, session,
+`execute_query`, raw Cypher or write surface. Its private opener remains inside
+the authority composition module and is not exported as a standalone public
+connection factory.
+
+The private adapter owns exactly three fixed, fail-fast read phases:
+
+1. exact Neo4j component and edition identity;
+2. exact generation-scoped full-text index inventory; and
+3. one fixed full-text query returning only generation identity, passage
+   identity, projection-document digest, language and raw branch-local score.
+
+All three managed transactions share one cumulative monotonic deadline. Each
+transaction receives only its remaining server-owned timeout. A timeout at any
+stage becomes a typed timeout without retaining partial hits. Other driver or
+service failures become a fixed credential-free unavailable result.
+
+## Authority and projection checks
+
+Before `COMPLETE` is possible, the branch binds and verifies:
+
+- the accepted retrieval, full-text and normalization component digests;
+- the exact active generation and generation-identity digest;
+- the exact signed/current rights-manifest digest;
+- a contiguous authority watermark at or above the request minimum;
+- zero open gaps and zero dead letters;
+- validation time, freshness deadline and the one-hour maximum age;
+- exact Neo4j Community `2026.06.0` and driver `6.2.0` compatibility;
+- one online generation-scoped `fulltext-2.0` index;
+- analyzer `standard-no-stop-words`;
+- synchronous index updates; and
+- indexed fields `authority_aliases`, `formal_tokens`, `han_bigrams`,
+  `latin_terms` and `retrieval_text`.
+
+Every graph row must match an authoritative document binding for the same
+passage, digest and language. Current rights, lifecycle and valid-time are
+rechecked before a hit is exposed. Projection text is not returned as fact.
+A wholly ineligible matched set is `POLICY_BLOCKED`, never `NO_MATCH`.
+
+`COMPLETE / NO_MATCH` is possible only after the authoritative view is current,
+the live component and index are compatible, and the fixed graph query
+successfully returns no eligible result inside the hard deadline.
+
+## Hard limits and receipts
+
+The branch fixes:
+
+- 5,000 ms cumulative timeout;
+- eight admitted results plus a ninth overflow sentinel;
+- 262,144 response bytes;
+- zero external calls;
+- zero provider spend;
+- `authority_effect=NONE`;
+- `hybrid_result_claimed=false`; and
+- `projection_text_factual_use_allowed=false`.
+
+A ninth row becomes `INCOMPLETE / RESULT_BOUND_EXCEEDED`; it is not silently
+truncated. A one-nanosecond overrun becomes `INCOMPLETE / QUERY_TIMEOUT` and
+clears hits and exclusions.
+
+The separate SQLite journal stores canonical request and receipt bytes and
+their SHA-256 identities. Reuse of an idempotency key with different request
+bytes fails. Replay and restart return the first receipt bytes without rerunning
+authority or Neo4j reads. Mutation, deletion and corrupted-byte paths fail
+closed. The journal is evidence only and never authority.
+
+## Outcomes
+
+- `COMPLETE`: healthy branch, including an honest `NO_MATCH`;
+- `STALE`: inactive or mismatched generation, rights manifest, watermark or
+  freshness;
+- `INCOMPLETE`: gaps, dead letters, populating index, overflow or timeout;
+- `POLICY_BLOCKED`: request/contract policy failure or wholly ineligible hits;
+- `UNAVAILABLE`: authority view, component, index, projection-integrity or
+  graph-read failure.
+
+## Rollback
+
+Rollback removes only the 5B2 contracts, retriever, authority capability,
+private fixed-read extension, tests and documentation. The immutable receipt
+journal may be retained as non-authoritative evidence or removed only under an
+explicit evidence-retention decision. Rollback never mutates SQLite authority,
+selects a graph-free production path, enables an alternate analyzer or index,
+or authorizes a model/provider, live source, credential, spend, publication,
+shadow, canary or public effect.

--- a/docs/traceability/increment-5b-branch-atoms.md
+++ b/docs/traceability/increment-5b-branch-atoms.md
@@ -5,13 +5,13 @@ whole requirement until later composition. The parent remains issue #251.
 
 | Atom | Issue | Delivery | Explicitly absent |
 |---|---:|---|---|
-| 5B1 | #289 | common branch records, immutable replay journal, SQLite exact lookup, relational Candidate-collision read | full text, vector, graph, fusion, deduplication, hydration, hybrid response |
-| 5B2 | pending | generation-scoped full-text branch | every other branch and composition |
+| 5B1 | #289 | common branch records, immutable replay journal, stale-safe SQLite exact lookup, relational Candidate-collision read | full text, vector, graph, fusion, deduplication, hydration, hybrid response |
+| 5B2 | #292 | bilingual normalizer, generation-scoped fixed Neo4j full-text read, authoritative binding checks and immutable branch receipt | exact/vector/graph calls, fusion, deduplication, hydration, factual projection use |
 | 5B3 | pending | deterministic fixed-point fixture/replay vector branch | model/provider execution and composition |
 | 5B4 | pending | bounded admitted-graph branch | raw/generated Cypher and composition |
 
-5B1 binds the accepted 5A contract and contributes implementation evidence for
-the 5B portions of `GRAG-030`–`GRAG-046`, applicable `GRPROD-*`, and
-`TRI-020`–`TRI-028`, without claiming delivery of `GRAG-031` or any complete
-hybrid requirement. The closed-world ownership counts in
-`newsroom/increment5/traceability.py` remain unchanged.
+5B1 and 5B2 bind the accepted 5A contract and contribute partial implementation
+evidence for the 5B portions of `GRAG-030`–`GRAG-046`, applicable
+`GRPROD-*`, and `TRI-020`–`TRI-028`. They do not claim delivery of
+`GRAG-031` or any complete hybrid requirement. The closed-world ownership
+counts in `newsroom/increment5/traceability.py` remain unchanged.

--- a/newsroom/authority/_neo4j_projection_system.py
+++ b/newsroom/authority/_neo4j_projection_system.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from threading import RLock
@@ -28,6 +28,14 @@ from .persistence import (
 from .policy import CommandRegistry, PayloadSchemaRegistry
 from .service import CommandService
 from .types import TrustScope, UtcTimestamp
+from .neo4j_fulltext_reader import (
+    Neo4jFullTextReadError,
+    Neo4jFullTextReadPhase,
+    Neo4jFullTextReadRequest,
+    Neo4jFullTextReadResult,
+    Neo4jFullTextReadTimeout,
+    Neo4jFullTextReader,
+)
 from newsroom.increment4.neo4j import Increment4Neo4jController
 from newsroom.projection.mapping import (
     ProjectionIdentitySource,
@@ -130,6 +138,22 @@ class _StructuralGraphAdapter(Protocol):
     def cleanup_generation(self, generation_id: str) -> int:
         ...
 
+    @property
+    def driver_version(self) -> str:
+        ...
+
+    def read_increment5_fulltext(
+        self,
+        *,
+        phase: str,
+        index_name: str | None,
+        lucene_expression: str | None,
+        generation_id: str | None,
+        limit: int,
+        timeout_ns: int,
+    ) -> Any:
+        ...
+
     def close(self) -> None:
         ...
 
@@ -138,6 +162,107 @@ def _open_structural_graph_adapter(
     config: Neo4jProjectorConfig,
 ) -> _StructuralGraphAdapter:
     return _open_neo4j_adapter(config)
+
+
+def _increment5_fulltext_record_mapping(
+    value: Any,
+    *,
+    identity: str,
+) -> dict[str, object]:
+    if isinstance(value, Mapping):
+        record = dict(value)
+    else:
+        try:
+            record = dict(value.items())
+        except Exception:
+            raise Neo4jFullTextReadError(
+                f"Neo4j full-text authority read returned malformed {identity}"
+            ) from None
+    if any(not isinstance(key, str) for key in record):
+        raise Neo4jFullTextReadError(
+            f"Neo4j full-text authority read returned malformed {identity}"
+        )
+    return record
+
+
+def _open_neo4j_fulltext_reader_with_adapter(
+    adapter: _StructuralGraphAdapter,
+) -> Neo4jFullTextReader:
+    """Reduce the private adapter to one owned, phased read capability."""
+
+    def read(
+        request: Neo4jFullTextReadRequest,
+    ) -> Neo4jFullTextReadResult:
+        try:
+            value = adapter.read_increment5_fulltext(
+                phase=request.phase.value,
+                index_name=request.index_name,
+                lucene_expression=request.lucene_expression,
+                generation_id=(
+                    None
+                    if request.generation_id is None
+                    else str(request.generation_id)
+                ),
+                limit=request.limit,
+                timeout_ns=request.timeout_ns,
+            )
+        except Neo4jReadError as exc:
+            if "timed out" in str(exc).casefold():
+                raise Neo4jFullTextReadTimeout(
+                    "Neo4j full-text authority read timed out"
+                ) from None
+            raise Neo4jFullTextReadError(
+                "Neo4j full-text authority read is unavailable"
+            ) from None
+        except Exception:
+            raise Neo4jFullTextReadError(
+                "Neo4j full-text authority read is unavailable"
+            ) from None
+        if request.phase is Neo4jFullTextReadPhase.COMPONENT:
+            component = (
+                None
+                if value is None
+                else _increment5_fulltext_record_mapping(
+                    value,
+                    identity="component",
+                )
+            )
+            return Neo4jFullTextReadResult(
+                phase=request.phase,
+                component=component,
+                driver_version=adapter.driver_version,
+            )
+        try:
+            records = tuple(
+                _increment5_fulltext_record_mapping(
+                    item,
+                    identity="row",
+                )
+                for item in value
+            )
+        except Neo4jFullTextReadError:
+            raise
+        except Exception:
+            raise Neo4jFullTextReadError(
+                "Neo4j full-text authority read returned malformed rows"
+            ) from None
+        if request.phase is Neo4jFullTextReadPhase.INDEX:
+            return Neo4jFullTextReadResult(
+                phase=request.phase,
+                indexes=records,
+                driver_version=adapter.driver_version,
+            )
+        return Neo4jFullTextReadResult(
+            phase=request.phase,
+            rows=records,
+            driver_version=adapter.driver_version,
+        )
+
+    return Neo4jFullTextReader(
+        driver_version=adapter.driver_version,
+        read=read,
+        close=adapter.close,
+    )
 
 
 class Neo4jStructuralProjector:

--- a/newsroom/authority/neo4j_fulltext_reader.py
+++ b/newsroom/authority/neo4j_fulltext_reader.py
@@ -1,0 +1,308 @@
+"""Bounded authority port for Increment 5 full-text Neo4j reads."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+import re
+from types import MappingProxyType
+
+from newsroom.projection.models import ProjectionGenerationId
+
+
+class Neo4jFullTextReadError(RuntimeError):
+    """A bounded full-text graph read is unavailable or malformed."""
+
+
+class Neo4jFullTextReadTimeout(Neo4jFullTextReadError):
+    """A bounded full-text graph-read budget expired."""
+
+
+class Neo4jFullTextReadPhase(StrEnum):
+    COMPONENT = "COMPONENT"
+    INDEX = "INDEX"
+    QUERY = "QUERY"
+
+
+_NEO4J_NAME = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,127}$")
+
+
+def _bounded_text(value: str, *, field: str, maximum_bytes: int) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or value != value.strip()
+        or len(value.encode("utf-8")) > maximum_bytes
+        or any(ord(character) < 0x20 for character in value)
+    ):
+        raise Neo4jFullTextReadError(f"{field} must be bounded canonical text")
+    return value
+
+
+def _timeout(value: int) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not 0 < value <= 5_000_000_000
+    ):
+        raise Neo4jFullTextReadError(
+            "full-text graph-read timeout must be within 5,000 ms"
+        )
+    return value
+
+
+def _index_name(value: str) -> str:
+    _bounded_text(value, field="fulltext_index_name", maximum_bytes=128)
+    if _NEO4J_NAME.fullmatch(value) is None:
+        raise Neo4jFullTextReadError(
+            "full-text index name must be a server-derived Neo4j name"
+        )
+    return value
+
+
+def _copy_record(
+    value: Mapping[str, object] | None,
+    *,
+    field: str,
+) -> Mapping[str, object] | None:
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise Neo4jFullTextReadError(f"{field} must be a mapping")
+    return MappingProxyType(dict(value))
+
+
+def _copy_records(
+    values: tuple[Mapping[str, object], ...],
+    *,
+    field: str,
+    maximum: int,
+) -> tuple[Mapping[str, object], ...]:
+    if not isinstance(values, tuple) or len(values) > maximum:
+        raise Neo4jFullTextReadError(f"{field} exceeds its fixed bound")
+    copied: list[Mapping[str, object]] = []
+    for value in values:
+        if not isinstance(value, Mapping):
+            raise Neo4jFullTextReadError(f"{field} contains a malformed record")
+        copied.append(MappingProxyType(dict(value)))
+    return tuple(copied)
+
+
+@dataclass(frozen=True, slots=True)
+class Neo4jFullTextReadRequest:
+    phase: Neo4jFullTextReadPhase
+    timeout_ns: int
+    index_name: str | None = None
+    lucene_expression: str | None = None
+    generation_id: ProjectionGenerationId | None = None
+    limit: int = 0
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.phase, Neo4jFullTextReadPhase):
+            raise Neo4jFullTextReadError("full-text read phase must be typed")
+        _timeout(self.timeout_ns)
+        if self.phase is Neo4jFullTextReadPhase.COMPONENT:
+            if any(
+                value is not None
+                for value in (
+                    self.index_name,
+                    self.lucene_expression,
+                    self.generation_id,
+                )
+            ) or self.limit != 0:
+                raise Neo4jFullTextReadError(
+                    "component read cannot carry index or query controls"
+                )
+            return
+        if self.index_name is None:
+            raise Neo4jFullTextReadError("full-text index read requires an index")
+        _index_name(self.index_name)
+        if self.phase is Neo4jFullTextReadPhase.INDEX:
+            if (
+                self.lucene_expression is not None
+                or self.generation_id is not None
+                or self.limit != 0
+            ):
+                raise Neo4jFullTextReadError(
+                    "index read cannot carry query controls"
+                )
+            return
+        if self.lucene_expression is None:
+            raise Neo4jFullTextReadError(
+                "full-text query read requires a Lucene expression"
+            )
+        _bounded_text(
+            self.lucene_expression,
+            field="fulltext_lucene_expression",
+            maximum_bytes=32_768,
+        )
+        if not isinstance(self.generation_id, ProjectionGenerationId):
+            raise Neo4jFullTextReadError(
+                "full-text generation identity must be typed"
+            )
+        if isinstance(self.limit, bool) or self.limit != 9:
+            raise Neo4jFullTextReadError(
+                "full-text overflow sentinel limit must equal 9"
+            )
+
+    @classmethod
+    def component(cls, *, timeout_ns: int) -> "Neo4jFullTextReadRequest":
+        return cls(
+            phase=Neo4jFullTextReadPhase.COMPONENT,
+            timeout_ns=timeout_ns,
+        )
+
+    @classmethod
+    def index(
+        cls,
+        *,
+        index_name: str,
+        timeout_ns: int,
+    ) -> "Neo4jFullTextReadRequest":
+        return cls(
+            phase=Neo4jFullTextReadPhase.INDEX,
+            timeout_ns=timeout_ns,
+            index_name=index_name,
+        )
+
+    @classmethod
+    def query(
+        cls,
+        *,
+        index_name: str,
+        lucene_expression: str,
+        generation_id: ProjectionGenerationId,
+        limit: int,
+        timeout_ns: int,
+    ) -> "Neo4jFullTextReadRequest":
+        return cls(
+            phase=Neo4jFullTextReadPhase.QUERY,
+            timeout_ns=timeout_ns,
+            index_name=index_name,
+            lucene_expression=lucene_expression,
+            generation_id=generation_id,
+            limit=limit,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class Neo4jFullTextReadResult:
+    phase: Neo4jFullTextReadPhase
+    driver_version: str
+    component: Mapping[str, object] | None = None
+    indexes: tuple[Mapping[str, object], ...] = ()
+    rows: tuple[Mapping[str, object], ...] = ()
+    read_count: int = 1
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.phase, Neo4jFullTextReadPhase):
+            raise Neo4jFullTextReadError("full-text result phase must be typed")
+        _bounded_text(
+            self.driver_version,
+            field="fulltext_driver_version",
+            maximum_bytes=64,
+        )
+        if self.read_count != 1:
+            raise Neo4jFullTextReadError(
+                "one full-text phase must retain exactly one Neo4j read"
+            )
+        component = _copy_record(self.component, field="fulltext_component")
+        indexes = _copy_records(
+            self.indexes,
+            field="fulltext_indexes",
+            maximum=16,
+        )
+        rows = _copy_records(
+            self.rows,
+            field="fulltext_rows",
+            maximum=9,
+        )
+        if self.phase is Neo4jFullTextReadPhase.COMPONENT:
+            if indexes or rows:
+                raise Neo4jFullTextReadError(
+                    "component result cannot carry index or query rows"
+                )
+        elif self.phase is Neo4jFullTextReadPhase.INDEX:
+            if component is not None or rows:
+                raise Neo4jFullTextReadError(
+                    "index result cannot carry component or query rows"
+                )
+        elif component is not None or indexes:
+            raise Neo4jFullTextReadError(
+                "query result cannot carry component or index rows"
+            )
+        object.__setattr__(self, "component", component)
+        object.__setattr__(self, "indexes", indexes)
+        object.__setattr__(self, "rows", rows)
+
+
+class Neo4jFullTextReader:
+    """Capability facade exposing one phased read, never a driver or session."""
+
+    __slots__ = ("__driver_version", "__read", "__close", "__closed")
+
+    def __init__(
+        self,
+        *,
+        driver_version: str,
+        read: Callable[[Neo4jFullTextReadRequest], Neo4jFullTextReadResult],
+        close: Callable[[], None] | None = None,
+    ) -> None:
+        _bounded_text(
+            driver_version,
+            field="fulltext_driver_version",
+            maximum_bytes=64,
+        )
+        if not callable(read) or (close is not None and not callable(close)):
+            raise TypeError("full-text authority port requires callable boundaries")
+        self.__driver_version = driver_version
+        self.__read = read
+        self.__close = close or (lambda: None)
+        self.__closed = False
+
+    @property
+    def driver_version(self) -> str:
+        return self.__driver_version
+
+    def read(self, request: Neo4jFullTextReadRequest) -> Neo4jFullTextReadResult:
+        if not isinstance(request, Neo4jFullTextReadRequest):
+            raise TypeError("full-text graph read requires a typed request")
+        if self.__closed:
+            raise Neo4jFullTextReadError("full-text authority port is closed")
+        result = self.__read(request)
+        if not isinstance(result, Neo4jFullTextReadResult):
+            raise Neo4jFullTextReadError(
+                "full-text authority port returned an untyped result"
+            )
+        if result.phase is not request.phase:
+            raise Neo4jFullTextReadError(
+                "full-text authority port returned another read phase"
+            )
+        if result.driver_version != self.__driver_version:
+            raise Neo4jFullTextReadError(
+                "full-text authority port driver identity changed"
+            )
+        return result
+
+    def close(self) -> None:
+        if self.__closed:
+            return
+        self.__closed = True
+        self.__close()
+
+    def __enter__(self) -> "Neo4jFullTextReader":
+        return self
+
+    def __exit__(self, _exc_type: object, _exc: object, _tb: object) -> None:
+        self.close()
+
+
+__all__ = [
+    "Neo4jFullTextReadError",
+    "Neo4jFullTextReadPhase",
+    "Neo4jFullTextReadRequest",
+    "Neo4jFullTextReadResult",
+    "Neo4jFullTextReadTimeout",
+    "Neo4jFullTextReader",
+]

--- a/newsroom/increment5/fulltext_contracts.py
+++ b/newsroom/increment5/fulltext_contracts.py
@@ -1,0 +1,766 @@
+"""Immutable contracts for the independent Increment 5B full-text branch."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+import re
+
+from newsroom.authority.canonical import (
+    MAX_SAFE_INTEGER,
+    canonical_json_bytes,
+    digest_bytes,
+    validate_sha256_digest,
+)
+from newsroom.authority.types import TrustScope, UtcTimestamp, require_token
+from newsroom.increment5.branch_contracts import (
+    BRANCH_RESULT_LIMIT,
+    BRANCH_TIMEOUT_MS,
+    BranchExclusionReason,
+    BranchRequestId,
+    Increment5BranchContractError,
+)
+from newsroom.increment5.decision import INCREMENT_5A_CONTRACT_DIGEST
+from newsroom.projection.models import ProjectionGenerationId, ProjectionGenerationState
+
+
+INCREMENT5_RETRIEVAL_CONTRACT_DIGEST = INCREMENT_5A_CONTRACT_DIGEST
+FULLTEXT_COMPONENT_DIGEST = (
+    "sha256:ec859d0a25d7684f6c3a693b59dca96337946b07552eae6aa870910eaf24465a"
+)
+NORMALIZATION_COMPONENT_DIGEST = (
+    "sha256:0ed4fa41238d589933905cb3bf55b4dd9fe290c563ff07ee8676d776ad104070"
+)
+FULLTEXT_POLICY_ID = "increment5-fulltext-branch-v1"
+FULLTEXT_ACTOR_ID = "retrieval_worker"
+FULLTEXT_PURPOSE = "bounded_fulltext_lookup"
+FULLTEXT_QUERY_ID = "increment5.fulltext.v1"
+FULLTEXT_PROVIDER = "fulltext-2.0"
+FULLTEXT_ANALYZER = "standard-no-stop-words"
+FULLTEXT_RESPONSE_BYTE_LIMIT = 262_144
+FULLTEXT_MAX_PROJECTION_AGE_SECONDS = 3_600
+FULLTEXT_MAX_QUERY_BYTES = 16_384
+FULLTEXT_MAX_LUCENE_QUERY_BYTES = 32_768
+FULLTEXT_MAX_TERMS = 64
+FULLTEXT_INDEXED_FIELDS = (
+    "authority_aliases",
+    "formal_tokens",
+    "han_bigrams",
+    "latin_terms",
+    "retrieval_text",
+)
+
+_NEO4J_NAME = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,127}$")
+
+
+class FullTextContractError(Increment5BranchContractError):
+    """A full-text request, projection snapshot or binding is malformed."""
+
+
+class FullTextLanguageMode(StrEnum):
+    EN_GB = "EN_GB"
+    ZH_HANT_HK = "ZH_HANT_HK"
+    MIXED_EN_GB_ZH_HANT_HK = "MIXED_EN_GB_ZH_HANT_HK"
+
+
+class FullTextIndexState(StrEnum):
+    ONLINE = "ONLINE"
+    POPULATING = "POPULATING"
+    FAILED = "FAILED"
+    MISSING = "MISSING"
+
+
+class FullTextProfile(StrEnum):
+    FIXTURE_REPLAY = "FIXTURE_REPLAY"
+    PRODUCTION_SHAPED_QUALIFICATION = "PRODUCTION_SHAPED_QUALIFICATION"
+
+
+def _bounded_text(
+    value: str,
+    *,
+    field: str,
+    maximum_bytes: int = 4_096,
+) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or value != value.strip()
+        or len(value.encode("utf-8")) > maximum_bytes
+    ):
+        raise FullTextContractError(f"{field} must be bounded canonical text")
+    return value
+
+
+def _non_negative(value: int, *, field: str) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not 0 <= value <= MAX_SAFE_INTEGER
+    ):
+        raise FullTextContractError(
+            f"{field} must be a canonical non-negative integer"
+        )
+    return value
+
+
+def _sorted_unique(
+    value: tuple[str, ...],
+    *,
+    field: str,
+    maximum_items: int = FULLTEXT_MAX_TERMS,
+    maximum_item_bytes: int = 1_024,
+    allow_empty: bool = True,
+) -> tuple[str, ...]:
+    if not isinstance(value, tuple):
+        raise FullTextContractError(f"{field} must be an immutable tuple")
+    if not allow_empty and not value:
+        raise FullTextContractError(f"{field} cannot be empty")
+    if len(value) > maximum_items:
+        raise FullTextContractError(f"{field} exceeds its item bound")
+    normalized = tuple(
+        _bounded_text(item, field=field, maximum_bytes=maximum_item_bytes)
+        for item in value
+    )
+    if normalized != tuple(sorted(set(normalized))):
+        raise FullTextContractError(f"{field} must be sorted and unique")
+    return normalized
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorityAliasTerm:
+    alias_id: str
+    surface_text: str
+    normalized_text: str
+    valid_from: UtcTimestamp | None
+    valid_until: UtcTimestamp | None
+    rights_current: bool
+    lifecycle: str
+
+    def __post_init__(self) -> None:
+        _bounded_text(self.alias_id, field="authority_alias_id", maximum_bytes=128)
+        _bounded_text(
+            self.surface_text,
+            field="authority_alias_surface_text",
+            maximum_bytes=1_024,
+        )
+        _bounded_text(
+            self.normalized_text,
+            field="authority_alias_normalized_text",
+            maximum_bytes=1_024,
+        )
+        if self.valid_from is not None and not isinstance(
+            self.valid_from, UtcTimestamp
+        ):
+            raise FullTextContractError("authority alias valid_from must be typed")
+        if self.valid_until is not None and not isinstance(
+            self.valid_until, UtcTimestamp
+        ):
+            raise FullTextContractError("authority alias valid_until must be typed")
+        if (
+            self.valid_from is not None
+            and self.valid_until is not None
+            and self.valid_until.value <= self.valid_from.value
+        ):
+            raise FullTextContractError("authority alias validity window is invalid")
+        if not isinstance(self.rights_current, bool):
+            raise FullTextContractError("authority alias rights flag must be boolean")
+        require_token(self.lifecycle, field="authority_alias_lifecycle")
+
+    def is_eligible_at(self, query_valid_time: UtcTimestamp) -> bool:
+        if not isinstance(query_valid_time, UtcTimestamp):
+            raise FullTextContractError("authority alias query-valid time must be typed")
+        if not self.rights_current or self.lifecycle != "ACTIVE":
+            return False
+        if (
+            self.valid_from is not None
+            and query_valid_time.value < self.valid_from.value
+        ):
+            return False
+        return not (
+            self.valid_until is not None
+            and query_valid_time.value >= self.valid_until.value
+        )
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "alias_id": self.alias_id,
+            "surface_text": self.surface_text,
+            "normalized_text": self.normalized_text,
+            "valid_from": (
+                None if self.valid_from is None else self.valid_from.to_text()
+            ),
+            "valid_until": (
+                None if self.valid_until is None else self.valid_until.to_text()
+            ),
+            "rights_current": self.rights_current,
+            "lifecycle": self.lifecycle,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class NormalizedFullTextQuery:
+    surface_text: str
+    normalized_text: str
+    language_mode: FullTextLanguageMode
+    latin_terms: tuple[str, ...]
+    han_bigrams: tuple[str, ...]
+    formal_tokens: tuple[str, ...]
+    authority_alias_terms: tuple[str, ...]
+    authority_alias_ids: tuple[str, ...]
+    lucene_query: str
+    implementation_version: str = "bilingual-search-normalizer-v1"
+    component_digest: str = NORMALIZATION_COMPONENT_DIGEST
+
+    def __post_init__(self) -> None:
+        _bounded_text(
+            self.surface_text,
+            field="fulltext_query_surface",
+            maximum_bytes=FULLTEXT_MAX_QUERY_BYTES,
+        )
+        _bounded_text(
+            self.normalized_text,
+            field="fulltext_query_normalized",
+            maximum_bytes=FULLTEXT_MAX_QUERY_BYTES,
+        )
+        if not isinstance(self.language_mode, FullTextLanguageMode):
+            raise FullTextContractError("full-text language mode must be typed")
+        _sorted_unique(self.latin_terms, field="fulltext_latin_terms")
+        _sorted_unique(self.han_bigrams, field="fulltext_han_bigrams")
+        _sorted_unique(self.formal_tokens, field="fulltext_formal_tokens")
+        _sorted_unique(
+            self.authority_alias_terms,
+            field="fulltext_authority_alias_terms",
+            maximum_items=32,
+        )
+        _sorted_unique(
+            self.authority_alias_ids,
+            field="fulltext_authority_alias_ids",
+            maximum_items=32,
+            maximum_item_bytes=128,
+        )
+        _bounded_text(
+            self.lucene_query,
+            field="fulltext_lucene_query",
+            maximum_bytes=FULLTEXT_MAX_LUCENE_QUERY_BYTES,
+        )
+        require_token(
+            self.implementation_version,
+            field="fulltext_normalizer_implementation_version",
+        )
+        validate_sha256_digest(
+            self.component_digest,
+            field="fulltext_normalization_component_digest",
+        )
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "surface_text": self.surface_text,
+            "normalized_text": self.normalized_text,
+            "language_mode": self.language_mode.value,
+            "latin_terms": list(self.latin_terms),
+            "han_bigrams": list(self.han_bigrams),
+            "formal_tokens": list(self.formal_tokens),
+            "authority_alias_terms": list(self.authority_alias_terms),
+            "authority_alias_ids": list(self.authority_alias_ids),
+            "lucene_query": self.lucene_query,
+            "implementation_version": self.implementation_version,
+            "component_digest": self.component_digest,
+        }
+
+    @property
+    def query_digest(self) -> str:
+        return digest_bytes(canonical_json_bytes(self.canonical_value()))
+
+    @classmethod
+    def from_canonical_value(
+        cls, value: dict[str, object]
+    ) -> "NormalizedFullTextQuery":
+        return cls(
+            surface_text=str(value["surface_text"]),
+            normalized_text=str(value["normalized_text"]),
+            language_mode=FullTextLanguageMode(str(value["language_mode"])),
+            latin_terms=tuple(str(item) for item in value["latin_terms"]),
+            han_bigrams=tuple(str(item) for item in value["han_bigrams"]),
+            formal_tokens=tuple(str(item) for item in value["formal_tokens"]),
+            authority_alias_terms=tuple(
+                str(item) for item in value["authority_alias_terms"]
+            ),
+            authority_alias_ids=tuple(
+                str(item) for item in value["authority_alias_ids"]
+            ),
+            lucene_query=str(value["lucene_query"]),
+            implementation_version=str(value["implementation_version"]),
+            component_digest=str(value["component_digest"]),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class FullTextProjectionSnapshot:
+    generation_id: ProjectionGenerationId
+    generation_state: ProjectionGenerationState
+    generation_identity_digest: str
+    document_label: str
+    index_name: str
+    index_state: FullTextIndexState
+    fulltext_component_digest: str
+    normalization_component_digest: str
+    rights_manifest_digest: str
+    profile: FullTextProfile
+    contiguous_ledger_seq: int
+    open_gap_count: int
+    dead_letter_count: int
+    validation_recorded_at: UtcTimestamp
+    freshness_deadline: UtcTimestamp
+    index_document_count: int
+    provider: str = FULLTEXT_PROVIDER
+    analyzer: str = FULLTEXT_ANALYZER
+    server_version: str = "2026.06.0"
+    driver_version: str = "6.2.0"
+    projection_role: str = "non-authoritative-rebuildable-context"
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.generation_id, ProjectionGenerationId):
+            raise FullTextContractError(
+                "full-text projection generation identity must be typed"
+            )
+        if not isinstance(self.generation_state, ProjectionGenerationState):
+            raise FullTextContractError(
+                "full-text projection generation state must be typed"
+            )
+        for field_name in (
+            "generation_identity_digest",
+            "fulltext_component_digest",
+            "normalization_component_digest",
+            "rights_manifest_digest",
+        ):
+            validate_sha256_digest(
+                getattr(self, field_name),
+                field=field_name,
+            )
+        for field_name in ("document_label", "index_name"):
+            if _NEO4J_NAME.fullmatch(getattr(self, field_name)) is None:
+                raise FullTextContractError(
+                    f"{field_name} is not a bounded server-derived name"
+                )
+        if not isinstance(self.index_state, FullTextIndexState):
+            raise FullTextContractError("full-text index state must be typed")
+        if not isinstance(self.profile, FullTextProfile):
+            raise FullTextContractError("full-text profile must be typed")
+        for field_name in (
+            "contiguous_ledger_seq",
+            "open_gap_count",
+            "dead_letter_count",
+            "index_document_count",
+        ):
+            _non_negative(getattr(self, field_name), field=field_name)
+        if not isinstance(self.validation_recorded_at, UtcTimestamp) or not isinstance(
+            self.freshness_deadline, UtcTimestamp
+        ):
+            raise FullTextContractError("full-text snapshot times must be typed")
+        if self.freshness_deadline.value < self.validation_recorded_at.value:
+            raise FullTextContractError(
+                "full-text freshness deadline precedes validation"
+            )
+        for field_name in (
+            "provider",
+            "analyzer",
+            "server_version",
+            "driver_version",
+        ):
+            _bounded_text(
+                getattr(self, field_name),
+                field=f"fulltext_{field_name}",
+                maximum_bytes=128,
+            )
+        if self.projection_role != "non-authoritative-rebuildable-context":
+            raise FullTextContractError("full-text projection role is invalid")
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "generation_id": str(self.generation_id),
+            "generation_state": self.generation_state.value,
+            "generation_identity_digest": self.generation_identity_digest,
+            "document_label": self.document_label,
+            "index_name": self.index_name,
+            "index_state": self.index_state.value,
+            "fulltext_component_digest": self.fulltext_component_digest,
+            "normalization_component_digest": self.normalization_component_digest,
+            "rights_manifest_digest": self.rights_manifest_digest,
+            "profile": self.profile.value,
+            "contiguous_ledger_seq": self.contiguous_ledger_seq,
+            "open_gap_count": self.open_gap_count,
+            "dead_letter_count": self.dead_letter_count,
+            "validation_recorded_at": self.validation_recorded_at.to_text(),
+            "freshness_deadline": self.freshness_deadline.to_text(),
+            "index_document_count": self.index_document_count,
+            "provider": self.provider,
+            "analyzer": self.analyzer,
+            "server_version": self.server_version,
+            "driver_version": self.driver_version,
+            "projection_role": self.projection_role,
+        }
+
+    @property
+    def snapshot_digest(self) -> str:
+        return digest_bytes(canonical_json_bytes(self.canonical_value()))
+
+    @classmethod
+    def from_canonical_value(
+        cls, value: dict[str, object]
+    ) -> "FullTextProjectionSnapshot":
+        return cls(
+            generation_id=ProjectionGenerationId.parse(
+                str(value["generation_id"])
+            ),
+            generation_state=ProjectionGenerationState(
+                str(value["generation_state"])
+            ),
+            generation_identity_digest=str(value["generation_identity_digest"]),
+            document_label=str(value["document_label"]),
+            index_name=str(value["index_name"]),
+            index_state=FullTextIndexState(str(value["index_state"])),
+            fulltext_component_digest=str(value["fulltext_component_digest"]),
+            normalization_component_digest=str(
+                value["normalization_component_digest"]
+            ),
+            rights_manifest_digest=str(value["rights_manifest_digest"]),
+            profile=FullTextProfile(str(value["profile"])),
+            contiguous_ledger_seq=int(value["contiguous_ledger_seq"]),
+            open_gap_count=int(value["open_gap_count"]),
+            dead_letter_count=int(value["dead_letter_count"]),
+            validation_recorded_at=UtcTimestamp.parse(
+                str(value["validation_recorded_at"])
+            ),
+            freshness_deadline=UtcTimestamp.parse(
+                str(value["freshness_deadline"])
+            ),
+            index_document_count=int(value["index_document_count"]),
+            provider=str(value["provider"]),
+            analyzer=str(value["analyzer"]),
+            server_version=str(value["server_version"]),
+            driver_version=str(value["driver_version"]),
+            projection_role=str(value["projection_role"]),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class FullTextDocumentBinding:
+    passage_id: str
+    dependency_root_id: str
+    source_identity: str
+    provenance_digest: str
+    language: str
+    rights_current: bool
+    lifecycle: str
+    valid_from: UtcTimestamp | None = None
+    valid_until: UtcTimestamp | None = None
+    trust_scope: TrustScope = TrustScope.OBSERVED
+
+    def __post_init__(self) -> None:
+        require_token(self.passage_id, field="fulltext_passage_id")
+        for field_name in (
+            "dependency_root_id",
+            "source_identity",
+        ):
+            _bounded_text(
+                getattr(self, field_name),
+                field=field_name,
+                maximum_bytes=256,
+            )
+        validate_sha256_digest(
+            self.provenance_digest,
+            field="fulltext_binding_provenance_digest",
+        )
+        if self.language not in {"en-GB", "zh-HK"}:
+            raise FullTextContractError("full-text binding language is invalid")
+        if not isinstance(self.rights_current, bool):
+            raise FullTextContractError(
+                "full-text binding rights flag must be boolean"
+            )
+        require_token(self.lifecycle, field="fulltext_binding_lifecycle")
+        if self.valid_from is not None and not isinstance(
+            self.valid_from, UtcTimestamp
+        ):
+            raise FullTextContractError("full-text binding valid_from must be typed")
+        if self.valid_until is not None and not isinstance(
+            self.valid_until, UtcTimestamp
+        ):
+            raise FullTextContractError("full-text binding valid_until must be typed")
+        if (
+            self.valid_from is not None
+            and self.valid_until is not None
+            and self.valid_until.value <= self.valid_from.value
+        ):
+            raise FullTextContractError("full-text binding validity window is invalid")
+        if self.trust_scope is not TrustScope.OBSERVED:
+            raise FullTextContractError(
+                "full-text projection bindings remain OBSERVED"
+            )
+
+    def exclusion_at(
+        self, query_valid_time: UtcTimestamp
+    ) -> BranchExclusionReason | None:
+        if not isinstance(query_valid_time, UtcTimestamp):
+            raise FullTextContractError(
+                "full-text binding query-valid time must be typed"
+            )
+        if not self.rights_current:
+            return BranchExclusionReason.RIGHTS_NOT_CURRENT
+        if self.lifecycle in {
+            "TOMBSTONED",
+            "RETIRED",
+            "REJECTED",
+            "REVOKED",
+            "MERGED",
+            "SPLIT",
+            "REVERSED",
+        }:
+            return BranchExclusionReason.TOMBSTONED
+        if self.lifecycle != "ACTIVE":
+            return BranchExclusionReason.STALE_SOURCE_VERSION
+        if (
+            self.valid_from is not None
+            and query_valid_time.value < self.valid_from.value
+        ) or (
+            self.valid_until is not None
+            and query_valid_time.value >= self.valid_until.value
+        ):
+            return BranchExclusionReason.OUTSIDE_QUERY_VALID_TIME
+        return None
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "passage_id": self.passage_id,
+            "dependency_root_id": self.dependency_root_id,
+            "source_identity": self.source_identity,
+            "provenance_digest": self.provenance_digest,
+            "language": self.language,
+            "rights_current": self.rights_current,
+            "lifecycle": self.lifecycle,
+            "valid_from": (
+                None if self.valid_from is None else self.valid_from.to_text()
+            ),
+            "valid_until": (
+                None if self.valid_until is None else self.valid_until.to_text()
+            ),
+            "trust_scope": self.trust_scope.value,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class FullTextAuthorityView:
+    snapshot: FullTextProjectionSnapshot
+    authority_aliases: tuple[AuthorityAliasTerm, ...]
+    document_bindings: tuple[FullTextDocumentBinding, ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.snapshot, FullTextProjectionSnapshot):
+            raise FullTextContractError("full-text authority snapshot must be typed")
+        if (
+            not isinstance(self.authority_aliases, tuple)
+            or len(self.authority_aliases) > 32
+            or any(
+                not isinstance(item, AuthorityAliasTerm)
+                for item in self.authority_aliases
+            )
+        ):
+            raise FullTextContractError(
+                "full-text authority aliases must be a bounded typed tuple"
+            )
+        alias_ids = tuple(item.alias_id for item in self.authority_aliases)
+        if alias_ids != tuple(sorted(set(alias_ids))):
+            raise FullTextContractError(
+                "full-text authority aliases must be sorted and unique"
+            )
+        if (
+            not isinstance(self.document_bindings, tuple)
+            or len(self.document_bindings) > 4_096
+            or any(
+                not isinstance(item, FullTextDocumentBinding)
+                for item in self.document_bindings
+            )
+        ):
+            raise FullTextContractError(
+                "full-text document bindings must be a bounded typed tuple"
+            )
+        passage_ids = tuple(item.passage_id for item in self.document_bindings)
+        if passage_ids != tuple(sorted(set(passage_ids))):
+            raise FullTextContractError(
+                "full-text document bindings must be sorted and unique"
+            )
+
+    @property
+    def binding_by_passage_id(self) -> dict[str, FullTextDocumentBinding]:
+        return {item.passage_id: item for item in self.document_bindings}
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "snapshot": self.snapshot.canonical_value(),
+            "authority_aliases": [
+                item.canonical_value() for item in self.authority_aliases
+            ],
+            "document_bindings": [
+                item.canonical_value() for item in self.document_bindings
+            ],
+        }
+
+    @property
+    def view_digest(self) -> str:
+        return digest_bytes(canonical_json_bytes(self.canonical_value()))
+
+
+@dataclass(frozen=True, slots=True)
+class FullTextBranchRequest:
+    request_id: BranchRequestId
+    idempotency_key: str
+    actor_id: str
+    purpose: str
+    policy_id: str
+    contract_digest: str
+    fulltext_component_digest: str
+    normalization_component_digest: str
+    expected_generation_id: ProjectionGenerationId
+    expected_generation_identity_digest: str
+    expected_rights_manifest_digest: str
+    query_text: str
+    language_mode: FullTextLanguageMode
+    query_valid_time: UtcTimestamp
+    serving_time: UtcTimestamp
+    minimum_watermark: int
+    result_limit: int = BRANCH_RESULT_LIMIT
+    timeout_ms: int = BRANCH_TIMEOUT_MS
+    response_byte_limit: int = FULLTEXT_RESPONSE_BYTE_LIMIT
+    max_projection_age_seconds: int = FULLTEXT_MAX_PROJECTION_AGE_SECONDS
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.request_id, BranchRequestId):
+            raise FullTextContractError(
+                "full-text request identity must be typed"
+            )
+        _bounded_text(
+            self.idempotency_key,
+            field="fulltext_idempotency_key",
+            maximum_bytes=256,
+        )
+        require_token(self.actor_id, field="fulltext_actor_id")
+        require_token(self.purpose, field="fulltext_purpose")
+        if self.actor_id != FULLTEXT_ACTOR_ID or self.purpose != FULLTEXT_PURPOSE:
+            raise FullTextContractError(
+                "full-text actor and purpose must equal the reviewed lane"
+            )
+        require_token(self.policy_id, field="fulltext_policy_id")
+        for field_name in (
+            "contract_digest",
+            "fulltext_component_digest",
+            "normalization_component_digest",
+            "expected_generation_identity_digest",
+            "expected_rights_manifest_digest",
+        ):
+            validate_sha256_digest(getattr(self, field_name), field=field_name)
+        if not isinstance(
+            self.expected_generation_id, ProjectionGenerationId
+        ):
+            raise FullTextContractError(
+                "expected full-text generation identity must be typed"
+            )
+        _bounded_text(
+            self.query_text,
+            field="fulltext_query_text",
+            maximum_bytes=FULLTEXT_MAX_QUERY_BYTES,
+        )
+        if not isinstance(self.language_mode, FullTextLanguageMode):
+            raise FullTextContractError("full-text language mode must be typed")
+        if not isinstance(self.query_valid_time, UtcTimestamp) or not isinstance(
+            self.serving_time, UtcTimestamp
+        ):
+            raise FullTextContractError("full-text request times must be typed")
+        _non_negative(self.minimum_watermark, field="minimum_watermark")
+        if self.result_limit != BRANCH_RESULT_LIMIT:
+            raise FullTextContractError(
+                "full-text result limit must remain fixed at 8"
+            )
+        if self.timeout_ms != BRANCH_TIMEOUT_MS:
+            raise FullTextContractError(
+                "full-text timeout must remain fixed at 5000 ms"
+            )
+        if self.response_byte_limit != FULLTEXT_RESPONSE_BYTE_LIMIT:
+            raise FullTextContractError(
+                "full-text response byte limit must remain fixed"
+            )
+        if (
+            self.max_projection_age_seconds
+            != FULLTEXT_MAX_PROJECTION_AGE_SECONDS
+        ):
+            raise FullTextContractError(
+                "full-text projection age limit must remain fixed"
+            )
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "schema_version": "newsroom.increment5.fulltext-branch-request.v1",
+            "request_id": str(self.request_id),
+            "idempotency_key": self.idempotency_key,
+            "actor_id": self.actor_id,
+            "purpose": self.purpose,
+            "policy_id": self.policy_id,
+            "contract_digest": self.contract_digest,
+            "fulltext_component_digest": self.fulltext_component_digest,
+            "normalization_component_digest": (
+                self.normalization_component_digest
+            ),
+            "expected_generation_id": str(self.expected_generation_id),
+            "expected_generation_identity_digest": (
+                self.expected_generation_identity_digest
+            ),
+            "expected_rights_manifest_digest": (
+                self.expected_rights_manifest_digest
+            ),
+            "query_text": self.query_text,
+            "language_mode": self.language_mode.value,
+            "query_valid_time": self.query_valid_time.to_text(),
+            "serving_time": self.serving_time.to_text(),
+            "minimum_watermark": self.minimum_watermark,
+            "result_limit": self.result_limit,
+            "timeout_ms": self.timeout_ms,
+            "response_byte_limit": self.response_byte_limit,
+            "max_projection_age_seconds": (
+                self.max_projection_age_seconds
+            ),
+        }
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return canonical_json_bytes(self.canonical_value())
+
+    @property
+    def request_digest(self) -> str:
+        return digest_bytes(self.canonical_bytes)
+
+
+__all__ = [
+    "AuthorityAliasTerm",
+    "FULLTEXT_ACTOR_ID",
+    "FULLTEXT_ANALYZER",
+    "FULLTEXT_COMPONENT_DIGEST",
+    "FULLTEXT_INDEXED_FIELDS",
+    "FULLTEXT_MAX_LUCENE_QUERY_BYTES",
+    "FULLTEXT_MAX_PROJECTION_AGE_SECONDS",
+    "FULLTEXT_MAX_QUERY_BYTES",
+    "FULLTEXT_MAX_TERMS",
+    "FULLTEXT_POLICY_ID",
+    "FULLTEXT_PROVIDER",
+    "FULLTEXT_PURPOSE",
+    "FULLTEXT_QUERY_ID",
+    "FULLTEXT_RESPONSE_BYTE_LIMIT",
+    "FullTextAuthorityView",
+    "FullTextBranchRequest",
+    "FullTextContractError",
+    "FullTextDocumentBinding",
+    "FullTextIndexState",
+    "FullTextLanguageMode",
+    "FullTextProfile",
+    "FullTextProjectionSnapshot",
+    "INCREMENT5_RETRIEVAL_CONTRACT_DIGEST",
+    "NORMALIZATION_COMPONENT_DIGEST",
+    "NormalizedFullTextQuery",
+]

--- a/newsroom/increment5/fulltext_journal.py
+++ b/newsroom/increment5/fulltext_journal.py
@@ -1,0 +1,291 @@
+"""Non-authoritative immutable SQLite journal for 5B2 full-text receipts."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+import sqlite3
+
+from newsroom.authority.canonical import digest_bytes
+from newsroom.increment5.branch_contracts import BranchOutcome
+from .fulltext_contracts import FullTextBranchRequest, FullTextContractError
+from .fulltext_normalizer import BilingualSearchNormalizer
+from .fulltext_receipts import FullTextBranchReceipt
+from .fulltext_snapshot_policy import fulltext_snapshot_failure
+
+
+class FullTextReceiptJournalError(RuntimeError):
+    """The full-text receipt journal is unavailable or inconsistent."""
+
+
+class FullTextReceiptIdempotencyConflict(FullTextReceiptJournalError):
+    """An idempotency key was reused for materially different request bytes."""
+
+
+@dataclass(frozen=True, slots=True)
+class FullTextJournalResult:
+    receipt: FullTextBranchReceipt
+    replayed: bool
+
+
+_SCHEMA = (
+    """CREATE TABLE IF NOT EXISTS increment5_fulltext_receipts(
+        idempotency_key TEXT PRIMARY KEY,
+        request_digest TEXT NOT NULL UNIQUE,
+        request_bytes BLOB NOT NULL,
+        receipt_digest TEXT NOT NULL UNIQUE,
+        receipt_bytes BLOB NOT NULL,
+        recorded_at TEXT NOT NULL,
+        CHECK(length(request_bytes)>0),
+        CHECK(length(receipt_bytes)>0)
+    ) STRICT""",
+    """CREATE TRIGGER IF NOT EXISTS immutable_increment5_fulltext_receipt_update
+       BEFORE UPDATE ON increment5_fulltext_receipts BEGIN
+       SELECT RAISE(ABORT,'immutable Increment 5 full-text receipt'); END""",
+    """CREATE TRIGGER IF NOT EXISTS immutable_increment5_fulltext_receipt_delete
+       BEFORE DELETE ON increment5_fulltext_receipts BEGIN
+       SELECT RAISE(ABORT,'Increment 5 full-text receipts are retained'); END""",
+)
+
+
+class FullTextReceiptJournal:
+    """Return the first canonical full-text receipt byte-for-byte on replay."""
+
+    def __init__(self, path: Path) -> None:
+        if not isinstance(path, Path):
+            raise TypeError("full-text journal path must be a pathlib.Path")
+        self._path = path.resolve()
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            with self._connect() as connection:
+                for statement in _SCHEMA:
+                    connection.execute(statement)
+        except sqlite3.Error as exc:
+            raise FullTextReceiptJournalError(
+                "cannot initialise Increment 5 full-text receipt journal"
+            ) from exc
+
+    def execute(
+        self,
+        request: FullTextBranchRequest,
+        producer: Callable[[], FullTextBranchReceipt],
+    ) -> FullTextJournalResult:
+        if not isinstance(request, FullTextBranchRequest):
+            raise TypeError("full-text journal request must be typed")
+        if not callable(producer):
+            raise TypeError("full-text receipt producer must be callable")
+
+        try:
+            existing = self._read_existing(request)
+            if existing is not None:
+                return FullTextJournalResult(
+                    receipt=existing,
+                    replayed=True,
+                )
+
+            # Authority and Neo4j work must never execute while this journal
+            # holds a SQLite write reservation.  Concurrent new requests may
+            # therefore run their independently bounded producers in parallel.
+            receipt = producer()
+            if not isinstance(receipt, FullTextBranchReceipt):
+                raise FullTextReceiptJournalError(
+                    "full-text producer returned an untyped receipt"
+                )
+            try:
+                self._require_request_binding(receipt, request)
+            except FullTextReceiptJournalError as exc:
+                raise FullTextReceiptJournalError(
+                    "produced full-text receipt differs from the stable request"
+                ) from exc
+            return self._insert_or_replay(request, receipt)
+        except FullTextReceiptIdempotencyConflict:
+            raise
+        except FullTextReceiptJournalError:
+            raise
+        except (sqlite3.Error, FullTextContractError) as exc:
+            raise FullTextReceiptJournalError(
+                "Increment 5 full-text receipt journal is unavailable or inconsistent"
+            ) from exc
+
+    def _read_existing(
+        self,
+        request: FullTextBranchRequest,
+    ) -> FullTextBranchReceipt | None:
+        connection = self._connect()
+        try:
+            row = connection.execute(
+                "SELECT request_digest,request_bytes,receipt_digest,receipt_bytes "
+                "FROM increment5_fulltext_receipts WHERE idempotency_key=?",
+                (request.idempotency_key,),
+            ).fetchone()
+            if row is None:
+                row = connection.execute(
+                    "SELECT request_digest,request_bytes,receipt_digest,receipt_bytes "
+                    "FROM increment5_fulltext_receipts WHERE request_digest=?",
+                    (request.request_digest,),
+                ).fetchone()
+            if row is None:
+                return None
+            return self._verified_receipt(row, request=request)
+        finally:
+            connection.close()
+
+    def _insert_or_replay(
+        self,
+        request: FullTextBranchRequest,
+        receipt: FullTextBranchReceipt,
+    ) -> FullTextJournalResult:
+        connection = self._connect()
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            row = connection.execute(
+                "SELECT request_digest,request_bytes,receipt_digest,receipt_bytes "
+                "FROM increment5_fulltext_receipts WHERE idempotency_key=?",
+                (request.idempotency_key,),
+            ).fetchone()
+            if row is None:
+                row = connection.execute(
+                    "SELECT request_digest,request_bytes,receipt_digest,receipt_bytes "
+                    "FROM increment5_fulltext_receipts WHERE request_digest=?",
+                    (request.request_digest,),
+                ).fetchone()
+            if row is not None:
+                retained = self._verified_receipt(row, request=request)
+                connection.commit()
+                return FullTextJournalResult(
+                    receipt=retained,
+                    replayed=True,
+                )
+
+            receipt_bytes = receipt.canonical_bytes
+            connection.execute(
+                "INSERT INTO increment5_fulltext_receipts("
+                "idempotency_key,request_digest,request_bytes,"
+                "receipt_digest,receipt_bytes,recorded_at"
+                ") VALUES(?,?,?,?,?,?)",
+                (
+                    request.idempotency_key,
+                    request.request_digest,
+                    request.canonical_bytes,
+                    receipt.receipt_digest,
+                    receipt_bytes,
+                    receipt.completed_at.to_text(),
+                ),
+            )
+            connection.commit()
+            return FullTextJournalResult(
+                receipt=receipt,
+                replayed=False,
+            )
+        finally:
+            connection.close()
+
+    @staticmethod
+    def _verified_receipt(
+        row: sqlite3.Row,
+        *,
+        request: FullTextBranchRequest,
+    ) -> FullTextBranchReceipt:
+        stored_request_digest = str(row["request_digest"])
+        stored_request_bytes = bytes(row["request_bytes"])
+        if (
+            stored_request_digest != request.request_digest
+            or stored_request_bytes != request.canonical_bytes
+        ):
+            raise FullTextReceiptIdempotencyConflict(
+                "Increment 5 full-text idempotency key was reused with another request"
+            )
+        receipt_bytes = bytes(row["receipt_bytes"])
+        if digest_bytes(receipt_bytes) != str(row["receipt_digest"]):
+            raise FullTextReceiptJournalError(
+                "stored full-text receipt digest differs"
+            )
+        receipt = FullTextBranchReceipt.from_canonical_bytes(receipt_bytes)
+        FullTextReceiptJournal._require_request_binding(receipt, request)
+        return receipt
+
+    @staticmethod
+    def _require_request_binding(
+        receipt: FullTextBranchReceipt,
+        request: FullTextBranchRequest,
+    ) -> None:
+        if (
+            receipt.request_id != request.request_id
+            or receipt.request_digest != request.request_digest
+            or receipt.contract_digest != request.contract_digest
+            or receipt.policy_id != request.policy_id
+            or receipt.fulltext_component_digest
+            != request.fulltext_component_digest
+            or receipt.normalization_component_digest
+            != request.normalization_component_digest
+            or receipt.started_at != request.serving_time
+            or receipt.completed_at != request.serving_time
+        ):
+            raise FullTextReceiptJournalError(
+                "stored full-text receipt request binding differs"
+            )
+        if receipt.snapshot is not None:
+            snapshot_failure = fulltext_snapshot_failure(
+                request,
+                receipt.snapshot,
+            )
+            if snapshot_failure is not None:
+                expected_outcome, expected_reason = snapshot_failure
+                timeout_override = (
+                    receipt.outcome is BranchOutcome.INCOMPLETE
+                    and receipt.reason_code == "QUERY_TIMEOUT"
+                )
+                if timeout_override:
+                    if (
+                        receipt.normalized_query is not None
+                        or receipt.neo4j_read_count != 0
+                        or receipt.hits
+                        or receipt.exclusions
+                    ):
+                        raise FullTextReceiptJournalError(
+                            "stored full-text receipt request binding differs"
+                        )
+                    return
+                if (
+                    receipt.outcome is not expected_outcome
+                    or receipt.reason_code != expected_reason
+                    or receipt.normalized_query is not None
+                    or receipt.neo4j_read_count != 0
+                    or receipt.hits
+                    or receipt.exclusions
+                ):
+                    raise FullTextReceiptJournalError(
+                        "stored full-text receipt request binding differs"
+                    )
+                return
+        if receipt.normalized_query is not None:
+            try:
+                BilingualSearchNormalizer().validate_request_binding(
+                    receipt.normalized_query,
+                    surface_text=request.query_text,
+                    language_mode=request.language_mode,
+                )
+            except FullTextContractError as exc:
+                raise FullTextReceiptJournalError(
+                    "stored full-text receipt request binding differs"
+                ) from exc
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(
+            self._path,
+            isolation_level=None,
+            timeout=5.0,
+        )
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA foreign_keys=ON")
+        connection.execute("PRAGMA busy_timeout=5000")
+        return connection
+
+
+__all__ = [
+    "FullTextJournalResult",
+    "FullTextReceiptIdempotencyConflict",
+    "FullTextReceiptJournal",
+    "FullTextReceiptJournalError",
+]

--- a/newsroom/increment5/fulltext_normalizer.py
+++ b/newsroom/increment5/fulltext_normalizer.py
@@ -1,0 +1,278 @@
+"""Reviewed bilingual normalizer and fixed Lucene query builder for 5B2."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+from newsroom.authority.types import UtcTimestamp
+
+from .fulltext_contracts import (
+    AuthorityAliasTerm,
+    FULLTEXT_MAX_TERMS,
+    FullTextContractError,
+    FullTextLanguageMode,
+    NORMALIZATION_COMPONENT_DIGEST,
+    NormalizedFullTextQuery,
+)
+
+
+_LATIN_TERM = re.compile(r"[a-z0-9]+(?:['’.-][a-z0-9]+)*", re.IGNORECASE)
+_FORMAL_TOKEN = re.compile(
+    r"(?<![a-z0-9])(?:[a-z]{1,16}[-/:.]?)?\d+(?:[-/:.]\d+)+(?![a-z0-9])"
+    r"|(?<![a-z0-9])[a-z]{1,16}-\d+[a-z0-9./:-]*(?![a-z0-9])",
+    re.IGNORECASE,
+)
+_HAN_SEQUENCE = re.compile(r"[\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff]+")
+_LUCENE_SPECIAL = frozenset(r'+-&|!(){}[]^"~*?:\/')
+
+
+def _collapse_nfkc(value: str) -> str:
+    normalized = value.replace("\r\n", "\n").replace("\r", "\n")
+    normalized = unicodedata.normalize("NFKC", normalized)
+    normalized = " ".join(normalized.split())
+    if not normalized:
+        raise FullTextContractError("normalized full-text query is empty")
+    return normalized
+
+
+def _casefold_latin(value: str) -> str:
+    # Unicode casefold does not convert traditional Han into another script.
+    return value.casefold()
+
+
+def _escape_lucene_term(value: str) -> str:
+    escaped: list[str] = []
+    for character in value:
+        if character in _LUCENE_SPECIAL:
+            escaped.append("\\")
+        escaped.append(character)
+    return "".join(escaped)
+
+
+def _field_clause(field: str, value: str) -> str:
+    if field not in {
+        "authority_aliases",
+        "formal_tokens",
+        "han_bigrams",
+        "latin_terms",
+        "retrieval_text",
+    }:
+        raise FullTextContractError("full-text query builder field is not reviewed")
+    return f'{field}:"{_escape_lucene_term(value)}"'
+
+
+def _bounded_sorted(values: set[str], *, field: str) -> tuple[str, ...]:
+    if len(values) > FULLTEXT_MAX_TERMS:
+        raise FullTextContractError(f"{field} exceeds the reviewed term bound")
+    return tuple(sorted(values))
+
+
+def _ascii_word_edge(character: str) -> bool:
+    return character.isascii() and character.isalnum()
+
+
+def _alias_is_mentioned(
+    normalized_text: str,
+    normalized_alias: str,
+) -> bool:
+    left = r"(?<![a-z0-9])" if _ascii_word_edge(normalized_alias[0]) else ""
+    right = r"(?![a-z0-9])" if _ascii_word_edge(normalized_alias[-1]) else ""
+    return re.search(
+        f"{left}{re.escape(normalized_alias)}{right}",
+        normalized_text,
+    ) is not None
+
+
+def _normalization_core(
+    surface_text: str,
+) -> tuple[str, str, tuple[str, ...], tuple[str, ...], tuple[str, ...]]:
+    collapsed = _collapse_nfkc(surface_text)
+    normalized = _casefold_latin(collapsed)
+    formal_tokens = {
+        match.group(0).casefold()
+        for match in _FORMAL_TOKEN.finditer(normalized)
+    }
+    latin_terms = {
+        match.group(0).casefold()
+        for match in _LATIN_TERM.finditer(normalized)
+        if any(
+            "a" <= character <= "z"
+            for character in match.group(0).casefold()
+        )
+    }
+    han_bigrams: set[str] = set()
+    for match in _HAN_SEQUENCE.finditer(normalized):
+        sequence = match.group(0)
+        han_bigrams.update(
+            sequence[index : index + 2]
+            for index in range(max(0, len(sequence) - 1))
+        )
+    return (
+        collapsed,
+        normalized,
+        _bounded_sorted(latin_terms, field="latin_terms"),
+        _bounded_sorted(han_bigrams, field="han_bigrams"),
+        _bounded_sorted(formal_tokens, field="formal_tokens"),
+    )
+
+
+def _build_lucene_query(
+    *,
+    normalized_text: str,
+    latin_terms: tuple[str, ...],
+    han_bigrams: tuple[str, ...],
+    formal_tokens: tuple[str, ...],
+    authority_alias_terms: tuple[str, ...],
+) -> str:
+    clauses = {_field_clause("retrieval_text", normalized_text)}
+    clauses.update(
+        _field_clause("latin_terms", item) for item in latin_terms
+    )
+    clauses.update(
+        _field_clause("han_bigrams", item) for item in han_bigrams
+    )
+    clauses.update(
+        _field_clause("formal_tokens", item) for item in formal_tokens
+    )
+    clauses.update(
+        _field_clause("authority_aliases", item)
+        for item in authority_alias_terms
+    )
+    return " OR ".join(sorted(clauses))
+
+
+class BilingualSearchNormalizer:
+    """NFKC bilingual normalization with no transliteration or script conversion."""
+
+    implementation_version = "bilingual-search-normalizer-v1"
+    component_digest = NORMALIZATION_COMPONENT_DIGEST
+
+    def validate_request_binding(
+        self,
+        query: NormalizedFullTextQuery,
+        *,
+        surface_text: str,
+        language_mode: FullTextLanguageMode,
+    ) -> None:
+        if not isinstance(query, NormalizedFullTextQuery):
+            raise FullTextContractError(
+                "retained full-text query must be typed"
+            )
+        if not isinstance(language_mode, FullTextLanguageMode):
+            raise FullTextContractError(
+                "retained full-text language mode must be typed"
+            )
+        collapsed, normalized, latin, han, formal = _normalization_core(
+            surface_text
+        )
+        if (
+            query.surface_text != collapsed
+            or query.normalized_text != normalized
+            or query.language_mode is not language_mode
+            or query.latin_terms != latin
+            or query.han_bigrams != han
+            or query.formal_tokens != formal
+            or query.implementation_version != self.implementation_version
+            or query.component_digest != self.component_digest
+        ):
+            raise FullTextContractError(
+                "retained full-text query differs from its request core"
+            )
+        if bool(query.authority_alias_terms) != bool(
+            query.authority_alias_ids
+        ) or any(
+            not _alias_is_mentioned(normalized, item)
+            for item in query.authority_alias_terms
+        ):
+            raise FullTextContractError(
+                "retained full-text authority aliases differ from request text"
+            )
+        expected_lucene = _build_lucene_query(
+            normalized_text=normalized,
+            latin_terms=latin,
+            han_bigrams=han,
+            formal_tokens=formal,
+            authority_alias_terms=query.authority_alias_terms,
+        )
+        if query.lucene_query != expected_lucene:
+            raise FullTextContractError(
+                "retained full-text Lucene expression differs"
+            )
+
+    def normalize(
+        self,
+        *,
+        surface_text: str,
+        language_mode: FullTextLanguageMode,
+        query_valid_time: UtcTimestamp,
+        authority_aliases: tuple[AuthorityAliasTerm, ...] = (),
+    ) -> NormalizedFullTextQuery:
+        if not isinstance(surface_text, str) or not surface_text:
+            raise FullTextContractError("full-text surface query is required")
+        if not isinstance(language_mode, FullTextLanguageMode):
+            raise FullTextContractError("full-text language mode must be typed")
+        if not isinstance(query_valid_time, UtcTimestamp):
+            raise FullTextContractError("normalizer query-valid time must be typed")
+        if not isinstance(authority_aliases, tuple):
+            raise FullTextContractError(
+                "authority aliases must be an immutable typed tuple"
+            )
+        if len(authority_aliases) > 32 or any(
+            not isinstance(item, AuthorityAliasTerm)
+            for item in authority_aliases
+        ):
+            raise FullTextContractError(
+                "authority aliases exceed their typed bound"
+            )
+
+        collapsed, normalized, latin, han, formal = (
+            _normalization_core(surface_text)
+        )
+
+        alias_pairs: list[tuple[str, str]] = []
+        for alias in authority_aliases:
+            if not alias.is_eligible_at(query_valid_time):
+                continue
+            normalized_alias = _casefold_latin(
+                _collapse_nfkc(alias.surface_text)
+            )
+            if normalized_alias != alias.normalized_text:
+                raise FullTextContractError(
+                    "authority alias normalized text differs from reviewed normalizer"
+                )
+            if _alias_is_mentioned(normalized, normalized_alias):
+                alias_pairs.append((alias.alias_id, normalized_alias))
+
+        alias_pairs = sorted(set(alias_pairs))
+        authority_alias_ids = tuple(sorted({item[0] for item in alias_pairs}))
+        authority_alias_terms = tuple(sorted({item[1] for item in alias_pairs}))
+        if len(authority_alias_ids) > 32:
+            raise FullTextContractError(
+                "eligible authority aliases exceed their bound"
+            )
+
+        lucene_query = _build_lucene_query(
+            normalized_text=normalized,
+            latin_terms=latin,
+            han_bigrams=han,
+            formal_tokens=formal,
+            authority_alias_terms=authority_alias_terms,
+        )
+
+        return NormalizedFullTextQuery(
+            surface_text=collapsed,
+            normalized_text=normalized,
+            language_mode=language_mode,
+            latin_terms=latin,
+            han_bigrams=han,
+            formal_tokens=formal,
+            authority_alias_terms=authority_alias_terms,
+            authority_alias_ids=authority_alias_ids,
+            lucene_query=lucene_query,
+            implementation_version=self.implementation_version,
+            component_digest=self.component_digest,
+        )
+
+
+__all__ = ["BilingualSearchNormalizer"]

--- a/newsroom/increment5/fulltext_receipts.py
+++ b/newsroom/increment5/fulltext_receipts.py
@@ -1,0 +1,440 @@
+"""Canonical independently attributable receipts for the 5B2 full-text branch."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from typing import Any
+
+from newsroom.authority.canonical import (
+    CanonicalizationError,
+    canonical_json_bytes,
+    digest_bytes,
+    validate_sha256_digest,
+)
+from newsroom.authority.types import TrustScope, UtcTimestamp, require_token
+from newsroom.increment5.branch_contracts import (
+    BRANCH_RESULT_LIMIT,
+    BRANCH_TIMEOUT_MS,
+    BranchExclusion,
+    BranchExclusionReason,
+    BranchOutcome,
+    BranchReceiptId,
+    BranchRequestId,
+)
+from newsroom.retrieval.models import (
+    RetrievalBranch,
+    RetrievalBranchHit,
+    RetrievalContractError,
+)
+
+from .fulltext_contracts import (
+    FULLTEXT_QUERY_ID,
+    FULLTEXT_RESPONSE_BYTE_LIMIT,
+    FullTextContractError,
+    FullTextProjectionSnapshot,
+    NormalizedFullTextQuery,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class FullTextBranchReceipt:
+    receipt_id: BranchReceiptId
+    request_id: BranchRequestId
+    request_digest: str
+    contract_digest: str
+    policy_id: str
+    fulltext_component_digest: str
+    normalization_component_digest: str
+    outcome: BranchOutcome
+    reason_code: str
+    started_at: UtcTimestamp
+    completed_at: UtcTimestamp
+    elapsed_ms: int
+    snapshot: FullTextProjectionSnapshot | None
+    authority_view_digest: str | None
+    normalized_query: NormalizedFullTextQuery | None
+    hits: tuple[RetrievalBranchHit, ...]
+    exclusions: tuple[BranchExclusion, ...]
+    authority_read_count: int
+    neo4j_read_count: int
+    implementation_version: str = "neo4j-fulltext-generation-v1"
+    external_call_count: int = 0
+    gross_cost_microunits: int = 0
+    authority_effect: str = "NONE"
+    hybrid_result_claimed: bool = False
+    projection_text_factual_use_allowed: bool = False
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.receipt_id, BranchReceiptId) or not isinstance(
+            self.request_id, BranchRequestId
+        ):
+            raise FullTextContractError(
+                "full-text receipt identities must be typed"
+            )
+        for field_name in (
+            "request_digest",
+            "contract_digest",
+            "fulltext_component_digest",
+            "normalization_component_digest",
+        ):
+            validate_sha256_digest(getattr(self, field_name), field=field_name)
+        if self.authority_view_digest is not None:
+            validate_sha256_digest(
+                self.authority_view_digest,
+                field="fulltext_authority_view_digest",
+            )
+        require_token(self.policy_id, field="fulltext_receipt_policy_id")
+        if not isinstance(self.outcome, BranchOutcome):
+            raise FullTextContractError(
+                "full-text receipt outcome must be typed"
+            )
+        require_token(self.reason_code, field="fulltext_reason_code")
+        if not isinstance(self.started_at, UtcTimestamp) or not isinstance(
+            self.completed_at, UtcTimestamp
+        ):
+            raise FullTextContractError("full-text receipt times must be typed")
+        if self.completed_at.value < self.started_at.value:
+            raise FullTextContractError(
+                "full-text receipt completion precedes start"
+            )
+        if (
+            isinstance(self.elapsed_ms, bool)
+            or not isinstance(self.elapsed_ms, int)
+            or not 0 <= self.elapsed_ms <= BRANCH_TIMEOUT_MS
+        ):
+            raise FullTextContractError(
+                "full-text elapsed time exceeds its hard bound"
+            )
+        if self.reason_code == "QUERY_TIMEOUT" and (
+            self.outcome is not BranchOutcome.INCOMPLETE
+            or self.elapsed_ms != BRANCH_TIMEOUT_MS
+        ):
+            raise FullTextContractError(
+                "full-text timeout receipt differs from its hard deadline"
+            )
+        if self.snapshot is not None and not isinstance(
+            self.snapshot, FullTextProjectionSnapshot
+        ):
+            raise FullTextContractError(
+                "full-text receipt snapshot must be typed"
+            )
+        if self.normalized_query is not None and not isinstance(
+            self.normalized_query, NormalizedFullTextQuery
+        ):
+            raise FullTextContractError(
+                "full-text receipt normalized query must be typed"
+            )
+        if not isinstance(self.hits, tuple) or len(self.hits) > BRANCH_RESULT_LIMIT:
+            raise FullTextContractError(
+                "full-text receipt hits exceed their fixed bound"
+            )
+        if any(
+            not isinstance(hit, RetrievalBranchHit)
+            or hit.branch is not RetrievalBranch.FULL_TEXT
+            for hit in self.hits
+        ):
+            raise FullTextContractError(
+                "full-text receipt hits must be typed FULL_TEXT hits"
+            )
+        ranks = tuple(hit.rank for hit in self.hits)
+        if ranks != tuple(range(1, len(self.hits) + 1)):
+            raise FullTextContractError(
+                "full-text receipt ranks must be contiguous"
+            )
+        if len({hit.result_key for hit in self.hits}) != len(self.hits):
+            raise FullTextContractError(
+                "full-text receipt result keys must be unique"
+            )
+        if self.hits and self.normalized_query is None:
+            raise FullTextContractError(
+                "full-text hits require normalized query evidence"
+            )
+        if self.normalized_query is not None and any(
+            hit.query_id != FULLTEXT_QUERY_ID
+            or hit.query_digest != self.normalized_query.query_digest
+            for hit in self.hits
+        ):
+            raise FullTextContractError(
+                "full-text hit query identity differs from normalized query"
+            )
+        if not isinstance(self.exclusions, tuple) or any(
+            not isinstance(item, BranchExclusion)
+            for item in self.exclusions
+        ):
+            raise FullTextContractError(
+                "full-text receipt exclusions must be typed"
+            )
+        for field_name, maximum in (
+            ("authority_read_count", 1),
+            ("neo4j_read_count", 3),
+        ):
+            value = getattr(self, field_name)
+            if (
+                isinstance(value, bool)
+                or not isinstance(value, int)
+                or not 0 <= value <= maximum
+            ):
+                raise FullTextContractError(
+                    f"{field_name} is outside its fixed bound"
+                )
+        if self.authority_read_count == 0 and (
+            self.snapshot is not None
+            or self.authority_view_digest is not None
+            or self.normalized_query is not None
+        ):
+            raise FullTextContractError(
+                "full-text authority evidence requires an authority read"
+            )
+        if self.authority_read_count == 1 and (
+            self.snapshot is None or self.authority_view_digest is None
+        ):
+            raise FullTextContractError(
+                "full-text authority read requires snapshot and view identity"
+            )
+        if self.neo4j_read_count and (
+            self.authority_read_count != 1 or self.normalized_query is None
+        ):
+            raise FullTextContractError(
+                "full-text Neo4j evidence requires canonical authority and query evidence"
+            )
+        if self.exclusions and self.neo4j_read_count != 3:
+            raise FullTextContractError(
+                "full-text exclusions require a completed graph query"
+            )
+        require_token(
+            self.implementation_version,
+            field="fulltext_implementation_version",
+        )
+        if (
+            self.external_call_count != 0
+            or self.gross_cost_microunits != 0
+            or self.authority_effect != "NONE"
+            or self.hybrid_result_claimed is not False
+            or self.projection_text_factual_use_allowed is not False
+        ):
+            raise FullTextContractError(
+                "full-text receipt cannot claim external, authority, hybrid or factual effect"
+            )
+        if self.outcome is not BranchOutcome.COMPLETE and self.hits:
+            raise FullTextContractError(
+                "non-complete full-text receipt cannot expose hits"
+            )
+        if self.outcome is BranchOutcome.COMPLETE and (
+            self.snapshot is None
+            or self.normalized_query is None
+            or self.authority_view_digest is None
+            or self.authority_read_count != 1
+            or self.neo4j_read_count != 3
+        ):
+            raise FullTextContractError(
+                "complete full-text receipt requires complete authority and Neo4j evidence"
+            )
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "schema_version": "newsroom.increment5.fulltext-branch-receipt.v1",
+            "receipt_id": str(self.receipt_id),
+            "request_id": str(self.request_id),
+            "request_digest": self.request_digest,
+            "branch": RetrievalBranch.FULL_TEXT.value,
+            "contract_digest": self.contract_digest,
+            "policy_id": self.policy_id,
+            "fulltext_component_digest": self.fulltext_component_digest,
+            "normalization_component_digest": (
+                self.normalization_component_digest
+            ),
+            "implementation_version": self.implementation_version,
+            "outcome": self.outcome.value,
+            "reason_code": self.reason_code,
+            "started_at": self.started_at.to_text(),
+            "completed_at": self.completed_at.to_text(),
+            "elapsed_ms": self.elapsed_ms,
+            "snapshot": (
+                None if self.snapshot is None else self.snapshot.canonical_value()
+            ),
+            "authority_view_digest": self.authority_view_digest,
+            "normalized_query": (
+                None
+                if self.normalized_query is None
+                else self.normalized_query.canonical_value()
+            ),
+            "hits": [hit.canonical_value() for hit in self.hits],
+            "exclusions": [
+                item.canonical_value() for item in self.exclusions
+            ],
+            "authority_read_count": self.authority_read_count,
+            "neo4j_read_count": self.neo4j_read_count,
+            "external_call_count": self.external_call_count,
+            "gross_cost_microunits": self.gross_cost_microunits,
+            "authority_effect": self.authority_effect,
+            "hybrid_result_claimed": self.hybrid_result_claimed,
+            "projection_text_factual_use_allowed": (
+                self.projection_text_factual_use_allowed
+            ),
+        }
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        value = canonical_json_bytes(self.canonical_value())
+        if len(value) > FULLTEXT_RESPONSE_BYTE_LIMIT:
+            raise FullTextContractError(
+                "full-text receipt exceeds the fixed response byte limit"
+            )
+        return value
+
+    @property
+    def receipt_digest(self) -> str:
+        return digest_bytes(self.canonical_bytes)
+
+    @classmethod
+    def from_canonical_bytes(cls, raw: bytes) -> "FullTextBranchReceipt":
+        value = _decode_canonical_json(raw)
+        if (
+            value.get("schema_version")
+            != "newsroom.increment5.fulltext-branch-receipt.v1"
+            or value.get("branch") != RetrievalBranch.FULL_TEXT.value
+        ):
+            raise FullTextContractError(
+                "stored full-text receipt schema differs"
+            )
+        try:
+            snapshot_value = value["snapshot"]
+            normalized_value = value["normalized_query"]
+            hits = tuple(
+                RetrievalBranchHit(
+                    branch=RetrievalBranch(str(item["branch"])),
+                    query_id=str(item["query_id"]),
+                    query_digest=str(item["query_digest"]),
+                    rank=int(item["rank"]),
+                    raw_score=str(item["raw_score"]),
+                    result_key=str(item["result_key"]),
+                    dependency_root_id=str(item["dependency_root_id"]),
+                    passage_id=(
+                        None
+                        if item["passage_id"] is None
+                        else str(item["passage_id"])
+                    ),
+                    trust_scope=TrustScope(str(item["trust_scope"])),
+                    source_kind=str(item["source_kind"]),
+                    source_identity=str(item["source_identity"]),
+                )
+                for item in value["hits"]
+            )
+            exclusions = tuple(
+                BranchExclusion(
+                    authority_kind=str(item["authority_kind"]),
+                    authority_id=str(item["authority_id"]),
+                    reason=BranchExclusionReason(str(item["reason"])),
+                )
+                for item in value["exclusions"]
+            )
+            receipt = cls(
+                receipt_id=BranchReceiptId.parse(str(value["receipt_id"])),
+                request_id=BranchRequestId.parse(str(value["request_id"])),
+                request_digest=str(value["request_digest"]),
+                contract_digest=str(value["contract_digest"]),
+                policy_id=str(value["policy_id"]),
+                fulltext_component_digest=str(
+                    value["fulltext_component_digest"]
+                ),
+                normalization_component_digest=str(
+                    value["normalization_component_digest"]
+                ),
+                implementation_version=str(value["implementation_version"]),
+                outcome=BranchOutcome(str(value["outcome"])),
+                reason_code=str(value["reason_code"]),
+                started_at=UtcTimestamp.parse(str(value["started_at"])),
+                completed_at=UtcTimestamp.parse(str(value["completed_at"])),
+                elapsed_ms=int(value["elapsed_ms"]),
+                snapshot=(
+                    None
+                    if snapshot_value is None
+                    else FullTextProjectionSnapshot.from_canonical_value(
+                        snapshot_value
+                    )
+                ),
+                authority_view_digest=(
+                    None
+                    if value["authority_view_digest"] is None
+                    else str(value["authority_view_digest"])
+                ),
+                normalized_query=(
+                    None
+                    if normalized_value is None
+                    else NormalizedFullTextQuery.from_canonical_value(
+                        normalized_value
+                    )
+                ),
+                hits=hits,
+                exclusions=exclusions,
+                authority_read_count=int(value["authority_read_count"]),
+                neo4j_read_count=int(value["neo4j_read_count"]),
+                external_call_count=int(value["external_call_count"]),
+                gross_cost_microunits=int(value["gross_cost_microunits"]),
+                authority_effect=str(value["authority_effect"]),
+                hybrid_result_claimed=bool(value["hybrid_result_claimed"]),
+                projection_text_factual_use_allowed=bool(
+                    value["projection_text_factual_use_allowed"]
+                ),
+            )
+            if receipt.canonical_bytes != raw:
+                raise FullTextContractError(
+                    "stored full-text receipt is not canonical"
+                )
+            return receipt
+        except FullTextContractError:
+            raise
+        except (
+            CanonicalizationError,
+            RetrievalContractError,
+            KeyError,
+            TypeError,
+            ValueError,
+        ) as exc:
+            raise FullTextContractError(
+                "stored full-text receipt fields differ from the canonical contract"
+            ) from exc
+
+
+def _without_duplicate_names(
+    pairs: list[tuple[str, Any]]
+) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for name, value in pairs:
+        if name in result:
+            raise FullTextContractError(
+                f"duplicate full-text receipt object name: {name}"
+            )
+        result[name] = value
+    return result
+
+
+def _decode_canonical_json(raw: bytes) -> dict[str, Any]:
+    if not isinstance(raw, bytes) or not raw:
+        raise FullTextContractError(
+            "stored full-text receipt bytes are required"
+        )
+    try:
+        value = json.loads(
+            raw.decode("utf-8", errors="strict"),
+            object_pairs_hook=_without_duplicate_names,
+        )
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        raise FullTextContractError(
+            "stored full-text receipt is not valid JSON"
+        ) from exc
+    try:
+        canonical = canonical_json_bytes(value)
+    except CanonicalizationError as exc:
+        raise FullTextContractError(
+            "stored full-text receipt is outside canonical JSON"
+        ) from exc
+    if not isinstance(value, dict) or canonical != raw:
+        raise FullTextContractError(
+            "stored full-text receipt must use canonical JSON"
+        )
+    return value
+
+
+__all__ = ["FullTextBranchReceipt"]

--- a/newsroom/increment5/fulltext_retriever.py
+++ b/newsroom/increment5/fulltext_retriever.py
@@ -1,0 +1,666 @@
+"""Independent Increment 5B2 full-text retriever over a bounded authority port."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+import math
+import time
+from typing import Any
+
+from newsroom.authority.canonical import (
+    CanonicalizationError,
+    validate_sha256_digest,
+)
+from newsroom.authority.neo4j_fulltext_reader import (
+    Neo4jFullTextReadError,
+    Neo4jFullTextReadRequest,
+    Neo4jFullTextReadTimeout,
+    Neo4jFullTextReader,
+)
+from newsroom.authority.types import UtcTimestamp
+from newsroom.increment5.branch_contracts import (
+    BRANCH_TIMEOUT_MS,
+    BranchExclusion,
+    BranchOutcome,
+    BranchReceiptId,
+)
+from newsroom.projection.models import ProjectionGenerationState
+from newsroom.projection.neo4j.models import (
+    NEO4J_B2_DRIVER_VERSION,
+    NEO4J_B2_SERVER_VERSION,
+)
+from newsroom.retrieval.models import (
+    RetrievalBranch,
+    RetrievalBranchHit,
+    canonical_score,
+)
+
+from .fulltext_contracts import (
+    FULLTEXT_ANALYZER,
+    FULLTEXT_COMPONENT_DIGEST,
+    FULLTEXT_INDEXED_FIELDS,
+    FULLTEXT_POLICY_ID,
+    FULLTEXT_PROVIDER,
+    FULLTEXT_QUERY_ID,
+    INCREMENT5_RETRIEVAL_CONTRACT_DIGEST,
+    NORMALIZATION_COMPONENT_DIGEST,
+    FullTextAuthorityView,
+    FullTextBranchRequest,
+    FullTextContractError,
+    FullTextIndexState,
+    NormalizedFullTextQuery,
+)
+from .fulltext_journal import FullTextJournalResult, FullTextReceiptJournal
+from .fulltext_normalizer import BilingualSearchNormalizer
+from .fulltext_receipts import FullTextBranchReceipt
+from .fulltext_snapshot_policy import fulltext_snapshot_failure
+
+
+class FullTextRetrieverError(RuntimeError):
+    """The independent full-text branch cannot safely execute."""
+
+
+class FullTextRetriever:
+    """Execute one fixed, read-only, generation-scoped full-text branch."""
+
+    def __init__(
+        self,
+        *,
+        graph_reader: Neo4jFullTextReader,
+        journal: FullTextReceiptJournal,
+        authority_view_provider: Callable[
+            [FullTextBranchRequest], FullTextAuthorityView
+        ],
+        receipt_id_factory: Callable[[], BranchReceiptId] = BranchReceiptId.new,
+        monotonic_ns: Callable[[], int] = time.monotonic_ns,
+        normalizer: BilingualSearchNormalizer | None = None,
+    ) -> None:
+        if not isinstance(graph_reader, Neo4jFullTextReader):
+            raise TypeError("full-text graph reader must be typed")
+        if not isinstance(journal, FullTextReceiptJournal):
+            raise TypeError("full-text receipt journal must be typed")
+        if not callable(authority_view_provider):
+            raise TypeError("full-text authority view provider must be callable")
+        if not callable(receipt_id_factory) or not callable(monotonic_ns):
+            raise TypeError("full-text factories must be callable")
+        if normalizer is not None and not isinstance(
+            normalizer, BilingualSearchNormalizer
+        ):
+            raise TypeError("full-text normalizer must be typed")
+
+        self._graph_reader = graph_reader
+        self._journal = journal
+        self._authority_view_provider = authority_view_provider
+        self._receipt_id_factory = receipt_id_factory
+        self._monotonic_ns = monotonic_ns
+        self._normalizer = normalizer or BilingualSearchNormalizer()
+
+    def retrieve(
+        self, request: FullTextBranchRequest
+    ) -> FullTextJournalResult:
+        if not isinstance(request, FullTextBranchRequest):
+            raise TypeError("full-text retrieval request must be typed")
+        return self._journal.execute(
+            request,
+            lambda: self._execute(request),
+        )
+
+    def _execute(
+        self, request: FullTextBranchRequest
+    ) -> FullTextBranchReceipt:
+        start_ns = self._monotonic_ns()
+        if request.contract_digest != INCREMENT5_RETRIEVAL_CONTRACT_DIGEST:
+            return self._receipt(
+                request,
+                start_ns=start_ns,
+                outcome=BranchOutcome.POLICY_BLOCKED,
+                reason_code="CONTRACT_MISMATCH",
+            )
+        if request.policy_id != FULLTEXT_POLICY_ID:
+            return self._receipt(
+                request,
+                start_ns=start_ns,
+                outcome=BranchOutcome.POLICY_BLOCKED,
+                reason_code="POLICY_MISMATCH",
+            )
+        if (
+            request.fulltext_component_digest != FULLTEXT_COMPONENT_DIGEST
+            or request.normalization_component_digest
+            != NORMALIZATION_COMPONENT_DIGEST
+        ):
+            return self._receipt(
+                request,
+                start_ns=start_ns,
+                outcome=BranchOutcome.POLICY_BLOCKED,
+                reason_code="COMPONENT_MISMATCH",
+            )
+        if request.query_valid_time.value > request.serving_time.value:
+            return self._receipt(
+                request,
+                start_ns=start_ns,
+                outcome=BranchOutcome.POLICY_BLOCKED,
+                reason_code="QUERY_VALID_TIME_IN_FUTURE",
+            )
+        if self._graph_reader.driver_version != NEO4J_B2_DRIVER_VERSION:
+            return self._receipt(
+                request,
+                start_ns=start_ns,
+                outcome=BranchOutcome.UNAVAILABLE,
+                reason_code="DRIVER_INCOMPATIBLE",
+            )
+
+        authority_read_count = 0
+        try:
+            view = self._authority_view_provider(request)
+            if not isinstance(view, FullTextAuthorityView):
+                raise FullTextContractError(
+                    "authority provider returned an untyped full-text view"
+                )
+            snapshot = view.snapshot
+            view_digest = view.view_digest
+            authority_read_count = 1
+        except Exception:
+            return self._receipt(
+                request,
+                start_ns=start_ns,
+                outcome=BranchOutcome.UNAVAILABLE,
+                reason_code="AUTHORITY_VIEW_UNAVAILABLE",
+                authority_read_count=authority_read_count,
+            )
+
+        snapshot_failure = self._snapshot_failure(request, view)
+        if snapshot_failure is not None:
+            outcome, reason = snapshot_failure
+            return self._receipt(
+                request,
+                start_ns=start_ns,
+                outcome=outcome,
+                reason_code=reason,
+                snapshot=snapshot,
+                authority_view_digest=view_digest,
+                authority_read_count=1,
+            )
+
+        try:
+            normalized = self._normalizer.normalize(
+                surface_text=request.query_text,
+                language_mode=request.language_mode,
+                query_valid_time=request.query_valid_time,
+                authority_aliases=view.authority_aliases,
+            )
+        except FullTextContractError:
+            return self._receipt(
+                request,
+                start_ns=start_ns,
+                outcome=BranchOutcome.POLICY_BLOCKED,
+                reason_code="QUERY_NORMALIZATION_REJECTED",
+                snapshot=snapshot,
+                authority_view_digest=view_digest,
+                authority_read_count=1,
+            )
+
+        neo4j_reads = 0
+        deadline_ns = start_ns + request.timeout_ms * 1_000_000
+        try:
+            component_result = self._graph_reader.read(
+                Neo4jFullTextReadRequest.component(
+                    timeout_ns=self._remaining_timeout_ns(
+                        start_ns=start_ns,
+                        deadline_ns=deadline_ns,
+                    )
+                )
+            )
+            neo4j_reads += component_result.read_count
+            self._require_compatibility(component_result.component, snapshot)
+
+            index_result = self._graph_reader.read(
+                Neo4jFullTextReadRequest.index(
+                    index_name=snapshot.index_name,
+                    timeout_ns=self._remaining_timeout_ns(
+                        start_ns=start_ns,
+                        deadline_ns=deadline_ns,
+                    ),
+                )
+            )
+            neo4j_reads += index_result.read_count
+            index_failure = self._index_failure(
+                list(index_result.indexes),
+                snapshot,
+            )
+            if index_failure is not None:
+                outcome, reason = index_failure
+                return self._receipt(
+                    request,
+                    start_ns=start_ns,
+                    outcome=outcome,
+                    reason_code=reason,
+                    authority_read_count=1,
+                    neo4j_read_count=neo4j_reads,
+                    snapshot=snapshot,
+                    authority_view_digest=view_digest,
+                    normalized_query=normalized,
+                )
+
+            query_result = self._graph_reader.read(
+                Neo4jFullTextReadRequest.query(
+                    index_name=snapshot.index_name,
+                    lucene_expression=normalized.lucene_query,
+                    generation_id=snapshot.generation_id,
+                    limit=request.result_limit + 1,
+                    timeout_ns=self._remaining_timeout_ns(
+                        start_ns=start_ns,
+                        deadline_ns=deadline_ns,
+                    ),
+                )
+            )
+            neo4j_reads += query_result.read_count
+            rows = list(query_result.rows)
+        except Neo4jFullTextReadTimeout:
+            # A port timeout can arrive before the repository-owned cumulative
+            # deadline.  The receipt builder independently promotes elapsed
+            # work at or beyond the hard bound to QUERY_TIMEOUT; an earlier
+            # transport or server timeout is unavailable rather than a false
+            # claim that 5,000 ms elapsed.
+            return self._receipt(
+                request,
+                start_ns=start_ns,
+                outcome=BranchOutcome.UNAVAILABLE,
+                reason_code="NEO4J_READ_UNAVAILABLE",
+                authority_read_count=1,
+                neo4j_read_count=neo4j_reads,
+                snapshot=snapshot,
+                authority_view_digest=view_digest,
+                normalized_query=normalized,
+            )
+        except Neo4jFullTextReadError:
+            return self._receipt(
+                request,
+                start_ns=start_ns,
+                outcome=BranchOutcome.UNAVAILABLE,
+                reason_code="NEO4J_READ_UNAVAILABLE",
+                authority_read_count=1,
+                neo4j_read_count=neo4j_reads,
+                snapshot=snapshot,
+                authority_view_digest=view_digest,
+                normalized_query=normalized,
+            )
+        except FullTextRetrieverError as exc:
+            reason = str(exc)
+            return self._receipt(
+                request,
+                start_ns=start_ns,
+                outcome=BranchOutcome.UNAVAILABLE,
+                reason_code=reason,
+                authority_read_count=1,
+                neo4j_read_count=neo4j_reads,
+                snapshot=snapshot,
+                authority_view_digest=view_digest,
+                normalized_query=normalized,
+            )
+        if len(rows) > request.result_limit:
+            return self._receipt(
+                request,
+                start_ns=start_ns,
+                outcome=BranchOutcome.INCOMPLETE,
+                reason_code="RESULT_BOUND_EXCEEDED",
+                snapshot=snapshot,
+                authority_view_digest=view_digest,
+                normalized_query=normalized,
+                authority_read_count=1,
+                neo4j_read_count=neo4j_reads,
+            )
+
+        try:
+            hits, exclusions = self._parse_hits(
+                rows,
+                request=request,
+                view=view,
+                normalized=normalized,
+            )
+        except FullTextContractError:
+            return self._receipt(
+                request,
+                start_ns=start_ns,
+                outcome=BranchOutcome.UNAVAILABLE,
+                reason_code="PROJECTION_INTEGRITY_ERROR",
+                snapshot=snapshot,
+                authority_view_digest=view_digest,
+                normalized_query=normalized,
+                authority_read_count=1,
+                neo4j_read_count=neo4j_reads,
+            )
+
+        if not hits and exclusions:
+            reason = (
+                "RIGHTS_BLOCKED"
+                if any(
+                    item.reason.value == "RIGHTS_NOT_CURRENT"
+                    for item in exclusions
+                )
+                else "AUTHORITY_STATE_BLOCKED"
+            )
+            return self._receipt(
+                request,
+                start_ns=start_ns,
+                outcome=BranchOutcome.POLICY_BLOCKED,
+                reason_code=reason,
+                snapshot=snapshot,
+                authority_view_digest=view_digest,
+                normalized_query=normalized,
+                exclusions=exclusions,
+                authority_read_count=1,
+                neo4j_read_count=neo4j_reads,
+            )
+
+        return self._receipt(
+            request,
+            start_ns=start_ns,
+            outcome=BranchOutcome.COMPLETE,
+            reason_code=(
+                "NO_MATCH"
+                if not hits
+                else "OK_WITH_EXCLUSIONS"
+                if exclusions
+                else "OK"
+            ),
+            snapshot=snapshot,
+            authority_view_digest=view_digest,
+            normalized_query=normalized,
+            hits=hits,
+            exclusions=exclusions,
+            authority_read_count=1,
+            neo4j_read_count=neo4j_reads,
+        )
+
+    def _remaining_timeout_ns(
+        self,
+        *,
+        start_ns: int,
+        deadline_ns: int,
+    ) -> int:
+        current_ns = self._monotonic_ns()
+        if (
+            isinstance(current_ns, bool)
+            or not isinstance(current_ns, int)
+            or current_ns < start_ns
+        ):
+            raise FullTextRetrieverError(
+                "full-text monotonic clock moved backwards"
+            )
+        remaining_ns = deadline_ns - current_ns
+        if remaining_ns <= 0:
+            raise Neo4jFullTextReadTimeout(
+                "full-text branch deadline is exhausted"
+            )
+        return remaining_ns
+
+    @staticmethod
+    def _snapshot_failure(
+        request: FullTextBranchRequest,
+        view: FullTextAuthorityView,
+    ) -> tuple[BranchOutcome, str] | None:
+        return fulltext_snapshot_failure(request, view.snapshot)
+
+    @staticmethod
+    def _require_compatibility(
+        record: Any,
+        snapshot: Any,
+    ) -> None:
+        if record is None:
+            raise FullTextRetrieverError("NEO4J_INCOMPATIBLE")
+        try:
+            version = str(record["version"])
+            edition = str(record["edition"]).lower()
+        except Exception:
+            raise FullTextRetrieverError("NEO4J_INCOMPATIBLE") from None
+        if (
+            version != NEO4J_B2_SERVER_VERSION
+            or version != snapshot.server_version
+            or edition != "community"
+        ):
+            raise FullTextRetrieverError("NEO4J_INCOMPATIBLE")
+
+    @staticmethod
+    def _index_failure(
+        rows: Any,
+        snapshot: Any,
+    ) -> tuple[BranchOutcome, str] | None:
+        if not isinstance(rows, list):
+            return BranchOutcome.UNAVAILABLE, "FULLTEXT_INDEX_MALFORMED"
+        if not rows:
+            return BranchOutcome.UNAVAILABLE, "FULLTEXT_INDEX_MISSING"
+        if len(rows) != 1:
+            return BranchOutcome.UNAVAILABLE, "FULLTEXT_INDEX_AMBIGUOUS"
+        row = rows[0]
+        if not isinstance(row, Mapping):
+            try:
+                row = dict(row)
+            except Exception:
+                return BranchOutcome.UNAVAILABLE, "FULLTEXT_INDEX_MALFORMED"
+        try:
+            name = str(row["name"])
+            index_type = str(row["type"]).upper()
+            state = str(row["state"]).upper()
+            entity_type = str(row["entityType"]).upper()
+            labels = tuple(str(item) for item in row["labelsOrTypes"])
+            properties = tuple(str(item) for item in row["properties"])
+            provider = str(row["indexProvider"])
+            options = row["options"]
+            if not isinstance(options, Mapping):
+                options = dict(options)
+            index_config = options["indexConfig"]
+            if not isinstance(index_config, Mapping):
+                index_config = dict(index_config)
+            analyzer = str(index_config["fulltext.analyzer"])
+            eventually_consistent = index_config[
+                "fulltext.eventually_consistent"
+            ]
+        except Exception:
+            return BranchOutcome.UNAVAILABLE, "FULLTEXT_INDEX_MALFORMED"
+        if (
+            name != snapshot.index_name
+            or index_type != "FULLTEXT"
+            or entity_type != "NODE"
+            or labels != (snapshot.document_label,)
+            or tuple(sorted(properties)) != FULLTEXT_INDEXED_FIELDS
+            or provider != FULLTEXT_PROVIDER
+            or analyzer != FULLTEXT_ANALYZER
+            or eventually_consistent is not False
+        ):
+            return BranchOutcome.UNAVAILABLE, "FULLTEXT_INDEX_INCOMPATIBLE"
+        if state == "POPULATING":
+            return BranchOutcome.INCOMPLETE, "FULLTEXT_INDEX_POPULATING"
+        if state != "ONLINE":
+            return BranchOutcome.UNAVAILABLE, "FULLTEXT_INDEX_UNAVAILABLE"
+        return None
+
+    @staticmethod
+    def _parse_hits(
+        rows: list[Any],
+        *,
+        request: FullTextBranchRequest,
+        view: FullTextAuthorityView,
+        normalized: NormalizedFullTextQuery,
+    ) -> tuple[
+        tuple[RetrievalBranchHit, ...],
+        tuple[BranchExclusion, ...],
+    ]:
+        parsed: list[
+            tuple[str, str, str, float]
+        ] = []
+        for raw in rows:
+            if not isinstance(raw, Mapping):
+                try:
+                    raw = dict(raw)
+                except Exception:
+                    raise FullTextContractError(
+                        "full-text result row is malformed"
+                    ) from None
+            if set(raw) != {
+                "generation_id",
+                "passage_id",
+                "document_digest",
+                "language",
+                "score",
+            }:
+                raise FullTextContractError(
+                    "full-text result row differs from the fixed contract"
+                )
+            generation_id = str(raw["generation_id"])
+            passage_id = str(raw["passage_id"])
+            document_digest = str(raw["document_digest"])
+            language = str(raw["language"])
+            score_value = raw["score"]
+            if generation_id != str(view.snapshot.generation_id):
+                raise FullTextContractError(
+                    "full-text result belongs to another generation"
+                )
+            if not passage_id or len(passage_id.encode("utf-8")) > 256:
+                raise FullTextContractError(
+                    "full-text result passage identity is invalid"
+                )
+            try:
+                validate_sha256_digest(
+                    document_digest,
+                    field="fulltext_result_document_digest",
+                )
+            except CanonicalizationError:
+                raise FullTextContractError(
+                    "full-text result document digest is invalid"
+                ) from None
+            if language not in {"en-GB", "zh-HK"}:
+                raise FullTextContractError(
+                    "full-text result language is invalid"
+                )
+            if (
+                isinstance(score_value, bool)
+                or not isinstance(score_value, (int, float))
+                or not math.isfinite(float(score_value))
+                or float(score_value) < 0.0
+            ):
+                raise FullTextContractError(
+                    "full-text result score is invalid"
+                )
+            parsed.append(
+                (
+                    passage_id,
+                    document_digest,
+                    language,
+                    float(score_value),
+                )
+            )
+        if len({item[0] for item in parsed}) != len(parsed):
+            raise FullTextContractError(
+                "full-text result passage identities are duplicated"
+            )
+        if parsed != sorted(
+            parsed,
+            key=lambda item: (-item[3], item[0]),
+        ):
+            raise FullTextContractError(
+                "full-text results differ from deterministic ordering"
+            )
+
+        bindings = view.binding_by_passage_id
+        hits: list[RetrievalBranchHit] = []
+        exclusions: list[BranchExclusion] = []
+        for passage_id, document_digest, language, score in parsed:
+            binding = bindings.get(passage_id)
+            if binding is None:
+                raise FullTextContractError(
+                    "full-text result lacks an authoritative document binding"
+                )
+            if (
+                binding.provenance_digest != document_digest
+                or binding.language != language
+            ):
+                raise FullTextContractError(
+                    "full-text projection result differs from authority binding"
+                )
+            exclusion = binding.exclusion_at(request.query_valid_time)
+            if exclusion is not None:
+                exclusions.append(
+                    BranchExclusion(
+                        authority_kind="PASSAGE",
+                        authority_id=passage_id,
+                        reason=exclusion,
+                    )
+                )
+                continue
+            hits.append(
+                RetrievalBranchHit(
+                    branch=RetrievalBranch.FULL_TEXT,
+                    query_id=FULLTEXT_QUERY_ID,
+                    query_digest=normalized.query_digest,
+                    rank=len(hits) + 1,
+                    raw_score=canonical_score(score),
+                    result_key=f"FULL_TEXT:{passage_id}",
+                    dependency_root_id=binding.dependency_root_id,
+                    passage_id=passage_id,
+                    trust_scope=binding.trust_scope,
+                    source_kind="GOVERNED_PASSAGE",
+                    source_identity=binding.source_identity,
+                )
+            )
+        return tuple(hits), tuple(exclusions)
+
+    def _receipt(
+        self,
+        request: FullTextBranchRequest,
+        *,
+        start_ns: int,
+        outcome: BranchOutcome,
+        reason_code: str,
+        snapshot: Any | None = None,
+        authority_view_digest: str | None = None,
+        normalized_query: NormalizedFullTextQuery | None = None,
+        hits: tuple[RetrievalBranchHit, ...] = (),
+        exclusions: tuple[BranchExclusion, ...] = (),
+        authority_read_count: int = 0,
+        neo4j_read_count: int = 0,
+    ) -> FullTextBranchReceipt:
+        completed_ns = self._monotonic_ns()
+        if completed_ns < start_ns:
+            raise FullTextRetrieverError(
+                "full-text monotonic clock moved backwards"
+            )
+        elapsed_ns = completed_ns - start_ns
+        timed_out = elapsed_ns >= BRANCH_TIMEOUT_MS * 1_000_000
+        if timed_out:
+            outcome = BranchOutcome.INCOMPLETE
+            reason_code = "QUERY_TIMEOUT"
+            hits = ()
+            exclusions = ()
+        elapsed_ms = min(
+            BRANCH_TIMEOUT_MS,
+            elapsed_ns // 1_000_000,
+        )
+        return FullTextBranchReceipt(
+            receipt_id=self._receipt_id_factory(),
+            request_id=request.request_id,
+            request_digest=request.request_digest,
+            contract_digest=request.contract_digest,
+            policy_id=request.policy_id,
+            fulltext_component_digest=request.fulltext_component_digest,
+            normalization_component_digest=(
+                request.normalization_component_digest
+            ),
+            outcome=outcome,
+            reason_code=reason_code,
+            started_at=request.serving_time,
+            completed_at=request.serving_time,
+            elapsed_ms=elapsed_ms,
+            snapshot=snapshot,
+            authority_view_digest=authority_view_digest,
+            normalized_query=normalized_query,
+            hits=hits,
+            exclusions=exclusions,
+            authority_read_count=authority_read_count,
+            neo4j_read_count=neo4j_read_count,
+        )
+
+
+__all__ = [
+    "FullTextRetriever",
+    "FullTextRetrieverError",
+]

--- a/newsroom/increment5/fulltext_snapshot_policy.py
+++ b/newsroom/increment5/fulltext_snapshot_policy.py
@@ -1,0 +1,83 @@
+"""Shared deterministic snapshot policy for the Increment 5B2 branch."""
+
+from __future__ import annotations
+
+from newsroom.increment5.branch_contracts import BranchOutcome
+from newsroom.projection.models import ProjectionGenerationState
+from newsroom.projection.neo4j.models import (
+    NEO4J_B2_DRIVER_VERSION,
+    NEO4J_B2_SERVER_VERSION,
+)
+
+from .fulltext_contracts import (
+    FULLTEXT_ANALYZER,
+    FULLTEXT_PROVIDER,
+    FullTextBranchRequest,
+    FullTextContractError,
+    FullTextIndexState,
+    FullTextProjectionSnapshot,
+)
+
+
+def fulltext_snapshot_failure(
+    request: FullTextBranchRequest,
+    snapshot: FullTextProjectionSnapshot,
+) -> tuple[BranchOutcome, str] | None:
+    """Return the exact fail-closed outcome for one retained projection snapshot."""
+
+    if not isinstance(request, FullTextBranchRequest):
+        raise FullTextContractError("full-text snapshot policy request must be typed")
+    if not isinstance(snapshot, FullTextProjectionSnapshot):
+        raise FullTextContractError("full-text snapshot policy value must be typed")
+    if snapshot.generation_state is not ProjectionGenerationState.ACTIVE:
+        return BranchOutcome.STALE, "GENERATION_NOT_ACTIVE"
+    if snapshot.generation_id != request.expected_generation_id:
+        return BranchOutcome.STALE, "GENERATION_MISMATCH"
+    if (
+        snapshot.generation_identity_digest
+        != request.expected_generation_identity_digest
+    ):
+        return BranchOutcome.STALE, "GENERATION_IDENTITY_MISMATCH"
+    if (
+        snapshot.fulltext_component_digest
+        != request.fulltext_component_digest
+        or snapshot.normalization_component_digest
+        != request.normalization_component_digest
+    ):
+        return BranchOutcome.STALE, "GENERATION_COMPONENT_MISMATCH"
+    if snapshot.rights_manifest_digest != request.expected_rights_manifest_digest:
+        return BranchOutcome.STALE, "RIGHTS_MANIFEST_MISMATCH"
+    if snapshot.contiguous_ledger_seq < request.minimum_watermark:
+        return BranchOutcome.STALE, "PROJECTION_WATERMARK_STALE"
+    if snapshot.open_gap_count:
+        return BranchOutcome.INCOMPLETE, "PROJECTION_GAPS_OPEN"
+    if snapshot.dead_letter_count:
+        return BranchOutcome.INCOMPLETE, "PROJECTION_DEAD_LETTERS_PRESENT"
+    if snapshot.validation_recorded_at.value > request.serving_time.value:
+        return BranchOutcome.INCOMPLETE, "PROJECTION_TIME_INVALID"
+    age_seconds = (
+        request.serving_time.value - snapshot.validation_recorded_at.value
+    ).total_seconds()
+    if (
+        request.serving_time.value > snapshot.freshness_deadline.value
+        or age_seconds > request.max_projection_age_seconds
+    ):
+        return BranchOutcome.STALE, "PROJECTION_FRESHNESS_STALE"
+    if snapshot.index_state is FullTextIndexState.POPULATING:
+        return BranchOutcome.INCOMPLETE, "FULLTEXT_INDEX_POPULATING"
+    if snapshot.index_state in {
+        FullTextIndexState.FAILED,
+        FullTextIndexState.MISSING,
+    }:
+        return BranchOutcome.UNAVAILABLE, "FULLTEXT_INDEX_UNAVAILABLE"
+    if (
+        snapshot.provider != FULLTEXT_PROVIDER
+        or snapshot.analyzer != FULLTEXT_ANALYZER
+        or snapshot.server_version != NEO4J_B2_SERVER_VERSION
+        or snapshot.driver_version != NEO4J_B2_DRIVER_VERSION
+    ):
+        return BranchOutcome.UNAVAILABLE, "COMPONENT_INCOMPATIBLE"
+    return None
+
+
+__all__ = ["fulltext_snapshot_failure"]

--- a/newsroom/projection/neo4j/_adapter.py
+++ b/newsroom/projection/neo4j/_adapter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
+import time
 from threading import RLock
 from typing import Any
 
@@ -41,6 +42,27 @@ _COMPONENT_QUERY = """
 CALL dbms.components() YIELD name, versions, edition
 WHERE name = 'Neo4j Kernel'
 RETURN versions[0] AS version, toLower(edition) AS edition
+"""
+
+_FULLTEXT_INDEX_INVENTORY_QUERY = """
+SHOW INDEXES
+YIELD name, type, state, entityType, labelsOrTypes, properties, indexProvider, options
+WHERE name = $index_name
+RETURN name, type, state, entityType, labelsOrTypes, properties, indexProvider, options
+ORDER BY name
+"""
+
+_FULLTEXT_READ_QUERY = """
+CALL db.index.fulltext.queryNodes($index_name, $query, {limit: $limit})
+YIELD node, score
+WHERE node.generation_id = $generation_id
+RETURN node.generation_id AS generation_id,
+       node.passage_id AS passage_id,
+       node.document_digest AS document_digest,
+       node.language AS language,
+       score
+ORDER BY score DESC, passage_id
+LIMIT $limit
 """
 
 _SCHEMA_QUERIES = (
@@ -224,14 +246,38 @@ RETURN size(nodes) AS deleted_count
 class _Neo4jAdapter:
     """Private fixed-query adapter. It is never returned by a public facade."""
 
-    __slots__ = ("_driver", "_config", "_driver_version", "_closed", "_lock")
+    __slots__ = (
+        "_driver",
+        "_config",
+        "_driver_version",
+        "_closed",
+        "_lock",
+        "_monotonic_ns",
+        "_unit_of_work",
+    )
 
-    def __init__(self, *, driver: Any, config: Neo4jProjectorConfig, driver_version: str) -> None:
+    def __init__(
+        self,
+        *,
+        driver: Any,
+        config: Neo4jProjectorConfig,
+        driver_version: str,
+        monotonic_ns: Callable[[], int] = time.monotonic_ns,
+        unit_of_work_factory: Callable[..., Callable] | None = None,
+    ) -> None:
+        if not callable(monotonic_ns):
+            raise TypeError("Neo4j monotonic clock must be callable")
+        if unit_of_work_factory is None:
+            unit_of_work_factory = _neo4j_unit_of_work_factory()
+        if not callable(unit_of_work_factory):
+            raise TypeError("Neo4j unit-of-work factory must be callable")
         self._driver = driver
         self._config = config
         self._driver_version = driver_version
         self._closed = False
         self._lock = RLock()
+        self._monotonic_ns = monotonic_ns
+        self._unit_of_work = unit_of_work_factory
 
     def verify_compatibility(self) -> Neo4jCompatibility:
         self._require_open()
@@ -301,6 +347,196 @@ class _Neo4jAdapter:
             source_event_id=batch.source_event_id,
             source_event_digest=batch.source_event_digest,
             batch_digest=batch.batch_digest,
+        )
+
+    @property
+    def driver_version(self) -> str:
+        return self._driver_version
+
+    def read_increment5_fulltext(
+        self,
+        *,
+        phase: str,
+        index_name: str | None,
+        lucene_expression: str | None,
+        generation_id: str | None,
+        limit: int,
+        timeout_ns: int,
+    ) -> Any:
+        """Execute one fixed phase of the Increment 5 full-text read port."""
+
+        self._require_open()
+        if phase not in {"COMPONENT", "INDEX", "QUERY"}:
+            raise Neo4jReadError(
+                "Neo4j Increment 5 full-text phase is invalid"
+            )
+        if (
+            isinstance(timeout_ns, bool)
+            or not isinstance(timeout_ns, int)
+            or not 0 < timeout_ns <= 5_000_000_000
+        ):
+            raise Neo4jReadError(
+                "Neo4j Increment 5 full-text timeout is invalid"
+            )
+        if phase == "COMPONENT":
+            if any(
+                value is not None
+                for value in (index_name, lucene_expression, generation_id)
+            ) or limit != 0:
+                raise Neo4jReadError(
+                    "Neo4j component phase carries forbidden controls"
+                )
+            callback = lambda transaction: transaction.run(
+                _COMPONENT_QUERY,
+                {},
+            ).single()
+            operation = "increment5.fulltext.component"
+        else:
+            if (
+                not isinstance(index_name, str)
+                or not index_name
+                or len(index_name.encode("utf-8")) > 128
+                or not index_name.isascii()
+                or not index_name[0].isalpha()
+                or any(
+                    not (character.isalnum() or character == "_")
+                    for character in index_name
+                )
+            ):
+                raise Neo4jReadError(
+                    "Neo4j Increment 5 full-text index identity is invalid"
+                )
+            if phase == "INDEX":
+                if (
+                    lucene_expression is not None
+                    or generation_id is not None
+                    or limit != 0
+                ):
+                    raise Neo4jReadError(
+                        "Neo4j index phase carries forbidden query controls"
+                    )
+                callback = lambda transaction: tuple(
+                    transaction.run(
+                        _FULLTEXT_INDEX_INVENTORY_QUERY,
+                        {"index_name": index_name},
+                    )
+                )
+                operation = "increment5.fulltext.index"
+            else:
+                if (
+                    not isinstance(lucene_expression, str)
+                    or not lucene_expression
+                    or lucene_expression != lucene_expression.strip()
+                    or len(lucene_expression.encode("utf-8")) > 32_768
+                    or any(
+                        ord(character) < 0x20
+                        for character in lucene_expression
+                    )
+                ):
+                    raise Neo4jReadError(
+                        "Neo4j Increment 5 full-text expression is invalid"
+                    )
+                if (
+                    not isinstance(generation_id, str)
+                    or not generation_id
+                    or generation_id != generation_id.strip()
+                    or len(generation_id.encode("utf-8")) > 128
+                    or any(ord(character) < 0x20 for character in generation_id)
+                ):
+                    raise Neo4jReadError(
+                        "Neo4j Increment 5 generation identity is invalid"
+                    )
+                if isinstance(limit, bool) or limit != 9:
+                    raise Neo4jReadError(
+                        "Neo4j Increment 5 full-text overflow limit must equal nine"
+                    )
+                callback = lambda transaction: tuple(
+                    transaction.run(
+                        _FULLTEXT_READ_QUERY,
+                        {
+                            "index_name": index_name,
+                            "query": lucene_expression,
+                            "generation_id": generation_id,
+                            "limit": limit,
+                        },
+                    )
+                )
+                operation = "increment5.fulltext.query"
+
+        started_ns = self._monotonic_ns()
+        if isinstance(started_ns, bool) or not isinstance(started_ns, int):
+            raise Neo4jReadError(
+                "Neo4j Increment 5 monotonic clock is invalid"
+            )
+        with self._lock:
+            current_ns = self._monotonic_ns()
+            if (
+                isinstance(current_ns, bool)
+                or not isinstance(current_ns, int)
+                or current_ns < started_ns
+            ):
+                raise Neo4jReadError(
+                    "Neo4j Increment 5 monotonic clock moved backwards"
+                )
+            remaining_ns = timeout_ns - (current_ns - started_ns)
+            if remaining_ns <= 0:
+                raise Neo4jReadError(
+                    "Neo4j Increment 5 full-text read timed out"
+                )
+            managed = self._unit_of_work(
+                timeout=remaining_ns / 1_000_000_000,
+                metadata={"newsroom_operation": operation},
+            )(callback)
+            try:
+                with self._driver.session(database=self._config.database) as session:
+                    result = session.execute_read(managed)
+            except Exception as exc:
+                completed_ns = self._monotonic_ns()
+                if (
+                    isinstance(completed_ns, bool)
+                    or not isinstance(completed_ns, int)
+                    or completed_ns < started_ns
+                ):
+                    raise Neo4jReadError(
+                        "Neo4j Increment 5 monotonic clock moved backwards"
+                    ) from None
+                if (
+                    completed_ns - started_ns > timeout_ns
+                    or self._increment5_fulltext_timeout(exc)
+                ):
+                    raise Neo4jReadError(
+                        "Neo4j Increment 5 full-text read timed out"
+                    ) from None
+                raise Neo4jReadError(
+                    "Neo4j Increment 5 full-text read failed"
+                ) from None
+            completed_ns = self._monotonic_ns()
+            if (
+                isinstance(completed_ns, bool)
+                or not isinstance(completed_ns, int)
+                or completed_ns < started_ns
+            ):
+                raise Neo4jReadError(
+                    "Neo4j Increment 5 monotonic clock moved backwards"
+                )
+            if completed_ns - started_ns > timeout_ns:
+                raise Neo4jReadError(
+                    "Neo4j Increment 5 full-text read timed out"
+                )
+            return result
+
+    @staticmethod
+    def _increment5_fulltext_timeout(error: Exception) -> bool:
+        identity = f"{type(error).__name__} {error}".casefold()
+        return any(
+            token in identity
+            for token in (
+                "deadline",
+                "terminated",
+                "timeout",
+                "timed out",
+                "transactiontimedout",
+            )
         )
 
     def read(

--- a/newsroom/tests/increment5b2_helpers.py
+++ b/newsroom/tests/increment5b2_helpers.py
@@ -1,0 +1,495 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any
+
+from newsroom.authority.canonical import digest_canonical
+from newsroom.authority.neo4j_fulltext_reader import (
+    Neo4jFullTextReadError,
+    Neo4jFullTextReadPhase,
+    Neo4jFullTextReadRequest,
+    Neo4jFullTextReadResult,
+    Neo4jFullTextReadTimeout,
+    Neo4jFullTextReader,
+)
+from newsroom.authority.types import UtcTimestamp
+from newsroom.increment5.branch_contracts import BranchReceiptId, BranchRequestId
+from newsroom.increment5.fulltext_contracts import (
+    FULLTEXT_ACTOR_ID,
+    FULLTEXT_ANALYZER,
+    FULLTEXT_COMPONENT_DIGEST,
+    FULLTEXT_INDEXED_FIELDS,
+    FULLTEXT_POLICY_ID,
+    FULLTEXT_PROVIDER,
+    FULLTEXT_PURPOSE,
+    INCREMENT5_RETRIEVAL_CONTRACT_DIGEST,
+    NORMALIZATION_COMPONENT_DIGEST,
+    AuthorityAliasTerm,
+    FullTextAuthorityView,
+    FullTextBranchRequest,
+    FullTextDocumentBinding,
+    FullTextIndexState,
+    FullTextLanguageMode,
+    FullTextProfile,
+    FullTextProjectionSnapshot,
+)
+from newsroom.increment5.fulltext_journal import FullTextReceiptJournal
+from newsroom.increment5.fulltext_retriever import FullTextRetriever
+from newsroom.projection.models import ProjectionGenerationId, ProjectionGenerationState
+from newsroom.projection.neo4j._adapter import (
+    _COMPONENT_QUERY,
+    _FULLTEXT_INDEX_INVENTORY_QUERY,
+    _FULLTEXT_READ_QUERY,
+)
+from newsroom.projection.neo4j.models import Neo4jProjectorConfig
+
+
+NOW = UtcTimestamp.parse("2042-03-12T12:00:00.000000Z")
+EARLIER = UtcTimestamp.parse("2042-03-12T11:30:00.000000Z")
+LATER = UtcTimestamp.parse("2042-03-12T12:30:00.000000Z")
+GENERATION_ID = ProjectionGenerationId.parse(
+    "00000000-0000-4000-8000-000000005220"
+)
+
+
+def digest(label: str) -> str:
+    return digest_canonical({"label": label})
+
+
+def snapshot(**changes: object) -> FullTextProjectionSnapshot:
+    value = FullTextProjectionSnapshot(
+        generation_id=GENERATION_ID,
+        generation_state=ProjectionGenerationState.ACTIVE,
+        generation_identity_digest=digest("fulltext-generation"),
+        document_label="NewsroomIncrement5FullText_g5220",
+        index_name="newsroom_increment5_fulltext_g5220",
+        index_state=FullTextIndexState.ONLINE,
+        fulltext_component_digest=FULLTEXT_COMPONENT_DIGEST,
+        normalization_component_digest=NORMALIZATION_COMPONENT_DIGEST,
+        rights_manifest_digest=digest("rights-manifest"),
+        profile=FullTextProfile.PRODUCTION_SHAPED_QUALIFICATION,
+        contiguous_ledger_seq=42,
+        open_gap_count=0,
+        dead_letter_count=0,
+        validation_recorded_at=EARLIER,
+        freshness_deadline=LATER,
+        index_document_count=4,
+    )
+    return replace(value, **changes)
+
+
+def aliases() -> tuple[AuthorityAliasTerm, ...]:
+    return (
+        AuthorityAliasTerm(
+            alias_id="alias-expired",
+            surface_text="Expired Authority",
+            normalized_text="expired authority",
+            valid_from=EARLIER,
+            valid_until=NOW,
+            rights_current=True,
+            lifecycle="ACTIVE",
+        ),
+        AuthorityAliasTerm(
+            alias_id="alias-synthetic-authority",
+            surface_text="Synthetic Authority",
+            normalized_text="synthetic authority",
+            valid_from=EARLIER,
+            valid_until=LATER,
+            rights_current=True,
+            lifecycle="ACTIVE",
+        ),
+    )
+
+
+def bindings() -> tuple[FullTextDocumentBinding, ...]:
+    return (
+        FullTextDocumentBinding(
+            passage_id="p-blocked",
+            dependency_root_id="root-blocked",
+            source_identity="source-blocked:revision-1",
+            provenance_digest=digest("document-blocked"),
+            language="en-GB",
+            rights_current=False,
+            lifecycle="ACTIVE",
+        ),
+        FullTextDocumentBinding(
+            passage_id="p-en",
+            dependency_root_id="root-en",
+            source_identity="source-en:revision-1",
+            provenance_digest=digest("document-en"),
+            language="en-GB",
+            rights_current=True,
+            lifecycle="ACTIVE",
+            valid_from=EARLIER,
+            valid_until=LATER,
+        ),
+        FullTextDocumentBinding(
+            passage_id="p-tomb",
+            dependency_root_id="root-tomb",
+            source_identity="source-tomb:revision-1",
+            provenance_digest=digest("document-tomb"),
+            language="en-GB",
+            rights_current=True,
+            lifecycle="TOMBSTONED",
+        ),
+        FullTextDocumentBinding(
+            passage_id="p-zh",
+            dependency_root_id="root-zh",
+            source_identity="source-zh:revision-1",
+            provenance_digest=digest("document-zh"),
+            language="zh-HK",
+            rights_current=True,
+            lifecycle="ACTIVE",
+            valid_from=EARLIER,
+            valid_until=LATER,
+        ),
+    )
+
+
+def authority_view(
+    *,
+    projection_snapshot: FullTextProjectionSnapshot | None = None,
+    authority_aliases: tuple[AuthorityAliasTerm, ...] | None = None,
+    document_bindings: tuple[FullTextDocumentBinding, ...] | None = None,
+) -> FullTextAuthorityView:
+    return FullTextAuthorityView(
+        snapshot=projection_snapshot or snapshot(),
+        authority_aliases=aliases() if authority_aliases is None else authority_aliases,
+        document_bindings=bindings() if document_bindings is None else document_bindings,
+    )
+
+
+def request(**changes: object) -> FullTextBranchRequest:
+    value = FullTextBranchRequest(
+        request_id=BranchRequestId.parse(
+            "00000000-0000-4000-8000-000000005221"
+        ),
+        idempotency_key="fulltext-request-a",
+        actor_id=FULLTEXT_ACTOR_ID,
+        purpose=FULLTEXT_PURPOSE,
+        policy_id=FULLTEXT_POLICY_ID,
+        contract_digest=INCREMENT5_RETRIEVAL_CONTRACT_DIGEST,
+        fulltext_component_digest=FULLTEXT_COMPONENT_DIGEST,
+        normalization_component_digest=NORMALIZATION_COMPONENT_DIGEST,
+        expected_generation_id=GENERATION_ID,
+        expected_generation_identity_digest=digest("fulltext-generation"),
+        expected_rights_manifest_digest=digest("rights-manifest"),
+        query_text="Synthetic Authority deadline 27 March 2042 合成網上平台",
+        language_mode=FullTextLanguageMode.MIXED_EN_GB_ZH_HANT_HK,
+        query_valid_time=NOW,
+        serving_time=NOW,
+        minimum_watermark=42,
+    )
+    return replace(value, **changes)
+
+
+def component_row(
+    *,
+    version: str = "2026.06.0",
+    edition: str = "community",
+) -> dict[str, object]:
+    return {"version": version, "edition": edition}
+
+
+def index_row(
+    projection_snapshot: FullTextProjectionSnapshot | None = None,
+    *,
+    state: str = "ONLINE",
+    provider: str = FULLTEXT_PROVIDER,
+    analyzer: str = FULLTEXT_ANALYZER,
+    eventually_consistent: bool = False,
+    properties: tuple[str, ...] = FULLTEXT_INDEXED_FIELDS,
+) -> dict[str, object]:
+    current = projection_snapshot or snapshot()
+    return {
+        "name": current.index_name,
+        "type": "FULLTEXT",
+        "state": state,
+        "entityType": "NODE",
+        "labelsOrTypes": [current.document_label],
+        "properties": list(properties),
+        "indexProvider": provider,
+        "options": {
+            "indexConfig": {
+                "fulltext.analyzer": analyzer,
+                "fulltext.eventually_consistent": eventually_consistent,
+            }
+        },
+    }
+
+
+def result_row(
+    passage_id: str,
+    score: float,
+    *,
+    projection_snapshot: FullTextProjectionSnapshot | None = None,
+    document_digest: str | None = None,
+    language: str | None = None,
+) -> dict[str, object]:
+    current = projection_snapshot or snapshot()
+    binding = {item.passage_id: item for item in bindings()}[passage_id]
+    return {
+        "generation_id": str(current.generation_id),
+        "passage_id": passage_id,
+        "document_digest": document_digest or binding.provenance_digest,
+        "language": language or binding.language,
+        "score": score,
+    }
+
+
+class FakeResult(list[dict[str, object]]):
+    def single(self) -> dict[str, object] | None:
+        if not self:
+            return None
+        return self[0]
+
+
+@dataclass
+class FakeScenario:
+    component: dict[str, object] | None
+    indexes: list[dict[str, object]]
+    rows: list[dict[str, object]]
+    failure_on: str | None = None
+
+
+class FakeTransaction:
+    def __init__(
+        self,
+        scenario: FakeScenario,
+        calls: list[tuple[str, dict[str, object]]],
+    ) -> None:
+        self._scenario = scenario
+        self._calls = calls
+
+    def run(
+        self,
+        statement: str,
+        parameters: dict[str, object] | None = None,
+    ) -> FakeResult:
+        values = parameters or {}
+        self._calls.append((statement, dict(values)))
+        if statement == _COMPONENT_QUERY:
+            if self._scenario.failure_on == "component":
+                raise RuntimeError("component read failed")
+            return FakeResult(
+                [] if self._scenario.component is None else [self._scenario.component]
+            )
+        if statement == _FULLTEXT_INDEX_INVENTORY_QUERY:
+            if self._scenario.failure_on == "index":
+                raise RuntimeError("index read failed")
+            return FakeResult(self._scenario.indexes)
+        if statement == _FULLTEXT_READ_QUERY:
+            if self._scenario.failure_on == "query":
+                raise RuntimeError("query timed out")
+            return FakeResult(self._scenario.rows)
+        raise AssertionError(f"unexpected Neo4j statement: {statement}")
+
+
+class FakeSession:
+    def __init__(self, driver: "FakeDriver") -> None:
+        self._driver = driver
+
+    def __enter__(self) -> "FakeSession":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def execute_read(self, work: Any) -> Any:
+        self._driver.execute_read_count += 1
+        transaction = FakeTransaction(
+            self._driver.scenario,
+            self._driver.calls,
+        )
+        return work(transaction)
+
+
+class FakeDriver:
+    def __init__(self, scenario: FakeScenario) -> None:
+        self.scenario = scenario
+        self.calls: list[tuple[str, dict[str, object]]] = []
+        self.session_count = 0
+        self.execute_read_count = 0
+        self.read_requests: list[Neo4jFullTextReadRequest] = []
+        self.closed = False
+
+    def session(self, *, database: str) -> FakeSession:
+        assert database == "neo4j"
+        self.session_count += 1
+        return FakeSession(self)
+
+    def reader(self, *, driver_version: str = "6.2.0") -> Neo4jFullTextReader:
+        return Neo4jFullTextReader(
+            driver_version=driver_version,
+            read=lambda request: self._read_port(
+                request,
+                driver_version=driver_version,
+            ),
+            close=self.close,
+        )
+
+    def _read_port(
+        self,
+        request: Neo4jFullTextReadRequest,
+        *,
+        driver_version: str,
+    ) -> Neo4jFullTextReadResult:
+        if not isinstance(request, Neo4jFullTextReadRequest):
+            raise TypeError("fake full-text read request must be typed")
+        self.session_count += 1
+        self.read_requests.append(request)
+        transaction = FakeTransaction(self.scenario, self.calls)
+        try:
+            self.execute_read_count += 1
+            if request.phase is Neo4jFullTextReadPhase.COMPONENT:
+                return Neo4jFullTextReadResult(
+                    phase=request.phase,
+                    component=transaction.run(_COMPONENT_QUERY).single(),
+                    driver_version=driver_version,
+                )
+            if request.phase is Neo4jFullTextReadPhase.INDEX:
+                return Neo4jFullTextReadResult(
+                    phase=request.phase,
+                    indexes=tuple(
+                        transaction.run(
+                            _FULLTEXT_INDEX_INVENTORY_QUERY,
+                            {"index_name": request.index_name},
+                        )
+                    ),
+                    driver_version=driver_version,
+                )
+            return Neo4jFullTextReadResult(
+                phase=request.phase,
+                rows=tuple(
+                    transaction.run(
+                        _FULLTEXT_READ_QUERY,
+                        {
+                            "index_name": request.index_name,
+                            "query": request.lucene_expression,
+                            "generation_id": str(request.generation_id),
+                            "limit": request.limit,
+                        },
+                    )
+                ),
+                driver_version=driver_version,
+            )
+        except Exception as exc:
+            if "timeout" in str(exc).lower() or "terminated" in str(exc).lower():
+                raise Neo4jFullTextReadTimeout(
+                    "fake full-text read timed out"
+                ) from None
+            raise Neo4jFullTextReadError(
+                "fake full-text read is unavailable"
+            ) from None
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class RecordingUnitOfWorkFactory:
+    def __init__(self) -> None:
+        self.options: list[dict[str, object]] = []
+
+    def __call__(self, **options: object):
+        self.options.append(dict(options))
+
+        def decorate(callback: Any) -> Any:
+            return callback
+
+        return decorate
+
+
+class SequenceClock:
+    def __init__(self, values: tuple[int, ...]) -> None:
+        self._values = iter(values)
+        self._last = values[-1]
+
+    def __call__(self) -> int:
+        try:
+            self._last = next(self._values)
+        except StopIteration:
+            pass
+        return self._last
+
+
+def config() -> Neo4jProjectorConfig:
+    return Neo4jProjectorConfig(
+        uri="bolt://neo4j.invalid:7687",
+        database="neo4j",
+        username="newsroom_reader",
+        password="not-a-real-secret",
+    )
+
+
+def default_scenario(
+    *,
+    projection_snapshot: FullTextProjectionSnapshot | None = None,
+    rows: list[dict[str, object]] | None = None,
+) -> FakeScenario:
+    current = projection_snapshot or snapshot()
+    return FakeScenario(
+        component=component_row(version=current.server_version),
+        indexes=[index_row(current)],
+        rows=(
+            [
+                result_row("p-en", 2.0, projection_snapshot=current),
+                result_row("p-zh", 1.5, projection_snapshot=current),
+            ]
+            if rows is None
+            else rows
+        ),
+    )
+
+
+def system(
+    tmp_path: Path,
+    *,
+    view: FullTextAuthorityView | None = None,
+    scenario: FakeScenario | None = None,
+    clock: Any | None = None,
+    provider: Any | None = None,
+    receipt_ids: tuple[str, ...] = (
+        "00000000-0000-4000-8000-000000005231",
+        "00000000-0000-4000-8000-000000005232",
+        "00000000-0000-4000-8000-000000005233",
+    ),
+) -> tuple[FakeDriver, RecordingUnitOfWorkFactory, FullTextRetriever]:
+    current_view = view or authority_view()
+    driver = FakeDriver(scenario or default_scenario(
+        projection_snapshot=current_view.snapshot
+    ))
+    factory = RecordingUnitOfWorkFactory()
+    ids = iter(BranchReceiptId.parse(item) for item in receipt_ids)
+    retriever = FullTextRetriever(
+        graph_reader=driver.reader(),
+        journal=FullTextReceiptJournal(tmp_path / "fulltext-receipts.sqlite3"),
+        authority_view_provider=provider or (lambda _request: current_view),
+        receipt_id_factory=lambda: next(ids),
+        monotonic_ns=clock or (lambda: 0),
+    )
+    return driver, factory, retriever
+
+
+__all__ = [
+    "EARLIER",
+    "GENERATION_ID",
+    "LATER",
+    "NOW",
+    "FakeDriver",
+    "FakeScenario",
+    "RecordingUnitOfWorkFactory",
+    "SequenceClock",
+    "aliases",
+    "authority_view",
+    "bindings",
+    "component_row",
+    "config",
+    "default_scenario",
+    "digest",
+    "index_row",
+    "request",
+    "result_row",
+    "snapshot",
+    "system",
+]

--- a/newsroom/tests/test_increment5b2_fulltext_retriever.py
+++ b/newsroom/tests/test_increment5b2_fulltext_retriever.py
@@ -1,0 +1,1283 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+import sqlite3
+
+import pytest
+
+from newsroom.authority.canonical import canonical_json_bytes, digest_bytes
+from newsroom.increment5.branch_contracts import (
+    BranchExclusionReason,
+    BranchOutcome,
+    BranchRequestId,
+)
+from newsroom.increment5.fulltext_contracts import (
+    FULLTEXT_COMPONENT_DIGEST,
+    FULLTEXT_INDEXED_FIELDS,
+    FULLTEXT_QUERY_ID,
+    NORMALIZATION_COMPONENT_DIGEST,
+    FullTextContractError,
+    FullTextIndexState,
+)
+from newsroom.increment5.fulltext_journal import (
+    FullTextReceiptIdempotencyConflict,
+    FullTextReceiptJournal,
+    FullTextReceiptJournalError,
+)
+from newsroom.increment5.fulltext_retriever import FullTextRetriever
+from newsroom.projection.models import ProjectionGenerationId, ProjectionGenerationState
+
+from .increment5b2_helpers import (
+    GENERATION_ID,
+    LATER,
+    NOW,
+    FakeDriver,
+    FakeScenario,
+    SequenceClock,
+    authority_view,
+    bindings,
+    component_row,
+    default_scenario,
+    digest,
+    index_row,
+    request,
+    result_row,
+    snapshot,
+    system,
+)
+
+
+def test_complete_fulltext_receipt_is_bounded_attributable_and_replayable(
+    tmp_path: Path,
+) -> None:
+    driver, work_factory, retriever = system(tmp_path)
+
+    first = retriever.retrieve(request())
+    assert first.replayed is False
+    receipt = first.receipt
+    assert receipt.outcome is BranchOutcome.COMPLETE
+    assert receipt.reason_code == "OK"
+    assert [item.passage_id for item in receipt.hits] == ["p-en", "p-zh"]
+    assert [item.rank for item in receipt.hits] == [1, 2]
+    assert [item.dependency_root_id for item in receipt.hits] == [
+        "root-en",
+        "root-zh",
+    ]
+    assert all(item.trust_scope.value == "OBSERVED" for item in receipt.hits)
+    assert receipt.authority_read_count == 1
+    assert receipt.neo4j_read_count == 3
+    assert receipt.external_call_count == 0
+    assert receipt.gross_cost_microunits == 0
+    assert receipt.authority_effect == "NONE"
+    assert receipt.hybrid_result_claimed is False
+    assert receipt.projection_text_factual_use_allowed is False
+    assert receipt.snapshot is not None
+    assert receipt.normalized_query is not None
+    assert all(
+        item.query_id == FULLTEXT_QUERY_ID
+        and item.query_digest == receipt.normalized_query.query_digest
+        for item in receipt.hits
+    )
+    assert receipt.authority_view_digest is not None
+    assert len(receipt.canonical_bytes) < 262_144
+
+    assert driver.execute_read_count == 3
+    assert len(driver.calls) == 3
+    fulltext_statement, parameters = driver.calls[-1]
+    assert request().query_text not in fulltext_statement
+    assert parameters["index_name"] == snapshot().index_name
+    assert parameters["generation_id"] == str(GENERATION_ID)
+    assert parameters["limit"] == 9
+    assert "\\(" not in str(parameters["query"])
+    before_calls = list(driver.calls)
+    replay = retriever.retrieve(request())
+    assert replay.replayed is True
+    assert replay.receipt.canonical_bytes == receipt.canonical_bytes
+    assert driver.calls == before_calls
+
+
+def test_journal_does_not_hold_write_lock_while_producing(
+    tmp_path: Path,
+) -> None:
+    journal_path = tmp_path / "fulltext-receipts.sqlite3"
+    inner_driver = FakeDriver(default_scenario())
+    inner_retriever = FullTextRetriever(
+        graph_reader=inner_driver.reader(),
+        journal=FullTextReceiptJournal(journal_path),
+        authority_view_provider=lambda _request: authority_view(),
+        monotonic_ns=lambda: 0,
+    )
+    inner_request = request(
+        request_id=BranchRequestId.parse(
+            "00000000-0000-4000-8000-000000005271"
+        ),
+        idempotency_key="nested-inner-request",
+    )
+    inner_result = None
+
+    def outer_provider(_request):
+        nonlocal inner_result
+        inner_result = inner_retriever.retrieve(inner_request)
+        return authority_view()
+
+    outer_driver = FakeDriver(default_scenario())
+    outer_retriever = FullTextRetriever(
+        graph_reader=outer_driver.reader(),
+        journal=FullTextReceiptJournal(journal_path),
+        authority_view_provider=outer_provider,
+        monotonic_ns=lambda: 0,
+    )
+    outer_request = request(
+        request_id=BranchRequestId.parse(
+            "00000000-0000-4000-8000-000000005272"
+        ),
+        idempotency_key="nested-outer-request",
+    )
+
+    outer_result = outer_retriever.retrieve(outer_request)
+
+    assert outer_result.replayed is False
+    assert outer_result.receipt.outcome is BranchOutcome.COMPLETE
+    assert inner_result is not None
+    assert inner_result.replayed is False
+    assert inner_result.receipt.outcome is BranchOutcome.COMPLETE
+    assert outer_driver.execute_read_count == 3
+    assert inner_driver.execute_read_count == 3
+
+    replay_journal = FullTextReceiptJournal(journal_path)
+    inner_replay = replay_journal.execute(
+        inner_request,
+        lambda: pytest.fail("retained inner receipt must replay"),
+    )
+    outer_replay = replay_journal.execute(
+        outer_request,
+        lambda: pytest.fail("retained outer receipt must replay"),
+    )
+    assert inner_replay.replayed is True
+    assert outer_replay.replayed is True
+    assert (
+        inner_replay.receipt.canonical_bytes
+        == inner_result.receipt.canonical_bytes
+    )
+    assert (
+        outer_replay.receipt.canonical_bytes
+        == outer_result.receipt.canonical_bytes
+    )
+
+
+def test_restart_returns_first_receipt_without_authority_or_neo4j_calls(
+    tmp_path: Path,
+) -> None:
+    driver, _factory, retriever = system(tmp_path)
+    first = retriever.retrieve(request()).receipt
+
+    failing_driver = FakeDriver(default_scenario())
+    restarted = FullTextRetriever(
+        graph_reader=failing_driver.reader(),
+        journal=FullTextReceiptJournal(
+            tmp_path / "fulltext-receipts.sqlite3"
+        ),
+        authority_view_provider=lambda _request: pytest.fail(
+            "replay must not read authority"
+        ),
+        receipt_id_factory=lambda: pytest.fail(
+            "replay must not mint a receipt"
+        ),
+        monotonic_ns=lambda: 0,
+    )
+    replay = restarted.retrieve(request())
+
+    assert replay.replayed is True
+    assert replay.receipt.canonical_bytes == first.canonical_bytes
+    assert failing_driver.calls == []
+
+
+def test_no_match_is_complete_only_after_all_three_neo4j_reads(
+    tmp_path: Path,
+) -> None:
+    driver, _factory, retriever = system(
+        tmp_path,
+        scenario=default_scenario(rows=[]),
+    )
+    receipt = retriever.retrieve(
+        request(idempotency_key="no-match")
+    ).receipt
+
+    assert receipt.outcome is BranchOutcome.COMPLETE
+    assert receipt.reason_code == "NO_MATCH"
+    assert receipt.neo4j_read_count == 3
+    assert not receipt.hits
+    assert driver.execute_read_count == 3
+
+
+@pytest.mark.parametrize(
+    ("lifecycle", "reason"),
+    [
+        ("HELD", BranchExclusionReason.STALE_SOURCE_VERSION),
+        ("UNRESOLVED", BranchExclusionReason.STALE_SOURCE_VERSION),
+        ("PROPOSED", BranchExclusionReason.STALE_SOURCE_VERSION),
+        ("MERGED", BranchExclusionReason.TOMBSTONED),
+        ("SPLIT", BranchExclusionReason.TOMBSTONED),
+        ("REVERSED", BranchExclusionReason.TOMBSTONED),
+    ],
+)
+def test_every_nonactive_passage_lifecycle_is_excluded(
+    lifecycle: str,
+    reason: BranchExclusionReason,
+) -> None:
+    binding = replace(bindings()[1], lifecycle=lifecycle)
+    assert binding.exclusion_at(NOW) is reason
+
+
+def test_current_rights_and_lifecycle_exclusions_are_explicit(
+    tmp_path: Path,
+) -> None:
+    rows = [
+        result_row("p-blocked", 3.0),
+        result_row("p-tomb", 2.0),
+        result_row("p-en", 1.0),
+    ]
+    _driver, _factory, retriever = system(
+        tmp_path,
+        scenario=default_scenario(rows=rows),
+    )
+    receipt = retriever.retrieve(
+        request(idempotency_key="with-exclusions")
+    ).receipt
+
+    assert receipt.outcome is BranchOutcome.COMPLETE
+    assert receipt.reason_code == "OK_WITH_EXCLUSIONS"
+    assert [item.passage_id for item in receipt.hits] == ["p-en"]
+    assert [(item.authority_id, item.reason) for item in receipt.exclusions] == [
+        ("p-blocked", BranchExclusionReason.RIGHTS_NOT_CURRENT),
+        ("p-tomb", BranchExclusionReason.TOMBSTONED),
+    ]
+
+
+def test_wholly_ineligible_result_set_is_not_reported_as_no_match(
+    tmp_path: Path,
+) -> None:
+    rows = [
+        result_row("p-blocked", 3.0),
+        result_row("p-tomb", 2.0),
+    ]
+    _driver, _factory, retriever = system(
+        tmp_path,
+        scenario=default_scenario(rows=rows),
+    )
+    receipt = retriever.retrieve(
+        request(idempotency_key="all-excluded")
+    ).receipt
+
+    assert receipt.outcome is BranchOutcome.POLICY_BLOCKED
+    assert receipt.reason_code == "RIGHTS_BLOCKED"
+    assert not receipt.hits
+    assert len(receipt.exclusions) == 2
+
+
+@pytest.mark.parametrize(
+    ("changes", "outcome", "reason"),
+    [
+        (
+            {"generation_state": ProjectionGenerationState.RETIRED},
+            BranchOutcome.STALE,
+            "GENERATION_NOT_ACTIVE",
+        ),
+        (
+            {
+                "generation_id": ProjectionGenerationId.parse(
+                    "00000000-0000-4000-8000-000000005299"
+                )
+            },
+            BranchOutcome.STALE,
+            "GENERATION_MISMATCH",
+        ),
+        (
+            {"generation_identity_digest": digest("other-generation")},
+            BranchOutcome.STALE,
+            "GENERATION_IDENTITY_MISMATCH",
+        ),
+        (
+            {"fulltext_component_digest": digest("other-fulltext")},
+            BranchOutcome.STALE,
+            "GENERATION_COMPONENT_MISMATCH",
+        ),
+        (
+            {"rights_manifest_digest": digest("other-rights")},
+            BranchOutcome.STALE,
+            "RIGHTS_MANIFEST_MISMATCH",
+        ),
+        (
+            {"contiguous_ledger_seq": 41},
+            BranchOutcome.STALE,
+            "PROJECTION_WATERMARK_STALE",
+        ),
+        (
+            {"open_gap_count": 1},
+            BranchOutcome.INCOMPLETE,
+            "PROJECTION_GAPS_OPEN",
+        ),
+        (
+            {"dead_letter_count": 1},
+            BranchOutcome.INCOMPLETE,
+            "PROJECTION_DEAD_LETTERS_PRESENT",
+        ),
+        (
+            {"freshness_deadline": NOW},
+            BranchOutcome.COMPLETE,
+            "OK",
+        ),
+        (
+            {"index_state": FullTextIndexState.POPULATING},
+            BranchOutcome.INCOMPLETE,
+            "FULLTEXT_INDEX_POPULATING",
+        ),
+        (
+            {"index_state": FullTextIndexState.FAILED},
+            BranchOutcome.UNAVAILABLE,
+            "FULLTEXT_INDEX_UNAVAILABLE",
+        ),
+        (
+            {"provider": "fulltext-1.0"},
+            BranchOutcome.UNAVAILABLE,
+            "COMPONENT_INCOMPATIBLE",
+        ),
+        (
+            {"analyzer": "standard"},
+            BranchOutcome.UNAVAILABLE,
+            "COMPONENT_INCOMPATIBLE",
+        ),
+        (
+            {"server_version": "2026.05.0"},
+            BranchOutcome.UNAVAILABLE,
+            "COMPONENT_INCOMPATIBLE",
+        ),
+    ],
+)
+def test_snapshot_failures_have_explicit_outcomes(
+    tmp_path: Path,
+    changes: dict[str, object],
+    outcome: BranchOutcome,
+    reason: str,
+) -> None:
+    current = snapshot(**changes)
+    view = authority_view(projection_snapshot=current)
+    scenario = default_scenario(projection_snapshot=current)
+    _driver, _factory, retriever = system(
+        tmp_path,
+        view=view,
+        scenario=scenario,
+    )
+    receipt = retriever.retrieve(
+        request(idempotency_key=f"snapshot-{reason.lower()}")
+    ).receipt
+
+    assert receipt.outcome is outcome
+    assert receipt.reason_code == reason
+    assert receipt.authority_read_count == 1
+    if reason != "OK":
+        assert receipt.neo4j_read_count == 0
+
+
+def test_timeout_override_of_stale_snapshot_is_journaled_and_replayed(
+    tmp_path: Path,
+) -> None:
+    current = snapshot(
+        generation_state=ProjectionGenerationState.RETIRED,
+    )
+    driver, _factory, retriever = system(
+        tmp_path,
+        view=authority_view(projection_snapshot=current),
+        scenario=default_scenario(projection_snapshot=current),
+        clock=SequenceClock((0, 5_000_000_001)),
+    )
+    current_request = request(
+        idempotency_key="stale-timeout-override"
+    )
+
+    first = retriever.retrieve(current_request)
+    receipt = first.receipt
+
+    assert first.replayed is False
+    assert receipt.outcome is BranchOutcome.INCOMPLETE
+    assert receipt.reason_code == "QUERY_TIMEOUT"
+    assert receipt.elapsed_ms == 5_000
+    assert receipt.snapshot == current
+    assert receipt.authority_read_count == 1
+    assert receipt.neo4j_read_count == 0
+    assert receipt.normalized_query is None
+    assert not receipt.hits
+    assert not receipt.exclusions
+    assert driver.calls == []
+    with pytest.raises(FullTextContractError, match="timeout receipt"):
+        replace(receipt, elapsed_ms=4_999)
+    with pytest.raises(FullTextContractError, match="timeout receipt"):
+        replace(receipt, outcome=BranchOutcome.STALE)
+
+    replay = retriever.retrieve(current_request)
+    assert replay.replayed is True
+    assert replay.receipt.canonical_bytes == receipt.canonical_bytes
+    assert driver.calls == []
+
+
+def test_projection_age_beyond_hard_hour_is_stale(tmp_path: Path) -> None:
+    current = snapshot(
+        validation_recorded_at=type(NOW).parse(
+            "2042-03-12T10:59:59.000000Z"
+        ),
+        freshness_deadline=LATER,
+    )
+    _driver, _factory, retriever = system(
+        tmp_path,
+        view=authority_view(projection_snapshot=current),
+        scenario=default_scenario(projection_snapshot=current),
+    )
+    receipt = retriever.retrieve(
+        request(idempotency_key="age-stale")
+    ).receipt
+
+    assert receipt.outcome is BranchOutcome.STALE
+    assert receipt.reason_code == "PROJECTION_FRESHNESS_STALE"
+
+
+@pytest.mark.parametrize(
+    ("indexes", "outcome", "reason"),
+    [
+        ([], BranchOutcome.UNAVAILABLE, "FULLTEXT_INDEX_MISSING"),
+        (
+            [index_row(state="POPULATING")],
+            BranchOutcome.INCOMPLETE,
+            "FULLTEXT_INDEX_POPULATING",
+        ),
+        (
+            [index_row(state="FAILED")],
+            BranchOutcome.UNAVAILABLE,
+            "FULLTEXT_INDEX_UNAVAILABLE",
+        ),
+        (
+            [index_row(provider="fulltext-1.0")],
+            BranchOutcome.UNAVAILABLE,
+            "FULLTEXT_INDEX_INCOMPATIBLE",
+        ),
+        (
+            [index_row(analyzer="standard")],
+            BranchOutcome.UNAVAILABLE,
+            "FULLTEXT_INDEX_INCOMPATIBLE",
+        ),
+        (
+            [index_row(eventually_consistent=True)],
+            BranchOutcome.UNAVAILABLE,
+            "FULLTEXT_INDEX_INCOMPATIBLE",
+        ),
+        (
+            [index_row(properties=("retrieval_text",))],
+            BranchOutcome.UNAVAILABLE,
+            "FULLTEXT_INDEX_INCOMPATIBLE",
+        ),
+        (
+            [index_row(), index_row()],
+            BranchOutcome.UNAVAILABLE,
+            "FULLTEXT_INDEX_AMBIGUOUS",
+        ),
+    ],
+)
+def test_live_index_inventory_fails_closed(
+    tmp_path: Path,
+    indexes: list[dict[str, object]],
+    outcome: BranchOutcome,
+    reason: str,
+) -> None:
+    scenario = default_scenario()
+    scenario.indexes = indexes
+    _driver, _factory, retriever = system(
+        tmp_path,
+        scenario=scenario,
+    )
+    receipt = retriever.retrieve(
+        request(idempotency_key=f"index-{reason.lower()}")
+    ).receipt
+
+    assert receipt.outcome is outcome
+    assert receipt.reason_code == reason
+    assert receipt.neo4j_read_count == 2
+    assert not receipt.hits
+
+
+def test_live_neo4j_component_mismatch_is_unavailable(tmp_path: Path) -> None:
+    scenario = default_scenario()
+    scenario.component = component_row(version="2026.05.0")
+    _driver, _factory, retriever = system(
+        tmp_path,
+        scenario=scenario,
+    )
+    receipt = retriever.retrieve(
+        request(idempotency_key="live-component-mismatch")
+    ).receipt
+
+    assert receipt.outcome is BranchOutcome.UNAVAILABLE
+    assert receipt.reason_code == "NEO4J_INCOMPATIBLE"
+    assert receipt.neo4j_read_count == 1
+
+
+def test_driver_version_mismatch_fails_before_authority_read(
+    tmp_path: Path,
+) -> None:
+    calls = 0
+
+    def provider(_request):
+        nonlocal calls
+        calls += 1
+        return authority_view()
+
+    driver = FakeDriver(default_scenario())
+    retriever = FullTextRetriever(
+        graph_reader=driver.reader(driver_version="6.1.0"),
+        journal=FullTextReceiptJournal(tmp_path / "driver-mismatch.sqlite3"),
+        authority_view_provider=provider,
+        monotonic_ns=lambda: 0,
+    )
+    receipt = retriever.retrieve(
+        request(idempotency_key="driver-mismatch")
+    ).receipt
+
+    assert receipt.outcome is BranchOutcome.UNAVAILABLE
+    assert receipt.reason_code == "DRIVER_INCOMPATIBLE"
+    assert receipt.authority_read_count == 0
+    assert calls == 0
+    assert driver.calls == []
+
+
+def test_untyped_authority_view_returns_journaled_unavailable_receipt(
+    tmp_path: Path,
+) -> None:
+    driver = FakeDriver(default_scenario())
+    retriever = FullTextRetriever(
+        graph_reader=driver.reader(),
+        journal=FullTextReceiptJournal(
+            tmp_path / "untyped-authority.sqlite3"
+        ),
+        authority_view_provider=lambda _request: object(),
+        monotonic_ns=lambda: 0,
+    )
+    current_request = request(idempotency_key="untyped-authority-view")
+
+    first = retriever.retrieve(current_request)
+    receipt = first.receipt
+
+    assert first.replayed is False
+    assert receipt.outcome is BranchOutcome.UNAVAILABLE
+    assert receipt.reason_code == "AUTHORITY_VIEW_UNAVAILABLE"
+    assert receipt.authority_read_count == 0
+    assert receipt.neo4j_read_count == 0
+    assert receipt.snapshot is None
+    assert receipt.authority_view_digest is None
+    assert driver.calls == []
+
+    replay = retriever.retrieve(current_request)
+    assert replay.replayed is True
+    assert replay.receipt.canonical_bytes == receipt.canonical_bytes
+    assert driver.calls == []
+
+
+def test_noncanonical_authority_view_returns_journaled_unavailable_receipt(
+    tmp_path: Path,
+) -> None:
+    corrupt_snapshot = snapshot()
+    object.__setattr__(
+        corrupt_snapshot,
+        "contiguous_ledger_seq",
+        9_007_199_254_740_992,
+    )
+    noncanonical_view = authority_view(
+        projection_snapshot=corrupt_snapshot
+    )
+    driver, _factory, retriever = system(
+        tmp_path,
+        view=noncanonical_view,
+    )
+    current_request = request(
+        idempotency_key="noncanonical-authority-view"
+    )
+
+    first = retriever.retrieve(current_request)
+    receipt = first.receipt
+
+    assert first.replayed is False
+    assert receipt.outcome is BranchOutcome.UNAVAILABLE
+    assert receipt.reason_code == "AUTHORITY_VIEW_UNAVAILABLE"
+    assert receipt.authority_read_count == 0
+    assert receipt.neo4j_read_count == 0
+    assert receipt.snapshot is None
+    assert receipt.authority_view_digest is None
+    assert driver.calls == []
+
+    replay = retriever.retrieve(current_request)
+    assert replay.replayed is True
+    assert replay.receipt.canonical_bytes == receipt.canonical_bytes
+    assert driver.calls == []
+
+
+def test_result_overflow_is_incomplete_instead_of_truncated(
+    tmp_path: Path,
+) -> None:
+    custom_bindings = tuple(
+        replace(
+            bindings()[1],
+            passage_id=f"p-overflow-{index}",
+            dependency_root_id=f"root-overflow-{index}",
+            source_identity=f"source-overflow:revision-{index}",
+            provenance_digest=digest(f"overflow-document-{index}"),
+        )
+        for index in range(9)
+    )
+    current_view = authority_view(document_bindings=custom_bindings)
+    rows = [
+        {
+            "generation_id": str(GENERATION_ID),
+            "passage_id": binding.passage_id,
+            "document_digest": binding.provenance_digest,
+            "language": binding.language,
+            "score": float(20 - index),
+        }
+        for index, binding in enumerate(custom_bindings)
+    ]
+    _driver, _factory, retriever = system(
+        tmp_path,
+        view=current_view,
+        scenario=default_scenario(rows=rows),
+    )
+    receipt = retriever.retrieve(
+        request(idempotency_key="overflow")
+    ).receipt
+
+    assert receipt.outcome is BranchOutcome.INCOMPLETE
+    assert receipt.reason_code == "RESULT_BOUND_EXCEEDED"
+    assert not receipt.hits
+
+
+@pytest.mark.parametrize(
+    ("case_id", "rows"),
+    [
+        (
+            "unknown-passage",
+            [
+                {
+                    "generation_id": str(GENERATION_ID),
+                    "passage_id": "p-unknown",
+                    "document_digest": digest("unknown"),
+                    "language": "en-GB",
+                    "score": 1.0,
+                }
+            ],
+        ),
+        (
+            "document-digest",
+            [result_row("p-en", 1.0, document_digest=digest("tampered"))],
+        ),
+        (
+            "malformed-document-digest",
+            [result_row("p-en", 1.0, document_digest="not-a-digest")],
+        ),
+        ("language", [result_row("p-en", 1.0, language="zh-HK")]),
+        (
+            "duplicate-passage",
+            [result_row("p-en", 1.0), result_row("p-en", 0.9)],
+        ),
+        (
+            "ordering",
+            [result_row("p-zh", 1.0), result_row("p-en", 2.0)],
+        ),
+    ],
+)
+def test_projection_result_integrity_failures_are_unavailable(
+    tmp_path: Path,
+    case_id: str,
+    rows: list[dict[str, object]],
+) -> None:
+    _driver, _factory, retriever = system(
+        tmp_path,
+        scenario=default_scenario(rows=rows),
+    )
+    receipt = retriever.retrieve(
+        request(idempotency_key=f"integrity-{case_id}")
+    ).receipt
+
+    assert receipt.outcome is BranchOutcome.UNAVAILABLE
+    assert receipt.reason_code == "PROJECTION_INTEGRITY_ERROR"
+    assert not receipt.hits
+
+
+def test_caller_lucene_syntax_is_only_a_bound_escaped_value(
+    tmp_path: Path,
+) -> None:
+    driver, _factory, retriever = system(
+        tmp_path,
+        scenario=default_scenario(rows=[]),
+    )
+    surface = 'foo") OR *:* OR (bar'
+    receipt = retriever.retrieve(
+        request(
+            idempotency_key="lucene-injection",
+            query_text=surface,
+        )
+    ).receipt
+
+    assert receipt.outcome is BranchOutcome.COMPLETE
+    statement, parameters = driver.calls[-1]
+    assert surface not in statement
+    assert parameters["query"] != surface
+    assert "\\*" in parameters["query"]
+    assert "\\:" in parameters["query"]
+    assert "\\)" in parameters["query"]
+    assert parameters["index_name"] == snapshot().index_name
+    assert set(parameters) == {
+        "index_name",
+        "query",
+        "generation_id",
+        "limit",
+    }
+
+
+def test_early_graph_timeout_is_journaled_as_unavailable(
+    tmp_path: Path,
+) -> None:
+    scenario = default_scenario()
+    scenario.failure_on = "query"
+    driver, _factory, retriever = system(
+        tmp_path,
+        scenario=scenario,
+        clock=SequenceClock((0, 0, 0, 0, 0)),
+    )
+    current_request = request(idempotency_key="early-neo4j-timeout")
+
+    first = retriever.retrieve(current_request)
+    receipt = first.receipt
+
+    assert first.replayed is False
+    assert receipt.outcome is BranchOutcome.UNAVAILABLE
+    assert receipt.reason_code == "NEO4J_READ_UNAVAILABLE"
+    assert receipt.elapsed_ms == 0
+    assert receipt.authority_read_count == 1
+    assert receipt.neo4j_read_count == 2
+    assert receipt.normalized_query is not None
+    assert not receipt.hits
+    assert not receipt.exclusions
+
+    before_calls = list(driver.calls)
+    replay = retriever.retrieve(current_request)
+    assert replay.replayed is True
+    assert replay.receipt.canonical_bytes == receipt.canonical_bytes
+    assert driver.calls == before_calls
+
+
+def test_exact_deadline_before_graph_read_is_query_timeout(
+    tmp_path: Path,
+) -> None:
+    driver, _factory, retriever = system(
+        tmp_path,
+        clock=SequenceClock((0, 5_000_000_000, 5_000_000_000)),
+    )
+    receipt = retriever.retrieve(
+        request(idempotency_key="exact-deadline-before-read")
+    ).receipt
+
+    assert receipt.outcome is BranchOutcome.INCOMPLETE
+    assert receipt.reason_code == "QUERY_TIMEOUT"
+    assert receipt.elapsed_ms == 5_000
+    assert receipt.authority_read_count == 1
+    assert receipt.neo4j_read_count == 0
+    assert not receipt.hits
+    assert not receipt.exclusions
+    assert driver.calls == []
+    assert driver.read_requests == []
+
+
+def test_one_nanosecond_overrun_is_an_explicit_timeout(
+    tmp_path: Path,
+) -> None:
+    # start + remaining-budget handoff + final receipt
+    clock = SequenceClock((0, 0, 0, 0, 5_000_000_001))
+    _driver, _factory, retriever = system(
+        tmp_path,
+        clock=clock,
+    )
+    receipt = retriever.retrieve(
+        request(idempotency_key="one-ns-overrun")
+    ).receipt
+
+    assert receipt.outcome is BranchOutcome.INCOMPLETE
+    assert receipt.reason_code == "QUERY_TIMEOUT"
+    assert receipt.elapsed_ms == 5_000
+    assert not receipt.hits
+
+
+def test_graph_reader_receives_each_remaining_nanosecond_budget(
+    tmp_path: Path,
+) -> None:
+    clock = SequenceClock(
+        (0, 100_000_000, 200_000_000, 300_000_000, 400_000_000)
+    )
+    driver, _factory, retriever = system(
+        tmp_path,
+        clock=clock,
+    )
+    receipt = retriever.retrieve(
+        request(idempotency_key="managed-timeout")
+    ).receipt
+
+    assert receipt.outcome is BranchOutcome.COMPLETE
+    assert len(driver.read_requests) == 3
+    assert [item.timeout_ns for item in driver.read_requests] == [
+        4_900_000_000,
+        4_800_000_000,
+        4_700_000_000,
+    ]
+
+
+def test_journal_rejects_semantic_conflict_and_retains_rows(
+    tmp_path: Path,
+) -> None:
+    _driver, _factory, retriever = system(tmp_path)
+    retriever.retrieve(request())
+
+    with pytest.raises(FullTextReceiptIdempotencyConflict):
+        retriever.retrieve(request(query_text="different query"))
+
+    journal_path = tmp_path / "fulltext-receipts.sqlite3"
+    with sqlite3.connect(journal_path) as connection:
+        with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+            connection.execute(
+                "UPDATE increment5_fulltext_receipts SET "
+                "receipt_digest='sha256:" + "0" * 64 + "'"
+            )
+        with pytest.raises(sqlite3.IntegrityError, match="retained"):
+            connection.execute(
+                "DELETE FROM increment5_fulltext_receipts"
+            )
+
+
+def test_journal_detects_corrupted_receipt_bytes(tmp_path: Path) -> None:
+    driver, _factory, retriever = system(tmp_path)
+    retriever.retrieve(request())
+    journal_path = tmp_path / "fulltext-receipts.sqlite3"
+    with sqlite3.connect(journal_path) as connection:
+        connection.execute(
+            "DROP TRIGGER immutable_increment5_fulltext_receipt_update"
+        )
+        connection.execute(
+            "UPDATE increment5_fulltext_receipts SET receipt_bytes=?",
+            (b"{}",),
+        )
+
+    restarted = FullTextRetriever(
+        graph_reader=driver.reader(),
+        journal=FullTextReceiptJournal(journal_path),
+        authority_view_provider=lambda _request: authority_view(),
+        monotonic_ns=lambda: 0,
+    )
+    with pytest.raises(
+        FullTextReceiptJournalError,
+        match="digest differs",
+    ):
+        restarted.retrieve(request())
+
+
+@pytest.mark.parametrize("passage_id", ["bad passage", "1bad"])
+def test_document_binding_rejects_non_token_passage_id(
+    passage_id: str,
+) -> None:
+    with pytest.raises(ValueError, match="valid authority token"):
+        replace(bindings()[0], passage_id=passage_id)
+
+
+def test_journal_rejects_rebound_request_identity(tmp_path: Path) -> None:
+    driver, _factory, retriever = system(tmp_path)
+    original = retriever.retrieve(request()).receipt
+    value = original.canonical_value()
+    value["request_id"] = "00000000-0000-4000-8000-000000005299"
+    corrupted = canonical_json_bytes(value)
+    journal_path = tmp_path / "fulltext-receipts.sqlite3"
+    with sqlite3.connect(journal_path) as connection:
+        connection.execute(
+            "DROP TRIGGER immutable_increment5_fulltext_receipt_update"
+        )
+        connection.execute(
+            "UPDATE increment5_fulltext_receipts SET "
+            "receipt_bytes=?,receipt_digest=?",
+            (corrupted, digest_bytes(corrupted)),
+        )
+
+    restarted = FullTextRetriever(
+        graph_reader=driver.reader(),
+        journal=FullTextReceiptJournal(journal_path),
+        authority_view_provider=lambda _request: authority_view(),
+        monotonic_ns=lambda: 0,
+    )
+    with pytest.raises(
+        FullTextReceiptJournalError,
+        match="request binding differs",
+    ):
+        restarted.retrieve(request())
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement"),
+    [
+        ("query_id", "increment5.fulltext.other"),
+        ("query_digest", digest("another-normalized-query")),
+    ],
+)
+def test_journal_rejects_hits_rebound_to_another_query(
+    tmp_path: Path,
+    field: str,
+    replacement: str,
+) -> None:
+    driver, _factory, retriever = system(tmp_path)
+    original = retriever.retrieve(request()).receipt
+    value = original.canonical_value()
+    assert value["hits"]
+    value["hits"][0][field] = replacement
+    corrupted = canonical_json_bytes(value)
+    journal_path = tmp_path / "fulltext-receipts.sqlite3"
+    with sqlite3.connect(journal_path) as connection:
+        connection.execute(
+            "DROP TRIGGER immutable_increment5_fulltext_receipt_update"
+        )
+        connection.execute(
+            "UPDATE increment5_fulltext_receipts SET "
+            "receipt_bytes=?,receipt_digest=?",
+            (corrupted, digest_bytes(corrupted)),
+        )
+
+    restarted = FullTextRetriever(
+        graph_reader=driver.reader(),
+        journal=FullTextReceiptJournal(journal_path),
+        authority_view_provider=lambda _request: authority_view(),
+        monotonic_ns=lambda: 0,
+    )
+    with pytest.raises(
+        FullTextReceiptJournalError,
+        match="unavailable or inconsistent",
+    ):
+        restarted.retrieve(request())
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement"),
+    [
+        ("generation_state", "RETIRED"),
+        (
+            "generation_id",
+            "00000000-0000-4000-8000-000000005299",
+        ),
+        (
+            "generation_identity_digest",
+            digest("another-generation-identity"),
+        ),
+        (
+            "fulltext_component_digest",
+            digest("another-snapshot-fulltext-component"),
+        ),
+        (
+            "normalization_component_digest",
+            digest("another-snapshot-normalization-component"),
+        ),
+        (
+            "rights_manifest_digest",
+            digest("another-rights-manifest"),
+        ),
+        ("contiguous_ledger_seq", 41),
+        ("open_gap_count", 1),
+        ("dead_letter_count", 1),
+        (
+            "freshness_deadline",
+            "2042-03-12T11:45:00.000000Z",
+        ),
+        ("index_state", "FAILED"),
+    ],
+)
+def test_journal_rejects_snapshot_rebound_from_request(
+    tmp_path: Path,
+    field: str,
+    replacement: object,
+) -> None:
+    driver, _factory, retriever = system(tmp_path)
+    original = retriever.retrieve(request()).receipt
+    value = original.canonical_value()
+    assert value["snapshot"] is not None
+    value["snapshot"][field] = replacement
+    corrupted = canonical_json_bytes(value)
+    journal_path = tmp_path / "fulltext-receipts.sqlite3"
+    with sqlite3.connect(journal_path) as connection:
+        connection.execute(
+            "DROP TRIGGER immutable_increment5_fulltext_receipt_update"
+        )
+        connection.execute(
+            "UPDATE increment5_fulltext_receipts SET "
+            "receipt_bytes=?,receipt_digest=?",
+            (corrupted, digest_bytes(corrupted)),
+        )
+
+    before_calls = list(driver.calls)
+    restarted = FullTextRetriever(
+        graph_reader=driver.reader(),
+        journal=FullTextReceiptJournal(journal_path),
+        authority_view_provider=lambda _request: authority_view(),
+        monotonic_ns=lambda: 0,
+    )
+    with pytest.raises(
+        FullTextReceiptJournalError,
+        match="request binding differs",
+    ):
+        restarted.retrieve(request())
+    assert driver.calls == before_calls
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement"),
+    [
+        ("language_mode", "EN_GB"),
+        ("lucene_query", 'retrieval_text:"another"'),
+        ("implementation_version", "another-normalizer-version"),
+        ("component_digest", digest("another-normalizer-component")),
+    ],
+)
+def test_journal_rejects_normalized_query_rebound_from_request(
+    tmp_path: Path,
+    field: str,
+    replacement: str,
+) -> None:
+    driver, _factory, retriever = system(tmp_path)
+    original = retriever.retrieve(request()).receipt
+    value = original.canonical_value()
+    assert value["normalized_query"] is not None
+    value["normalized_query"][field] = replacement
+    rebound_digest = digest_bytes(
+        canonical_json_bytes(value["normalized_query"])
+    )
+    for hit in value["hits"]:
+        hit["query_digest"] = rebound_digest
+    corrupted = canonical_json_bytes(value)
+    journal_path = tmp_path / "fulltext-receipts.sqlite3"
+    with sqlite3.connect(journal_path) as connection:
+        connection.execute(
+            "DROP TRIGGER immutable_increment5_fulltext_receipt_update"
+        )
+        connection.execute(
+            "UPDATE increment5_fulltext_receipts SET "
+            "receipt_bytes=?,receipt_digest=?",
+            (corrupted, digest_bytes(corrupted)),
+        )
+
+    before_calls = list(driver.calls)
+    restarted = FullTextRetriever(
+        graph_reader=driver.reader(),
+        journal=FullTextReceiptJournal(journal_path),
+        authority_view_provider=lambda _request: authority_view(),
+        monotonic_ns=lambda: 0,
+    )
+    with pytest.raises(
+        FullTextReceiptJournalError,
+        match="request binding differs",
+    ):
+        restarted.retrieve(request())
+    assert driver.calls == before_calls
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"contract_digest": digest("another-contract")},
+        {"policy_id": "another-fulltext-policy"},
+        {"fulltext_component_digest": digest("another-fulltext-component")},
+        {
+            "normalization_component_digest": digest(
+                "another-normalization-component"
+            )
+        },
+        {
+            "started_at": LATER.to_text(),
+            "completed_at": LATER.to_text(),
+        },
+    ],
+)
+def test_journal_rejects_receipt_fields_rebound_from_request(
+    tmp_path: Path,
+    changes: dict[str, object],
+) -> None:
+    driver, _factory, retriever = system(tmp_path)
+    original = retriever.retrieve(request()).receipt
+    value = original.canonical_value()
+    value.update(changes)
+    corrupted = canonical_json_bytes(value)
+    journal_path = tmp_path / "fulltext-receipts.sqlite3"
+    with sqlite3.connect(journal_path) as connection:
+        connection.execute(
+            "DROP TRIGGER immutable_increment5_fulltext_receipt_update"
+        )
+        connection.execute(
+            "UPDATE increment5_fulltext_receipts SET "
+            "receipt_bytes=?,receipt_digest=?",
+            (corrupted, digest_bytes(corrupted)),
+        )
+
+    restarted = FullTextRetriever(
+        graph_reader=driver.reader(),
+        journal=FullTextReceiptJournal(journal_path),
+        authority_view_provider=lambda _request: authority_view(),
+        monotonic_ns=lambda: 0,
+    )
+    with pytest.raises(
+        FullTextReceiptJournalError,
+        match="request binding differs",
+    ):
+        restarted.retrieve(request())
+
+
+def test_journal_translates_canonical_malformed_receipt_fields(
+    tmp_path: Path,
+) -> None:
+    driver, _factory, retriever = system(tmp_path)
+    original = retriever.retrieve(request()).receipt
+    value = original.canonical_value()
+    value["fulltext_component_digest"] = "not-a-digest"
+    corrupted = canonical_json_bytes(value)
+    journal_path = tmp_path / "fulltext-receipts.sqlite3"
+    with sqlite3.connect(journal_path) as connection:
+        connection.execute(
+            "DROP TRIGGER immutable_increment5_fulltext_receipt_update"
+        )
+        connection.execute(
+            "UPDATE increment5_fulltext_receipts SET "
+            "receipt_bytes=?,receipt_digest=?",
+            (corrupted, digest_bytes(corrupted)),
+        )
+
+    restarted = FullTextRetriever(
+        graph_reader=driver.reader(),
+        journal=FullTextReceiptJournal(journal_path),
+        authority_view_provider=lambda _request: authority_view(),
+        monotonic_ns=lambda: 0,
+    )
+    with pytest.raises(
+        FullTextReceiptJournalError,
+        match="unavailable or inconsistent",
+    ):
+        restarted.retrieve(request())
+
+
+def test_request_rejects_oversized_and_unbounded_controls() -> None:
+    with pytest.raises(FullTextContractError, match="bounded"):
+        request(query_text="x" * 16_385)
+    with pytest.raises(FullTextContractError, match="fixed at 8"):
+        request(result_limit=9)
+    with pytest.raises(FullTextContractError, match="fixed at 5000"):
+        request(timeout_ms=5_001)
+    with pytest.raises(FullTextContractError, match="response byte limit"):
+        request(response_byte_limit=262_145)
+    with pytest.raises(FullTextContractError, match="canonical non-negative"):
+        request(minimum_watermark=9_007_199_254_740_992)
+    with pytest.raises(FullTextContractError, match="canonical non-negative"):
+        snapshot(index_document_count=9_007_199_254_740_992)
+
+
+@pytest.mark.parametrize(
+    ("changes", "reason"),
+    [
+        (
+            {"contract_digest": digest("wrong-contract")},
+            "CONTRACT_MISMATCH",
+        ),
+        (
+            {"policy_id": "unreviewed-fulltext-policy"},
+            "POLICY_MISMATCH",
+        ),
+        (
+            {"fulltext_component_digest": digest("wrong-fulltext")},
+            "COMPONENT_MISMATCH",
+        ),
+        (
+            {"normalization_component_digest": digest("wrong-normalizer")},
+            "COMPONENT_MISMATCH",
+        ),
+        (
+            {"query_valid_time": LATER},
+            "QUERY_VALID_TIME_IN_FUTURE",
+        ),
+    ],
+)
+def test_request_policy_failures_do_not_read_authority_or_neo4j(
+    tmp_path: Path,
+    changes: dict[str, object],
+    reason: str,
+) -> None:
+    provider_calls = 0
+
+    def provider(_request):
+        nonlocal provider_calls
+        provider_calls += 1
+        return authority_view()
+
+    driver, _factory, retriever = system(
+        tmp_path,
+        provider=provider,
+    )
+    receipt = retriever.retrieve(
+        request(
+            idempotency_key=f"policy-{reason.lower()}",
+            **changes,
+        )
+    ).receipt
+
+    assert receipt.outcome is BranchOutcome.POLICY_BLOCKED
+    assert receipt.reason_code == reason
+    assert receipt.authority_read_count == 0
+    assert receipt.neo4j_read_count == 0
+    assert provider_calls == 0
+    assert driver.calls == []
+
+
+def test_authority_provider_failure_is_explicit_unavailable(
+    tmp_path: Path,
+) -> None:
+    driver, _factory, retriever = system(
+        tmp_path,
+        provider=lambda _request: (_ for _ in ()).throw(
+            RuntimeError("authority unavailable")
+        ),
+    )
+    receipt = retriever.retrieve(
+        request(idempotency_key="authority-unavailable")
+    ).receipt
+
+    assert receipt.outcome is BranchOutcome.UNAVAILABLE
+    assert receipt.reason_code == "AUTHORITY_VIEW_UNAVAILABLE"
+    assert receipt.authority_read_count == 0
+    assert driver.calls == []
+
+
+@pytest.mark.parametrize("failure_on", ("component", "index", "query"))
+def test_neo4j_read_failure_is_explicit_unavailable(
+    tmp_path: Path,
+    failure_on: str,
+) -> None:
+    scenario = default_scenario()
+    scenario.failure_on = failure_on
+    _driver, _factory, retriever = system(
+        tmp_path,
+        scenario=scenario,
+    )
+    receipt = retriever.retrieve(
+        request(idempotency_key=f"read-failure-{failure_on}")
+    ).receipt
+
+    assert receipt.outcome in {
+        BranchOutcome.UNAVAILABLE,
+        BranchOutcome.INCOMPLETE,
+    }
+    assert receipt.reason_code in {
+        "NEO4J_READ_UNAVAILABLE",
+        "QUERY_TIMEOUT",
+    }
+    assert not receipt.hits

--- a/newsroom/tests/test_increment5b2_neo4j_authority_port.py
+++ b/newsroom/tests/test_increment5b2_neo4j_authority_port.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+import pytest
+
+from newsroom.authority._neo4j_projection_system import (
+    _open_neo4j_fulltext_reader_with_adapter,
+)
+from newsroom.authority.neo4j_fulltext_reader import (
+    Neo4jFullTextReadError,
+    Neo4jFullTextReadPhase,
+    Neo4jFullTextReadRequest,
+    Neo4jFullTextReadTimeout,
+)
+from newsroom.projection.neo4j._adapter import (
+    _COMPONENT_QUERY,
+    _FULLTEXT_INDEX_INVENTORY_QUERY,
+    _FULLTEXT_READ_QUERY,
+    _Neo4jAdapter,
+)
+
+from .increment5b2_helpers import (
+    GENERATION_ID,
+    FakeDriver,
+    RecordingUnitOfWorkFactory,
+    SequenceClock,
+    config,
+    default_scenario,
+    snapshot,
+)
+
+
+def test_authority_port_owns_three_fixed_server_timed_phases() -> None:
+    clock = SequenceClock(
+        (
+            0,
+            100_000_000,
+            200_000_000,
+            300_000_000,
+            400_000_000,
+            500_000_000,
+            600_000_000,
+            700_000_000,
+            800_000_000,
+        )
+    )
+    factory = RecordingUnitOfWorkFactory()
+    driver = FakeDriver(default_scenario())
+    adapter = _Neo4jAdapter(
+        driver=driver,
+        config=config(),
+        driver_version="6.2.0",
+        monotonic_ns=clock,
+        unit_of_work_factory=factory,
+    )
+    reader = _open_neo4j_fulltext_reader_with_adapter(adapter)
+
+    component = reader.read(
+        Neo4jFullTextReadRequest.component(
+            timeout_ns=5_000_000_000,
+        )
+    )
+    indexes = reader.read(
+        Neo4jFullTextReadRequest.index(
+            index_name=snapshot().index_name,
+            timeout_ns=4_800_000_000,
+        )
+    )
+    rows = reader.read(
+        Neo4jFullTextReadRequest.query(
+            index_name=snapshot().index_name,
+            lucene_expression=(
+                "latin_terms:(synthetic) OR "
+                "han_bigrams:(合成) OR "
+                "retrieval_text:(synthetic)"
+            ),
+            generation_id=GENERATION_ID,
+            limit=9,
+            timeout_ns=4_600_000_000,
+        )
+    )
+
+    assert component.driver_version == "6.2.0"
+    assert component.read_count == 1
+    assert component.component == {
+        "version": "2026.06.0",
+        "edition": "community",
+    }
+    assert len(indexes.indexes) == 1
+    assert len(rows.rows) == 2
+    assert driver.execute_read_count == 3
+    assert [statement for statement, _parameters in driver.calls] == [
+        _COMPONENT_QUERY,
+        _FULLTEXT_INDEX_INVENTORY_QUERY,
+        _FULLTEXT_READ_QUERY,
+    ]
+    assert [round(float(item["timeout"]), 1) for item in factory.options] == [
+        4.9,
+        4.7,
+        4.5,
+    ]
+    assert [item["metadata"]["newsroom_operation"] for item in factory.options] == [
+        "increment5.fulltext.component",
+        "increment5.fulltext.index",
+        "increment5.fulltext.query",
+    ]
+    assert not hasattr(reader, "driver")
+    assert not hasattr(reader, "session")
+    assert not hasattr(reader, "execute_query")
+
+    reader.close()
+    reader.close()
+    assert driver.closed is True
+
+
+class _Neo4jRecordLike:
+    def __init__(self, values: dict[str, object]) -> None:
+        self._values = dict(values)
+
+    def __iter__(self):
+        return iter(self._values.values())
+
+    def items(self):
+        return self._values.items()
+
+
+class _RecordReturningAdapter:
+    driver_version = "6.2.0"
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def read_increment5_fulltext(
+        self,
+        *,
+        phase: str,
+        index_name: str | None,
+        lucene_expression: str | None,
+        generation_id: str | None,
+        limit: int,
+        timeout_ns: int,
+    ):
+        assert timeout_ns > 0
+        if phase == "COMPONENT":
+            return _Neo4jRecordLike(
+                {
+                    "version": "2026.06.0",
+                    "edition": "community",
+                }
+            )
+        if phase == "INDEX":
+            return (
+                _Neo4jRecordLike(
+                    {
+                        "name": index_name or "",
+                        "state": "ONLINE",
+                    }
+                ),
+            )
+        assert lucene_expression
+        assert generation_id
+        assert limit == 9
+        return (
+            _Neo4jRecordLike(
+                {
+                    "generation_id": generation_id,
+                    "passage_id": "p-en",
+                    "score": 1.0,
+                }
+            ),
+        )
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_authority_port_copies_neo4j_records_to_plain_mappings() -> None:
+    adapter = _RecordReturningAdapter()
+    reader = _open_neo4j_fulltext_reader_with_adapter(adapter)
+
+    component = reader.read(
+        Neo4jFullTextReadRequest.component(timeout_ns=5_000_000_000)
+    )
+    indexes = reader.read(
+        Neo4jFullTextReadRequest.index(
+            index_name=snapshot().index_name,
+            timeout_ns=4_900_000_000,
+        )
+    )
+    rows = reader.read(
+        Neo4jFullTextReadRequest.query(
+            index_name=snapshot().index_name,
+            lucene_expression="retrieval_text:(synthetic)",
+            generation_id=GENERATION_ID,
+            limit=9,
+            timeout_ns=4_800_000_000,
+        )
+    )
+
+    assert component.component == {
+        "version": "2026.06.0",
+        "edition": "community",
+    }
+    assert indexes.indexes == (
+        {
+            "name": snapshot().index_name,
+            "state": "ONLINE",
+        },
+    )
+    assert rows.rows == (
+        {
+            "generation_id": str(GENERATION_ID),
+            "passage_id": "p-en",
+            "score": 1.0,
+        },
+    )
+    reader.close()
+    assert adapter.closed is True
+
+
+def test_authority_port_rejects_generic_or_unbounded_read_controls() -> None:
+    with pytest.raises(Neo4jFullTextReadError, match="controls"):
+        Neo4jFullTextReadRequest(
+            phase=Neo4jFullTextReadPhase.COMPONENT,
+            timeout_ns=5_000_000_000,
+            index_name=snapshot().index_name,
+        )
+    with pytest.raises(Neo4jFullTextReadError, match="limit"):
+        Neo4jFullTextReadRequest.query(
+            index_name=snapshot().index_name,
+            lucene_expression="retrieval_text:(synthetic)",
+            generation_id=GENERATION_ID,
+            limit=10,
+            timeout_ns=5_000_000_000,
+        )
+    with pytest.raises(Neo4jFullTextReadError, match="timeout"):
+        Neo4jFullTextReadRequest.component(
+            timeout_ns=5_000_000_001,
+        )
+
+
+class _ClockConsumingLock:
+    def __init__(self, clock: SequenceClock) -> None:
+        self._clock = clock
+
+    def __enter__(self):
+        self._clock()
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+
+def test_authority_port_charges_lock_wait_to_phase_timeout() -> None:
+    clock = SequenceClock((0, 5_000_000_001, 5_000_000_001))
+    factory = RecordingUnitOfWorkFactory()
+    driver = FakeDriver(default_scenario())
+    adapter = _Neo4jAdapter(
+        driver=driver,
+        config=config(),
+        driver_version="6.2.0",
+        monotonic_ns=clock,
+        unit_of_work_factory=factory,
+    )
+    adapter._lock = _ClockConsumingLock(clock)
+    reader = _open_neo4j_fulltext_reader_with_adapter(adapter)
+
+    with pytest.raises(Neo4jFullTextReadTimeout, match="timed out"):
+        reader.read(
+            Neo4jFullTextReadRequest.component(
+                timeout_ns=5_000_000_000,
+            )
+        )
+
+    assert factory.options == []
+    assert driver.calls == []
+    assert driver.execute_read_count == 0
+
+
+def test_authority_port_maps_server_timeout_to_typed_failure() -> None:
+    clock = SequenceClock((0, 100_000_000, 200_000_000))
+    driver = FakeDriver(default_scenario())
+    driver.scenario.failure_on = "query"
+    adapter = _Neo4jAdapter(
+        driver=driver,
+        config=config(),
+        driver_version="6.2.0",
+        monotonic_ns=clock,
+        unit_of_work_factory=RecordingUnitOfWorkFactory(),
+    )
+    reader = _open_neo4j_fulltext_reader_with_adapter(adapter)
+
+    with pytest.raises(Neo4jFullTextReadTimeout, match="timed out"):
+        reader.read(
+            Neo4jFullTextReadRequest.query(
+                index_name=snapshot().index_name,
+                lucene_expression="retrieval_text:(synthetic)",
+                generation_id=GENERATION_ID,
+                limit=9,
+                timeout_ns=5_000_000_000,
+            )
+        )
+
+
+def test_authority_port_redacts_unavailable_adapter_failure() -> None:
+    clock = SequenceClock((0, 100_000_000, 200_000_000))
+    driver = FakeDriver(default_scenario())
+    driver.scenario.failure_on = "component"
+    adapter = _Neo4jAdapter(
+        driver=driver,
+        config=config(),
+        driver_version="6.2.0",
+        monotonic_ns=clock,
+        unit_of_work_factory=RecordingUnitOfWorkFactory(),
+    )
+    reader = _open_neo4j_fulltext_reader_with_adapter(adapter)
+
+    with pytest.raises(Neo4jFullTextReadError, match="unavailable") as failure:
+        reader.read(
+            Neo4jFullTextReadRequest.component(
+                timeout_ns=5_000_000_000,
+            )
+        )
+    assert "component read failed" not in str(failure.value)

--- a/newsroom/tests/test_increment5b2_normalizer.py
+++ b/newsroom/tests/test_increment5b2_normalizer.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import pytest
+
+from newsroom.increment5.fulltext_contracts import (
+    FullTextContractError,
+    FullTextLanguageMode,
+)
+from newsroom.increment5.fulltext_normalizer import BilingualSearchNormalizer
+
+from .increment5b2_helpers import NOW, aliases
+
+
+def test_normalizer_canonicalizes_english_without_caller_lucene_syntax() -> None:
+    normalizer = BilingualSearchNormalizer()
+    result = normalizer.normalize(
+        surface_text='  SYNTHETIC\r\nAuthority (deadline): "27/03/2042"  ',
+        language_mode=FullTextLanguageMode.EN_GB,
+        query_valid_time=NOW,
+        authority_aliases=aliases(),
+    )
+
+    assert result.normalized_text == (
+        'synthetic authority (deadline): "27/03/2042"'
+    )
+    assert result.latin_terms == (
+        "authority",
+        "deadline",
+        "synthetic",
+    )
+    assert "27/03/2042" in result.formal_tokens
+    assert result.authority_alias_ids == ("alias-synthetic-authority",)
+    assert result.authority_alias_terms == ("synthetic authority",)
+    assert 'retrieval_text:"synthetic authority \\(deadline\\)\\: ' in result.lucene_query
+    assert "\\/" in result.lucene_query
+    assert "\\(" in result.lucene_query
+    assert '\\"' in result.lucene_query
+    assert result.lucene_query == " OR ".join(
+        sorted(result.lucene_query.split(" OR "))
+    )
+
+
+def test_normalizer_preserves_traditional_han_and_emits_exact_bigrams() -> None:
+    result = BilingualSearchNormalizer().normalize(
+        surface_text="合成網上平台 截止日期 二〇四二年三月二十七日",
+        language_mode=FullTextLanguageMode.ZH_HANT_HK,
+        query_valid_time=NOW,
+    )
+
+    assert "網上" in result.han_bigrams
+    assert "平台" in result.han_bigrams
+    assert "截止" in result.han_bigrams
+    assert "合成網上平台" in result.normalized_text
+    assert "网上" not in result.normalized_text
+    assert not result.authority_alias_ids
+
+
+def test_normalizer_mixed_language_is_deterministic_and_nfkc() -> None:
+    normalizer = BilingualSearchNormalizer()
+    first = normalizer.normalize(
+        surface_text="ＡＢＣ １２-３４ 合成網上平台",
+        language_mode=FullTextLanguageMode.MIXED_EN_GB_ZH_HANT_HK,
+        query_valid_time=NOW,
+    )
+    second = normalizer.normalize(
+        surface_text="ABC 12-34 合成網上平台",
+        language_mode=FullTextLanguageMode.MIXED_EN_GB_ZH_HANT_HK,
+        query_valid_time=NOW,
+    )
+
+    assert first.normalized_text == "abc 12-34 合成網上平台"
+    assert first.query_digest == second.query_digest
+    assert first.formal_tokens == ("12-34",)
+    assert first.latin_terms == ("abc",)
+
+
+def test_normalizer_uses_only_current_typed_authority_aliases() -> None:
+    result = BilingualSearchNormalizer().normalize(
+        surface_text="Synthetic Authority and Expired Authority",
+        language_mode=FullTextLanguageMode.EN_GB,
+        query_valid_time=NOW,
+        authority_aliases=aliases(),
+    )
+
+    assert result.authority_alias_ids == ("alias-synthetic-authority",)
+    assert result.authority_alias_terms == ("synthetic authority",)
+    assert "expired authority" not in result.authority_alias_terms
+
+
+def test_normalizer_requires_ascii_alias_term_boundaries() -> None:
+    base = aliases()[1]
+    ai_alias = type(base)(
+        alias_id="alias-ai",
+        surface_text="AI",
+        normalized_text="ai",
+        valid_from=base.valid_from,
+        valid_until=base.valid_until,
+        rights_current=True,
+        lifecycle="ACTIVE",
+    )
+
+    false_positive = BilingualSearchNormalizer().normalize(
+        surface_text="Paid leave policy",
+        language_mode=FullTextLanguageMode.EN_GB,
+        query_valid_time=NOW,
+        authority_aliases=(ai_alias,),
+    )
+    exact_mention = BilingualSearchNormalizer().normalize(
+        surface_text="AI policy",
+        language_mode=FullTextLanguageMode.EN_GB,
+        query_valid_time=NOW,
+        authority_aliases=(ai_alias,),
+    )
+
+    assert false_positive.authority_alias_ids == ()
+    assert false_positive.authority_alias_terms == ()
+    assert 'authority_aliases:"ai"' not in false_positive.lucene_query
+    assert exact_mention.authority_alias_ids == ("alias-ai",)
+    assert exact_mention.authority_alias_terms == ("ai",)
+    assert 'authority_aliases:"ai"' in exact_mention.lucene_query
+
+
+def test_normalizer_deduplicates_multiple_authority_ids_for_one_term() -> None:
+    base = aliases()[1]
+    duplicate = type(base)(
+        alias_id="alias-synthetic-authority-2",
+        surface_text=base.surface_text,
+        normalized_text=base.normalized_text,
+        valid_from=base.valid_from,
+        valid_until=base.valid_until,
+        rights_current=base.rights_current,
+        lifecycle=base.lifecycle,
+    )
+    result = BilingualSearchNormalizer().normalize(
+        surface_text="Synthetic Authority",
+        language_mode=FullTextLanguageMode.EN_GB,
+        query_valid_time=NOW,
+        authority_aliases=tuple(sorted((base, duplicate), key=lambda item: item.alias_id)),
+    )
+
+    assert result.authority_alias_ids == (
+        "alias-synthetic-authority",
+        "alias-synthetic-authority-2",
+    )
+    assert result.authority_alias_terms == ("synthetic authority",)
+
+
+@pytest.mark.parametrize(
+    "surface",
+    (
+        "",
+        " ",
+        "\r\n\t",
+        "x" * 16_385,
+    ),
+)
+def test_normalizer_rejects_empty_or_oversized_query(surface: str) -> None:
+    with pytest.raises(FullTextContractError):
+        BilingualSearchNormalizer().normalize(
+            surface_text=surface,
+            language_mode=FullTextLanguageMode.EN_GB,
+            query_valid_time=NOW,
+        )
+
+
+def test_normalizer_rejects_alias_bytes_from_another_normalizer() -> None:
+    alias = aliases()[1]
+    mismatched = type(alias)(
+        alias_id=alias.alias_id,
+        surface_text=alias.surface_text,
+        normalized_text="another normalized value",
+        valid_from=alias.valid_from,
+        valid_until=alias.valid_until,
+        rights_current=True,
+        lifecycle="ACTIVE",
+    )
+    with pytest.raises(
+        FullTextContractError,
+        match="differs from reviewed normalizer",
+    ):
+        BilingualSearchNormalizer().normalize(
+            surface_text="Synthetic Authority",
+            language_mode=FullTextLanguageMode.EN_GB,
+            query_valid_time=NOW,
+            authority_aliases=(mismatched,),
+        )


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-5b2
Canonical-PR: self
Checkpoint-Ref: checkpoint/increment-5b2-journal-lock-scope-20260805
Close-When: merged
Branch-Retention: keep

## Scope

Implements Increment 5B2 / issue #292 under parent #251, on exact accepted base `main@4acc389e1a2709cdb09a96de937cb163ad6525ba`.

This PR delivers one independently attributable `FULL_TEXT` branch only:

- immutable typed request, hit, exclusion and receipt contracts;
- reviewed en-GB / zh-Hant-HK / mixed-language normalization;
- fixed repository-owned field-scoped Lucene query construction;
- one authority-owned, read-only Neo4j full-text port;
- exact active generation, component, rights-manifest, watermark, gap, dead-letter, freshness and index-contract checks;
- fixed cumulative 5,000 ms, eight-result, 262,144-byte, zero-call and zero-spend bounds;
- immutable byte-identical SQLite receipt replay with conflict and corruption rejection.

## Authority, timeout, concurrency and replay boundaries

The private Neo4j adapter still has exactly one production importer: `newsroom/authority/_neo4j_projection_system.py`.

The retriever receives no driver, session, transaction factory, configuration object, raw query, index name or generic graph capability. It receives only a typed `Neo4jFullTextReader`. Live Neo4j `Record` values are copied through their mapping interface before crossing that port.

Each Neo4j full-text phase starts its monotonic budget before acquiring the shared adapter lock. Lock queueing is charged to the caller's remaining nanosecond budget; an exhausted phase fails before creating a managed transaction, opening a session or issuing a read. The completion check uses the same pre-lock origin.

The receipt journal performs an unlocked existing-receipt lookup, produces authority/Neo4j evidence outside any SQLite write reservation, then enters one short `BEGIN IMMEDIATE` transaction that rechecks idempotency and request identity before inserting or replaying the first retained receipt. Concurrent new requests therefore do not serialize their bounded producers behind a journal write lock.

Production and retained replay share one deterministic projection-snapshot policy. A replayed snapshot is checked against exact generation, generation identity, components, rights manifest, minimum watermark, gap/dead-letter state, validation/freshness window, index state, provider, analyzer and fixed server/driver identities. A snapshot that would have failed live execution cannot be rebound to a `COMPLETE` receipt.

`QUERY_TIMEOUT` is reserved for actual exhaustion of the repository-owned cumulative 5,000 ms branch deadline and is contract-bound to `INCOMPLETE` plus `elapsed_ms=5000`. A Neo4j timeout arriving before that deadline is instead journalled as `UNAVAILABLE / NEO4J_READ_UNAVAILABLE` with truthful elapsed time. When a stale snapshot is observed but the cumulative request crosses the deadline before receipt completion, the branch-wide timeout remains dominant; replay still requires zero normalized-query, Neo4j, hit and exclusion evidence.

The bilingual normalizer and replay validator share one authority-alias mention rule. ASCII-word aliases require explicit term boundaries, so `AI` cannot match inside `paid`; traditional-Han aliases retain exact substring semantics. Retained normalized queries remain independently derivable from request text, language mode, component identity and the fixed Lucene builder.

Every passage lifecycle other than `ACTIVE` is excluded. Terminal tombstone and lineage states remain `TOMBSTONED`; held, unresolved, proposal-only or otherwise nonactive states are `STALE_SOURCE_VERSION`. Projection text remains advisory and cannot be used as fact before later authoritative hydration.

## Exact clean head

```text
head:              3f2c778b6d62514b5fccce41b47d027b54b861d3
tree:              86cac583c181a0b9b3b6867a12da58cd7fd49504
parent/base:       4acc389e1a2709cdb09a96de937cb163ad6525ba
commits over base: 1
changed files:     15
checkpoint:        checkpoint/increment-5b2-journal-lock-scope-20260805
```

## Verification

Disposable support run `31045436909` passed on the exact product bytes, including:

- deterministic nested concurrent requests sharing one receipt database;
- first-writer-wins insertion and byte-identical replay after lock-free production;
- immediate graph-timeout classification and exact-deadline zero-read timeout behavior;
- stale-snapshot timeout precedence and hard timeout receipt invariants;
- deterministic adapter lock-wait exhaustion with zero unit-of-work, session, transaction and driver reads;
- focused Increment 5B2 retriever and Neo4j authority-port evidence;
- complete deterministic repository evidence;
- existing clustering evaluation gate; and
- support-file cleanup and product-only publication as `a8dc40025b0ad0992915c8be503f32f2294a44b5` / tree `86cac583c181a0b9b3b6867a12da58cd7fd49504`.

The same fifteen-file tree is re-parented directly over the fixed main base as the single canonical commit above. All six permanent workflows, a fresh exact-head substantive review and zero unresolved review threads remain required before merge.

## Non-effects

No SQLite authority mutation, graph write, vector query, admitted-graph traversal, fusion, cross-mode score comparison, dependency-root deduplication, hydration, Candidate creation/admission, live source, model/provider execution, credential use, external call, spend, publication, shadow/canary or production activation is added.

Tracks #292. Parent #251 remains open for 5B3 and 5B4.