### PR TITLE
Support: execute pinned final Increment 5B4 wrapper

### DIFF
--- a/scripts/support/increment5b4-final-wrapper-trigger.txt
+++ b/scripts/support/increment5b4-final-wrapper-trigger.txt
@@ -1,0 +1,6 @@
+Emit one same-repository pull_request event against the support base that already contains the pinned path-correction wrapper.
+
+base_commit=6060d3453e19bd64aaca8360751c6ee043b1d5ab
+carrier_commit=14e149f4866cdefa3f4f6be6527a6422c6537009
+expected_base=7976909e58a47749ac39fa212f5ecac325294ace
+canonical_branch=agent/increment-5b4-admitted-graph


### PR DESCRIPTION
Disposable support runner only. Do not merge into `main`.

This is the sole open support/preflight PR for canonical Increment 5B4. Its base already contains the pinned path-correction wrapper; this one-file marker exists only to emit the same-repository `pull_request` event.

Pinned identities:

- wrapper base `6060d3453e19bd64aaca8360751c6ee043b1d5ab`;
- reviewed carrier `14e149f4866cdefa3f4f6be6527a6422c6537009`;
- product base `7976909e58a47749ac39fa212f5ecac325294ace`.

The wrapper removes exactly two redundant directory transitions from the already-reviewed materializer. It changes no product bytes. It will run focused and complete deterministic tests, then publish exactly seven product files to the canonical branch only on success.