### PR TITLE
Support: execute fully bound final Increment 5B4 wrapper

### DIFF
--- a/scripts/support/increment5b4-final-wrapper-trigger-v4.txt
+++ b/scripts/support/increment5b4-final-wrapper-trigger-v4.txt
@@ -1,0 +1,6 @@
+Emit one same-repository pull_request event against the fully bound final wrapper.
+
+base_commit=d0bea83b484bc5cb5780f6e361aaa233eb0a63aa
+carrier_commit=14e149f4866cdefa3f4f6be6527a6422c6537009
+product_base=7976909e58a47749ac39fa212f5ecac325294ace
+canonical_branch=agent/increment-5b4-admitted-graph


### PR DESCRIPTION
Disposable support runner only. Do not merge into `main`.

This is the sole open support/preflight PR for canonical Increment 5B4. Its base contains the valid wrapper, pinned carrier history, and all exact environment bindings. The one-file marker exists only to emit a same-repository `pull_request` event.

Pinned identities:

- wrapper base `d0bea83b484bc5cb5780f6e361aaa233eb0a63aa`;
- reviewed carrier `14e149f4866cdefa3f4f6be6527a6422c6537009`;
- product base `7976909e58a47749ac39fa212f5ecac325294ace`.

The wrapper changes no product bytes. It removes exactly two redundant working-directory transitions, runs focused and complete deterministic tests, and publishes exactly seven product files only on success.