### PR TITLE
Repository: deterministic PR lifecycle without automatic ref deletion

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,38 @@
+Lifecycle: canonical
+Delivery-Atom: replace-me
+Canonical-PR: self
+Checkpoint-Ref: NONE
+Close-When: merged
+Branch-Retention: keep
+
+<!--
+Required lifecycle metadata:
+- canonical: Canonical-PR self, Close-When merged, Branch-Retention keep
+- support: draft, support/ branch, reference canonical #, never merge
+- preflight: draft, preflight/ branch, reference canonical #, never merge
+- Branch-Retention must always be keep; automated branch deletion is unsupported.
+See docs/operations/pr-lifecycle.md.
+-->
+
+## Scope
+
+Describe the independently attributable delivery atom.
+
+## Exact state
+
+```text
+base:
+head:
+tree:
+commits over base:
+changed files:
+```
+
+## Verification
+
+List focused tests, complete repository evidence, permanent workflows and current
+review state.
+
+## Non-effects
+
+State explicitly what this PR does not activate, mutate or authorize.

--- a/.github/workflows/pr-lifecycle.yml
+++ b/.github/workflows/pr-lifecycle.yml
@@ -1,0 +1,95 @@
+name: PR Lifecycle
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - converted_to_draft
+      - ready_for_review
+      - synchronize
+      - labeled
+      - unlabeled
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: Close eligible disposable PRs after reviewing the dry run
+        required: true
+        type: boolean
+        default: false
+      confirmation:
+        description: Type CLOSE_ELIGIBLE_DISPOSABLE_PRS to authorize apply
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  validate:
+    if: github.event_name == 'pull_request_target'
+    permissions:
+      contents: read
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Validate lifecycle metadata
+        run: python -m scripts.sdlc.pr_lifecycle validate-event
+
+  inventory-dry-run:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+      pull-requests: read
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build read-only lifecycle inventory
+        run: python -m scripts.sdlc.pr_lifecycle inventory
+
+  inventory-apply:
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      inputs.apply == true &&
+      inputs.confirmation == 'CLOSE_ELIGIBLE_DISPOSABLE_PRS'
+    needs: inventory-dry-run
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+      PR_HOUSEKEEPING_APPLY: CLOSE_ELIGIBLE_DISPOSABLE_PRS
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Revalidate and apply eligible lifecycle closures
+        run: python -m scripts.sdlc.pr_lifecycle inventory --apply

--- a/docs/operations/pr-lifecycle.md
+++ b/docs/operations/pr-lifecycle.md
@@ -1,0 +1,142 @@
+# Pull-request lifecycle and housekeeping
+
+Open pull requests are an operational queue, not an archive. Historical evidence
+belongs in commits, workflow runs, comments and checkpoint refs. A PR remains open
+only while it represents current work.
+
+## Lifecycle classes
+
+Every PR declares exactly one class in the first metadata block of its body.
+
+### Canonical
+
+A canonical PR is the only merge candidate for one delivery atom.
+
+```text
+Lifecycle: canonical
+Delivery-Atom: increment-5b3
+Canonical-PR: self
+Checkpoint-Ref: checkpoint/increment-5b3-final-YYYYMMDD
+Close-When: merged
+Branch-Retention: keep
+```
+
+There may be only one open canonical PR for the same `Delivery-Atom`. A canonical
+PR is never auto-closed and never uses a `support/` or `preflight/` branch.
+
+### Support
+
+A support PR executes or materialises a bounded correction for one canonical PR.
+It is always a draft and is never merged.
+
+```text
+Lifecycle: support
+Delivery-Atom: increment-5b3
+Canonical-PR: #123
+Checkpoint-Ref: checkpoint/increment-5b3-correction-YYYYMMDD
+Close-When: checkpointed
+Branch-Retention: keep
+```
+
+The branch starts with `support/`. After the exact product tree is verified,
+re-parented and checkpointed, close the support PR in the same work session. The
+repository's existing `infra` label is the explicit automation opt-in; metadata
+alone never authorizes automated closure.
+
+### Preflight
+
+A preflight PR reviews or verifies an exact immutable candidate for one canonical
+PR. It is always a draft and is never merged.
+
+```text
+Lifecycle: preflight
+Delivery-Atom: increment-5b3
+Canonical-PR: #123
+Checkpoint-Ref: NONE
+Close-When: canonical-merged
+Branch-Retention: keep
+```
+
+The branch starts with `preflight/`.
+
+## Metadata contract
+
+The following six fields are mandatory and unique:
+
+```text
+Lifecycle:
+Delivery-Atom:
+Canonical-PR:
+Checkpoint-Ref:
+Close-When:
+Branch-Retention:
+```
+
+`Delivery-Atom` is a bounded lowercase identifier. `Canonical-PR` is `self` or
+`#<number>`. `Checkpoint-Ref` is a safe branch ref or `NONE`. Every non-`NONE`
+checkpoint uses the dedicated `checkpoint/` namespace.
+
+Valid close conditions are:
+
+- `merged`: canonical PR only;
+- `checkpointed`: disposable PR closes only when its declared checkpoint resolves
+  to its current head and its canonical binding remains valid;
+- `canonical-merged`: disposable PR closes only after its canonical PR is
+  independently revalidated as merged.
+
+`Branch-Retention` has exactly one supported value: `keep`. Automated branch
+cleanup is deliberately unsupported. GitHub's ref deletion endpoint has no
+compare-and-delete operation, so a check followed by deletion cannot safely bind
+the mutation to the checked commit. Branch cleanup is therefore a separate manual
+owner action outside this automation; checkpoint refs and disposable branches are
+retained by every automated closure.
+
+## Operating limits
+
+- One open canonical PR per delivery atom.
+- No more than two open support/preflight PRs per canonical PR.
+- Duplicate same-repository open head refs fail the inventory closed.
+- A disposable PR closes in the same work session after its declared condition is
+  satisfied.
+- No unexplained open PR may remain older than seven days.
+- Canonical PRs are never closed by automation.
+- Automated housekeeping never deletes a Git ref.
+
+## Automation
+
+`.github/workflows/pr-lifecycle.yml` runs trusted default-branch code.
+
+On PR creation or metadata changes it validates the event body and actual PR
+surface. Weekly scheduled runs and manual dispatches build a repository-wide
+inventory. The dry-run job has read-only permissions. A separate apply job has
+only the issue and pull-request write permissions needed to comment and close an
+eligible disposable PR; repository contents remain read-only.
+
+Manual apply requires all three independently checked values:
+
+1. workflow-dispatch input `apply=true`;
+2. workflow-dispatch input `confirmation=CLOSE_ELIGIBLE_DISPOSABLE_PRS`; and
+3. the exact `PR_HOUSEKEEPING_APPLY=CLOSE_ELIGIBLE_DISPOSABLE_PRS` process guard.
+
+Both inventory jobs receive the workflow token explicitly; its effective rights
+remain constrained by each job's permission block. Before every mutation, apply
+mode re-reads the current PR state, body, labels, head repository, head SHA,
+checkpoint and canonical binding. The target must remain open and unmerged, the
+lifecycle must match the planned snapshot, and checkpointed closures must bind the
+checkpoint to the current head. Apply comments with an audit record before closing
+an eligible, `infra`-labelled disposable PR. It never merges or closes a canonical
+PR and never deletes a branch.
+
+## Recovery
+
+The source of truth for recovery is:
+
+1. the canonical merge commit or exact candidate commit;
+2. the product tree identity;
+3. the checkpoint ref;
+4. permanent and disposable workflow runs; and
+5. closure comments.
+
+An open support PR is not a recovery mechanism and must not be retained merely as
+historical evidence. Its branch and checkpoint may remain as immutable recovery
+refs until an owner performs a separate, deliberate cleanup.

--- a/newsroom/checks/pr_lifecycle.py
+++ b/newsroom/checks/pr_lifecycle.py
@@ -1,0 +1,519 @@
+"""Deterministic pull-request lifecycle contracts and housekeeping plans."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from enum import StrEnum
+import re
+from typing import Iterable, Mapping
+
+
+class PrLifecycleError(ValueError):
+    """Pull-request lifecycle metadata or inventory is invalid."""
+
+
+class LifecycleKind(StrEnum):
+    CANONICAL = "canonical"
+    SUPPORT = "support"
+    PREFLIGHT = "preflight"
+
+
+class CloseWhen(StrEnum):
+    MERGED = "merged"
+    CHECKPOINTED = "checkpointed"
+    CANONICAL_MERGED = "canonical-merged"
+
+
+class BranchRetention(StrEnum):
+    KEEP = "keep"
+    DELETE_AFTER_CHECKPOINT = "delete-after-checkpoint"
+
+
+_METADATA_KEYS = (
+    "Lifecycle",
+    "Delivery-Atom",
+    "Canonical-PR",
+    "Checkpoint-Ref",
+    "Close-When",
+    "Branch-Retention",
+)
+_METADATA_LINE = re.compile(
+    r"^(Lifecycle|Delivery-Atom|Canonical-PR|Checkpoint-Ref|Close-When|Branch-Retention):[ \t]*(.*)$"
+)
+_ATOM = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
+_PR_REFERENCE = re.compile(r"^#([1-9][0-9]*)$")
+_REF_TEXT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]{0,199}$")
+_REPOSITORY = re.compile(
+    r"^[A-Za-z0-9_.-]{1,100}/[A-Za-z0-9_.-]{1,100}$"
+)
+_COMMIT_SHA = re.compile(r"^[0-9a-f]{40}$")
+HOUSEKEEPING_LABEL = "infra"
+_MAX_DISPOSABLE_PER_CANONICAL = 2
+_STALE_AFTER = timedelta(days=7)
+
+
+@dataclass(frozen=True, slots=True)
+class PrLifecycle:
+    kind: LifecycleKind
+    delivery_atom: str
+    canonical_pr: int | None
+    checkpoint_ref: str | None
+    close_when: CloseWhen
+    branch_retention: BranchRetention
+
+    @property
+    def canonical_is_self(self) -> bool:
+        return self.canonical_pr is None
+
+    @property
+    def is_disposable(self) -> bool:
+        return self.kind in {LifecycleKind.SUPPORT, LifecycleKind.PREFLIGHT}
+
+
+@dataclass(frozen=True, slots=True)
+class OpenPullRequest:
+    number: int
+    body: str
+    draft: bool
+    head_ref: str
+    created_at: datetime
+    labels: frozenset[str] = frozenset()
+    head_repository: str | None = None
+    head_sha: str | None = None
+
+    def __post_init__(self) -> None:
+        if isinstance(self.number, bool) or not isinstance(self.number, int) or self.number <= 0:
+            raise PrLifecycleError("pull-request number must be positive")
+        if not isinstance(self.body, str):
+            raise PrLifecycleError("pull-request body must be text")
+        if not isinstance(self.draft, bool):
+            raise PrLifecycleError("pull-request draft state must be boolean")
+        _validate_ref(self.head_ref, field="head_ref")
+        if not isinstance(self.created_at, datetime) or self.created_at.tzinfo is None:
+            raise PrLifecycleError("pull-request creation time must be timezone-aware")
+        if not isinstance(self.labels, frozenset) or any(
+            not isinstance(label, str) or not label or label != label.strip()
+            for label in self.labels
+        ):
+            raise PrLifecycleError("pull-request labels must be immutable text")
+        if self.head_repository is not None:
+            _validate_repository(self.head_repository, field="head_repository")
+        if self.head_sha is not None and (
+            not isinstance(self.head_sha, str)
+            or _COMMIT_SHA.fullmatch(self.head_sha) is None
+        ):
+            raise PrLifecycleError(
+                "pull-request head SHA must be lowercase full commit text"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class CloseAction:
+    pr_number: int
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class HousekeepingPlan:
+    close_actions: tuple[CloseAction, ...]
+    warnings: tuple[str, ...]
+
+
+def parse_pr_lifecycle(body: str) -> PrLifecycle:
+    """Parse exactly one value for every lifecycle field from a PR body."""
+
+    if not isinstance(body, str):
+        raise PrLifecycleError("pull-request body must be text")
+    values: dict[str, str] = {}
+    duplicates: set[str] = set()
+    for raw_line in body.splitlines():
+        match = _METADATA_LINE.fullmatch(raw_line)
+        if match is None:
+            continue
+        key, raw_value = match.groups()
+        if key in values:
+            duplicates.add(key)
+        values[key] = raw_value.strip()
+    if duplicates:
+        raise PrLifecycleError(
+            "duplicate lifecycle fields: " + ", ".join(sorted(duplicates))
+        )
+    missing = [key for key in _METADATA_KEYS if key not in values]
+    if missing:
+        raise PrLifecycleError(
+            "missing lifecycle fields: " + ", ".join(missing)
+        )
+    empty = [key for key in _METADATA_KEYS if not values[key]]
+    if empty:
+        raise PrLifecycleError(
+            "empty lifecycle fields: " + ", ".join(empty)
+        )
+    try:
+        kind = LifecycleKind(values["Lifecycle"])
+        close_when = CloseWhen(values["Close-When"])
+        retention = BranchRetention(values["Branch-Retention"])
+    except ValueError as exc:
+        raise PrLifecycleError("unsupported lifecycle metadata value") from exc
+
+    delivery_atom = values["Delivery-Atom"]
+    if _ATOM.fullmatch(delivery_atom) is None:
+        raise PrLifecycleError(
+            "Delivery-Atom must be a bounded lowercase identifier"
+        )
+
+    canonical_text = values["Canonical-PR"]
+    if canonical_text == "self":
+        canonical_pr = None
+    else:
+        match = _PR_REFERENCE.fullmatch(canonical_text)
+        if match is None:
+            raise PrLifecycleError("Canonical-PR must be self or #<number>")
+        canonical_pr = int(match.group(1))
+
+    checkpoint_text = values["Checkpoint-Ref"]
+    checkpoint_ref = None if checkpoint_text == "NONE" else checkpoint_text
+    if checkpoint_ref is not None:
+        _validate_ref(checkpoint_ref, field="Checkpoint-Ref")
+
+    lifecycle = PrLifecycle(
+        kind=kind,
+        delivery_atom=delivery_atom,
+        canonical_pr=canonical_pr,
+        checkpoint_ref=checkpoint_ref,
+        close_when=close_when,
+        branch_retention=retention,
+    )
+    _validate_lifecycle_shape(lifecycle)
+    return lifecycle
+
+
+def validate_pull_request_lifecycle(
+    lifecycle: PrLifecycle,
+    *,
+    pr_number: int,
+    draft: bool,
+    head_ref: str,
+) -> None:
+    """Validate metadata against the actual pull-request surface."""
+
+    if not isinstance(lifecycle, PrLifecycle):
+        raise PrLifecycleError("lifecycle must be typed")
+    if isinstance(pr_number, bool) or not isinstance(pr_number, int) or pr_number <= 0:
+        raise PrLifecycleError("pull-request number must be positive")
+    if not isinstance(draft, bool):
+        raise PrLifecycleError("pull-request draft state must be boolean")
+    _validate_ref(head_ref, field="head_ref")
+    if lifecycle.branch_retention is not BranchRetention.KEEP:
+        raise PrLifecycleError(
+            "automatic branch deletion is unsupported; "
+            "Branch-Retention must be keep"
+        )
+
+    if lifecycle.kind is LifecycleKind.CANONICAL:
+        if lifecycle.canonical_pr is not None:
+            raise PrLifecycleError("canonical PR must declare Canonical-PR: self")
+        if lifecycle.close_when is not CloseWhen.MERGED:
+            raise PrLifecycleError("canonical PR must close only when merged")
+        if lifecycle.branch_retention is not BranchRetention.KEEP:
+            raise PrLifecycleError("canonical branch retention must be keep")
+        if head_ref.startswith(("support/", "preflight/")):
+            raise PrLifecycleError("canonical PR cannot use a disposable branch prefix")
+        return
+
+    if lifecycle.canonical_pr is None:
+        raise PrLifecycleError("disposable PR must reference a canonical PR")
+    if lifecycle.canonical_pr == pr_number:
+        raise PrLifecycleError("disposable PR cannot reference itself")
+    if not draft:
+        raise PrLifecycleError("support and preflight PRs must remain drafts")
+    expected_prefix = (
+        "support/"
+        if lifecycle.kind is LifecycleKind.SUPPORT
+        else "preflight/"
+    )
+    if not head_ref.startswith(expected_prefix):
+        raise PrLifecycleError(
+            f"{lifecycle.kind.value} PR branch must start with {expected_prefix}"
+        )
+    if lifecycle.close_when is CloseWhen.MERGED:
+        raise PrLifecycleError("disposable PR cannot use Close-When: merged")
+    if (
+        lifecycle.close_when is CloseWhen.CHECKPOINTED
+        and lifecycle.checkpoint_ref is None
+    ):
+        raise PrLifecycleError(
+            "checkpointed disposable PR requires a checkpoint ref"
+        )
+
+
+def validate_pull_request_event(event: Mapping[str, object]) -> PrLifecycle:
+    """Validate a pull_request or pull_request_target event payload."""
+
+    try:
+        raw_pr = event["pull_request"]
+        if not isinstance(raw_pr, Mapping):
+            raise TypeError
+        number = int(raw_pr["number"])
+        draft = raw_pr["draft"]
+        body = raw_pr.get("body") or ""
+        raw_head = raw_pr["head"]
+        if not isinstance(raw_head, Mapping):
+            raise TypeError
+        head_ref = raw_head["ref"]
+    except (KeyError, TypeError, ValueError) as exc:
+        raise PrLifecycleError("GitHub pull-request event is malformed") from exc
+    lifecycle = parse_pr_lifecycle(str(body))
+    validate_pull_request_lifecycle(
+        lifecycle,
+        pr_number=number,
+        draft=draft,  # type: ignore[arg-type]
+        head_ref=head_ref,  # type: ignore[arg-type]
+    )
+    return lifecycle
+
+
+def plan_housekeeping(
+    open_pull_requests: Iterable[OpenPullRequest],
+    *,
+    merged_canonical_prs: frozenset[int] = frozenset(),
+    existing_checkpoint_refs: frozenset[str] = frozenset(),
+    repository_full_name: str | None = None,
+    now: datetime | None = None,
+) -> HousekeepingPlan:
+    """Build a deterministic, fail-closed plan for open PRs.
+
+    Canonical PRs are never auto-closed. Disposable PRs are closeable only when
+    their declared checkpoint or canonical-merge condition is independently true.
+    """
+
+    if not isinstance(merged_canonical_prs, frozenset) or any(
+        isinstance(item, bool) or not isinstance(item, int) or item <= 0
+        for item in merged_canonical_prs
+    ):
+        raise PrLifecycleError("merged canonical PR inventory is malformed")
+    if not isinstance(existing_checkpoint_refs, frozenset):
+        raise PrLifecycleError("checkpoint ref inventory must be immutable")
+    for ref in existing_checkpoint_refs:
+        _validate_ref(ref, field="checkpoint ref")
+    current = now or datetime.now(timezone.utc)
+    if not isinstance(current, datetime) or current.tzinfo is None:
+        raise PrLifecycleError("housekeeping time must be timezone-aware")
+    if repository_full_name is not None:
+        _validate_repository(
+            repository_full_name,
+            field="repository_full_name",
+        )
+
+    prs = tuple(sorted(open_pull_requests, key=lambda item: item.number))
+    if len({item.number for item in prs}) != len(prs):
+        raise PrLifecycleError("open pull-request inventory contains duplicates")
+
+    parsed: dict[int, PrLifecycle] = {}
+    for pr in prs:
+        lifecycle = parse_pr_lifecycle(pr.body)
+        validate_pull_request_lifecycle(
+            lifecycle,
+            pr_number=pr.number,
+            draft=pr.draft,
+            head_ref=pr.head_ref,
+        )
+        parsed[pr.number] = lifecycle
+
+    if repository_full_name is not None:
+        same_repository_heads: dict[str, list[int]] = {}
+        for pr in prs:
+            if pr.head_repository != repository_full_name:
+                continue
+            same_repository_heads.setdefault(pr.head_ref, []).append(pr.number)
+        shared_heads = {
+            ref: tuple(numbers)
+            for ref, numbers in same_repository_heads.items()
+            if len(numbers) > 1
+        }
+        if shared_heads:
+            detail = ", ".join(
+                f"{ref}: " + ", ".join(f"#{number}" for number in numbers)
+                for ref, numbers in sorted(shared_heads.items())
+            )
+            raise PrLifecycleError(
+                "open pull requests share same-repository head refs: " + detail
+            )
+
+    canonical_by_atom: dict[str, OpenPullRequest] = {}
+    for pr in prs:
+        lifecycle = parsed[pr.number]
+        if lifecycle.kind is not LifecycleKind.CANONICAL:
+            continue
+        previous = canonical_by_atom.get(lifecycle.delivery_atom)
+        if previous is not None:
+            raise PrLifecycleError(
+                "multiple open canonical PRs for delivery atom "
+                f"{lifecycle.delivery_atom}: #{previous.number}, #{pr.number}"
+            )
+        canonical_by_atom[lifecycle.delivery_atom] = pr
+
+    disposable_counts: dict[int, int] = {}
+    for pr in prs:
+        lifecycle = parsed[pr.number]
+        if not lifecycle.is_disposable:
+            continue
+        assert lifecycle.canonical_pr is not None
+        disposable_counts[lifecycle.canonical_pr] = (
+            disposable_counts.get(lifecycle.canonical_pr, 0) + 1
+        )
+        canonical = next(
+            (item for item in prs if item.number == lifecycle.canonical_pr),
+            None,
+        )
+        if canonical is not None:
+            canonical_lifecycle = parsed[canonical.number]
+            if canonical_lifecycle.kind is not LifecycleKind.CANONICAL:
+                raise PrLifecycleError(
+                    f"#{pr.number} references non-canonical open PR "
+                    f"#{canonical.number}"
+                )
+            if canonical_lifecycle.delivery_atom != lifecycle.delivery_atom:
+                raise PrLifecycleError(
+                    f"#{pr.number} delivery atom differs from canonical "
+                    f"#{canonical.number}"
+                )
+        elif lifecycle.canonical_pr not in merged_canonical_prs:
+            raise PrLifecycleError(
+                f"#{pr.number} references neither an open nor merged canonical PR"
+            )
+    excess = {
+        number: count
+        for number, count in disposable_counts.items()
+        if count > _MAX_DISPOSABLE_PER_CANONICAL
+    }
+    if excess:
+        detail = ", ".join(
+            f"#{number} has {count}"
+            for number, count in sorted(excess.items())
+        )
+        raise PrLifecycleError(
+            "too many open disposable PRs per canonical PR: " + detail
+        )
+
+    actions: list[CloseAction] = []
+    warnings: list[str] = []
+    for pr in prs:
+        lifecycle = parsed[pr.number]
+        age = current.astimezone(timezone.utc) - pr.created_at.astimezone(
+            timezone.utc
+        )
+        if age > _STALE_AFTER:
+            warnings.append(
+                f"#{pr.number} has remained open for {age.days} days"
+            )
+        if not lifecycle.is_disposable:
+            continue
+        assert lifecycle.canonical_pr is not None
+        if HOUSEKEEPING_LABEL not in pr.labels:
+            warnings.append(
+                f"#{pr.number} lacks required housekeeping label "
+                f"{HOUSEKEEPING_LABEL}"
+            )
+            continue
+        close_reason: str | None = None
+        if lifecycle.close_when is CloseWhen.CHECKPOINTED:
+            if (
+                lifecycle.checkpoint_ref is not None
+                and lifecycle.checkpoint_ref in existing_checkpoint_refs
+            ):
+                close_reason = (
+                    "declared checkpoint exists: "
+                    f"{lifecycle.checkpoint_ref}"
+                )
+        elif (
+            lifecycle.close_when is CloseWhen.CANONICAL_MERGED
+            and lifecycle.canonical_pr in merged_canonical_prs
+        ):
+            close_reason = (
+                f"canonical PR #{lifecycle.canonical_pr} is merged"
+            )
+        if close_reason is None:
+            continue
+
+        actions.append(
+            CloseAction(
+                pr_number=pr.number,
+                reason=close_reason,
+            )
+        )
+
+    return HousekeepingPlan(
+        close_actions=tuple(actions),
+        warnings=tuple(sorted(warnings)),
+    )
+
+
+def _validate_lifecycle_shape(lifecycle: PrLifecycle) -> None:
+    if (
+        lifecycle.checkpoint_ref is not None
+        and not lifecycle.checkpoint_ref.startswith("checkpoint/")
+    ):
+        raise PrLifecycleError(
+            "checkpoint ref must use the dedicated checkpoint/ namespace"
+        )
+    if lifecycle.branch_retention is not BranchRetention.KEEP:
+        raise PrLifecycleError(
+            "automatic branch deletion is unsupported; "
+            "Branch-Retention must be keep"
+        )
+    if lifecycle.kind is LifecycleKind.CANONICAL:
+        if lifecycle.canonical_pr is not None:
+            raise PrLifecycleError("canonical lifecycle must reference self")
+        if lifecycle.close_when is not CloseWhen.MERGED:
+            raise PrLifecycleError("canonical lifecycle must close when merged")
+        if lifecycle.branch_retention is not BranchRetention.KEEP:
+            raise PrLifecycleError("canonical lifecycle must retain its branch")
+        return
+    if lifecycle.canonical_pr is None:
+        raise PrLifecycleError("disposable lifecycle requires canonical PR")
+    if lifecycle.close_when is CloseWhen.MERGED:
+        raise PrLifecycleError("disposable lifecycle cannot close when merged")
+    if (
+        lifecycle.close_when is CloseWhen.CHECKPOINTED
+        and lifecycle.checkpoint_ref is None
+    ):
+        raise PrLifecycleError("checkpoint closure requires checkpoint ref")
+
+
+def _validate_repository(value: str, *, field: str) -> str:
+    if not isinstance(value, str) or _REPOSITORY.fullmatch(value) is None:
+        raise PrLifecycleError(f"{field} must be owner/name")
+    return value
+
+
+def _validate_ref(value: str, *, field: str) -> str:
+    if (
+        not isinstance(value, str)
+        or _REF_TEXT.fullmatch(value) is None
+        or value.endswith(("/", "."))
+        or value.startswith(("/", "."))
+        or "//" in value
+        or ".." in value
+        or "@{" in value
+        or value.endswith(".lock")
+    ):
+        raise PrLifecycleError(f"{field} is not a safe bounded Git ref")
+    return value
+
+
+__all__ = [
+    "BranchRetention",
+    "CloseAction",
+    "CloseWhen",
+    "HOUSEKEEPING_LABEL",
+    "HousekeepingPlan",
+    "LifecycleKind",
+    "OpenPullRequest",
+    "PrLifecycle",
+    "PrLifecycleError",
+    "parse_pr_lifecycle",
+    "plan_housekeeping",
+    "validate_pull_request_event",
+    "validate_pull_request_lifecycle",
+]

--- a/newsroom/tests/test_pr_lifecycle.py
+++ b/newsroom/tests/test_pr_lifecycle.py
@@ -1,0 +1,965 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import importlib.util
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+from newsroom.checks.pr_lifecycle import (
+    HOUSEKEEPING_LABEL,
+    BranchRetention,
+    CloseAction,
+    CloseWhen,
+    HousekeepingPlan,
+    LifecycleKind,
+    OpenPullRequest,
+    PrLifecycleError,
+    parse_pr_lifecycle,
+    plan_housekeeping,
+    validate_pull_request_event,
+    validate_pull_request_lifecycle,
+)
+
+
+NOW = datetime(2026, 8, 5, 12, 0, tzinfo=timezone.utc)
+
+
+def body(
+    *,
+    lifecycle: str = "canonical",
+    atom: str = "increment-5b2",
+    canonical: str = "self",
+    checkpoint: str = "checkpoint/increment-5b2",
+    close_when: str = "merged",
+    retention: str = "keep",
+) -> str:
+    return "\n".join(
+        (
+            f"Lifecycle: {lifecycle}",
+            f"Delivery-Atom: {atom}",
+            f"Canonical-PR: {canonical}",
+            f"Checkpoint-Ref: {checkpoint}",
+            f"Close-When: {close_when}",
+            f"Branch-Retention: {retention}",
+            "",
+            "## Scope",
+            "Product change.",
+        )
+    )
+
+
+def open_pr(
+    number: int,
+    *,
+    pr_body: str,
+    draft: bool,
+    head_ref: str,
+    age_days: int = 0,
+    labels: frozenset[str] = frozenset({HOUSEKEEPING_LABEL}),
+    head_repository: str | None = "fol2/newsroom",
+    head_sha: str | None = "a" * 40,
+) -> OpenPullRequest:
+    return OpenPullRequest(
+        number=number,
+        body=pr_body,
+        draft=draft,
+        head_ref=head_ref,
+        created_at=NOW - timedelta(days=age_days),
+        labels=labels,
+        head_repository=head_repository,
+        head_sha=head_sha,
+    )
+
+
+def test_parse_canonical_lifecycle() -> None:
+    lifecycle = parse_pr_lifecycle(body())
+
+    assert lifecycle.kind is LifecycleKind.CANONICAL
+    assert lifecycle.delivery_atom == "increment-5b2"
+    assert lifecycle.canonical_pr is None
+    assert lifecycle.checkpoint_ref == "checkpoint/increment-5b2"
+    assert lifecycle.close_when is CloseWhen.MERGED
+    assert lifecycle.branch_retention is BranchRetention.KEEP
+
+
+def test_parser_rejects_missing_duplicate_and_unsafe_metadata() -> None:
+    with pytest.raises(PrLifecycleError, match="missing lifecycle fields"):
+        parse_pr_lifecycle("Lifecycle: canonical")
+    with pytest.raises(PrLifecycleError, match="duplicate lifecycle fields"):
+        parse_pr_lifecycle(body() + "\nLifecycle: support")
+    with pytest.raises(PrLifecycleError, match="safe bounded Git ref"):
+        parse_pr_lifecycle(body(checkpoint="checkpoint/../escape"))
+
+
+def test_canonical_surface_cannot_use_disposable_semantics() -> None:
+    with pytest.raises(PrLifecycleError, match="canonical lifecycle"):
+        parse_pr_lifecycle(body(close_when="checkpointed"))
+    lifecycle = parse_pr_lifecycle(body())
+    with pytest.raises(PrLifecycleError, match="disposable branch prefix"):
+        validate_pull_request_lifecycle(
+            lifecycle,
+            pr_number=10,
+            draft=False,
+            head_ref="support/not-canonical",
+        )
+
+
+def test_support_and_preflight_require_draft_and_matching_prefix() -> None:
+    support = parse_pr_lifecycle(
+        body(
+            lifecycle="support",
+            canonical="#10",
+            close_when="checkpointed",
+        )
+    )
+    validate_pull_request_lifecycle(
+        support,
+        pr_number=11,
+        draft=True,
+        head_ref="support/increment-5b2-correction",
+    )
+    with pytest.raises(PrLifecycleError, match="must remain drafts"):
+        validate_pull_request_lifecycle(
+            support,
+            pr_number=11,
+            draft=False,
+            head_ref="support/increment-5b2-correction",
+        )
+
+    preflight = parse_pr_lifecycle(
+        body(
+            lifecycle="preflight",
+            canonical="#10",
+            close_when="canonical-merged",
+            checkpoint="NONE",
+        )
+    )
+    validate_pull_request_lifecycle(
+        preflight,
+        pr_number=12,
+        draft=True,
+        head_ref="preflight/increment-5b2-exact-tree",
+    )
+
+
+def test_validate_pull_request_event_uses_actual_surface() -> None:
+    event = {
+        "pull_request": {
+            "number": 11,
+            "draft": True,
+            "body": body(
+                lifecycle="support",
+                canonical="#10",
+                close_when="checkpointed",
+            ),
+            "head": {"ref": "support/increment-5b2-correction"},
+        }
+    }
+    lifecycle = validate_pull_request_event(event)
+    assert lifecycle.kind is LifecycleKind.SUPPORT
+    assert lifecycle.canonical_pr == 10
+
+
+def test_workflow_module_entrypoint_runs_without_installed_package(
+    tmp_path: Path,
+) -> None:
+    repository_root = Path(__file__).resolve().parents[2]
+    event_path = tmp_path / "pull-request-event.json"
+    event_path.write_text(
+        json.dumps(
+            {
+                "pull_request": {
+                    "number": 10,
+                    "draft": False,
+                    "body": body(),
+                    "head": {"ref": "agent/increment-5b2"},
+                }
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    environment = os.environ.copy()
+    environment.pop("PYTHONPATH", None)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-S",
+            "-m",
+            "scripts.sdlc.pr_lifecycle",
+            "validate-event",
+            "--event",
+            str(event_path),
+        ],
+        cwd=repository_root,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "validated PR lifecycle: canonical / increment-5b2" in result.stdout
+
+
+def test_apply_requires_exact_confirmation_before_api_access() -> None:
+    repository_root = Path(__file__).resolve().parents[2]
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "GITHUB_REPOSITORY": "fol2/newsroom",
+            "GITHUB_TOKEN": "not-used-before-guard",
+            "PR_HOUSEKEEPING_APPLY": "true",
+        }
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-S",
+            "-m",
+            "scripts.sdlc.pr_lifecycle",
+            "inventory",
+            "--apply",
+        ],
+        cwd=repository_root,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode == 2
+    assert "exact housekeeping confirmation" in result.stderr
+    assert "GitHub API" not in result.stderr
+
+
+def test_plan_never_closes_canonical_and_closes_checkpointed_support() -> None:
+    canonical = open_pr(
+        10,
+        pr_body=body(),
+        draft=False,
+        head_ref="agent/increment-5b2",
+    )
+    support = open_pr(
+        11,
+        pr_body=body(
+            lifecycle="support",
+            canonical="#10",
+            close_when="checkpointed",
+        ),
+        draft=True,
+        head_ref="support/increment-5b2-correction",
+    )
+    plan = plan_housekeeping(
+        (canonical, support),
+        existing_checkpoint_refs=frozenset(
+            {"checkpoint/increment-5b2"}
+        ),
+        now=NOW,
+    )
+
+    assert [item.pr_number for item in plan.close_actions] == [11]
+    assert "checkpoint/increment-5b2" in plan.close_actions[0].reason
+    assert set(plan.close_actions[0].__dataclass_fields__) == {
+        "pr_number",
+        "reason",
+    }
+
+
+def test_automatic_branch_deletion_metadata_is_rejected() -> None:
+    with pytest.raises(
+        PrLifecycleError,
+        match="automatic branch deletion is unsupported",
+    ):
+        parse_pr_lifecycle(
+            body(
+                lifecycle="support",
+                canonical="#10",
+                close_when="canonical-merged",
+                retention="delete-after-checkpoint",
+            )
+        )
+
+def test_plan_rejects_unknown_or_mismatched_canonical_reference() -> None:
+    support = open_pr(
+        11,
+        pr_body=body(
+            lifecycle="support",
+            canonical="#10",
+            close_when="checkpointed",
+        ),
+        draft=True,
+        head_ref="support/increment-5b2-correction",
+    )
+    with pytest.raises(PrLifecycleError, match="neither an open nor merged"):
+        plan_housekeeping((support,), now=NOW)
+
+    canonical = open_pr(
+        10,
+        pr_body=body(atom="another-atom"),
+        draft=False,
+        head_ref="agent/another-atom",
+    )
+    with pytest.raises(PrLifecycleError, match="delivery atom differs"):
+        plan_housekeeping((canonical, support), now=NOW)
+
+
+def test_plan_rejects_multiple_canonical_prs_for_one_atom() -> None:
+    first = open_pr(
+        10,
+        pr_body=body(),
+        draft=True,
+        head_ref="agent/increment-5b2-a",
+    )
+    second = open_pr(
+        12,
+        pr_body=body(),
+        draft=True,
+        head_ref="agent/increment-5b2-b",
+    )
+    with pytest.raises(PrLifecycleError, match="multiple open canonical"):
+        plan_housekeeping((first, second), now=NOW)
+
+
+def test_plan_rejects_more_than_two_disposable_prs_per_canonical() -> None:
+    canonical = open_pr(
+        10,
+        pr_body=body(),
+        draft=True,
+        head_ref="agent/increment-5b2",
+    )
+    disposable = tuple(
+        open_pr(
+            number,
+            pr_body=body(
+                lifecycle="support",
+                canonical="#10",
+                close_when="checkpointed",
+            ),
+            draft=True,
+            head_ref=f"support/increment-5b2-{number}",
+        )
+        for number in (11, 12, 13)
+    )
+    with pytest.raises(PrLifecycleError, match="too many open disposable"):
+        plan_housekeeping((canonical, *disposable), now=NOW)
+
+
+def test_plan_rejects_shared_same_repository_head_refs() -> None:
+    canonical = open_pr(
+        10,
+        pr_body=body(),
+        draft=False,
+        head_ref="agent/increment-5b2",
+    )
+    keep = open_pr(
+        11,
+        pr_body=body(
+            lifecycle="support",
+            canonical="#10",
+            close_when="checkpointed",
+            retention="keep",
+        ),
+        draft=True,
+        head_ref="support/shared-head",
+    )
+    delete = open_pr(
+        12,
+        pr_body=body(
+            lifecycle="support",
+            canonical="#10",
+            close_when="checkpointed",
+            retention="keep",
+        ),
+        draft=True,
+        head_ref="support/shared-head",
+    )
+
+    with pytest.raises(
+        PrLifecycleError,
+        match="share same-repository head refs",
+    ):
+        plan_housekeeping(
+            (canonical, keep, delete),
+            existing_checkpoint_refs=frozenset(
+                {"checkpoint/increment-5b2"}
+            ),
+            repository_full_name="fol2/newsroom",
+            now=NOW,
+        )
+
+
+def test_plan_warns_for_unexplained_age_without_auto_closing() -> None:
+    canonical = open_pr(
+        10,
+        pr_body=body(),
+        draft=True,
+        head_ref="agent/increment-5b2",
+        age_days=8,
+    )
+    plan = plan_housekeeping((canonical,), now=NOW)
+
+    assert plan.close_actions == ()
+    assert plan.warnings == ("#10 has remained open for 8 days",)
+
+
+def test_checkpoint_ref_requires_dedicated_namespace() -> None:
+    with pytest.raises(PrLifecycleError, match="checkpoint/ namespace"):
+        parse_pr_lifecycle(
+            body(
+                lifecycle="support",
+                canonical="#10",
+                checkpoint="main",
+                close_when="checkpointed",
+            )
+        )
+
+
+def test_unlabelled_disposable_is_never_closed() -> None:
+    canonical = open_pr(
+        10,
+        pr_body=body(),
+        draft=False,
+        head_ref="agent/increment-5b2",
+    )
+    support = open_pr(
+        11,
+        pr_body=body(
+            lifecycle="support",
+            canonical="#10",
+            close_when="checkpointed",
+        ),
+        draft=True,
+        head_ref="support/increment-5b2-correction",
+        labels=frozenset(),
+    )
+    plan = plan_housekeeping(
+        (canonical, support),
+        existing_checkpoint_refs=frozenset(
+            {"checkpoint/increment-5b2"}
+        ),
+        now=NOW,
+    )
+
+    assert plan.close_actions == ()
+    assert plan.warnings == (
+        "#11 lacks required housekeeping label infra",
+    )
+
+
+def test_merged_canonical_metadata_must_match_disposable_atom() -> None:
+    repository_root = Path(__file__).resolve().parents[2]
+    module_path = repository_root / "scripts/sdlc/pr_lifecycle.py"
+    spec = importlib.util.spec_from_file_location(
+        "test_pr_lifecycle_merged_cli",
+        module_path,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+    support = module._open_pr_from_json(
+        {
+            "number": 11,
+            "body": body(
+                lifecycle="support",
+                atom="increment-5b3",
+                canonical="#10",
+                close_when="canonical-merged",
+            ),
+            "draft": True,
+            "head": {
+                "ref": "support/increment-5b3",
+                "sha": "a" * 40,
+                "repo": {"full_name": "fol2/newsroom"},
+            },
+            "labels": [{"name": HOUSEKEEPING_LABEL}],
+            "created_at": "2026-08-05T12:00:00Z",
+        }
+    )
+
+    class FakeClient:
+        def get_pull_request(self, number: int):
+            assert number == 10
+            return {
+                "number": 10,
+                "body": body(atom="different-atom"),
+                "draft": False,
+                "head": {
+                    "ref": "agent/different-atom",
+                    "sha": "b" * 40,
+                    "repo": {"full_name": "fol2/newsroom"},
+                },
+                "labels": [],
+                "created_at": "2026-08-01T12:00:00Z",
+                "merged_at": "2026-08-02T12:00:00Z",
+            }
+
+    lifecycles = {
+        support.number: module.parse_pr_lifecycle(support.body)
+    }
+    with pytest.raises(module.GithubApiError, match="delivery atom differs"):
+        module._verified_merged_canonical_prs(
+            FakeClient(),
+            open_prs=(support,),
+            lifecycles=lifecycles,
+        )
+
+
+@pytest.mark.parametrize(
+    ("current_state", "merged_at"),
+    (
+        ("closed", None),
+        ("closed", "2026-08-05T12:30:00Z"),
+        ("open", "2026-08-05T12:30:00Z"),
+    ),
+)
+def test_apply_requires_action_pr_to_remain_open_and_unmerged(
+    current_state: str,
+    merged_at: str | None,
+) -> None:
+    repository_root = Path(__file__).resolve().parents[2]
+    module_path = repository_root / "scripts/sdlc/pr_lifecycle.py"
+    spec = importlib.util.spec_from_file_location(
+        "test_pr_lifecycle_action_state_cli",
+        module_path,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+    support_body = body(
+        lifecycle="support",
+        canonical="#10",
+        close_when="checkpointed",
+    )
+
+    class FakeClient:
+        def __init__(self) -> None:
+            self.effects: list[str] = []
+
+        def get_pull_request(self, number: int):
+            assert number == 11
+            return {
+                "number": 11,
+                "state": current_state,
+                "body": support_body,
+                "draft": True,
+                "head": {
+                    "ref": "support/increment-5b2-correction",
+                    "sha": "a" * 40,
+                    "repo": {"full_name": "fol2/newsroom"},
+                },
+                "labels": [{"name": HOUSEKEEPING_LABEL}],
+                "created_at": "2026-08-05T12:00:00Z",
+                "merged_at": merged_at,
+            }
+
+        def comment(self, *_args):
+            self.effects.append("comment")
+
+        def close_pull_request(self, *_args):
+            self.effects.append("close")
+
+        def delete_branch(self, *_args):
+            self.effects.append("delete")
+
+    client = FakeClient()
+    plan = HousekeepingPlan(
+        close_actions=(
+            CloseAction(
+                pr_number=11,
+                reason="declared checkpoint exists",
+            ),
+        ),
+        warnings=(),
+    )
+    with pytest.raises(module.GithubApiError, match="open and unmerged"):
+        module._apply_plan(
+            client,
+            plan,
+            lifecycles={11: module.parse_pr_lifecycle(support_body)},
+            repository="fol2/newsroom",
+        )
+    assert client.effects == []
+
+
+def test_apply_revalidates_current_disposable_surface() -> None:
+    repository_root = Path(__file__).resolve().parents[2]
+    module_path = repository_root / "scripts/sdlc/pr_lifecycle.py"
+    spec = importlib.util.spec_from_file_location(
+        "test_pr_lifecycle_surface_cli",
+        module_path,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+    class FakeClient:
+        def __init__(self) -> None:
+            self.effects: list[str] = []
+
+        def get_pull_request(self, number: int):
+            assert number == 11
+            return {
+                "number": 11,
+                "state": "open",
+                "body": body(
+                    lifecycle="support",
+                    canonical="#10",
+                    close_when="checkpointed",
+                ),
+                "draft": False,
+                "head": {
+                    "ref": "support/increment-5b2-correction",
+                    "sha": "a" * 40,
+                    "repo": {"full_name": "fol2/newsroom"},
+                },
+                "labels": [{"name": HOUSEKEEPING_LABEL}],
+                "created_at": "2026-08-05T12:00:00Z",
+                "merged_at": None,
+            }
+
+        def comment(self, *_args):
+            self.effects.append("comment")
+
+        def close_pull_request(self, *_args):
+            self.effects.append("close")
+
+        def delete_branch(self, *_args):
+            self.effects.append("delete")
+
+    client = FakeClient()
+    plan = HousekeepingPlan(
+        close_actions=(
+            CloseAction(
+                pr_number=11,
+                reason="declared checkpoint exists",
+            ),
+        ),
+        warnings=(),
+    )
+    with pytest.raises(module.PrLifecycleError, match="must remain drafts"):
+        module._apply_plan(
+            client,
+            plan,
+            lifecycles={},
+            repository="fol2/newsroom",
+        )
+    assert client.effects == []
+
+
+def test_checkpointed_keep_closure_requires_current_head_checkpoint() -> None:
+    repository_root = Path(__file__).resolve().parents[2]
+    module_path = repository_root / "scripts/sdlc/pr_lifecycle.py"
+    spec = importlib.util.spec_from_file_location(
+        "test_pr_lifecycle_checkpoint_keep_cli",
+        module_path,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+    support_body = body(
+        lifecycle="support",
+        canonical="#10",
+        close_when="checkpointed",
+        retention="keep",
+    )
+
+    class FakeClient:
+        def __init__(self) -> None:
+            self.effects: list[str] = []
+
+        def get_pull_request(self, number: int):
+            assert number == 11
+            return {
+                "number": 11,
+                "state": "open",
+                "body": support_body,
+                "draft": True,
+                "head": {
+                    "ref": "support/increment-5b2-correction",
+                    "sha": "a" * 40,
+                    "repo": {"full_name": "fol2/newsroom"},
+                },
+                "labels": [{"name": HOUSEKEEPING_LABEL}],
+                "created_at": "2026-08-05T12:00:00Z",
+                "merged_at": None,
+            }
+
+        def branch_sha(self, ref: str):
+            assert ref == "checkpoint/increment-5b2"
+            return "b" * 40
+
+        def comment(self, *_args):
+            self.effects.append("comment")
+
+        def close_pull_request(self, *_args):
+            self.effects.append("close")
+
+        def delete_branch(self, *_args):
+            self.effects.append("delete")
+
+    client = FakeClient()
+    plan = HousekeepingPlan(
+        close_actions=(
+            CloseAction(
+                pr_number=11,
+                reason="declared checkpoint exists",
+            ),
+        ),
+        warnings=(),
+    )
+    with pytest.raises(module.GithubApiError, match="current head"):
+        module._apply_plan(
+            client,
+            plan,
+            lifecycles={11: module.parse_pr_lifecycle(support_body)},
+            repository="fol2/newsroom",
+        )
+    assert client.effects == []
+
+
+@pytest.mark.parametrize(
+    ("canonical_state", "canonical_atom", "expected_error"),
+    (
+        ("closed", "increment-5b2", "no longer open"),
+        ("open", "different-atom", "delivery atom differs"),
+    ),
+)
+def test_checkpointed_apply_revalidates_current_canonical(
+    canonical_state: str,
+    canonical_atom: str,
+    expected_error: str,
+) -> None:
+    repository_root = Path(__file__).resolve().parents[2]
+    module_path = repository_root / "scripts/sdlc/pr_lifecycle.py"
+    spec = importlib.util.spec_from_file_location(
+        "test_pr_lifecycle_checkpoint_canonical_cli",
+        module_path,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+    support_body = body(
+        lifecycle="support",
+        canonical="#10",
+        close_when="checkpointed",
+        retention="keep",
+    )
+    planned_canonical_body = body()
+
+    class FakeClient:
+        def __init__(self) -> None:
+            self.effects: list[str] = []
+
+        def get_pull_request(self, number: int):
+            if number == 11:
+                return {
+                    "number": 11,
+                    "state": "open",
+                    "body": support_body,
+                    "draft": True,
+                    "head": {
+                        "ref": "support/increment-5b2-correction",
+                        "sha": "a" * 40,
+                        "repo": {"full_name": "fol2/newsroom"},
+                    },
+                    "labels": [{"name": HOUSEKEEPING_LABEL}],
+                    "created_at": "2026-08-05T12:00:00Z",
+                    "merged_at": None,
+                }
+            assert number == 10
+            return {
+                "number": 10,
+                "state": canonical_state,
+                "body": body(atom=canonical_atom),
+                "draft": False,
+                "head": {
+                    "ref": f"agent/{canonical_atom}",
+                    "sha": "b" * 40,
+                    "repo": {"full_name": "fol2/newsroom"},
+                },
+                "labels": [],
+                "created_at": "2026-08-01T12:00:00Z",
+                "merged_at": None,
+            }
+
+        def branch_sha(self, ref: str):
+            assert ref == "checkpoint/increment-5b2"
+            return "a" * 40
+
+        def comment(self, *_args):
+            self.effects.append("comment")
+
+        def close_pull_request(self, *_args):
+            self.effects.append("close")
+
+        def delete_branch(self, *_args):
+            self.effects.append("delete")
+
+    client = FakeClient()
+    plan = HousekeepingPlan(
+        close_actions=(
+            CloseAction(
+                pr_number=11,
+                reason="declared checkpoint exists",
+            ),
+        ),
+        warnings=(),
+    )
+    with pytest.raises(module.GithubApiError, match=expected_error):
+        module._apply_plan(
+            client,
+            plan,
+            lifecycles={
+                10: module.parse_pr_lifecycle(planned_canonical_body),
+                11: module.parse_pr_lifecycle(support_body),
+            },
+            repository="fol2/newsroom",
+        )
+    assert client.effects == []
+
+
+def test_apply_revalidates_current_merged_canonical_binding() -> None:
+    repository_root = Path(__file__).resolve().parents[2]
+    module_path = repository_root / "scripts/sdlc/pr_lifecycle.py"
+    spec = importlib.util.spec_from_file_location(
+        "test_pr_lifecycle_canonical_apply_cli",
+        module_path,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+    support_body = body(
+        lifecycle="support",
+        canonical="#10",
+        close_when="canonical-merged",
+        retention="keep",
+    )
+
+    class FakeClient:
+        def __init__(self) -> None:
+            self.effects: list[str] = []
+
+        def get_pull_request(self, number: int):
+            if number == 11:
+                return {
+                    "number": 11,
+                    "state": "open",
+                    "body": support_body,
+                    "draft": True,
+                    "head": {
+                        "ref": "support/increment-5b2-correction",
+                        "sha": "a" * 40,
+                        "repo": {"full_name": "fol2/newsroom"},
+                    },
+                    "labels": [{"name": HOUSEKEEPING_LABEL}],
+                    "created_at": "2026-08-05T12:00:00Z",
+                    "merged_at": None,
+                }
+            assert number == 10
+            return {
+                "number": 10,
+                "body": body(atom="unrelated-atom"),
+                "draft": False,
+                "head": {
+                    "ref": "agent/unrelated-atom",
+                    "sha": "b" * 40,
+                    "repo": {"full_name": "fol2/newsroom"},
+                },
+                "labels": [],
+                "created_at": "2026-08-01T12:00:00Z",
+                "merged_at": "2026-08-02T12:00:00Z",
+            }
+
+        def comment(self, *_args):
+            self.effects.append("comment")
+
+        def close_pull_request(self, *_args):
+            self.effects.append("close")
+
+        def delete_branch(self, *_args):
+            self.effects.append("delete")
+
+    client = FakeClient()
+    plan = HousekeepingPlan(
+        close_actions=(
+            CloseAction(
+                pr_number=11,
+                reason="canonical PR #10 is merged",
+            ),
+        ),
+        warnings=(),
+    )
+    with pytest.raises(module.GithubApiError, match="delivery atom differs"):
+        module._apply_plan(
+            client,
+            plan,
+            lifecycles={11: module.parse_pr_lifecycle(support_body)},
+            repository="fol2/newsroom",
+        )
+    assert client.effects == []
+
+
+def test_workflow_separates_dry_run_and_two_key_apply() -> None:
+    repository_root = Path(__file__).resolve().parents[2]
+    workflow = (
+        repository_root / ".github/workflows/pr-lifecycle.yml"
+    ).read_text(encoding="utf-8")
+    cli = (
+        repository_root / "scripts/sdlc/pr_lifecycle.py"
+    ).read_text(encoding="utf-8")
+
+    assert "inventory-dry-run:" in workflow
+    assert "inventory-apply:" in workflow
+    assert "inputs.apply == true" in workflow
+    assert (
+        "inputs.confirmation == 'CLOSE_ELIGIBLE_DISPOSABLE_PRS'"
+        in workflow
+    )
+    assert "PR_HOUSEKEEPING_APPLY: CLOSE_ELIGIBLE_DISPOSABLE_PRS" in workflow
+    assert workflow.count("GITHUB_TOKEN: ${{ github.token }}") == 2
+    assert "python scripts/sdlc/pr_lifecycle.py" not in workflow
+    apply_permissions = workflow.split("inventory-apply:", 1)[1].split(
+        "runs-on:", 1
+    )[0]
+    assert "contents: read" in apply_permissions
+    assert "contents: write" not in workflow
+    assert "def delete_branch" not in cli
+    assert "client.delete_branch" not in cli
+    assert 'request("DELETE", f"/git/refs/heads/' not in cli
+    assert "Automatic branch deletion: `DISABLED`" in cli
+
+def test_pull_request_head_sha_must_be_full_lowercase_commit() -> None:
+    with pytest.raises(PrLifecycleError, match="head SHA"):
+        open_pr(
+            11,
+            pr_body=body(),
+            draft=True,
+            head_ref="agent/increment-5b2",
+            head_sha="ABC",
+        )
+
+
+def test_close_action_has_no_branch_deletion_capability() -> None:
+    assert set(CloseAction.__dataclass_fields__) == {"pr_number", "reason"}
+    action = CloseAction(pr_number=11, reason="checkpoint verified")
+    assert action.pr_number == 11
+    assert action.reason == "checkpoint verified"

--- a/scripts/sdlc/pr_lifecycle.py
+++ b/scripts/sdlc/pr_lifecycle.py
@@ -1,0 +1,603 @@
+#!/usr/bin/env python3
+"""Validate PR lifecycle metadata and plan/apply bounded housekeeping."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import importlib.util
+import json
+import os
+from pathlib import Path
+import sys
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+_CONTRACT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "newsroom"
+    / "checks"
+    / "pr_lifecycle.py"
+)
+_CONTRACT_SPEC = importlib.util.spec_from_file_location(
+    "newsroom_pr_lifecycle_contract",
+    _CONTRACT_PATH,
+)
+if _CONTRACT_SPEC is None or _CONTRACT_SPEC.loader is None:
+    raise RuntimeError("cannot load exact PR lifecycle contract")
+_CONTRACT = importlib.util.module_from_spec(_CONTRACT_SPEC)
+sys.modules[_CONTRACT_SPEC.name] = _CONTRACT
+_CONTRACT_SPEC.loader.exec_module(_CONTRACT)
+
+HOUSEKEEPING_LABEL = _CONTRACT.HOUSEKEEPING_LABEL
+HousekeepingPlan = _CONTRACT.HousekeepingPlan
+OpenPullRequest = _CONTRACT.OpenPullRequest
+PrLifecycleError = _CONTRACT.PrLifecycleError
+parse_pr_lifecycle = _CONTRACT.parse_pr_lifecycle
+plan_housekeeping = _CONTRACT.plan_housekeeping
+validate_pull_request_event = _CONTRACT.validate_pull_request_event
+validate_pull_request_lifecycle = (
+    _CONTRACT.validate_pull_request_lifecycle
+)
+
+
+_API = "https://api.github.com"
+_API_VERSION = "2022-11-28"
+
+
+class GithubApiError(RuntimeError):
+    """The bounded GitHub housekeeping API call failed."""
+
+
+class GithubClient:
+    def __init__(self, *, repository: str, token: str) -> None:
+        if (
+            not isinstance(repository, str)
+            or repository.count("/") != 1
+            or any(not part for part in repository.split("/"))
+        ):
+            raise GithubApiError("GITHUB_REPOSITORY must be owner/name")
+        if not isinstance(token, str) or not token:
+            raise GithubApiError("GITHUB_TOKEN is required")
+        self._repository = repository
+        self._token = token
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        payload: dict[str, object] | None = None,
+        allow_not_found: bool = False,
+    ) -> Any:
+        url = f"{_API}/repos/{self._repository}{path}"
+        data = (
+            None
+            if payload is None
+            else json.dumps(payload, sort_keys=True).encode("utf-8")
+        )
+        request = Request(
+            url,
+            data=data,
+            method=method,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self._token}",
+                "Content-Type": "application/json",
+                "User-Agent": "newsroom-pr-lifecycle-v1",
+                "X-GitHub-Api-Version": _API_VERSION,
+            },
+        )
+        try:
+            with urlopen(request, timeout=30) as response:
+                raw = response.read()
+        except HTTPError as exc:
+            if allow_not_found and exc.code == 404:
+                return None
+            detail = exc.read(2048).decode("utf-8", errors="replace")
+            raise GithubApiError(
+                f"GitHub API {method} {path} failed: HTTP {exc.code}: {detail}"
+            ) from exc
+        except (OSError, URLError) as exc:
+            raise GithubApiError(
+                f"GitHub API {method} {path} is unavailable"
+            ) from exc
+        if not raw:
+            return None
+        try:
+            return json.loads(raw.decode("utf-8"))
+        except (UnicodeError, json.JSONDecodeError) as exc:
+            raise GithubApiError(
+                f"GitHub API {method} {path} returned malformed JSON"
+            ) from exc
+
+    def list_open_pull_requests(self) -> list[dict[str, object]]:
+        results: list[dict[str, object]] = []
+        page = 1
+        while True:
+            value = self.request(
+                "GET",
+                f"/pulls?state=open&per_page=100&page={page}",
+            )
+            if not isinstance(value, list):
+                raise GithubApiError("open pull-request response is malformed")
+            rows = [item for item in value if isinstance(item, dict)]
+            if len(rows) != len(value):
+                raise GithubApiError("open pull-request row is malformed")
+            results.extend(rows)
+            if len(value) < 100:
+                return results
+            page += 1
+            if page > 20:
+                raise GithubApiError("open pull-request pagination is unbounded")
+
+    def get_pull_request(self, number: int) -> dict[str, object]:
+        value = self.request("GET", f"/pulls/{number}")
+        if not isinstance(value, dict):
+            raise GithubApiError(f"pull request #{number} response is malformed")
+        return value
+
+    def pull_request_is_merged(self, number: int) -> bool:
+        value = self.request("GET", f"/pulls/{number}")
+        if not isinstance(value, dict):
+            raise GithubApiError(f"pull request #{number} response is malformed")
+        return value.get("merged_at") is not None
+
+    def branch_sha(self, ref: str) -> str | None:
+        encoded = quote(ref, safe="")
+        value = self.request(
+            "GET",
+            f"/git/ref/heads/{encoded}",
+            allow_not_found=True,
+        )
+        if value is None:
+            return None
+        if not isinstance(value, dict):
+            raise GithubApiError(f"branch {ref} response is malformed")
+        raw_object = value.get("object")
+        if not isinstance(raw_object, dict):
+            raise GithubApiError(f"branch {ref} object is malformed")
+        sha = raw_object.get("sha")
+        if (
+            not isinstance(sha, str)
+            or len(sha) != 40
+            or any(character not in "0123456789abcdef" for character in sha)
+        ):
+            raise GithubApiError(f"branch {ref} SHA is malformed")
+        return sha
+
+    def branch_exists(self, ref: str) -> bool:
+        return self.branch_sha(ref) is not None
+
+    def comment(self, number: int, body: str) -> None:
+        self.request(
+            "POST",
+            f"/issues/{number}/comments",
+            payload={"body": body},
+        )
+
+    def close_pull_request(self, number: int) -> None:
+        value = self.request(
+            "PATCH",
+            f"/pulls/{number}",
+            payload={"state": "closed"},
+        )
+        if not isinstance(value, dict) or value.get("state") != "closed":
+            raise GithubApiError(f"pull request #{number} did not close")
+
+
+def validate_event(path: Path) -> int:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise PrLifecycleError("cannot read GitHub event payload") from exc
+    if not isinstance(value, dict):
+        raise PrLifecycleError("GitHub event payload must be an object")
+    lifecycle = validate_pull_request_event(value)
+    print(
+        "validated PR lifecycle: "
+        f"{lifecycle.kind.value} / {lifecycle.delivery_atom}"
+    )
+    _write_summary(
+        "\n".join(
+            (
+                "## PR lifecycle validation",
+                "",
+                f"- Lifecycle: `{lifecycle.kind.value}`",
+                f"- Delivery atom: `{lifecycle.delivery_atom}`",
+                "- Result: **PASS**",
+            )
+        )
+    )
+    return 0
+
+
+def _verified_merged_canonical_prs(
+    client: GithubClient,
+    *,
+    open_prs: tuple[OpenPullRequest, ...],
+    lifecycles: dict[int, object],
+) -> frozenset[int]:
+    open_numbers = {item.number for item in open_prs}
+    referenced = {
+        getattr(lifecycle, "canonical_pr")
+        for lifecycle in lifecycles.values()
+        if getattr(lifecycle, "canonical_pr") is not None
+    }
+    verified: dict[int, object] = {}
+    for number in sorted(referenced - open_numbers):
+        raw = client.get_pull_request(number)
+        if raw.get("merged_at") is None:
+            continue
+        canonical_pr = _open_pr_from_json(raw)
+        canonical_lifecycle = parse_pr_lifecycle(canonical_pr.body)
+        validate_pull_request_lifecycle(
+            canonical_lifecycle,
+            pr_number=canonical_pr.number,
+            draft=canonical_pr.draft,
+            head_ref=canonical_pr.head_ref,
+        )
+        if not canonical_lifecycle.canonical_is_self:
+            raise GithubApiError(
+                f"merged pull request #{number} is not canonical"
+            )
+        verified[number] = canonical_lifecycle
+
+    for pr in open_prs:
+        lifecycle = lifecycles[pr.number]
+        canonical_number = getattr(lifecycle, "canonical_pr")
+        if (
+            not getattr(lifecycle, "is_disposable")
+            or canonical_number in open_numbers
+        ):
+            continue
+        canonical_lifecycle = verified.get(canonical_number)
+        if canonical_lifecycle is None:
+            continue
+        if (
+            getattr(canonical_lifecycle, "delivery_atom")
+            != getattr(lifecycle, "delivery_atom")
+        ):
+            raise GithubApiError(
+                f"#{pr.number} delivery atom differs from merged canonical "
+                f"#{canonical_number}"
+            )
+    return frozenset(verified)
+
+
+def inventory(*, apply: bool) -> int:
+    repository = os.environ.get("GITHUB_REPOSITORY", "")
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if (
+        apply
+        and os.environ.get("PR_HOUSEKEEPING_APPLY")
+        != "CLOSE_ELIGIBLE_DISPOSABLE_PRS"
+    ):
+        raise PrLifecycleError(
+            "apply mode requires the exact housekeeping confirmation"
+        )
+    client = GithubClient(repository=repository, token=token)
+    raw_prs = client.list_open_pull_requests()
+    open_prs = tuple(_open_pr_from_json(item) for item in raw_prs)
+
+    lifecycles = {
+        item.number: parse_pr_lifecycle(item.body)
+        for item in open_prs
+    }
+    merged_canonical = _verified_merged_canonical_prs(
+        client,
+        open_prs=open_prs,
+        lifecycles=lifecycles,
+    )
+    checkpoint_refs = {
+        lifecycle.checkpoint_ref
+        for lifecycle in lifecycles.values()
+        if lifecycle.checkpoint_ref is not None
+    }
+    existing_checkpoints = frozenset(
+        ref
+        for ref in sorted(checkpoint_refs)
+        if client.branch_exists(ref)
+    )
+    plan = plan_housekeeping(
+        open_prs,
+        merged_canonical_prs=merged_canonical,
+        existing_checkpoint_refs=existing_checkpoints,
+        repository_full_name=repository,
+        now=datetime.now(timezone.utc),
+    )
+
+    if apply:
+        _apply_plan(
+            client,
+            plan,
+            lifecycles=lifecycles,
+            repository=repository,
+        )
+    output = _render_plan(
+        plan,
+        open_count=len(open_prs),
+        apply=apply,
+    )
+    print(output)
+    _write_summary(output)
+    return 0
+
+
+def _open_pr_from_json(value: dict[str, object]) -> OpenPullRequest:
+    try:
+        number = int(value["number"])
+        body = value.get("body") or ""
+        draft = value["draft"]
+        head = value["head"]
+        if not isinstance(head, dict):
+            raise TypeError
+        head_ref = head["ref"]
+        head_sha = str(head["sha"])
+        raw_head_repository = head.get("repo")
+        if raw_head_repository is None:
+            head_repository = None
+        elif isinstance(raw_head_repository, dict):
+            head_repository = str(raw_head_repository["full_name"])
+        else:
+            raise TypeError
+        raw_labels = value.get("labels", [])
+        if not isinstance(raw_labels, list) or any(
+            not isinstance(item, dict) or not isinstance(item.get("name"), str)
+            for item in raw_labels
+        ):
+            raise TypeError
+        labels = frozenset(str(item["name"]) for item in raw_labels)
+        created_at = datetime.fromisoformat(
+            str(value["created_at"]).replace("Z", "+00:00")
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        raise GithubApiError("open pull-request inventory row is malformed") from exc
+    return OpenPullRequest(
+        number=number,
+        body=str(body),
+        draft=draft,  # type: ignore[arg-type]
+        head_ref=head_ref,  # type: ignore[arg-type]
+        created_at=created_at,
+        labels=labels,
+        head_repository=head_repository,
+        head_sha=head_sha,
+    )
+
+
+
+def _validated_current_canonical(
+    client: GithubClient,
+    *,
+    action_pr_number: int,
+    lifecycle: object,
+    planned_lifecycles: dict[int, object],
+    require_merged: bool,
+) -> object:
+    canonical_number = getattr(lifecycle, "canonical_pr", None)
+    if (
+        isinstance(canonical_number, bool)
+        or not isinstance(canonical_number, int)
+        or canonical_number <= 0
+    ):
+        raise GithubApiError(
+            f"pull request #{action_pr_number} lacks a canonical PR"
+        )
+
+    raw_canonical = client.get_pull_request(canonical_number)
+    planned_canonical = planned_lifecycles.get(canonical_number)
+    if require_merged or planned_canonical is None:
+        if raw_canonical.get("merged_at") is None:
+            raise GithubApiError(
+                f"pull request #{action_pr_number} canonical PR is not merged"
+            )
+    elif (
+        raw_canonical.get("state") != "open"
+        or raw_canonical.get("merged_at") is not None
+    ):
+        raise GithubApiError(
+            f"pull request #{action_pr_number} canonical PR is no longer open"
+        )
+
+    canonical_pr = _open_pr_from_json(raw_canonical)
+    canonical_lifecycle = parse_pr_lifecycle(canonical_pr.body)
+    validate_pull_request_lifecycle(
+        canonical_lifecycle,
+        pr_number=canonical_pr.number,
+        draft=canonical_pr.draft,
+        head_ref=canonical_pr.head_ref,
+    )
+    if (
+        not canonical_lifecycle.canonical_is_self
+        or canonical_lifecycle.delivery_atom
+        != getattr(lifecycle, "delivery_atom", None)
+    ):
+        raise GithubApiError(
+            f"pull request #{action_pr_number} delivery atom differs "
+            "from its current canonical PR"
+        )
+    if (
+        planned_canonical is not None
+        and canonical_lifecycle != planned_canonical
+    ):
+        raise GithubApiError(
+            f"pull request #{action_pr_number} canonical lifecycle changed "
+            "after planning"
+        )
+    return canonical_lifecycle
+
+
+def _apply_plan(
+    client: GithubClient,
+    plan: HousekeepingPlan,
+    *,
+    lifecycles: dict[int, object],
+    repository: str,
+) -> None:
+    recorded_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    for action in plan.close_actions:
+        raw_current = client.get_pull_request(action.pr_number)
+        if (
+            raw_current.get("state") != "open"
+            or raw_current.get("merged_at") is not None
+        ):
+            raise GithubApiError(
+                f"pull request #{action.pr_number} is no longer open and unmerged"
+            )
+        current = _open_pr_from_json(raw_current)
+        lifecycle = parse_pr_lifecycle(current.body)
+        validate_pull_request_lifecycle(
+            lifecycle,
+            pr_number=current.number,
+            draft=current.draft,
+            head_ref=current.head_ref,
+        )
+        planned_lifecycle = lifecycles.get(action.pr_number)
+        if planned_lifecycle is None or lifecycle != planned_lifecycle:
+            raise GithubApiError(
+                f"pull request #{action.pr_number} lifecycle changed after planning"
+            )
+        if lifecycle.branch_retention.value != "keep":
+            raise GithubApiError(
+                f"pull request #{action.pr_number} requests unsupported "
+                "automatic branch deletion"
+            )
+        if not lifecycle.is_disposable:
+            raise GithubApiError(
+                f"pull request #{action.pr_number} is no longer disposable"
+            )
+        if HOUSEKEEPING_LABEL not in current.labels:
+            raise GithubApiError(
+                f"pull request #{action.pr_number} lost its housekeeping label"
+            )
+        checkpoint = lifecycle.checkpoint_ref
+        if lifecycle.close_when.value == "checkpointed":
+            checkpoint_sha = (
+                None if checkpoint is None else client.branch_sha(checkpoint)
+            )
+            if (
+                current.head_sha is None
+                or checkpoint_sha != current.head_sha
+            ):
+                raise GithubApiError(
+                    f"pull request #{action.pr_number} checkpoint no longer "
+                    "identifies its current head"
+                )
+            _validated_current_canonical(
+                client,
+                action_pr_number=action.pr_number,
+                lifecycle=lifecycle,
+                planned_lifecycles=lifecycles,
+                require_merged=False,
+            )
+        elif lifecycle.close_when.value == "canonical-merged":
+            _validated_current_canonical(
+                client,
+                action_pr_number=action.pr_number,
+                lifecycle=lifecycle,
+                planned_lifecycles=lifecycles,
+                require_merged=True,
+            )
+        else:
+            raise GithubApiError(
+                f"pull request #{action.pr_number} close condition changed"
+            )
+        comment = "\n".join(
+            (
+                "Automated lifecycle housekeeping closure.",
+                "",
+                f"- Repository: `{repository}`",
+                f"- Recorded at: `{recorded_at}`",
+                f"- Reason: {action.reason}",
+                f"- Checkpoint: `{checkpoint or 'NONE'}`",
+                "- Automatic branch deletion: `DISABLED`",
+                "- Branch retention: `keep`",
+                "",
+                "This action never merges or auto-closes a canonical PR.",
+            )
+        )
+        client.comment(action.pr_number, comment)
+        client.close_pull_request(action.pr_number)
+
+
+def _render_plan(
+    plan: HousekeepingPlan,
+    *,
+    open_count: int,
+    apply: bool,
+) -> str:
+    lines = [
+        "## PR lifecycle housekeeping",
+        "",
+        f"- Mode: `{'APPLY' if apply else 'DRY_RUN'}`",
+        f"- Open PRs inspected: `{open_count}`",
+        f"- Disposable PRs eligible for closure: `{len(plan.close_actions)}`",
+        f"- Age warnings: `{len(plan.warnings)}`",
+        "- Automatic branch deletion: `DISABLED`",
+        "",
+    ]
+    if plan.close_actions:
+        lines.extend(
+            (
+                "| PR | Reason |",
+                "|---:|---|",
+            )
+        )
+        lines.extend(
+            f"| #{item.pr_number} | {item.reason} |"
+            for item in plan.close_actions
+        )
+        lines.append("")
+    if plan.warnings:
+        lines.append("### Warnings")
+        lines.extend(f"- {warning}" for warning in plan.warnings)
+        lines.append("")
+    if not plan.close_actions and not plan.warnings:
+        lines.append("No lifecycle action is required.")
+    return "\n".join(lines)
+
+
+def _write_summary(text: str) -> None:
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not path:
+        return
+    with Path(path).open("a", encoding="utf-8") as handle:
+        handle.write(text)
+        handle.write("\n")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    validate = subparsers.add_parser("validate-event")
+    validate.add_argument(
+        "--event",
+        type=Path,
+        default=Path(os.environ.get("GITHUB_EVENT_PATH", "")),
+    )
+
+    inventory_parser = subparsers.add_parser("inventory")
+    inventory_parser.add_argument("--apply", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.command == "validate-event":
+            if not str(args.event):
+                raise PrLifecycleError("GitHub event path is required")
+            return validate_event(args.event)
+        if args.command == "inventory":
+            return inventory(apply=args.apply)
+        raise PrLifecycleError("unsupported lifecycle command")
+    except (PrLifecycleError, GithubApiError) as exc:
+        print(f"PR lifecycle error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: repository-pr-lifecycle-v1
Canonical-PR: self
Checkpoint-Ref: checkpoint/pr-lifecycle-v1-retain-branches-final-20260806
Close-When: merged
Branch-Retention: keep

## Scope

Implements issue #304 as one repository-governance atom on the exact post-5B2 base `main@7a4164f0a0b7c7c70cd68b2a5485110e7ca576f3`:

- strict canonical/support/preflight lifecycle metadata;
- one canonical PR per delivery atom and at most two open disposable PRs per canonical;
- trusted default-branch lifecycle validation;
- read-only scheduled/manual inventory;
- separately permissioned, explicitly confirmed apply mode;
- exact checkpoint-gated and canonical-merged disposable closure; and
- explicit prohibition on automatic canonical closure or Git-ref deletion.

## Authorization, import and mutation boundaries

The CLI loads the exact stdlib-only lifecycle contract directly from `newsroom/checks/pr_lifecycle.py`; trusted workflow execution does not depend on an editable install, inherited `PYTHONPATH`, package-initializer side effects or third-party imports.

Planning validates every open PR, rejects duplicate canonical delivery atoms, caps disposable PRs, and rejects duplicate same-repository open head refs before producing any action.

Immediately before every effect, apply mode re-fetches the target PR and requires it to remain open and unmerged. It revalidates the body, draft state, branch prefix, label, head repository, head SHA, checkpoint and canonical binding. Any lifecycle metadata or current-state drift invalidates the plan.

Every `checkpointed` closure requires the dedicated checkpoint SHA to equal the freshly fetched current PR head SHA. Its referenced canonical PR is independently revalidated. A `canonical-merged` closure independently re-fetches and validates the merged canonical immediately before effects.

`Branch-Retention` supports exactly `keep`. GitHub exposes ref deletion but no compare-and-delete primitive, so automatic deletion cannot atomically bind the mutation to the ref state that was checked. The CLI therefore has no ref-deletion method, housekeeping plans contain no branch-deletion action, the apply job retains `contents: read`, and automated closure always retains both branch and checkpoint refs. Any later cleanup is a separate deliberate owner action outside this automation.

Both inventory jobs receive `${{ github.token }}` explicitly while remaining restricted by separate job permission blocks. Apply requires dry-run success, `apply=true`, exact confirmation `CLOSE_ELIGIBLE_DISPOSABLE_PRS`, and the exact `PR_HOUSEKEEPING_APPLY=CLOSE_ELIGIBLE_DISPOSABLE_PRS` process guard. It can comment on and close an eligible disposable PR; it never merges a PR, closes a canonical PR or deletes a ref.

## Exact clean head

```text
head:              c32457b895972cb721e3c5a2e97e2ddf2250db25
tree:              0da01f931e0ecc6dbe570ace9fd40955b3976041
parent/base:       7a4164f0a0b7c7c70cd68b2a5485110e7ca576f3
commits over base: 1
changed files:     6
checkpoint:        checkpoint/pr-lifecycle-v1-retain-branches-final-20260806
```

## Verification and exact-byte assembly

Support evidence run `31057451644` passed on the final no-delete product:

- 28 focused lifecycle tests passed;
- 2,093 complete deterministic repository tests passed;
- 38 intentional skips; and
- clustering regression gate passed.

Export run `31057901874` preserved the tested product at commit `646f6bd0845d798817dea9e17aa9ae62d7e1e076`. Because the support Actions token correctly lacked permission to modify a permanent workflow path, the exact tested `.github/workflows/pr-lifecycle.yml` bytes were exported through `scripts/support/exported_pr_lifecycle_product.yml` with blob identity `5465b3d9ee61ef84d3a40896b86497add6f0d7f1`.

The canonical commit above was assembled over the fixed base from the five directly published tested product blobs plus that tested workflow-carrier blob, remapped to the permanent workflow path. The non-product carrier path itself is absent from the canonical diff.

A superseded assembly at `1cd636582275a55ffd07449be9eb7fba8e97dc30` incorrectly selected the unchanged permanent-workflow blob from the export tree. SDLC run `31058595152` exposed this immediately through the focused workflow-permission regression: all infrastructure and service evidence passed, while one core test correctly rejected `contents: write`. That commit and checkpoint target were replaced rather than patched; they are not the current PR head.

The six canonical product files are:

- `.github/pull_request_template.md`;
- `.github/workflows/pr-lifecycle.yml`;
- `docs/operations/pr-lifecycle.md`;
- `newsroom/checks/pr_lifecycle.py`;
- `newsroom/tests/test_pr_lifecycle.py`; and
- `scripts/sdlc/pr_lifecycle.py`.

All permanent workflows on the current canonical head, a fresh exact-head substantive review and zero unresolved review threads remain required before merge.

## Non-effects

The framework does not alter newsroom product authority, activate production, authorize publication, call an external provider, merge a PR, auto-close a canonical PR or delete any Git ref.

Tracks #304.