### PR TITLE
Support: recover exact reviewed Increment 5B4 worktree

### DIFF
--- a/scripts/support/increment5b4-reviewed-run-trigger-v5.txt
+++ b/scripts/support/increment5b4-reviewed-run-trigger-v5.txt
@@ -1,8 +1,9 @@
 Keep this support-only pull request open until the final clean Increment 5B4 materializer publishes and uploads its exact seven-file worktree.
 
-base_workflow_commit=14e149f4866cdefa3f4f6be6527a6422c6537009
-base_workflow_blob=7b01e89f81300cba3a3a496c45721eb0537270a7
+carrier_commit=14e149f4866cdefa3f4f6be6527a6422c6537009
+wrapper_commit=6060d3453e19bd64aaca8360751c6ee043b1d5ab
 expected_base=7976909e58a47749ac39fa212f5ecac325294ace
 expected_source=30eb9dd5e7d6c03018d30289ef3fa05f3b76d523
 canonical_branch=agent/increment-5b4-admitted-graph
-focused_local=64 passed, 1 skipped
+focused_github=64 passed, 2 skipped
+correction=remove exactly two redundant cd product transitions

--- a/scripts/support/increment5b4-reviewed-run-trigger-v5.txt
+++ b/scripts/support/increment5b4-reviewed-run-trigger-v5.txt
@@ -1,0 +1,5 @@
+Keep this support-only pull request open until the repaired Increment 5B4 runner uploads its exact reviewed worktree artifact.
+
+base=2ddd6833c28790905f2e6c69c0e175a44b62bdf8
+reviewed_carrier=d8f92de968edccdeb58d4ae80a15a04919e25e18
+source=30eb9dd5e7d6c03018d30289ef3fa05f3b76d523

--- a/scripts/support/increment5b4-reviewed-run-trigger-v5.txt
+++ b/scripts/support/increment5b4-reviewed-run-trigger-v5.txt
@@ -1,6 +1,8 @@
 Keep this support-only pull request open until the final clean Increment 5B4 materializer publishes and uploads its exact seven-file worktree.
 
-base_workflow=24264dec641c87f7fe51e763347dd9f9a98ce689
+base_workflow_commit=14e149f4866cdefa3f4f6be6527a6422c6537009
+base_workflow_blob=7b01e89f81300cba3a3a496c45721eb0537270a7
 expected_base=7976909e58a47749ac39fa212f5ecac325294ace
 expected_source=30eb9dd5e7d6c03018d30289ef3fa05f3b76d523
 canonical_branch=agent/increment-5b4-admitted-graph
+focused_local=64 passed, 1 skipped

--- a/scripts/support/increment5b4-reviewed-run-trigger-v5.txt
+++ b/scripts/support/increment5b4-reviewed-run-trigger-v5.txt
@@ -1,5 +1,6 @@
-Keep this support-only pull request open until the repaired Increment 5B4 runner uploads its exact reviewed worktree artifact.
+Keep this support-only pull request open until the final clean Increment 5B4 materializer publishes and uploads its exact seven-file worktree.
 
-base=2ddd6833c28790905f2e6c69c0e175a44b62bdf8
-reviewed_carrier=d8f92de968edccdeb58d4ae80a15a04919e25e18
-source=30eb9dd5e7d6c03018d30289ef3fa05f3b76d523
+base_workflow=24264dec641c87f7fe51e763347dd9f9a98ce689
+expected_base=7976909e58a47749ac39fa212f5ecac325294ace
+expected_source=30eb9dd5e7d6c03018d30289ef3fa05f3b76d523
+canonical_branch=agent/increment-5b4-admitted-graph


### PR DESCRIPTION
Disposable support runner only. Do not merge into `main`.

This is the sole open support/preflight PR for canonical Increment 5B4. It remains open until the repaired base-owned workflow uploads `increment5b4-reviewed-worktree-<run_id>`.

Pinned identities:

- support base `2ddd6833c28790905f2e6c69c0e175a44b62bdf8`;
- reviewed carrier `d8f92de968edccdeb58d4ae80a15a04919e25e18`;
- source `30eb9dd5e7d6c03018d30289ef3fa05f3b76d523`.

The PR changes only a support trigger marker and grants no product, authority, provider, publication, or activation effect. Close after worktree recovery.