### PR TITLE
Support: retain repaired Increment 5B4 reviewed worktree

### DIFF
--- a/scripts/support/increment5b4-reviewed-run-trigger-v4.txt
+++ b/scripts/support/increment5b4-reviewed-run-trigger-v4.txt
@@ -1,0 +1,6 @@
+Open a same-repository support-only pull request so the repaired base-owned 5B4 hardening workflow receives a pull_request event.
+
+base=support/run-increment-5b4-reviewed-hardening-v2-20260806
+base_head=a2275ebcb58e1bef9b2adf681ede73b969035463
+reviewed_carrier=d8f92de968edccdeb58d4ae80a15a04919e25e18
+source=30eb9dd5e7d6c03018d30289ef3fa05f3b76d523


### PR DESCRIPTION
Disposable support runner only; do not merge into `main`.

This is the only open support/preflight PR for canonical Increment 5B4. It targets the existing support runner branch solely to emit a same-repository `pull_request` event after repairing the runner and adding an always-uploaded exact worktree artifact.

Pinned identities:

- support base `a2275ebcb58e1bef9b2adf681ede73b969035463`;
- reviewed carrier `d8f92de968edccdeb58d4ae80a15a04919e25e18`;
- source `30eb9dd5e7d6c03018d30289ef3fa05f3b76d523`.

Expected artifact: `increment5b4-reviewed-worktree-<run_id>`.

The PR contains only a support trigger marker and grants no product, authority, publication, provider, or activation effect. Close after the artifact is recovered.