### PR TITLE
Support: execute widened final Increment 5B4 wrapper

### DIFF
--- a/scripts/support/increment5b4-final-wrapper-trigger-v3.txt
+++ b/scripts/support/increment5b4-final-wrapper-trigger-v3.txt
@@ -1,0 +1,6 @@
+Emit one same-repository pull_request event against the widened pinned carrier wrapper.
+
+base_commit=5e83aa07b25e42c9773835d649df7939e1999343
+carrier_commit=14e149f4866cdefa3f4f6be6527a6422c6537009
+product_base=7976909e58a47749ac39fa212f5ecac325294ace
+canonical_branch=agent/increment-5b4-admitted-graph


### PR DESCRIPTION
Disposable support runner only. Do not merge into `main`.

This is the sole open support/preflight PR for canonical Increment 5B4. Its base contains the syntactically valid wrapper with enough history to retrieve the pinned reviewed carrier. The one-file marker exists only to emit a same-repository `pull_request` event.

Pinned identities:

- wrapper base `5e83aa07b25e42c9773835d649df7939e1999343`;
- reviewed carrier `14e149f4866cdefa3f4f6be6527a6422c6537009`;
- product base `7976909e58a47749ac39fa212f5ecac325294ace`.

The wrapper changes no product bytes. It removes exactly two redundant working-directory transitions, runs focused and complete deterministic tests, and publishes exactly seven product files only on success.