### PR TITLE
Support: run exact Increment 5B4 publisher

### DIFF
--- a/scripts/support/increment5b4-nine-publisher-trigger.txt
+++ b/scripts/support/increment5b4-nine-publisher-trigger.txt
@@ -1,11 +1,12 @@
-Emit one same-repository pull_request event for the code-tree-clean Increment 5B4 publisher.
+Emit one same-repository pull_request event for the clean-tree Increment 5B4 publisher.
 
-publisher_script=b019b45810e6cbd1ab59480c29812f23674b6cc8
+publisher_script=e23dc6fa8485bad5a6e1ab7327b56ab15b8a4c3c
 publisher_workflow=345da63f603e7ac0bbf25ecc4e2fd7ac4e3363ec
 payload_commit=9546b1a7e22376110578a5140087b6a6e9d96622
 product_base=7976909e58a47749ac39fa212f5ecac325294ace
 payload_sha256=02049f9d5b446a77344bc52f167ab98bc2c42170b3d2356fc299308f90e09a13
 carrier_correction=offset 14936 s-to-k before digest verification
+format_correction=assert and remove one extra EOF newline from two reviewed test files
 verification_order=commit local atom, verify clean tree, run focused and full suites, then push
 product_files=9
 canonical_branch=agent/increment-5b4-admitted-graph

--- a/scripts/support/increment5b4-nine-publisher-trigger.txt
+++ b/scripts/support/increment5b4-nine-publisher-trigger.txt
@@ -1,10 +1,11 @@
-Emit one same-repository pull_request event for the checked-in corrected Increment 5B4 publisher.
+Emit one same-repository pull_request event for the code-tree-clean Increment 5B4 publisher.
 
-publisher_script=b504d867582931048f2980e4a9ad7000d95313d7
+publisher_script=b019b45810e6cbd1ab59480c29812f23674b6cc8
 publisher_workflow=345da63f603e7ac0bbf25ecc4e2fd7ac4e3363ec
 payload_commit=9546b1a7e22376110578a5140087b6a6e9d96622
 product_base=7976909e58a47749ac39fa212f5ecac325294ace
 payload_sha256=02049f9d5b446a77344bc52f167ab98bc2c42170b3d2356fc299308f90e09a13
 carrier_correction=offset 14936 s-to-k before digest verification
+verification_order=commit local atom, verify clean tree, run focused and full suites, then push
 product_files=9
 canonical_branch=agent/increment-5b4-admitted-graph

--- a/scripts/support/increment5b4-nine-publisher-trigger.txt
+++ b/scripts/support/increment5b4-nine-publisher-trigger.txt
@@ -1,8 +1,9 @@
 Emit one same-repository pull_request event against the immutable nine-file Increment 5B4 publisher base.
 
-publisher_base=fd17fe9995603cb26fd4a14671736600623ed930
+publisher_workflow=b7bf7e54b9fd298672a671c3a31df11b33e7d519
+payload_commit=9546b1a7e22376110578a5140087b6a6e9d96622
 product_base=7976909e58a47749ac39fa212f5ecac325294ace
 payload_sha256=02049f9d5b446a77344bc52f167ab98bc2c42170b3d2356fc299308f90e09a13
 product_files=9
 canonical_branch=agent/increment-5b4-admitted-graph
-correction=private local fetch ref avoids support namespace collision
+correction=payload identity is pinned independently of pull-request base metadata

--- a/scripts/support/increment5b4-nine-publisher-trigger.txt
+++ b/scripts/support/increment5b4-nine-publisher-trigger.txt
@@ -1,9 +1,10 @@
-Emit one same-repository pull_request event against the immutable nine-file Increment 5B4 publisher base.
+Emit one same-repository pull_request event for the checked-in corrected Increment 5B4 publisher.
 
-publisher_workflow=b7bf7e54b9fd298672a671c3a31df11b33e7d519
+publisher_script=b504d867582931048f2980e4a9ad7000d95313d7
+publisher_workflow=345da63f603e7ac0bbf25ecc4e2fd7ac4e3363ec
 payload_commit=9546b1a7e22376110578a5140087b6a6e9d96622
 product_base=7976909e58a47749ac39fa212f5ecac325294ace
 payload_sha256=02049f9d5b446a77344bc52f167ab98bc2c42170b3d2356fc299308f90e09a13
+carrier_correction=offset 14936 s-to-k before digest verification
 product_files=9
 canonical_branch=agent/increment-5b4-admitted-graph
-correction=payload identity is pinned independently of pull-request base metadata

--- a/scripts/support/increment5b4-nine-publisher-trigger.txt
+++ b/scripts/support/increment5b4-nine-publisher-trigger.txt
@@ -1,0 +1,7 @@
+Emit one same-repository pull_request event against the immutable nine-file Increment 5B4 publisher base.
+
+publisher_base=9546b1a7e22376110578a5140087b6a6e9d96622
+product_base=7976909e58a47749ac39fa212f5ecac325294ace
+payload_sha256=02049f9d5b446a77344bc52f167ab98bc2c42170b3d2356fc299308f90e09a13
+product_files=9
+canonical_branch=agent/increment-5b4-admitted-graph

--- a/scripts/support/increment5b4-nine-publisher-trigger.txt
+++ b/scripts/support/increment5b4-nine-publisher-trigger.txt
@@ -1,7 +1,8 @@
 Emit one same-repository pull_request event against the immutable nine-file Increment 5B4 publisher base.
 
-publisher_base=9546b1a7e22376110578a5140087b6a6e9d96622
+publisher_base=fd17fe9995603cb26fd4a14671736600623ed930
 product_base=7976909e58a47749ac39fa212f5ecac325294ace
 payload_sha256=02049f9d5b446a77344bc52f167ab98bc2c42170b3d2356fc299308f90e09a13
 product_files=9
 canonical_branch=agent/increment-5b4-admitted-graph
+correction=private local fetch ref avoids support namespace collision


### PR DESCRIPTION
Support-only pull request. Do not merge into main.

The base contains the complete verified publisher and six immutable payload chunks. This marker exists only to trigger that base-owned workflow.

Publisher base: `9546b1a7e22376110578a5140087b6a6e9d96622`
Product base: `7976909e58a47749ac39fa212f5ecac325294ace`
Payload: `sha256:02049f9d5b446a77344bc52f167ab98bc2c42170b3d2356fc299308f90e09a13`
Inventory: nine product files.

The workflow tests the reconstructed product and publishes the canonical product branch only when verification succeeds.