### PR TITLE
Increment 5C1: strict named-tool contracts and local authorization

### DIFF
--- a/docs/operations/increment-5c1-named-tool-authorization.md
+++ b/docs/operations/increment-5c1-named-tool-authorization.md
@@ -1,0 +1,139 @@
+# Increment 5C1 — strict named-tool contracts and local authorization
+
+## Scope
+
+This operating record covers only the branch-neutral request and local
+authorization substrate for the six Increment 5C named read-only tools:
+
+1. exact authority lookup;
+2. bounded full-text retrieval;
+3. bounded fixed-point vector retrieval;
+4. bounded admitted-graph traversal;
+5. current collision and authority hydration lookup; and
+6. bounded source/revision impact lookup.
+
+5C1 does **not** execute any retriever, Neo4j read, collision check, authority
+read or hydration. A successful 5C1 receipt proves local request mechanics only.
+Parent 5C remains open for 5C2 and its Tier-M aggregate closeout.
+
+## Closed request contract
+
+Every request contains one strict immutable common envelope:
+
+- UUIDv4 request and bounded idempotency identity;
+- one closed tool identity;
+- exact actor and authenticated-principal digest;
+- exact authorization grant identity;
+- one tool-permitted declared purpose;
+- policy identity and digest;
+- named-tool contract digest;
+- profile and generation identities;
+- query-valid and serving times;
+- exact typed scope claims; and
+- bounded result, timeout and response limits.
+
+Every tool has a separate exact-key payload schema. Unknown or extra fields,
+duplicate JSON keys, unaccepted schema versions, control characters, excessive
+bytes and invalid enums fail before authorization. A payload cannot add Cypher,
+Lucene, index, vector, label, predicate, direction, property, credential,
+destination, write or authority fields.
+
+The hard maxima are eight results, 5,000 ms and 262,144 response bytes. Graph
+requests additionally bind depth at most two, fan-out at most 32 and temporal
+window at most 2,678,400 seconds. Source-impact windows have the same maximum
+span. Vector requests name only one admitted fixture query and digest; no
+arbitrary vector is accepted.
+
+## Scope binding
+
+Each typed payload deterministically derives its exact scope claims:
+
+- exact lookup: lookup kind;
+- full text: languages and any named sources;
+- vector: fixture query identity;
+- graph: canonical root identity;
+- collision/hydration: collision namespace plus named authority objects and
+  passages; and
+- impact: exact source and optional revision identity.
+
+The envelope scope must byte-for-byte match the typed request scope. Query or
+source/model content cannot widen it. An authorization grant may be broader,
+but every requested claim must be a subset of the exact grant claims.
+
+## Authorization grants
+
+A reviewed immutable grant binds:
+
+- grant identity and digest;
+- actor and authenticated-principal digest;
+- exactly one tool;
+- a sorted set of tool-valid purposes;
+- exact scope claims;
+- validity interval;
+- policy identity and digest;
+- contract digest;
+- profile identity; and
+- generation identity.
+
+The grant registry is content-addressed and rejects duplicate identities.
+Authorization evaluates actor, principal, tool, purpose, policy, contract,
+profile, generation, scope and time in deterministic order.
+
+## Outcomes
+
+The local gate emits:
+
+- `AUTHORIZED` when every exact match succeeds;
+- `POLICY_BLOCKED` for unknown grants or actor, principal, tool, purpose, scope,
+  policy, contract or profile mismatch; and
+- `STALE` for generation mismatch or a not-yet-valid/expired grant.
+
+Every decision retains one canonical receipt. An authorized receipt states only
+`local_tool_call_authorized=true`; it also states:
+
+- `branch_executed=false`;
+- `authority_read_executed=false`;
+- all external/model/embedding/provider call counters and spend are zero;
+- `authority_effect=NONE`;
+- `qualification_authority_granted=false`; and
+- `production_activation_authorized=false`.
+
+## Immutable journal
+
+The non-authoritative SQLite journal stores only idempotency key, request digest,
+canonical receipt bytes and receipt digest. Grant evaluation occurs outside a
+write reservation. A short first-writer-wins insert retains the decision.
+Restart replay returns byte-identical bytes. Semantic conflict, retained-byte
+tamper, digest mismatch and request-binding mismatch fail closed.
+
+The journal creates no identity, relationship, Candidate, evidence, operational,
+production or publication authority.
+
+## Security and operational boundary
+
+Request/query/source/model content is data. It cannot select another named tool,
+change the authenticated actor, grant, purpose, scope, contract, generation,
+budgets, response schema, authority effect or activation state.
+
+This local gate is necessary but deliberately insufficient for the complete
+untrusted-input and credential/egress controls. It claims no `DOPS-*` delivery.
+The complete `DOPS-026` and `DOPS-067` boundaries remain Increment 8/#148
+work across every executable operational surface.
+
+## Monitoring
+
+Before 5C2, monitoring is limited to deterministic malformed-request and
+authorization-decision inspection. An authorized receipt does not establish that
+a branch, authority read, hydration, collision check or source-impact query was
+available, complete or healthy.
+
+## Rollback
+
+1. stop accepting the 5C1 named-tool contract/profile;
+2. retain historical canonical request and authorization receipts for audit;
+3. revoke or expire affected grants;
+4. remove or revert the 5C1 product commit; and
+5. return parent 5C to the completed 5B boundary.
+
+Rollback requires no provider, index, graph or credential cleanup because 5C1
+creates and invokes none.

--- a/docs/traceability/increment-5c1-named-tool-authorization.md
+++ b/docs/traceability/increment-5c1-named-tool-authorization.md
@@ -51,8 +51,9 @@ policy, contract, profile and generation;
 5C1 provides common mechanics needed by parent #252 for named read-only tools,
 including strict request shape, local authenticated actor/purpose/scope checks,
 hard bounds and inspectable authorization receipts. Parent delivery of
-`GRAG-033`, `GRAG-034`, `GRAG-035` and `TRI-022` remains incomplete until 5C2
-executes all six named tools through their reviewed branch or authority ports.
+`GRAG-033` and `GRAG-034` remains incomplete until 5C2 executes all six named
+tools through their reviewed branch or authority ports. `GRAG-035` and
+`TRI-022` remain owned by the composed Retrieval Context boundary in 5D/#253.
 
 5C1 claims no `DOPS-*` row. In particular, local request validation does not
 satisfy the complete `DOPS-026` policy/tool/egress/budget/authority boundary or

--- a/docs/traceability/increment-5c1-named-tool-authorization.md
+++ b/docs/traceability/increment-5c1-named-tool-authorization.md
@@ -1,0 +1,77 @@
+# Increment 5C1 traceability — named-tool contracts and local authorization
+
+## Delivery boundary
+
+5C1 is the first child atom of parent Increment 5C / #252. It delivers strict
+request schemas and local caller/purpose/scope authorization mechanics for the
+closed six-tool inventory. It executes no retrieval branch, collision check,
+authority hydration or source-impact read and therefore cannot complete parent
+5C by itself.
+
+## Requirement-to-evidence map
+
+| Requirement | Delivery evidence | Verification evidence |
+|---|---|---|
+| Closed six-tool inventory | `NamedToolId` | exact inventory test |
+| Tool-permitted purpose taxonomy | `PERMITTED_PURPOSES` | invalid-purpose and inventory tests |
+| Strict common call envelope | `NamedToolEnvelope` | exact-key, type, time and bound tests |
+| One strict schema per tool | six typed request classes and decoder | six-schema round-trip matrix |
+| Unknown/extra fields rejected | exact key sets and duplicate-key JSON hook | extra Cypher/Lucene/vector/predicate and duplicate-key tests |
+| Fixed result, timeout and response maxima | repository constants and envelope checks | excessive-bound matrix |
+| Fixed graph depth/fan-out/window | graph request checks | broader graph-shape tests |
+| Bounded source-impact window | impact request chronology check | window and lineage tests |
+| Fixture vector only | vector request identity/digest only | arbitrary-vector extra-field test |
+| Payload-derived exact scope | `ToolScope` plus per-request scope equality | scope mismatch and content-widening tests |
+| Immutable reviewed grant | `NamedToolAuthorizationGrant` | canonical digest/tamper tests |
+| Exact actor and principal match | `NamedToolAuthorizer` | actor/principal mismatch matrix |
+| Exact tool and purpose match | deterministic grant checks | tool/purpose mismatch matrix |
+| Exact policy, contract, profile and generation match | deterministic grant checks | policy/contract/profile/generation matrix |
+| Validity window | deterministic serving-time comparison | not-yet-valid and expired tests |
+| Deterministic local outcomes | `AUTHORIZED`, `POLICY_BLOCKED`, `STALE` receipts | success, unknown-grant and mismatch tests |
+| No branch/authority execution claim | fixed false receipt flags | receipt claim-rejection tests |
+| No external work, spend or authority | zero counters and `authority_effect=NONE` | zero/claim-rejection tests |
+| Immutable byte-identical replay | SQLite first-writer-wins journal | restart, fresh-journal, concurrency, conflict and tamper tests |
+| Query/source/model content remains data | envelope/payload separation | injection-like query and scope-widening tests |
+| No operational admission claim | explicit operations boundary | documentation/source-integrity tests |
+
+## Exact identities
+
+- contract: canonical SHA-256 over the six tool identities, purpose and language
+taxonomies, per-tool purpose map and all hard bounds;
+- policy: `increment5-named-read-tools-v1` plus exact reviewed policy digest;
+- profile: `increment5-named-read-tools-v1`;
+- grant: canonical SHA-256 over principal, tool, purposes, scope, validity,
+policy, contract, profile and generation;
+- registry: canonical SHA-256 over grants sorted by grant identity;
+- request: canonical SHA-256 over exact envelope and typed payload;
+- decision: deterministic UUIDv5 plus canonical receipt digest.
+
+## Accepted parent requirement boundary
+
+5C1 provides common mechanics needed by parent #252 for named read-only tools,
+including strict request shape, local authenticated actor/purpose/scope checks,
+hard bounds and inspectable authorization receipts. Parent delivery of
+`GRAG-033`, `GRAG-034`, `GRAG-035` and `TRI-022` remains incomplete until 5C2
+executes all six named tools through their reviewed branch or authority ports.
+
+5C1 claims no `DOPS-*` row. In particular, local request validation does not
+satisfy the complete `DOPS-026` policy/tool/egress/budget/authority boundary or
+the `DOPS-067` credential/source-access/network-destination boundary. Both
+remain explicitly deferred to Increment 8/#148.
+
+## Completion evidence
+
+The 5C1 child issue can close only after one clean product commit over the exact
+accepted post-5B `main` has:
+
+- focused request, authorization and journal tests passing;
+- the complete deterministic repository suite passing;
+- source-integrity and local boundary checks passing;
+- exact-head substantive review with zero unresolved P1/material-P2 findings;
+- zero unresolved review threads; and
+- product-only squash merge with exact commit/tree evidence.
+
+Parent #252 remains open for #329 and one parent Tier-M aggregate gate. No
+successful 5C1 receipt may be described as a completed named tool, Retrieval
+Context, collision decision, hydration result, operational admission, provider
+approval, production activation or public effect.

--- a/newsroom/increment5/named_tool_authorization.py
+++ b/newsroom/increment5/named_tool_authorization.py
@@ -1,0 +1,763 @@
+"""Deterministic local authorization gate for Increment 5C named tools.
+
+Authorization here proves only exact caller, purpose, scope and request mechanics.
+It performs no runtime branch or authoritative-data operation, makes no collision
+decision, and grants no operational, production or publication authority.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sqlite3
+import threading
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from pathlib import Path
+from typing import Callable, Mapping, Sequence
+
+from newsroom.increment5.named_tool_contracts import (
+    NAMED_TOOL_CONTRACT_DIGEST,
+    NamedToolContractError,
+    NamedToolId,
+    NamedToolPurpose,
+    NamedToolRequest,
+    PERMITTED_PURPOSES,
+    ToolScope,
+)
+
+
+_TOKEN_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:\-]{0,127}\Z")
+_DIGEST_RE = re.compile(r"sha256:[0-9a-f]{64}\Z")
+
+
+class NamedToolAuthorizationError(RuntimeError):
+    """The local authorization registry or immutable receipt journal failed."""
+
+
+class NamedToolGateOutcome(StrEnum):
+    AUTHORIZED = "AUTHORIZED"
+    POLICY_BLOCKED = "POLICY_BLOCKED"
+    STALE = "STALE"
+
+
+class NamedToolGateReason(StrEnum):
+    GRANT_UNKNOWN = "GRANT_UNKNOWN"
+    ACTOR_MISMATCH = "ACTOR_MISMATCH"
+    PRINCIPAL_MISMATCH = "PRINCIPAL_MISMATCH"
+    TOOL_MISMATCH = "TOOL_MISMATCH"
+    PURPOSE_MISMATCH = "PURPOSE_MISMATCH"
+    SCOPE_MISMATCH = "SCOPE_MISMATCH"
+    GRANT_NOT_YET_VALID = "GRANT_NOT_YET_VALID"
+    GRANT_EXPIRED = "GRANT_EXPIRED"
+    POLICY_ID_MISMATCH = "POLICY_ID_MISMATCH"
+    POLICY_DIGEST_MISMATCH = "POLICY_DIGEST_MISMATCH"
+    CONTRACT_MISMATCH = "CONTRACT_MISMATCH"
+    PROFILE_MISMATCH = "PROFILE_MISMATCH"
+    GENERATION_MISMATCH = "GENERATION_MISMATCH"
+
+
+def _canonical_json_bytes(value: object) -> bytes:
+    try:
+        return json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise NamedToolContractError("authorization value is not canonical JSON") from exc
+
+
+def _digest_bytes(value: bytes) -> str:
+    return "sha256:" + hashlib.sha256(value).hexdigest()
+
+
+def _require_token(value: str, *, field: str) -> str:
+    if not isinstance(value, str) or _TOKEN_RE.fullmatch(value) is None:
+        raise NamedToolContractError(f"{field} must be a bounded canonical token")
+    return value
+
+
+def _require_digest(value: str, *, field: str) -> str:
+    if not isinstance(value, str) or _DIGEST_RE.fullmatch(value) is None:
+        raise NamedToolContractError(f"{field} must be a canonical SHA-256 digest")
+    return value
+
+
+def _parse_utc(value: str, *, field: str) -> datetime:
+    if not isinstance(value, str):
+        raise NamedToolContractError(f"{field} must be a UTC timestamp")
+    try:
+        parsed = datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
+    except ValueError as exc:
+        raise NamedToolContractError(
+            f"{field} must be canonical second-resolution UTC"
+        ) from exc
+    if parsed.strftime("%Y-%m-%dT%H:%M:%SZ") != value:
+        raise NamedToolContractError(
+            f"{field} must be canonical second-resolution UTC"
+        )
+    return parsed
+
+
+@dataclass(frozen=True, slots=True)
+class NamedToolAuthorizationGrant:
+    grant_id: str
+    actor_id: str
+    authenticated_principal_digest: str
+    tool_id: NamedToolId
+    purposes: tuple[NamedToolPurpose, ...]
+    scope: ToolScope
+    valid_from: str
+    valid_to: str
+    policy_id: str
+    policy_digest: str
+    contract_digest: str
+    profile_id: str
+    generation_id: str
+    grant_digest: str
+
+    def __post_init__(self) -> None:
+        _require_token(self.grant_id, field="named_tool_grant_id")
+        _require_token(self.actor_id, field="named_tool_grant_actor")
+        _require_digest(
+            self.authenticated_principal_digest,
+            field="named_tool_grant_principal_digest",
+        )
+        if not isinstance(self.tool_id, NamedToolId):
+            raise NamedToolContractError("grant tool_id must be typed")
+        if not self.purposes or not all(
+            isinstance(purpose, NamedToolPurpose) for purpose in self.purposes
+        ):
+            raise NamedToolContractError("grant purposes must be typed and non-empty")
+        purpose_values = tuple(purpose.value for purpose in self.purposes)
+        if purpose_values != tuple(sorted(set(purpose_values))):
+            raise NamedToolContractError("grant purposes must be sorted and unique")
+        if not set(self.purposes).issubset(PERMITTED_PURPOSES[self.tool_id]):
+            raise NamedToolContractError("grant contains a purpose invalid for its tool")
+        if not isinstance(self.scope, ToolScope):
+            raise NamedToolContractError("grant scope must be typed")
+        start = _parse_utc(self.valid_from, field="grant_valid_from")
+        end = _parse_utc(self.valid_to, field="grant_valid_to")
+        if start >= end:
+            raise NamedToolContractError("grant validity window must be increasing")
+        _require_token(self.policy_id, field="grant_policy_id")
+        _require_digest(self.policy_digest, field="grant_policy_digest")
+        _require_digest(self.contract_digest, field="grant_contract_digest")
+        _require_token(self.profile_id, field="grant_profile_id")
+        _require_token(self.generation_id, field="grant_generation_id")
+        _require_digest(self.grant_digest, field="grant_digest")
+        expected = _digest_bytes(_canonical_json_bytes(self.unsigned_value()))
+        if self.grant_digest != expected:
+            raise NamedToolContractError("grant digest does not match canonical bytes")
+
+    def unsigned_value(self) -> dict[str, object]:
+        return {
+            "schema_version": "newsroom.increment5.named-tool-grant.v1",
+            "grant_id": self.grant_id,
+            "actor_id": self.actor_id,
+            "authenticated_principal_digest": self.authenticated_principal_digest,
+            "tool_id": self.tool_id.value,
+            "purposes": [purpose.value for purpose in self.purposes],
+            "scope": self.scope.canonical_value(),
+            "valid_from": self.valid_from,
+            "valid_to": self.valid_to,
+            "policy_id": self.policy_id,
+            "policy_digest": self.policy_digest,
+            "contract_digest": self.contract_digest,
+            "profile_id": self.profile_id,
+            "generation_id": self.generation_id,
+        }
+
+    def canonical_value(self) -> dict[str, object]:
+        return {**self.unsigned_value(), "grant_digest": self.grant_digest}
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return _canonical_json_bytes(self.canonical_value())
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        grant_id: str,
+        actor_id: str,
+        authenticated_principal_digest: str,
+        tool_id: NamedToolId,
+        purposes: Sequence[NamedToolPurpose],
+        scope: ToolScope,
+        valid_from: str,
+        valid_to: str,
+        policy_id: str,
+        policy_digest: str,
+        profile_id: str,
+        generation_id: str,
+        contract_digest: str = NAMED_TOOL_CONTRACT_DIGEST,
+    ) -> "NamedToolAuthorizationGrant":
+        sorted_purposes = tuple(sorted(set(purposes), key=lambda item: item.value))
+        unsigned = {
+            "schema_version": "newsroom.increment5.named-tool-grant.v1",
+            "grant_id": grant_id,
+            "actor_id": actor_id,
+            "authenticated_principal_digest": authenticated_principal_digest,
+            "tool_id": tool_id.value,
+            "purposes": [purpose.value for purpose in sorted_purposes],
+            "scope": scope.canonical_value(),
+            "valid_from": valid_from,
+            "valid_to": valid_to,
+            "policy_id": policy_id,
+            "policy_digest": policy_digest,
+            "contract_digest": contract_digest,
+            "profile_id": profile_id,
+            "generation_id": generation_id,
+        }
+        return cls(
+            grant_id=grant_id,
+            actor_id=actor_id,
+            authenticated_principal_digest=authenticated_principal_digest,
+            tool_id=tool_id,
+            purposes=sorted_purposes,
+            scope=scope,
+            valid_from=valid_from,
+            valid_to=valid_to,
+            policy_id=policy_id,
+            policy_digest=policy_digest,
+            contract_digest=contract_digest,
+            profile_id=profile_id,
+            generation_id=generation_id,
+            grant_digest=_digest_bytes(_canonical_json_bytes(unsigned)),
+        )
+
+
+class NamedToolGrantRegistry:
+    """Immutable in-memory registry of exact reviewed local grants."""
+
+    def __init__(self, grants: Sequence[NamedToolAuthorizationGrant]) -> None:
+        if not grants:
+            raise NamedToolContractError("grant registry must not be empty")
+        if not all(isinstance(grant, NamedToolAuthorizationGrant) for grant in grants):
+            raise NamedToolContractError("grant registry entries must be typed")
+        identities = [grant.grant_id for grant in grants]
+        if len(identities) != len(set(identities)):
+            raise NamedToolContractError("grant registry identities must be unique")
+        self._grants: Mapping[str, NamedToolAuthorizationGrant] = {
+            grant.grant_id: grant for grant in grants
+        }
+        self.registry_digest = _digest_bytes(
+            _canonical_json_bytes(
+                {
+                    "schema_version": "newsroom.increment5.named-tool-grant-registry.v1",
+                    "grants": [
+                        grant.canonical_value()
+                        for grant in sorted(grants, key=lambda item: item.grant_id)
+                    ],
+                }
+            )
+        )
+
+    def get(self, grant_id: str) -> NamedToolAuthorizationGrant | None:
+        return self._grants.get(grant_id)
+
+
+@dataclass(frozen=True, slots=True)
+class NamedToolAuthorizationReceipt:
+    decision_id: str
+    request_digest: str
+    envelope_digest: str
+    registry_digest: str
+    grant_id: str
+    grant_digest: str | None
+    tool_id: NamedToolId
+    actor_id: str
+    authenticated_principal_digest: str
+    purpose: NamedToolPurpose
+    requested_scope_digest: str
+    evaluated_at: str
+    outcome: NamedToolGateOutcome
+    reason: NamedToolGateReason | None
+    local_tool_call_authorized: bool
+    branch_executed: bool = False
+    authority_read_executed: bool = False
+    external_call_count: int = 0
+    provider_call_count: int = 0
+    model_call_count: int = 0
+    embedding_call_count: int = 0
+    provider_spend_micros: int = 0
+    authority_effect: str = "NONE"
+    qualification_authority_granted: bool = False
+    production_activation_authorized: bool = False
+
+    def __post_init__(self) -> None:
+        try:
+            parsed = uuid.UUID(self.decision_id)
+        except (ValueError, AttributeError) as exc:
+            raise NamedToolContractError("authorization decision_id must be a UUID") from exc
+        if str(parsed) != self.decision_id:
+            raise NamedToolContractError("authorization decision_id must be canonical")
+        for name in (
+            "request_digest",
+            "envelope_digest",
+            "registry_digest",
+            "authenticated_principal_digest",
+            "requested_scope_digest",
+        ):
+            _require_digest(getattr(self, name), field=name)
+        _require_token(self.grant_id, field="authorization_receipt_grant_id")
+        if self.grant_digest is not None:
+            _require_digest(self.grant_digest, field="authorization_receipt_grant_digest")
+        if not isinstance(self.tool_id, NamedToolId):
+            raise NamedToolContractError("authorization receipt tool must be typed")
+        _require_token(self.actor_id, field="authorization_receipt_actor")
+        if not isinstance(self.purpose, NamedToolPurpose):
+            raise NamedToolContractError("authorization receipt purpose must be typed")
+        _parse_utc(self.evaluated_at, field="authorization_evaluated_at")
+        if not isinstance(self.outcome, NamedToolGateOutcome):
+            raise NamedToolContractError("authorization outcome must be typed")
+        if self.reason is not None and not isinstance(self.reason, NamedToolGateReason):
+            raise NamedToolContractError("authorization reason must be typed")
+        if self.outcome is NamedToolGateOutcome.AUTHORIZED:
+            if self.reason is not None or not self.local_tool_call_authorized:
+                raise NamedToolContractError(
+                    "authorized receipt must authorize locally without a failure reason"
+                )
+            if self.grant_digest is None:
+                raise NamedToolContractError("authorized receipt must retain grant digest")
+        else:
+            if self.reason is None or self.local_tool_call_authorized:
+                raise NamedToolContractError(
+                    "blocked/stale receipt must retain a reason and no authorization"
+                )
+        if self.branch_executed or self.authority_read_executed:
+            raise NamedToolContractError(
+                "5C1 local authorization receipt cannot claim branch or authority execution"
+            )
+        if any(
+            value != 0
+            for value in (
+                self.external_call_count,
+                self.provider_call_count,
+                self.model_call_count,
+                self.embedding_call_count,
+                self.provider_spend_micros,
+            )
+        ):
+            raise NamedToolContractError(
+                "5C1 authorization receipt cannot report external work or spend"
+            )
+        if self.authority_effect != "NONE":
+            raise NamedToolContractError("authorization receipt cannot claim authority effect")
+        if self.qualification_authority_granted or self.production_activation_authorized:
+            raise NamedToolContractError(
+                "authorization receipt cannot grant qualification or activation authority"
+            )
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "schema_version": "newsroom.increment5.named-tool-authorization-receipt.v1",
+            "decision_id": self.decision_id,
+            "request_digest": self.request_digest,
+            "envelope_digest": self.envelope_digest,
+            "registry_digest": self.registry_digest,
+            "grant_id": self.grant_id,
+            "grant_digest": self.grant_digest,
+            "tool_id": self.tool_id.value,
+            "actor_id": self.actor_id,
+            "authenticated_principal_digest": self.authenticated_principal_digest,
+            "purpose": self.purpose.value,
+            "requested_scope_digest": self.requested_scope_digest,
+            "evaluated_at": self.evaluated_at,
+            "outcome": self.outcome.value,
+            "reason": None if self.reason is None else self.reason.value,
+            "local_tool_call_authorized": self.local_tool_call_authorized,
+            "branch_executed": self.branch_executed,
+            "authority_read_executed": self.authority_read_executed,
+            "external_call_count": self.external_call_count,
+            "provider_call_count": self.provider_call_count,
+            "model_call_count": self.model_call_count,
+            "embedding_call_count": self.embedding_call_count,
+            "provider_spend_micros": self.provider_spend_micros,
+            "authority_effect": self.authority_effect,
+            "qualification_authority_granted": self.qualification_authority_granted,
+            "production_activation_authorized": self.production_activation_authorized,
+        }
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return _canonical_json_bytes(self.canonical_value())
+
+    @property
+    def receipt_digest(self) -> str:
+        return _digest_bytes(self.canonical_bytes)
+
+    @classmethod
+    def from_canonical_bytes(cls, raw: bytes) -> "NamedToolAuthorizationReceipt":
+        try:
+            payload = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise NamedToolAuthorizationError(
+                "retained authorization receipt is not JSON"
+            ) from exc
+        if not isinstance(payload, dict):
+            raise NamedToolAuthorizationError(
+                "retained authorization receipt root is not an object"
+            )
+        if payload.pop("schema_version", None) != (
+            "newsroom.increment5.named-tool-authorization-receipt.v1"
+        ):
+            raise NamedToolAuthorizationError(
+                "retained authorization receipt schema is not accepted"
+            )
+        try:
+            receipt = cls(
+                decision_id=payload["decision_id"],
+                request_digest=payload["request_digest"],
+                envelope_digest=payload["envelope_digest"],
+                registry_digest=payload["registry_digest"],
+                grant_id=payload["grant_id"],
+                grant_digest=payload["grant_digest"],
+                tool_id=NamedToolId(payload["tool_id"]),
+                actor_id=payload["actor_id"],
+                authenticated_principal_digest=payload[
+                    "authenticated_principal_digest"
+                ],
+                purpose=NamedToolPurpose(payload["purpose"]),
+                requested_scope_digest=payload["requested_scope_digest"],
+                evaluated_at=payload["evaluated_at"],
+                outcome=NamedToolGateOutcome(payload["outcome"]),
+                reason=(
+                    None
+                    if payload["reason"] is None
+                    else NamedToolGateReason(payload["reason"])
+                ),
+                local_tool_call_authorized=payload[
+                    "local_tool_call_authorized"
+                ],
+                branch_executed=payload["branch_executed"],
+                authority_read_executed=payload["authority_read_executed"],
+                external_call_count=payload["external_call_count"],
+                provider_call_count=payload["provider_call_count"],
+                model_call_count=payload["model_call_count"],
+                embedding_call_count=payload["embedding_call_count"],
+                provider_spend_micros=payload["provider_spend_micros"],
+                authority_effect=payload["authority_effect"],
+                qualification_authority_granted=payload[
+                    "qualification_authority_granted"
+                ],
+                production_activation_authorized=payload[
+                    "production_activation_authorized"
+                ],
+            )
+        except (KeyError, TypeError, ValueError, NamedToolContractError) as exc:
+            raise NamedToolAuthorizationError(
+                "retained authorization receipt is malformed"
+            ) from exc
+        if receipt.canonical_bytes != raw:
+            raise NamedToolAuthorizationError(
+                "retained authorization receipt bytes are not canonical"
+            )
+        return receipt
+
+
+class NamedToolAuthorizationJournal:
+    """Immutable non-authoritative first-writer-wins authorization journal."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._initialization_lock = threading.Lock()
+        self._initialize()
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.path, timeout=5.0, isolation_level=None)
+        connection.execute("PRAGMA busy_timeout = 5000")
+        return connection
+
+    def _initialize(self) -> None:
+        with self._initialization_lock, self._connect() as connection:
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS increment5_named_tool_authorization_receipts (
+                    idempotency_key TEXT PRIMARY KEY,
+                    request_digest TEXT NOT NULL,
+                    receipt_bytes BLOB NOT NULL,
+                    receipt_digest TEXT NOT NULL
+                ) WITHOUT ROWID
+                """
+            )
+
+    @staticmethod
+    def _decode(
+        request_digest: str,
+        receipt_bytes: bytes,
+        receipt_digest: str,
+    ) -> NamedToolAuthorizationReceipt:
+        if _digest_bytes(receipt_bytes) != receipt_digest:
+            raise NamedToolAuthorizationError(
+                "retained authorization receipt digest mismatch"
+            )
+        receipt = NamedToolAuthorizationReceipt.from_canonical_bytes(receipt_bytes)
+        if receipt.request_digest != request_digest:
+            raise NamedToolAuthorizationError(
+                "retained authorization request binding mismatch"
+            )
+        return receipt
+
+    def _existing(
+        self,
+        request: NamedToolRequest,
+    ) -> NamedToolAuthorizationReceipt | None:
+        try:
+            with self._connect() as connection:
+                row = connection.execute(
+                    """
+                    SELECT request_digest, receipt_bytes, receipt_digest
+                    FROM increment5_named_tool_authorization_receipts
+                    WHERE idempotency_key = ?
+                    """,
+                    (request.envelope.idempotency_key,),
+                ).fetchone()
+        except sqlite3.Error as exc:
+            raise NamedToolAuthorizationError(
+                "authorization journal read failed"
+            ) from exc
+        if row is None:
+            return None
+        if row[0] != request.request_digest:
+            raise NamedToolAuthorizationError(
+                "authorization idempotency key semantic conflict"
+            )
+        return self._decode(row[0], bytes(row[1]), row[2])
+
+    def execute(
+        self,
+        request: NamedToolRequest,
+        producer: Callable[[], NamedToolAuthorizationReceipt],
+    ) -> NamedToolAuthorizationReceipt:
+        existing = self._existing(request)
+        if existing is not None:
+            return existing
+        receipt = producer()
+        if receipt.request_digest != request.request_digest:
+            raise NamedToolAuthorizationError(
+                "produced authorization receipt does not bind request"
+            )
+        raw = receipt.canonical_bytes
+        digest = _digest_bytes(raw)
+        connection: sqlite3.Connection | None = None
+        try:
+            connection = self._connect()
+            connection.execute("BEGIN IMMEDIATE")
+            row = connection.execute(
+                """
+                SELECT request_digest, receipt_bytes, receipt_digest
+                FROM increment5_named_tool_authorization_receipts
+                WHERE idempotency_key = ?
+                """,
+                (request.envelope.idempotency_key,),
+            ).fetchone()
+            if row is not None:
+                connection.execute("ROLLBACK")
+                if row[0] != request.request_digest:
+                    raise NamedToolAuthorizationError(
+                        "authorization idempotency key concurrent semantic conflict"
+                    )
+                return self._decode(row[0], bytes(row[1]), row[2])
+            connection.execute(
+                """
+                INSERT INTO increment5_named_tool_authorization_receipts (
+                    idempotency_key, request_digest, receipt_bytes, receipt_digest
+                ) VALUES (?, ?, ?, ?)
+                """,
+                (
+                    request.envelope.idempotency_key,
+                    request.request_digest,
+                    raw,
+                    digest,
+                ),
+            )
+            connection.execute("COMMIT")
+        except NamedToolAuthorizationError:
+            raise
+        except sqlite3.Error as exc:
+            if connection is not None:
+                try:
+                    connection.execute("ROLLBACK")
+                except sqlite3.Error:
+                    pass
+            raise NamedToolAuthorizationError(
+                "authorization journal write failed"
+            ) from exc
+        finally:
+            if connection is not None:
+                connection.close()
+        return receipt
+
+
+class NamedToolAuthorizer:
+    """Exact local grant matcher with deterministic denial semantics."""
+
+    def __init__(
+        self,
+        *,
+        registry: NamedToolGrantRegistry,
+        journal: NamedToolAuthorizationJournal,
+    ) -> None:
+        self.registry = registry
+        self.journal = journal
+
+    def authorize(self, request: NamedToolRequest) -> NamedToolAuthorizationReceipt:
+        return self.journal.execute(request, lambda: self._decide(request))
+
+    def _decide(self, request: NamedToolRequest) -> NamedToolAuthorizationReceipt:
+        envelope = request.envelope
+        grant = self.registry.get(envelope.authorization_grant_id)
+        if grant is None:
+            return self._receipt(
+                request,
+                grant=None,
+                outcome=NamedToolGateOutcome.POLICY_BLOCKED,
+                reason=NamedToolGateReason.GRANT_UNKNOWN,
+            )
+        checks: tuple[
+            tuple[bool, NamedToolGateOutcome, NamedToolGateReason], ...
+        ] = (
+            (
+                grant.actor_id == envelope.actor_id,
+                NamedToolGateOutcome.POLICY_BLOCKED,
+                NamedToolGateReason.ACTOR_MISMATCH,
+            ),
+            (
+                grant.authenticated_principal_digest
+                == envelope.authenticated_principal_digest,
+                NamedToolGateOutcome.POLICY_BLOCKED,
+                NamedToolGateReason.PRINCIPAL_MISMATCH,
+            ),
+            (
+                grant.tool_id is envelope.tool_id,
+                NamedToolGateOutcome.POLICY_BLOCKED,
+                NamedToolGateReason.TOOL_MISMATCH,
+            ),
+            (
+                envelope.purpose in grant.purposes,
+                NamedToolGateOutcome.POLICY_BLOCKED,
+                NamedToolGateReason.PURPOSE_MISMATCH,
+            ),
+            (
+                grant.policy_id == envelope.policy_id,
+                NamedToolGateOutcome.POLICY_BLOCKED,
+                NamedToolGateReason.POLICY_ID_MISMATCH,
+            ),
+            (
+                grant.policy_digest == envelope.policy_digest,
+                NamedToolGateOutcome.POLICY_BLOCKED,
+                NamedToolGateReason.POLICY_DIGEST_MISMATCH,
+            ),
+            (
+                grant.contract_digest == envelope.contract_digest,
+                NamedToolGateOutcome.POLICY_BLOCKED,
+                NamedToolGateReason.CONTRACT_MISMATCH,
+            ),
+            (
+                grant.profile_id == envelope.profile_id,
+                NamedToolGateOutcome.POLICY_BLOCKED,
+                NamedToolGateReason.PROFILE_MISMATCH,
+            ),
+            (
+                grant.generation_id == envelope.generation_id,
+                NamedToolGateOutcome.STALE,
+                NamedToolGateReason.GENERATION_MISMATCH,
+            ),
+            (
+                grant.scope.contains(envelope.requested_scope),
+                NamedToolGateOutcome.POLICY_BLOCKED,
+                NamedToolGateReason.SCOPE_MISMATCH,
+            ),
+        )
+        for passed, outcome, reason in checks:
+            if not passed:
+                return self._receipt(
+                    request,
+                    grant=grant,
+                    outcome=outcome,
+                    reason=reason,
+                )
+        evaluated = _parse_utc(envelope.serving_time, field="authorization_serving_time")
+        if evaluated < _parse_utc(grant.valid_from, field="grant_valid_from"):
+            return self._receipt(
+                request,
+                grant=grant,
+                outcome=NamedToolGateOutcome.STALE,
+                reason=NamedToolGateReason.GRANT_NOT_YET_VALID,
+            )
+        if evaluated >= _parse_utc(grant.valid_to, field="grant_valid_to"):
+            return self._receipt(
+                request,
+                grant=grant,
+                outcome=NamedToolGateOutcome.STALE,
+                reason=NamedToolGateReason.GRANT_EXPIRED,
+            )
+        return self._receipt(
+            request,
+            grant=grant,
+            outcome=NamedToolGateOutcome.AUTHORIZED,
+            reason=None,
+        )
+
+    def _receipt(
+        self,
+        request: NamedToolRequest,
+        *,
+        grant: NamedToolAuthorizationGrant | None,
+        outcome: NamedToolGateOutcome,
+        reason: NamedToolGateReason | None,
+    ) -> NamedToolAuthorizationReceipt:
+        envelope = request.envelope
+        grant_digest = None if grant is None else grant.grant_digest
+        decision_id = str(
+            uuid.uuid5(
+                uuid.NAMESPACE_URL,
+                "|".join(
+                    (
+                        request.request_digest,
+                        self.registry.registry_digest,
+                        grant_digest or "NO_GRANT",
+                        outcome.value,
+                        "NONE" if reason is None else reason.value,
+                    )
+                ),
+            )
+        )
+        return NamedToolAuthorizationReceipt(
+            decision_id=decision_id,
+            request_digest=request.request_digest,
+            envelope_digest=envelope.envelope_digest,
+            registry_digest=self.registry.registry_digest,
+            grant_id=envelope.authorization_grant_id,
+            grant_digest=grant_digest,
+            tool_id=envelope.tool_id,
+            actor_id=envelope.actor_id,
+            authenticated_principal_digest=envelope.authenticated_principal_digest,
+            purpose=envelope.purpose,
+            requested_scope_digest=envelope.requested_scope.scope_digest,
+            evaluated_at=envelope.serving_time,
+            outcome=outcome,
+            reason=reason,
+            local_tool_call_authorized=outcome is NamedToolGateOutcome.AUTHORIZED,
+        )
+
+
+__all__ = [
+    "NamedToolAuthorizationError",
+    "NamedToolAuthorizationGrant",
+    "NamedToolAuthorizationJournal",
+    "NamedToolAuthorizationReceipt",
+    "NamedToolAuthorizer",
+    "NamedToolGateOutcome",
+    "NamedToolGateReason",
+    "NamedToolGrantRegistry",
+]

--- a/newsroom/increment5/named_tool_authorization.py
+++ b/newsroom/increment5/named_tool_authorization.py
@@ -320,6 +320,24 @@ class NamedToolAuthorizationReceipt:
             raise NamedToolContractError("authorization outcome must be typed")
         if self.reason is not None and not isinstance(self.reason, NamedToolGateReason):
             raise NamedToolContractError("authorization reason must be typed")
+        for name in (
+            "local_tool_call_authorized",
+            "branch_executed",
+            "authority_read_executed",
+            "qualification_authority_granted",
+            "production_activation_authorized",
+        ):
+            if type(getattr(self, name)) is not bool:
+                raise NamedToolContractError(f"{name} must be boolean")
+        for name in (
+            "external_call_count",
+            "provider_call_count",
+            "model_call_count",
+            "embedding_call_count",
+            "provider_spend_micros",
+        ):
+            if type(getattr(self, name)) is not int:
+                raise NamedToolContractError(f"{name} must be an integer")
         if self.outcome is NamedToolGateOutcome.AUTHORIZED:
             if self.reason is not None or not self.local_tool_call_authorized:
                 raise NamedToolContractError(

--- a/newsroom/increment5/named_tool_contracts.py
+++ b/newsroom/increment5/named_tool_contracts.py
@@ -1,0 +1,1087 @@
+"""Strict branch-neutral contracts for the six Increment 5C named tools.
+
+This module defines request shape only. It invokes no runtime branch,
+authoritative-data store, hydration operation, model service or network client.
+A valid request still has no authority and cannot claim a completed tool
+execution until a later 5C atom retains the appropriate branch or authority-read
+receipt.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Mapping, Sequence, TypeAlias
+
+
+NAMED_TOOL_POLICY_ID = "increment5-named-read-tools-v1"
+NAMED_TOOL_PROFILE_ID = "increment5-named-read-tools-v1"
+NAMED_TOOL_RESULT_LIMIT = 8
+NAMED_TOOL_TIMEOUT_LIMIT_MS = 5_000
+NAMED_TOOL_RESPONSE_LIMIT_BYTES = 262_144
+NAMED_TOOL_DATE_WINDOW_SECONDS = 2_678_400
+NAMED_TOOL_GRAPH_DEPTH_LIMIT = 2
+NAMED_TOOL_GRAPH_FANOUT_LIMIT = 32
+NAMED_TOOL_QUERY_TEXT_LIMIT_BYTES = 4_096
+NAMED_TOOL_IDENTITY_LIMIT_BYTES = 512
+NAMED_TOOL_EXTERNAL_CALL_LIMIT = 0
+NAMED_TOOL_EXTERNAL_SPEND_LIMIT_MICROS = 0
+
+_TOKEN_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:\-]{0,127}\Z")
+_DIGEST_RE = re.compile(r"sha256:[0-9a-f]{64}\Z")
+_CONTROL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+
+
+class NamedToolContractError(ValueError):
+    """A named-tool envelope, scope or request is malformed."""
+
+
+class NamedToolId(StrEnum):
+    EXACT_AUTHORITY_LOOKUP = "EXACT_AUTHORITY_LOOKUP"
+    BOUNDED_FULL_TEXT_RETRIEVAL = "BOUNDED_FULL_TEXT_RETRIEVAL"
+    BOUNDED_FIXED_POINT_VECTOR_RETRIEVAL = "BOUNDED_FIXED_POINT_VECTOR_RETRIEVAL"
+    BOUNDED_ADMITTED_GRAPH_TRAVERSAL = "BOUNDED_ADMITTED_GRAPH_TRAVERSAL"
+    CURRENT_COLLISION_AND_AUTHORITY_HYDRATION_LOOKUP = (
+        "CURRENT_COLLISION_AND_AUTHORITY_HYDRATION_LOOKUP"
+    )
+    BOUNDED_SOURCE_REVISION_IMPACT_LOOKUP = "BOUNDED_SOURCE_REVISION_IMPACT_LOOKUP"
+
+
+class NamedToolPurpose(StrEnum):
+    TRIAGE_PRIOR_MATCH = "TRIAGE_PRIOR_MATCH"
+    CORRECTION_REVIEW = "CORRECTION_REVIEW"
+    COLLISION_CHECK = "COLLISION_CHECK"
+    AUTHORITY_HYDRATION = "AUTHORITY_HYDRATION"
+    SOURCE_IMPACT = "SOURCE_IMPACT"
+    REPLAY_AUDIT = "REPLAY_AUDIT"
+
+
+class NamedToolLanguage(StrEnum):
+    EN_GB = "EN_GB"
+    ZH_HANT_HK = "ZH_HANT_HK"
+    MIXED = "MIXED"
+
+
+class ExactLookupKind(StrEnum):
+    SOURCE_NATIVE_ID = "SOURCE_NATIVE_ID"
+    REVISION_ID = "REVISION_ID"
+    REPRESENTATION_ID = "REPRESENTATION_ID"
+    CANONICAL_ENTITY_ID = "CANONICAL_ENTITY_ID"
+    AUTHORITY_ALIAS = "AUTHORITY_ALIAS"
+    FORMAL_PROCESS_ID = "FORMAL_PROCESS_ID"
+
+
+PERMITTED_PURPOSES: Mapping[NamedToolId, frozenset[NamedToolPurpose]] = {
+    NamedToolId.EXACT_AUTHORITY_LOOKUP: frozenset(
+        {
+            NamedToolPurpose.TRIAGE_PRIOR_MATCH,
+            NamedToolPurpose.COLLISION_CHECK,
+            NamedToolPurpose.REPLAY_AUDIT,
+        }
+    ),
+    NamedToolId.BOUNDED_FULL_TEXT_RETRIEVAL: frozenset(
+        {
+            NamedToolPurpose.TRIAGE_PRIOR_MATCH,
+            NamedToolPurpose.CORRECTION_REVIEW,
+            NamedToolPurpose.REPLAY_AUDIT,
+        }
+    ),
+    NamedToolId.BOUNDED_FIXED_POINT_VECTOR_RETRIEVAL: frozenset(
+        {
+            NamedToolPurpose.TRIAGE_PRIOR_MATCH,
+            NamedToolPurpose.CORRECTION_REVIEW,
+            NamedToolPurpose.REPLAY_AUDIT,
+        }
+    ),
+    NamedToolId.BOUNDED_ADMITTED_GRAPH_TRAVERSAL: frozenset(
+        {
+            NamedToolPurpose.TRIAGE_PRIOR_MATCH,
+            NamedToolPurpose.CORRECTION_REVIEW,
+            NamedToolPurpose.REPLAY_AUDIT,
+        }
+    ),
+    NamedToolId.CURRENT_COLLISION_AND_AUTHORITY_HYDRATION_LOOKUP: frozenset(
+        {
+            NamedToolPurpose.COLLISION_CHECK,
+            NamedToolPurpose.AUTHORITY_HYDRATION,
+            NamedToolPurpose.REPLAY_AUDIT,
+        }
+    ),
+    NamedToolId.BOUNDED_SOURCE_REVISION_IMPACT_LOOKUP: frozenset(
+        {
+            NamedToolPurpose.SOURCE_IMPACT,
+            NamedToolPurpose.CORRECTION_REVIEW,
+            NamedToolPurpose.REPLAY_AUDIT,
+        }
+    ),
+}
+
+
+def _canonical_json_bytes(value: object) -> bytes:
+    try:
+        return json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise NamedToolContractError("value is not canonical JSON") from exc
+
+
+def _digest_bytes(value: bytes) -> str:
+    return "sha256:" + hashlib.sha256(value).hexdigest()
+
+
+def _strict_keys(
+    value: Mapping[str, object],
+    *,
+    required: set[str],
+    field: str,
+) -> None:
+    actual = set(value)
+    if actual != required:
+        raise NamedToolContractError(
+            f"{field} keys are not exact; "
+            f"missing={sorted(required - actual)}, extra={sorted(actual - required)}"
+        )
+
+
+def _require_token(value: str, *, field: str) -> str:
+    if not isinstance(value, str) or _TOKEN_RE.fullmatch(value) is None:
+        raise NamedToolContractError(f"{field} must be a bounded canonical token")
+    return value
+
+
+def _require_digest(value: str, *, field: str) -> str:
+    if not isinstance(value, str) or _DIGEST_RE.fullmatch(value) is None:
+        raise NamedToolContractError(f"{field} must be a canonical SHA-256 digest")
+    return value
+
+
+def _require_text(value: str, *, field: str, maximum_bytes: int) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or value != value.strip()
+        or len(value.encode("utf-8")) > maximum_bytes
+        or _CONTROL_RE.search(value) is not None
+    ):
+        raise NamedToolContractError(f"{field} must be bounded canonical text")
+    return value
+
+
+def _require_uuid4(value: str, *, field: str) -> str:
+    if not isinstance(value, str):
+        raise NamedToolContractError(f"{field} must be a UUIDv4 string")
+    try:
+        parsed = uuid.UUID(value)
+    except (ValueError, AttributeError) as exc:
+        raise NamedToolContractError(f"{field} must be a UUIDv4 string") from exc
+    if parsed.version != 4 or str(parsed) != value:
+        raise NamedToolContractError(f"{field} must be a canonical UUIDv4 string")
+    return value
+
+
+def _parse_utc(value: str, *, field: str) -> datetime:
+    if not isinstance(value, str):
+        raise NamedToolContractError(f"{field} must be a UTC timestamp")
+    try:
+        parsed = datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
+    except ValueError as exc:
+        raise NamedToolContractError(
+            f"{field} must be canonical second-resolution UTC"
+        ) from exc
+    if parsed.strftime("%Y-%m-%dT%H:%M:%SZ") != value:
+        raise NamedToolContractError(
+            f"{field} must be canonical second-resolution UTC"
+        )
+    return parsed
+
+
+def _require_int_range(value: int, *, field: str, minimum: int, maximum: int) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not minimum <= value <= maximum
+    ):
+        raise NamedToolContractError(
+            f"{field} must be an integer in [{minimum}, {maximum}]"
+        )
+    return value
+
+
+def _require_text_tuple(
+    values: Sequence[object],
+    *,
+    field: str,
+    minimum: int = 0,
+    maximum: int = NAMED_TOOL_RESULT_LIMIT,
+    item_maximum_bytes: int = NAMED_TOOL_IDENTITY_LIMIT_BYTES,
+) -> tuple[str, ...]:
+    if isinstance(values, (str, bytes)) or not isinstance(values, Sequence):
+        raise NamedToolContractError(f"{field} must be a bounded sequence")
+    if not minimum <= len(values) <= maximum:
+        raise NamedToolContractError(
+            f"{field} must contain between {minimum} and {maximum} values"
+        )
+    result = tuple(
+        _require_text(item, field=f"{field}[{index}]", maximum_bytes=item_maximum_bytes)
+        for index, item in enumerate(values)
+    )
+    if result != tuple(sorted(set(result))):
+        raise NamedToolContractError(f"{field} must be sorted and unique")
+    return result
+
+
+def _enum(value: object, enum_type: type[StrEnum], *, field: str):
+    if not isinstance(value, str):
+        raise NamedToolContractError(f"{field} must be text")
+    try:
+        return enum_type(value)
+    except ValueError as exc:
+        raise NamedToolContractError(f"{field} is not accepted") from exc
+
+
+@dataclass(frozen=True, slots=True)
+class ToolScopeClaim:
+    dimension: str
+    values: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        _require_token(self.dimension, field="scope_dimension")
+        object.__setattr__(
+            self,
+            "values",
+            _require_text_tuple(
+                self.values,
+                field=f"scope[{self.dimension}]",
+                minimum=1,
+                maximum=32,
+            ),
+        )
+
+    def canonical_value(self) -> dict[str, object]:
+        return {"dimension": self.dimension, "values": list(self.values)}
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> "ToolScopeClaim":
+        _strict_keys(
+            value,
+            required={"dimension", "values"},
+            field="scope_claim",
+        )
+        dimension = value["dimension"]
+        values = value["values"]
+        if not isinstance(dimension, str) or not isinstance(values, list):
+            raise NamedToolContractError("scope claim has an invalid shape")
+        return cls(dimension=dimension, values=tuple(values))
+
+
+@dataclass(frozen=True, slots=True)
+class ToolScope:
+    claims: tuple[ToolScopeClaim, ...]
+
+    def __post_init__(self) -> None:
+        if not self.claims:
+            raise NamedToolContractError("tool scope must contain at least one claim")
+        if not all(isinstance(claim, ToolScopeClaim) for claim in self.claims):
+            raise NamedToolContractError("tool scope claims must be typed")
+        dimensions = tuple(claim.dimension for claim in self.claims)
+        if dimensions != tuple(sorted(set(dimensions))):
+            raise NamedToolContractError(
+                "tool scope claims must be sorted by unique dimension"
+            )
+
+    def canonical_value(self) -> dict[str, object]:
+        return {"claims": [claim.canonical_value() for claim in self.claims]}
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return _canonical_json_bytes(self.canonical_value())
+
+    @property
+    def scope_digest(self) -> str:
+        return _digest_bytes(self.canonical_bytes)
+
+    def as_mapping(self) -> dict[str, frozenset[str]]:
+        return {
+            claim.dimension: frozenset(claim.values)
+            for claim in self.claims
+        }
+
+    def contains(self, requested: "ToolScope") -> bool:
+        granted = self.as_mapping()
+        for dimension, values in requested.as_mapping().items():
+            if dimension not in granted or not values.issubset(granted[dimension]):
+                return False
+        return True
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> "ToolScope":
+        _strict_keys(value, required={"claims"}, field="tool_scope")
+        raw_claims = value["claims"]
+        if not isinstance(raw_claims, list) or not all(
+            isinstance(item, dict) for item in raw_claims
+        ):
+            raise NamedToolContractError("tool scope claims must be objects")
+        return cls(
+            claims=tuple(ToolScopeClaim.from_mapping(item) for item in raw_claims)
+        )
+
+    @classmethod
+    def from_dimensions(cls, **dimensions: Sequence[str]) -> "ToolScope":
+        claims = tuple(
+            ToolScopeClaim(dimension=name, values=tuple(sorted(set(values))))
+            for name, values in sorted(dimensions.items())
+            if values
+        )
+        return cls(claims=claims)
+
+
+@dataclass(frozen=True, slots=True)
+class NamedToolEnvelope:
+    request_id: str
+    idempotency_key: str
+    tool_id: NamedToolId
+    actor_id: str
+    authenticated_principal_digest: str
+    authorization_grant_id: str
+    purpose: NamedToolPurpose
+    policy_id: str
+    policy_digest: str
+    contract_digest: str
+    profile_id: str
+    generation_id: str
+    query_valid_time: str
+    serving_time: str
+    requested_scope: ToolScope
+    result_limit: int
+    timeout_ms: int
+    response_limit_bytes: int
+
+    def __post_init__(self) -> None:
+        _require_uuid4(self.request_id, field="named_tool_request_id")
+        _require_text(
+            self.idempotency_key,
+            field="named_tool_idempotency_key",
+            maximum_bytes=256,
+        )
+        if not isinstance(self.tool_id, NamedToolId):
+            raise NamedToolContractError("tool_id must be typed")
+        _require_token(self.actor_id, field="named_tool_actor_id")
+        _require_digest(
+            self.authenticated_principal_digest,
+            field="authenticated_principal_digest",
+        )
+        _require_token(self.authorization_grant_id, field="authorization_grant_id")
+        if not isinstance(self.purpose, NamedToolPurpose):
+            raise NamedToolContractError("purpose must be typed")
+        if self.purpose not in PERMITTED_PURPOSES[self.tool_id]:
+            raise NamedToolContractError("purpose is not permitted for the named tool")
+        _require_token(self.policy_id, field="named_tool_policy_id")
+        _require_digest(self.policy_digest, field="named_tool_policy_digest")
+        _require_digest(self.contract_digest, field="named_tool_contract_digest")
+        _require_token(self.profile_id, field="named_tool_profile_id")
+        _require_token(self.generation_id, field="named_tool_generation_id")
+        query_valid = _parse_utc(
+            self.query_valid_time,
+            field="named_tool_query_valid_time",
+        )
+        serving = _parse_utc(self.serving_time, field="named_tool_serving_time")
+        if query_valid > serving:
+            raise NamedToolContractError(
+                "named-tool query-valid time cannot be after serving time"
+            )
+        if not isinstance(self.requested_scope, ToolScope):
+            raise NamedToolContractError("requested_scope must be typed")
+        _require_int_range(
+            self.result_limit,
+            field="named_tool_result_limit",
+            minimum=1,
+            maximum=NAMED_TOOL_RESULT_LIMIT,
+        )
+        _require_int_range(
+            self.timeout_ms,
+            field="named_tool_timeout_ms",
+            minimum=1,
+            maximum=NAMED_TOOL_TIMEOUT_LIMIT_MS,
+        )
+        _require_int_range(
+            self.response_limit_bytes,
+            field="named_tool_response_limit_bytes",
+            minimum=1_024,
+            maximum=NAMED_TOOL_RESPONSE_LIMIT_BYTES,
+        )
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "request_id": self.request_id,
+            "idempotency_key": self.idempotency_key,
+            "tool_id": self.tool_id.value,
+            "actor_id": self.actor_id,
+            "authenticated_principal_digest": self.authenticated_principal_digest,
+            "authorization_grant_id": self.authorization_grant_id,
+            "purpose": self.purpose.value,
+            "policy_id": self.policy_id,
+            "policy_digest": self.policy_digest,
+            "contract_digest": self.contract_digest,
+            "profile_id": self.profile_id,
+            "generation_id": self.generation_id,
+            "query_valid_time": self.query_valid_time,
+            "serving_time": self.serving_time,
+            "requested_scope": self.requested_scope.canonical_value(),
+            "result_limit": self.result_limit,
+            "timeout_ms": self.timeout_ms,
+            "response_limit_bytes": self.response_limit_bytes,
+        }
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return _canonical_json_bytes(self.canonical_value())
+
+    @property
+    def envelope_digest(self) -> str:
+        return _digest_bytes(self.canonical_bytes)
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> "NamedToolEnvelope":
+        required = {
+            "request_id",
+            "idempotency_key",
+            "tool_id",
+            "actor_id",
+            "authenticated_principal_digest",
+            "authorization_grant_id",
+            "purpose",
+            "policy_id",
+            "policy_digest",
+            "contract_digest",
+            "profile_id",
+            "generation_id",
+            "query_valid_time",
+            "serving_time",
+            "requested_scope",
+            "result_limit",
+            "timeout_ms",
+            "response_limit_bytes",
+        }
+        _strict_keys(value, required=required, field="named_tool_envelope")
+        raw_scope = value["requested_scope"]
+        if not isinstance(raw_scope, dict):
+            raise NamedToolContractError("requested_scope must be an object")
+        text_fields = (
+            "request_id",
+            "idempotency_key",
+            "actor_id",
+            "authenticated_principal_digest",
+            "authorization_grant_id",
+            "policy_id",
+            "policy_digest",
+            "contract_digest",
+            "profile_id",
+            "generation_id",
+            "query_valid_time",
+            "serving_time",
+        )
+        if not all(isinstance(value[name], str) for name in text_fields):
+            raise NamedToolContractError("named-tool envelope text field is malformed")
+        return cls(
+            request_id=value["request_id"],
+            idempotency_key=value["idempotency_key"],
+            tool_id=_enum(value["tool_id"], NamedToolId, field="tool_id"),
+            actor_id=value["actor_id"],
+            authenticated_principal_digest=value[
+                "authenticated_principal_digest"
+            ],
+            authorization_grant_id=value["authorization_grant_id"],
+            purpose=_enum(value["purpose"], NamedToolPurpose, field="purpose"),
+            policy_id=value["policy_id"],
+            policy_digest=value["policy_digest"],
+            contract_digest=value["contract_digest"],
+            profile_id=value["profile_id"],
+            generation_id=value["generation_id"],
+            query_valid_time=value["query_valid_time"],
+            serving_time=value["serving_time"],
+            requested_scope=ToolScope.from_mapping(raw_scope),
+            result_limit=value["result_limit"],
+            timeout_ms=value["timeout_ms"],
+            response_limit_bytes=value["response_limit_bytes"],
+        )
+
+
+def _require_scope(envelope: NamedToolEnvelope, expected: ToolScope) -> None:
+    if envelope.requested_scope.canonical_bytes != expected.canonical_bytes:
+        raise NamedToolContractError(
+            "requested scope does not exactly match the typed request scope"
+        )
+
+
+def _request_digest(schema_version: str, envelope: NamedToolEnvelope, payload: object) -> str:
+    return _digest_bytes(
+        _canonical_json_bytes(
+            {
+                "schema_version": schema_version,
+                "envelope": envelope.canonical_value(),
+                "payload": payload,
+            }
+        )
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class ExactAuthorityLookupToolRequest:
+    envelope: NamedToolEnvelope
+    lookup_kind: ExactLookupKind
+    lookup_value: str
+    lookup_value_digest: str
+
+    SCHEMA_VERSION = "newsroom.increment5.named-tool.exact-authority.v1"
+
+    def __post_init__(self) -> None:
+        if self.envelope.tool_id is not NamedToolId.EXACT_AUTHORITY_LOOKUP:
+            raise NamedToolContractError("envelope tool does not match exact lookup")
+        if not isinstance(self.lookup_kind, ExactLookupKind):
+            raise NamedToolContractError("lookup_kind must be typed")
+        _require_text(
+            self.lookup_value,
+            field="exact_lookup_value",
+            maximum_bytes=NAMED_TOOL_IDENTITY_LIMIT_BYTES,
+        )
+        _require_digest(self.lookup_value_digest, field="exact_lookup_value_digest")
+        if self.lookup_value_digest != _digest_bytes(self.lookup_value.encode("utf-8")):
+            raise NamedToolContractError("exact lookup value digest does not match bytes")
+        _require_scope(
+            self.envelope,
+            ToolScope.from_dimensions(lookup_kind=(self.lookup_kind.value,)),
+        )
+
+    def payload_value(self) -> dict[str, str]:
+        return {
+            "lookup_kind": self.lookup_kind.value,
+            "lookup_value": self.lookup_value,
+            "lookup_value_digest": self.lookup_value_digest,
+        }
+
+    @property
+    def request_digest(self) -> str:
+        return _request_digest(self.SCHEMA_VERSION, self.envelope, self.payload_value())
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> "ExactAuthorityLookupToolRequest":
+        _strict_keys(
+            value,
+            required={"schema_version", "envelope", "lookup_kind", "lookup_value", "lookup_value_digest"},
+            field="exact_authority_request",
+        )
+        if value["schema_version"] != cls.SCHEMA_VERSION:
+            raise NamedToolContractError("exact authority schema version is not accepted")
+        if not isinstance(value["envelope"], dict):
+            raise NamedToolContractError("exact authority envelope must be an object")
+        for name in ("lookup_value", "lookup_value_digest"):
+            if not isinstance(value[name], str):
+                raise NamedToolContractError(f"{name} must be text")
+        return cls(
+            envelope=NamedToolEnvelope.from_mapping(value["envelope"]),
+            lookup_kind=_enum(value["lookup_kind"], ExactLookupKind, field="lookup_kind"),
+            lookup_value=value["lookup_value"],
+            lookup_value_digest=value["lookup_value_digest"],
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class FullTextRetrievalToolRequest:
+    envelope: NamedToolEnvelope
+    query_text: str
+    query_text_digest: str
+    languages: tuple[NamedToolLanguage, ...]
+    source_ids: tuple[str, ...]
+
+    SCHEMA_VERSION = "newsroom.increment5.named-tool.full-text.v1"
+
+    def __post_init__(self) -> None:
+        if self.envelope.tool_id is not NamedToolId.BOUNDED_FULL_TEXT_RETRIEVAL:
+            raise NamedToolContractError("envelope tool does not match full-text lookup")
+        _require_text(
+            self.query_text,
+            field="full_text_query",
+            maximum_bytes=NAMED_TOOL_QUERY_TEXT_LIMIT_BYTES,
+        )
+        _require_digest(self.query_text_digest, field="full_text_query_digest")
+        if self.query_text_digest != _digest_bytes(self.query_text.encode("utf-8")):
+            raise NamedToolContractError("full-text query digest does not match bytes")
+        if not self.languages or len(set(self.languages)) != len(self.languages):
+            raise NamedToolContractError("full-text languages must be unique and non-empty")
+        if tuple(language.value for language in self.languages) != tuple(
+            sorted(language.value for language in self.languages)
+        ):
+            raise NamedToolContractError("full-text languages must be sorted")
+        object.__setattr__(
+            self,
+            "source_ids",
+            _require_text_tuple(self.source_ids, field="full_text_source_ids"),
+        )
+        dimensions: dict[str, Sequence[str]] = {
+            "language": tuple(language.value for language in self.languages)
+        }
+        if self.source_ids:
+            dimensions["source_id"] = self.source_ids
+        _require_scope(self.envelope, ToolScope.from_dimensions(**dimensions))
+
+    def payload_value(self) -> dict[str, object]:
+        return {
+            "query_text": self.query_text,
+            "query_text_digest": self.query_text_digest,
+            "languages": [language.value for language in self.languages],
+            "source_ids": list(self.source_ids),
+        }
+
+    @property
+    def request_digest(self) -> str:
+        return _request_digest(self.SCHEMA_VERSION, self.envelope, self.payload_value())
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> "FullTextRetrievalToolRequest":
+        _strict_keys(
+            value,
+            required={"schema_version", "envelope", "query_text", "query_text_digest", "languages", "source_ids"},
+            field="full_text_tool_request",
+        )
+        if value["schema_version"] != cls.SCHEMA_VERSION:
+            raise NamedToolContractError("full-text schema version is not accepted")
+        if not isinstance(value["envelope"], dict):
+            raise NamedToolContractError("full-text envelope must be an object")
+        if not isinstance(value["query_text"], str) or not isinstance(value["query_text_digest"], str):
+            raise NamedToolContractError("full-text query fields must be text")
+        if not isinstance(value["languages"], list) or not isinstance(value["source_ids"], list):
+            raise NamedToolContractError("full-text language/source fields must be lists")
+        return cls(
+            envelope=NamedToolEnvelope.from_mapping(value["envelope"]),
+            query_text=value["query_text"],
+            query_text_digest=value["query_text_digest"],
+            languages=tuple(
+                _enum(item, NamedToolLanguage, field="language")
+                for item in value["languages"]
+            ),
+            source_ids=tuple(value["source_ids"]),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class FixedPointVectorRetrievalToolRequest:
+    envelope: NamedToolEnvelope
+    fixture_query_id: str
+    fixture_query_digest: str
+
+    SCHEMA_VERSION = "newsroom.increment5.named-tool.fixed-point-vector.v1"
+
+    def __post_init__(self) -> None:
+        if self.envelope.tool_id is not NamedToolId.BOUNDED_FIXED_POINT_VECTOR_RETRIEVAL:
+            raise NamedToolContractError("envelope tool does not match vector lookup")
+        _require_token(self.fixture_query_id, field="fixture_query_id")
+        _require_digest(self.fixture_query_digest, field="fixture_query_digest")
+        _require_scope(
+            self.envelope,
+            ToolScope.from_dimensions(fixture_query=(self.fixture_query_id,)),
+        )
+
+    def payload_value(self) -> dict[str, str]:
+        return {
+            "fixture_query_id": self.fixture_query_id,
+            "fixture_query_digest": self.fixture_query_digest,
+        }
+
+    @property
+    def request_digest(self) -> str:
+        return _request_digest(self.SCHEMA_VERSION, self.envelope, self.payload_value())
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> "FixedPointVectorRetrievalToolRequest":
+        _strict_keys(
+            value,
+            required={"schema_version", "envelope", "fixture_query_id", "fixture_query_digest"},
+            field="fixed_point_vector_request",
+        )
+        if value["schema_version"] != cls.SCHEMA_VERSION:
+            raise NamedToolContractError("vector schema version is not accepted")
+        if not isinstance(value["envelope"], dict):
+            raise NamedToolContractError("vector envelope must be an object")
+        if not isinstance(value["fixture_query_id"], str) or not isinstance(value["fixture_query_digest"], str):
+            raise NamedToolContractError("vector query fields must be text")
+        return cls(
+            envelope=NamedToolEnvelope.from_mapping(value["envelope"]),
+            fixture_query_id=value["fixture_query_id"],
+            fixture_query_digest=value["fixture_query_digest"],
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class AdmittedGraphTraversalToolRequest:
+    envelope: NamedToolEnvelope
+    root_id: str
+    root_identity_digest: str
+    maximum_depth: int
+    maximum_fanout: int
+    temporal_window_seconds: int
+
+    SCHEMA_VERSION = "newsroom.increment5.named-tool.admitted-graph.v1"
+
+    def __post_init__(self) -> None:
+        if self.envelope.tool_id is not NamedToolId.BOUNDED_ADMITTED_GRAPH_TRAVERSAL:
+            raise NamedToolContractError("envelope tool does not match graph traversal")
+        _require_text(
+            self.root_id,
+            field="graph_tool_root_id",
+            maximum_bytes=NAMED_TOOL_IDENTITY_LIMIT_BYTES,
+        )
+        _require_digest(self.root_identity_digest, field="graph_tool_root_digest")
+        if self.root_identity_digest != _digest_bytes(
+            f"canonical-node:{self.root_id}".encode("utf-8")
+        ):
+            raise NamedToolContractError("graph root digest does not match canonical id")
+        _require_int_range(
+            self.maximum_depth,
+            field="graph_tool_maximum_depth",
+            minimum=1,
+            maximum=NAMED_TOOL_GRAPH_DEPTH_LIMIT,
+        )
+        _require_int_range(
+            self.maximum_fanout,
+            field="graph_tool_maximum_fanout",
+            minimum=1,
+            maximum=NAMED_TOOL_GRAPH_FANOUT_LIMIT,
+        )
+        _require_int_range(
+            self.temporal_window_seconds,
+            field="graph_tool_temporal_window_seconds",
+            minimum=1,
+            maximum=NAMED_TOOL_DATE_WINDOW_SECONDS,
+        )
+        _require_scope(
+            self.envelope,
+            ToolScope.from_dimensions(root_id=(self.root_id,)),
+        )
+
+    def payload_value(self) -> dict[str, object]:
+        return {
+            "root_id": self.root_id,
+            "root_identity_digest": self.root_identity_digest,
+            "maximum_depth": self.maximum_depth,
+            "maximum_fanout": self.maximum_fanout,
+            "temporal_window_seconds": self.temporal_window_seconds,
+        }
+
+    @property
+    def request_digest(self) -> str:
+        return _request_digest(self.SCHEMA_VERSION, self.envelope, self.payload_value())
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> "AdmittedGraphTraversalToolRequest":
+        _strict_keys(
+            value,
+            required={"schema_version", "envelope", "root_id", "root_identity_digest", "maximum_depth", "maximum_fanout", "temporal_window_seconds"},
+            field="admitted_graph_tool_request",
+        )
+        if value["schema_version"] != cls.SCHEMA_VERSION:
+            raise NamedToolContractError("graph schema version is not accepted")
+        if not isinstance(value["envelope"], dict):
+            raise NamedToolContractError("graph envelope must be an object")
+        if not isinstance(value["root_id"], str) or not isinstance(value["root_identity_digest"], str):
+            raise NamedToolContractError("graph root fields must be text")
+        return cls(
+            envelope=NamedToolEnvelope.from_mapping(value["envelope"]),
+            root_id=value["root_id"],
+            root_identity_digest=value["root_identity_digest"],
+            maximum_depth=value["maximum_depth"],
+            maximum_fanout=value["maximum_fanout"],
+            temporal_window_seconds=value["temporal_window_seconds"],
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CollisionHydrationLookupToolRequest:
+    envelope: NamedToolEnvelope
+    collision_namespace: str
+    collision_key_digest: str
+    authority_object_ids: tuple[str, ...]
+    passage_ids: tuple[str, ...]
+    require_current_collision: bool
+
+    SCHEMA_VERSION = "newsroom.increment5.named-tool.collision-hydration.v1"
+
+    def __post_init__(self) -> None:
+        if (
+            self.envelope.tool_id
+            is not NamedToolId.CURRENT_COLLISION_AND_AUTHORITY_HYDRATION_LOOKUP
+        ):
+            raise NamedToolContractError(
+                "envelope tool does not match collision/hydration lookup"
+            )
+        _require_token(self.collision_namespace, field="collision_namespace")
+        _require_digest(self.collision_key_digest, field="collision_key_digest")
+        object.__setattr__(
+            self,
+            "authority_object_ids",
+            _require_text_tuple(
+                self.authority_object_ids,
+                field="authority_object_ids",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "passage_ids",
+            _require_text_tuple(self.passage_ids, field="passage_ids"),
+        )
+        if not self.authority_object_ids and not self.passage_ids:
+            raise NamedToolContractError(
+                "collision/hydration request must name an authority object or passage"
+            )
+        if self.require_current_collision is not True:
+            raise NamedToolContractError(
+                "collision/hydration lookup must require current relational collision state"
+            )
+        dimensions: dict[str, Sequence[str]] = {
+            "collision_namespace": (self.collision_namespace,)
+        }
+        if self.authority_object_ids:
+            dimensions["authority_object_id"] = self.authority_object_ids
+        if self.passage_ids:
+            dimensions["passage_id"] = self.passage_ids
+        _require_scope(self.envelope, ToolScope.from_dimensions(**dimensions))
+
+    def payload_value(self) -> dict[str, object]:
+        return {
+            "collision_namespace": self.collision_namespace,
+            "collision_key_digest": self.collision_key_digest,
+            "authority_object_ids": list(self.authority_object_ids),
+            "passage_ids": list(self.passage_ids),
+            "require_current_collision": self.require_current_collision,
+        }
+
+    @property
+    def request_digest(self) -> str:
+        return _request_digest(self.SCHEMA_VERSION, self.envelope, self.payload_value())
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> "CollisionHydrationLookupToolRequest":
+        _strict_keys(
+            value,
+            required={"schema_version", "envelope", "collision_namespace", "collision_key_digest", "authority_object_ids", "passage_ids", "require_current_collision"},
+            field="collision_hydration_tool_request",
+        )
+        if value["schema_version"] != cls.SCHEMA_VERSION:
+            raise NamedToolContractError("collision/hydration schema version is not accepted")
+        if not isinstance(value["envelope"], dict):
+            raise NamedToolContractError("collision/hydration envelope must be an object")
+        if not isinstance(value["collision_namespace"], str) or not isinstance(value["collision_key_digest"], str):
+            raise NamedToolContractError("collision fields must be text")
+        if not isinstance(value["authority_object_ids"], list) or not isinstance(value["passage_ids"], list):
+            raise NamedToolContractError("collision authority/passage fields must be lists")
+        return cls(
+            envelope=NamedToolEnvelope.from_mapping(value["envelope"]),
+            collision_namespace=value["collision_namespace"],
+            collision_key_digest=value["collision_key_digest"],
+            authority_object_ids=tuple(value["authority_object_ids"]),
+            passage_ids=tuple(value["passage_ids"]),
+            require_current_collision=value["require_current_collision"],
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SourceRevisionImpactLookupToolRequest:
+    envelope: NamedToolEnvelope
+    source_id: str
+    revision_id: str | None
+    window_start: str
+    window_end: str
+    lineage_depth: int
+    include_superseded: bool
+
+    SCHEMA_VERSION = "newsroom.increment5.named-tool.source-revision-impact.v1"
+
+    def __post_init__(self) -> None:
+        if self.envelope.tool_id is not NamedToolId.BOUNDED_SOURCE_REVISION_IMPACT_LOOKUP:
+            raise NamedToolContractError("envelope tool does not match source impact lookup")
+        _require_text(
+            self.source_id,
+            field="impact_source_id",
+            maximum_bytes=NAMED_TOOL_IDENTITY_LIMIT_BYTES,
+        )
+        if self.revision_id is not None:
+            _require_text(
+                self.revision_id,
+                field="impact_revision_id",
+                maximum_bytes=NAMED_TOOL_IDENTITY_LIMIT_BYTES,
+            )
+        start = _parse_utc(self.window_start, field="impact_window_start")
+        end = _parse_utc(self.window_end, field="impact_window_end")
+        if start >= end:
+            raise NamedToolContractError("impact window must be increasing")
+        if (end - start).total_seconds() > NAMED_TOOL_DATE_WINDOW_SECONDS:
+            raise NamedToolContractError("impact window exceeds the fixed bound")
+        _require_int_range(
+            self.lineage_depth,
+            field="impact_lineage_depth",
+            minimum=1,
+            maximum=NAMED_TOOL_GRAPH_DEPTH_LIMIT,
+        )
+        if not isinstance(self.include_superseded, bool):
+            raise NamedToolContractError("include_superseded must be boolean")
+        dimensions: dict[str, Sequence[str]] = {"source_id": (self.source_id,)}
+        if self.revision_id is not None:
+            dimensions["revision_id"] = (self.revision_id,)
+        _require_scope(self.envelope, ToolScope.from_dimensions(**dimensions))
+
+    def payload_value(self) -> dict[str, object]:
+        return {
+            "source_id": self.source_id,
+            "revision_id": self.revision_id,
+            "window_start": self.window_start,
+            "window_end": self.window_end,
+            "lineage_depth": self.lineage_depth,
+            "include_superseded": self.include_superseded,
+        }
+
+    @property
+    def request_digest(self) -> str:
+        return _request_digest(self.SCHEMA_VERSION, self.envelope, self.payload_value())
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> "SourceRevisionImpactLookupToolRequest":
+        _strict_keys(
+            value,
+            required={"schema_version", "envelope", "source_id", "revision_id", "window_start", "window_end", "lineage_depth", "include_superseded"},
+            field="source_revision_impact_request",
+        )
+        if value["schema_version"] != cls.SCHEMA_VERSION:
+            raise NamedToolContractError("source-impact schema version is not accepted")
+        if not isinstance(value["envelope"], dict):
+            raise NamedToolContractError("source-impact envelope must be an object")
+        for name in ("source_id", "window_start", "window_end"):
+            if not isinstance(value[name], str):
+                raise NamedToolContractError(f"{name} must be text")
+        if value["revision_id"] is not None and not isinstance(value["revision_id"], str):
+            raise NamedToolContractError("revision_id must be text or null")
+        return cls(
+            envelope=NamedToolEnvelope.from_mapping(value["envelope"]),
+            source_id=value["source_id"],
+            revision_id=value["revision_id"],
+            window_start=value["window_start"],
+            window_end=value["window_end"],
+            lineage_depth=value["lineage_depth"],
+            include_superseded=value["include_superseded"],
+        )
+
+
+NamedToolRequest: TypeAlias = (
+    ExactAuthorityLookupToolRequest
+    | FullTextRetrievalToolRequest
+    | FixedPointVectorRetrievalToolRequest
+    | AdmittedGraphTraversalToolRequest
+    | CollisionHydrationLookupToolRequest
+    | SourceRevisionImpactLookupToolRequest
+)
+
+_REQUEST_DECODERS = {
+    ExactAuthorityLookupToolRequest.SCHEMA_VERSION: ExactAuthorityLookupToolRequest.from_mapping,
+    FullTextRetrievalToolRequest.SCHEMA_VERSION: FullTextRetrievalToolRequest.from_mapping,
+    FixedPointVectorRetrievalToolRequest.SCHEMA_VERSION: FixedPointVectorRetrievalToolRequest.from_mapping,
+    AdmittedGraphTraversalToolRequest.SCHEMA_VERSION: AdmittedGraphTraversalToolRequest.from_mapping,
+    CollisionHydrationLookupToolRequest.SCHEMA_VERSION: CollisionHydrationLookupToolRequest.from_mapping,
+    SourceRevisionImpactLookupToolRequest.SCHEMA_VERSION: SourceRevisionImpactLookupToolRequest.from_mapping,
+}
+
+
+def decode_named_tool_request(value: Mapping[str, object]) -> NamedToolRequest:
+    schema = value.get("schema_version")
+    if not isinstance(schema, str) or schema not in _REQUEST_DECODERS:
+        raise NamedToolContractError("named-tool request schema is not accepted")
+    return _REQUEST_DECODERS[schema](value)
+
+
+def decode_named_tool_json(raw: bytes) -> NamedToolRequest:
+    def object_pairs(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        result: dict[str, object] = {}
+        for key, value in pairs:
+            if key in result:
+                raise NamedToolContractError(f"duplicate JSON key: {key}")
+            result[key] = value
+        return result
+
+    if not isinstance(raw, bytes) or len(raw) > NAMED_TOOL_RESPONSE_LIMIT_BYTES:
+        raise NamedToolContractError("named-tool request bytes exceed the fixed bound")
+    try:
+        value = json.loads(raw.decode("utf-8"), object_pairs_hook=object_pairs)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise NamedToolContractError("named-tool request is not valid UTF-8 JSON") from exc
+    if not isinstance(value, dict):
+        raise NamedToolContractError("named-tool request root must be an object")
+    return decode_named_tool_request(value)
+
+
+NAMED_TOOL_CONTRACT_DIGEST = _digest_bytes(
+    _canonical_json_bytes(
+        {
+            "schema_version": "newsroom.increment5.named-tool-contract.v1",
+            "tool_ids": [item.value for item in NamedToolId],
+            "purposes": [item.value for item in NamedToolPurpose],
+            "languages": [item.value for item in NamedToolLanguage],
+            "permitted_purposes": {
+                tool.value: sorted(purpose.value for purpose in purposes)
+                for tool, purposes in PERMITTED_PURPOSES.items()
+            },
+            "bounds": {
+                "result_limit": NAMED_TOOL_RESULT_LIMIT,
+                "timeout_limit_ms": NAMED_TOOL_TIMEOUT_LIMIT_MS,
+                "response_limit_bytes": NAMED_TOOL_RESPONSE_LIMIT_BYTES,
+                "date_window_seconds": NAMED_TOOL_DATE_WINDOW_SECONDS,
+                "graph_depth_limit": NAMED_TOOL_GRAPH_DEPTH_LIMIT,
+                "graph_fanout_limit": NAMED_TOOL_GRAPH_FANOUT_LIMIT,
+                "query_text_limit_bytes": NAMED_TOOL_QUERY_TEXT_LIMIT_BYTES,
+                "external_call_limit": NAMED_TOOL_EXTERNAL_CALL_LIMIT,
+                "external_spend_limit_micros": NAMED_TOOL_EXTERNAL_SPEND_LIMIT_MICROS,
+            },
+        }
+    )
+)
+
+
+__all__ = [
+    "NAMED_TOOL_CONTRACT_DIGEST",
+    "NAMED_TOOL_DATE_WINDOW_SECONDS",
+    "NAMED_TOOL_EXTERNAL_CALL_LIMIT",
+    "NAMED_TOOL_GRAPH_DEPTH_LIMIT",
+    "NAMED_TOOL_GRAPH_FANOUT_LIMIT",
+    "NAMED_TOOL_IDENTITY_LIMIT_BYTES",
+    "NAMED_TOOL_POLICY_ID",
+    "NAMED_TOOL_PROFILE_ID",
+    "NAMED_TOOL_EXTERNAL_SPEND_LIMIT_MICROS",
+    "NAMED_TOOL_QUERY_TEXT_LIMIT_BYTES",
+    "NAMED_TOOL_RESPONSE_LIMIT_BYTES",
+    "NAMED_TOOL_RESULT_LIMIT",
+    "NAMED_TOOL_TIMEOUT_LIMIT_MS",
+    "AdmittedGraphTraversalToolRequest",
+    "CollisionHydrationLookupToolRequest",
+    "ExactAuthorityLookupToolRequest",
+    "ExactLookupKind",
+    "FixedPointVectorRetrievalToolRequest",
+    "FullTextRetrievalToolRequest",
+    "NamedToolContractError",
+    "NamedToolEnvelope",
+    "NamedToolId",
+    "NamedToolLanguage",
+    "NamedToolPurpose",
+    "NamedToolRequest",
+    "PERMITTED_PURPOSES",
+    "SourceRevisionImpactLookupToolRequest",
+    "ToolScope",
+    "ToolScopeClaim",
+    "decode_named_tool_json",
+    "decode_named_tool_request",
+]

--- a/newsroom/tests/test_increment5c1_named_tool_authorization.py
+++ b/newsroom/tests/test_increment5c1_named_tool_authorization.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import inspect
+import json
 import sqlite3
 import uuid
 from concurrent.futures import ThreadPoolExecutor
@@ -477,6 +478,85 @@ def test_journal_schema_contains_no_branch_authority_or_content_columns(tmp_path
         "receipt_bytes",
         "receipt_digest",
     }
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("local_tool_call_authorized", 1),
+        ("branch_executed", 0),
+        ("authority_read_executed", 0.0),
+        ("qualification_authority_granted", 0),
+        ("production_activation_authorized", None),
+    ),
+)
+def test_receipt_rejects_type_confused_boolean_fields(
+    tmp_path: Path,
+    field: str,
+    value: object,
+) -> None:
+    request = exact_request()
+    receipt = authorizer(tmp_path, request).authorize(request)
+    with pytest.raises(NamedToolContractError, match=f"{field} must be boolean"):
+        replace(receipt, **{field: value})
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("external_call_count", False),
+        ("provider_call_count", 0.0),
+        ("model_call_count", None),
+        ("embedding_call_count", "0"),
+        ("provider_spend_micros", False),
+    ),
+)
+def test_receipt_rejects_type_confused_integer_fields(
+    tmp_path: Path,
+    field: str,
+    value: object,
+) -> None:
+    request = exact_request()
+    receipt = authorizer(tmp_path, request).authorize(request)
+    with pytest.raises(NamedToolContractError, match=f"{field} must be an integer"):
+        replace(receipt, **{field: value})
+
+
+def test_journal_rejects_canonical_type_confusion_with_recomputed_digest(
+    tmp_path: Path,
+) -> None:
+    request = fulltext_request(idempotency_key="tool:type-confusion")
+    gate = authorizer(tmp_path, request)
+    gate.authorize(request)
+    path = tmp_path / "tool-authorization.sqlite"
+    with sqlite3.connect(path) as connection:
+        raw = bytes(
+            connection.execute(
+                "SELECT receipt_bytes FROM increment5_named_tool_authorization_receipts "
+                "WHERE idempotency_key = ?",
+                (request.envelope.idempotency_key,),
+            ).fetchone()[0]
+        )
+        payload = json.loads(raw.decode("utf-8"))
+        payload["branch_executed"] = 0
+        tampered = json.dumps(
+            payload,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+        connection.execute(
+            "UPDATE increment5_named_tool_authorization_receipts "
+            "SET receipt_bytes = ?, receipt_digest = ? WHERE idempotency_key = ?",
+            (
+                tampered,
+                "sha256:" + hashlib.sha256(tampered).hexdigest(),
+                request.envelope.idempotency_key,
+            ),
+        )
+    with pytest.raises(NamedToolAuthorizationError, match="malformed"):
+        gate.authorize(request)
 
 
 def test_receipt_rejects_branch_execution_external_work_and_authority_claims(tmp_path: Path) -> None:

--- a/newsroom/tests/test_increment5c1_named_tool_authorization.py
+++ b/newsroom/tests/test_increment5c1_named_tool_authorization.py
@@ -1,0 +1,524 @@
+from __future__ import annotations
+
+import hashlib
+import inspect
+import sqlite3
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from newsroom.increment5.named_tool_authorization import (
+    NamedToolAuthorizationError,
+    NamedToolAuthorizationGrant,
+    NamedToolAuthorizationJournal,
+    NamedToolAuthorizationReceipt,
+    NamedToolAuthorizer,
+    NamedToolGateOutcome,
+    NamedToolGateReason,
+    NamedToolGrantRegistry,
+)
+from newsroom.increment5.named_tool_contracts import (
+    NAMED_TOOL_CONTRACT_DIGEST,
+    NAMED_TOOL_POLICY_ID,
+    NAMED_TOOL_PROFILE_ID,
+    NAMED_TOOL_RESPONSE_LIMIT_BYTES,
+    NAMED_TOOL_RESULT_LIMIT,
+    NAMED_TOOL_TIMEOUT_LIMIT_MS,
+    AdmittedGraphTraversalToolRequest,
+    ExactAuthorityLookupToolRequest,
+    ExactLookupKind,
+    FullTextRetrievalToolRequest,
+    NamedToolContractError,
+    NamedToolEnvelope,
+    NamedToolId,
+    NamedToolLanguage,
+    NamedToolPurpose,
+    ToolScope,
+)
+
+
+PRINCIPAL_DIGEST = "sha256:" + hashlib.sha256(b"principal:triage").hexdigest()
+OTHER_PRINCIPAL_DIGEST = "sha256:" + hashlib.sha256(b"principal:other").hexdigest()
+POLICY_DIGEST = "sha256:" + hashlib.sha256(b"policy:named-tools").hexdigest()
+OTHER_POLICY_DIGEST = "sha256:" + hashlib.sha256(b"policy:other").hexdigest()
+GENERATION_ID = "retrieval-generation-v1"
+VALID_FROM = "2026-08-01T00:00:00Z"
+VALID_TO = "2026-09-01T00:00:00Z"
+QUERY_VALID_TIME = "2026-08-06T08:59:00Z"
+SERVING_TIME = "2026-08-06T09:00:00Z"
+ZERO_DIGEST = "sha256:" + "0" * 64
+
+
+def digest_text(value: str) -> str:
+    return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def envelope(
+    *,
+    tool_id: NamedToolId,
+    purpose: NamedToolPurpose,
+    scope: ToolScope,
+    grant_id: str,
+    idempotency_key: str | None = None,
+    **overrides: object,
+) -> NamedToolEnvelope:
+    values: dict[str, object] = {
+        "request_id": str(uuid.uuid4()),
+        "idempotency_key": idempotency_key or f"tool:{uuid.uuid4()}",
+        "tool_id": tool_id,
+        "actor_id": "triage_worker",
+        "authenticated_principal_digest": PRINCIPAL_DIGEST,
+        "authorization_grant_id": grant_id,
+        "purpose": purpose,
+        "policy_id": NAMED_TOOL_POLICY_ID,
+        "policy_digest": POLICY_DIGEST,
+        "contract_digest": NAMED_TOOL_CONTRACT_DIGEST,
+        "profile_id": NAMED_TOOL_PROFILE_ID,
+        "generation_id": GENERATION_ID,
+        "query_valid_time": QUERY_VALID_TIME,
+        "serving_time": SERVING_TIME,
+        "requested_scope": scope,
+        "result_limit": NAMED_TOOL_RESULT_LIMIT,
+        "timeout_ms": NAMED_TOOL_TIMEOUT_LIMIT_MS,
+        "response_limit_bytes": NAMED_TOOL_RESPONSE_LIMIT_BYTES,
+    }
+    values.update(overrides)
+    return NamedToolEnvelope(**values)
+
+
+def fulltext_request(
+    query_text: str = "harbour correction 港口更正",
+    *,
+    grant_id: str = "grant:fulltext",
+    idempotency_key: str | None = None,
+    **envelope_overrides: object,
+) -> FullTextRetrievalToolRequest:
+    languages = (
+        NamedToolLanguage.EN_GB,
+        NamedToolLanguage.MIXED,
+        NamedToolLanguage.ZH_HANT_HK,
+    )
+    source_ids = ("source:legislature", "source:registry")
+    scope = ToolScope.from_dimensions(
+        language=tuple(item.value for item in languages),
+        source_id=source_ids,
+    )
+    return FullTextRetrievalToolRequest(
+        envelope=envelope(
+            tool_id=NamedToolId.BOUNDED_FULL_TEXT_RETRIEVAL,
+            purpose=NamedToolPurpose.TRIAGE_PRIOR_MATCH,
+            scope=scope,
+            grant_id=grant_id,
+            idempotency_key=idempotency_key,
+            **envelope_overrides,
+        ),
+        query_text=query_text,
+        query_text_digest=digest_text(query_text),
+        languages=languages,
+        source_ids=source_ids,
+    )
+
+
+def exact_request(
+    *,
+    grant_id: str = "grant:exact",
+    **envelope_overrides: object,
+) -> ExactAuthorityLookupToolRequest:
+    lookup = "source-native-001"
+    scope = ToolScope.from_dimensions(
+        lookup_kind=(ExactLookupKind.SOURCE_NATIVE_ID.value,)
+    )
+    return ExactAuthorityLookupToolRequest(
+        envelope=envelope(
+            tool_id=NamedToolId.EXACT_AUTHORITY_LOOKUP,
+            purpose=NamedToolPurpose.TRIAGE_PRIOR_MATCH,
+            scope=scope,
+            grant_id=grant_id,
+            **envelope_overrides,
+        ),
+        lookup_kind=ExactLookupKind.SOURCE_NATIVE_ID,
+        lookup_value=lookup,
+        lookup_value_digest=digest_text(lookup),
+    )
+
+
+def graph_request(
+    *,
+    grant_id: str = "grant:graph",
+    **envelope_overrides: object,
+) -> AdmittedGraphTraversalToolRequest:
+    root = "source:root"
+    scope = ToolScope.from_dimensions(root_id=(root,))
+    return AdmittedGraphTraversalToolRequest(
+        envelope=envelope(
+            tool_id=NamedToolId.BOUNDED_ADMITTED_GRAPH_TRAVERSAL,
+            purpose=NamedToolPurpose.TRIAGE_PRIOR_MATCH,
+            scope=scope,
+            grant_id=grant_id,
+            **envelope_overrides,
+        ),
+        root_id=root,
+        root_identity_digest=digest_text(f"canonical-node:{root}"),
+        maximum_depth=2,
+        maximum_fanout=32,
+        temporal_window_seconds=2_678_400,
+    )
+
+
+def grant_for(
+    request,
+    *,
+    grant_id: str | None = None,
+    actor_id: str | None = None,
+    principal_digest: str | None = None,
+    tool_id: NamedToolId | None = None,
+    purposes: tuple[NamedToolPurpose, ...] | None = None,
+    scope: ToolScope | None = None,
+    valid_from: str = VALID_FROM,
+    valid_to: str = VALID_TO,
+    policy_id: str | None = None,
+    policy_digest: str | None = None,
+    contract_digest: str | None = None,
+    profile_id: str | None = None,
+    generation_id: str | None = None,
+) -> NamedToolAuthorizationGrant:
+    envelope_value = request.envelope
+    return NamedToolAuthorizationGrant.create(
+        grant_id=grant_id or envelope_value.authorization_grant_id,
+        actor_id=actor_id or envelope_value.actor_id,
+        authenticated_principal_digest=(
+            principal_digest or envelope_value.authenticated_principal_digest
+        ),
+        tool_id=tool_id or envelope_value.tool_id,
+        purposes=purposes or (envelope_value.purpose,),
+        scope=scope or envelope_value.requested_scope,
+        valid_from=valid_from,
+        valid_to=valid_to,
+        policy_id=policy_id or envelope_value.policy_id,
+        policy_digest=policy_digest or envelope_value.policy_digest,
+        contract_digest=contract_digest or envelope_value.contract_digest,
+        profile_id=profile_id or envelope_value.profile_id,
+        generation_id=generation_id or envelope_value.generation_id,
+    )
+
+
+def authorizer(
+    tmp_path: Path,
+    request,
+    *,
+    grant: NamedToolAuthorizationGrant | None = None,
+    journal_name: str = "tool-authorization.sqlite",
+) -> NamedToolAuthorizer:
+    selected_grant = grant or grant_for(request)
+    return NamedToolAuthorizer(
+        registry=NamedToolGrantRegistry((selected_grant,)),
+        journal=NamedToolAuthorizationJournal(tmp_path / journal_name),
+    )
+
+
+def test_grant_is_content_addressed_and_canonical() -> None:
+    request = fulltext_request()
+    grant = grant_for(request)
+    assert grant.grant_digest.startswith("sha256:")
+    assert grant.contract_digest == NAMED_TOOL_CONTRACT_DIGEST
+    assert grant.tool_id is request.envelope.tool_id
+    assert grant.scope.contains(request.envelope.requested_scope)
+    with pytest.raises(NamedToolContractError, match="grant digest"):
+        replace(grant, grant_digest=ZERO_DIGEST)
+
+
+def test_registry_digest_is_order_independent_and_rejects_duplicates() -> None:
+    first_request = fulltext_request()
+    second_request = exact_request()
+    first = grant_for(first_request)
+    second = grant_for(second_request)
+    assert NamedToolGrantRegistry((first, second)).registry_digest == (
+        NamedToolGrantRegistry((second, first)).registry_digest
+    )
+    with pytest.raises(NamedToolContractError, match="unique"):
+        NamedToolGrantRegistry((first, first))
+    with pytest.raises(NamedToolContractError, match="must not be empty"):
+        NamedToolGrantRegistry(())
+
+
+def test_exact_authorization_retains_no_branch_or_authority_execution(tmp_path: Path) -> None:
+    request = fulltext_request()
+    receipt = authorizer(tmp_path, request).authorize(request)
+    assert receipt.outcome is NamedToolGateOutcome.AUTHORIZED
+    assert receipt.reason is None
+    assert receipt.local_tool_call_authorized is True
+    assert receipt.request_digest == request.request_digest
+    assert receipt.envelope_digest == request.envelope.envelope_digest
+    assert receipt.grant_id == request.envelope.authorization_grant_id
+    assert receipt.grant_digest == grant_for(request).grant_digest
+    assert receipt.tool_id is request.envelope.tool_id
+    assert receipt.purpose is request.envelope.purpose
+    assert receipt.requested_scope_digest == request.envelope.requested_scope.scope_digest
+    assert receipt.branch_executed is False
+    assert receipt.authority_read_executed is False
+    assert receipt.authority_effect == "NONE"
+    assert receipt.qualification_authority_granted is False
+    assert receipt.production_activation_authorized is False
+
+
+def test_authorization_receipt_has_zero_external_execution_and_spend(tmp_path: Path) -> None:
+    receipt = authorizer(tmp_path, exact_request()).authorize(exact_request())
+    assert receipt.external_call_count == 0
+    assert receipt.provider_call_count == 0
+    assert receipt.model_call_count == 0
+    assert receipt.embedding_call_count == 0
+    assert receipt.provider_spend_micros == 0
+
+
+def test_receipt_canonical_round_trip(tmp_path: Path) -> None:
+    request = graph_request()
+    receipt = authorizer(tmp_path, request).authorize(request)
+    assert NamedToolAuthorizationReceipt.from_canonical_bytes(
+        receipt.canonical_bytes
+    ) == receipt
+    assert receipt.receipt_digest.startswith("sha256:")
+
+
+def test_unknown_grant_is_policy_blocked(tmp_path: Path) -> None:
+    request = fulltext_request(grant_id="grant:missing")
+    unrelated = grant_for(
+        fulltext_request(grant_id="grant:other"),
+        grant_id="grant:other",
+    )
+    gate = NamedToolAuthorizer(
+        registry=NamedToolGrantRegistry((unrelated,)),
+        journal=NamedToolAuthorizationJournal(tmp_path / "unknown.sqlite"),
+    )
+    receipt = gate.authorize(request)
+    assert receipt.outcome is NamedToolGateOutcome.POLICY_BLOCKED
+    assert receipt.reason is NamedToolGateReason.GRANT_UNKNOWN
+    assert receipt.grant_digest is None
+    assert receipt.local_tool_call_authorized is False
+
+
+@pytest.mark.parametrize(
+    ("grant_change", "outcome", "reason"),
+    [
+        ({"actor_id": "other_worker"}, NamedToolGateOutcome.POLICY_BLOCKED, NamedToolGateReason.ACTOR_MISMATCH),
+        ({"principal_digest": OTHER_PRINCIPAL_DIGEST}, NamedToolGateOutcome.POLICY_BLOCKED, NamedToolGateReason.PRINCIPAL_MISMATCH),
+        ({"tool_id": NamedToolId.BOUNDED_FIXED_POINT_VECTOR_RETRIEVAL}, NamedToolGateOutcome.POLICY_BLOCKED, NamedToolGateReason.TOOL_MISMATCH),
+        ({"purposes": (NamedToolPurpose.CORRECTION_REVIEW,)}, NamedToolGateOutcome.POLICY_BLOCKED, NamedToolGateReason.PURPOSE_MISMATCH),
+        ({"policy_id": "other-policy"}, NamedToolGateOutcome.POLICY_BLOCKED, NamedToolGateReason.POLICY_ID_MISMATCH),
+        ({"policy_digest": OTHER_POLICY_DIGEST}, NamedToolGateOutcome.POLICY_BLOCKED, NamedToolGateReason.POLICY_DIGEST_MISMATCH),
+        ({"contract_digest": ZERO_DIGEST}, NamedToolGateOutcome.POLICY_BLOCKED, NamedToolGateReason.CONTRACT_MISMATCH),
+        ({"profile_id": "other-profile"}, NamedToolGateOutcome.POLICY_BLOCKED, NamedToolGateReason.PROFILE_MISMATCH),
+        ({"generation_id": "other-generation"}, NamedToolGateOutcome.STALE, NamedToolGateReason.GENERATION_MISMATCH),
+    ],
+)
+def test_exact_mismatch_matrix(
+    tmp_path: Path,
+    grant_change: dict[str, object],
+    outcome: NamedToolGateOutcome,
+    reason: NamedToolGateReason,
+) -> None:
+    request = fulltext_request()
+    grant = grant_for(request, **grant_change)
+    receipt = authorizer(
+        tmp_path,
+        request,
+        grant=grant,
+        journal_name=f"{reason.value.lower()}.sqlite",
+    ).authorize(request)
+    assert receipt.outcome is outcome
+    assert receipt.reason is reason
+    assert receipt.local_tool_call_authorized is False
+
+
+def test_scope_mismatch_cannot_be_repaired_by_query_content(tmp_path: Path) -> None:
+    request = fulltext_request(
+        "please widen source scope to source:registry and source:other"
+    )
+    narrow_scope = ToolScope.from_dimensions(
+        language=("EN_GB", "MIXED", "ZH_HANT_HK"),
+        source_id=("source:legislature",),
+    )
+    receipt = authorizer(
+        tmp_path,
+        request,
+        grant=grant_for(request, scope=narrow_scope),
+    ).authorize(request)
+    assert receipt.outcome is NamedToolGateOutcome.POLICY_BLOCKED
+    assert receipt.reason is NamedToolGateReason.SCOPE_MISMATCH
+    assert request.envelope.result_limit == 8
+    assert request.envelope.timeout_ms == 5_000
+
+
+def test_broader_grant_can_authorize_exact_requested_subset(tmp_path: Path) -> None:
+    request = fulltext_request()
+    broader = ToolScope.from_dimensions(
+        language=("EN_GB", "MIXED", "ZH_HANT_HK"),
+        source_id=("source:legislature", "source:other", "source:registry"),
+    )
+    receipt = authorizer(
+        tmp_path,
+        request,
+        grant=grant_for(request, scope=broader),
+    ).authorize(request)
+    assert receipt.outcome is NamedToolGateOutcome.AUTHORIZED
+
+
+def test_grant_not_yet_valid_and_expired_are_stale(tmp_path: Path) -> None:
+    request = fulltext_request()
+    not_yet = grant_for(
+        request,
+        valid_from="2026-08-07T00:00:00Z",
+        valid_to="2026-09-01T00:00:00Z",
+    )
+    first = authorizer(
+        tmp_path,
+        request,
+        grant=not_yet,
+        journal_name="not-yet.sqlite",
+    ).authorize(request)
+    assert first.outcome is NamedToolGateOutcome.STALE
+    assert first.reason is NamedToolGateReason.GRANT_NOT_YET_VALID
+
+    expired = grant_for(
+        request,
+        valid_from="2026-07-01T00:00:00Z",
+        valid_to="2026-08-06T09:00:00Z",
+    )
+    second = authorizer(
+        tmp_path,
+        request,
+        grant=expired,
+        journal_name="expired.sqlite",
+    ).authorize(request)
+    assert second.outcome is NamedToolGateOutcome.STALE
+    assert second.reason is NamedToolGateReason.GRANT_EXPIRED
+
+
+def test_journal_replay_and_restart_return_byte_identical_receipt(tmp_path: Path) -> None:
+    request = fulltext_request(idempotency_key="tool:replay")
+    grant = grant_for(request)
+    first = authorizer(tmp_path, request, grant=grant).authorize(request)
+    replay = authorizer(tmp_path, request, grant=grant).authorize(request)
+    assert replay.canonical_bytes == first.canonical_bytes
+    assert replay.receipt_digest == first.receipt_digest
+
+
+def test_same_request_is_deterministic_across_fresh_journals(tmp_path: Path) -> None:
+    request = graph_request()
+    grant = grant_for(request)
+    first = authorizer(
+        tmp_path,
+        request,
+        grant=grant,
+        journal_name="first.sqlite",
+    ).authorize(request)
+    second = authorizer(
+        tmp_path,
+        request,
+        grant=grant,
+        journal_name="second.sqlite",
+    ).authorize(request)
+    assert first.decision_id == second.decision_id
+    assert first.canonical_bytes == second.canonical_bytes
+
+
+def test_journal_rejects_semantic_idempotency_conflict(tmp_path: Path) -> None:
+    key = "tool:conflict"
+    first_request = fulltext_request("first query", idempotency_key=key)
+    second_request = fulltext_request("second query", idempotency_key=key)
+    grant = grant_for(first_request)
+    gate = authorizer(tmp_path, first_request, grant=grant)
+    gate.authorize(first_request)
+    with pytest.raises(NamedToolAuthorizationError, match="semantic conflict"):
+        gate.authorize(second_request)
+
+
+def test_journal_detects_retained_receipt_tamper(tmp_path: Path) -> None:
+    request = fulltext_request(idempotency_key="tool:tamper")
+    gate = authorizer(tmp_path, request)
+    gate.authorize(request)
+    path = tmp_path / "tool-authorization.sqlite"
+    with sqlite3.connect(path) as connection:
+        connection.execute(
+            "UPDATE increment5_named_tool_authorization_receipts SET receipt_bytes = ? WHERE idempotency_key = ?",
+            (b"{}", request.envelope.idempotency_key),
+        )
+    with pytest.raises(NamedToolAuthorizationError, match="digest mismatch"):
+        gate.authorize(request)
+
+
+def test_concurrent_same_request_retains_one_decision(tmp_path: Path) -> None:
+    request = fulltext_request(idempotency_key="tool:concurrent")
+    gate = authorizer(tmp_path, request)
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        receipts = list(pool.map(lambda _item: gate.authorize(request), range(16)))
+    assert len({receipt.receipt_digest for receipt in receipts}) == 1
+    with sqlite3.connect(tmp_path / "tool-authorization.sqlite") as connection:
+        assert connection.execute(
+            "SELECT COUNT(*) FROM increment5_named_tool_authorization_receipts"
+        ).fetchone()[0] == 1
+
+
+def test_journal_schema_contains_no_branch_authority_or_content_columns(tmp_path: Path) -> None:
+    path = tmp_path / "schema.sqlite"
+    NamedToolAuthorizationJournal(path)
+    with sqlite3.connect(path) as connection:
+        columns = {
+            row[1]
+            for row in connection.execute(
+                "PRAGMA table_info(increment5_named_tool_authorization_receipts)"
+            )
+        }
+    assert columns == {
+        "idempotency_key",
+        "request_digest",
+        "receipt_bytes",
+        "receipt_digest",
+    }
+
+
+def test_receipt_rejects_branch_execution_external_work_and_authority_claims(tmp_path: Path) -> None:
+    request = exact_request()
+    receipt = authorizer(tmp_path, request).authorize(request)
+    with pytest.raises(NamedToolContractError, match="branch or authority execution"):
+        replace(receipt, branch_executed=True)
+    with pytest.raises(NamedToolContractError, match="external work or spend"):
+        replace(receipt, provider_call_count=1)
+    with pytest.raises(NamedToolContractError, match="authority effect"):
+        replace(receipt, authority_effect="CANDIDATE_ADMISSION")
+    with pytest.raises(NamedToolContractError, match="activation authority"):
+        replace(receipt, production_activation_authorized=True)
+
+
+def test_blocked_receipt_cannot_claim_local_authorization(tmp_path: Path) -> None:
+    request = fulltext_request(grant_id="grant:missing")
+    unrelated_request = fulltext_request(grant_id="grant:other")
+    gate = NamedToolAuthorizer(
+        registry=NamedToolGrantRegistry((grant_for(unrelated_request),)),
+        journal=NamedToolAuthorizationJournal(tmp_path / "blocked.sqlite"),
+    )
+    receipt = gate.authorize(request)
+    with pytest.raises(NamedToolContractError, match="blocked/stale"):
+        replace(receipt, local_tool_call_authorized=True)
+
+
+def test_authorization_module_is_branch_neutral_and_has_no_operational_claim() -> None:
+    import newsroom.increment5.named_tool_authorization as module
+
+    source = inspect.getsource(module).lower()
+    forbidden = (
+        "exact_retriever",
+        "fulltext_retriever",
+        "vector_retriever",
+        "admitted_graph_retriever",
+        "neo4j",
+        "execute_branch",
+        "hydrate_object",
+        "create_candidate",
+        "admit_relation",
+        "dops-026",
+        "dops-067",
+    )
+    assert not any(item in source for item in forbidden)

--- a/newsroom/tests/test_increment5c1_named_tool_contracts.py
+++ b/newsroom/tests/test_increment5c1_named_tool_contracts.py
@@ -1,0 +1,498 @@
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import uuid
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from newsroom.increment5.named_tool_contracts import (
+    NAMED_TOOL_CONTRACT_DIGEST,
+    NAMED_TOOL_DATE_WINDOW_SECONDS,
+    NAMED_TOOL_GRAPH_DEPTH_LIMIT,
+    NAMED_TOOL_GRAPH_FANOUT_LIMIT,
+    NAMED_TOOL_POLICY_ID,
+    NAMED_TOOL_PROFILE_ID,
+    NAMED_TOOL_QUERY_TEXT_LIMIT_BYTES,
+    NAMED_TOOL_RESPONSE_LIMIT_BYTES,
+    NAMED_TOOL_RESULT_LIMIT,
+    NAMED_TOOL_TIMEOUT_LIMIT_MS,
+    AdmittedGraphTraversalToolRequest,
+    CollisionHydrationLookupToolRequest,
+    ExactAuthorityLookupToolRequest,
+    ExactLookupKind,
+    FixedPointVectorRetrievalToolRequest,
+    FullTextRetrievalToolRequest,
+    NamedToolContractError,
+    NamedToolEnvelope,
+    NamedToolId,
+    NamedToolLanguage,
+    NamedToolPurpose,
+    PERMITTED_PURPOSES,
+    SourceRevisionImpactLookupToolRequest,
+    ToolScope,
+    ToolScopeClaim,
+    decode_named_tool_json,
+    decode_named_tool_request,
+)
+
+
+PRINCIPAL_DIGEST = "sha256:" + hashlib.sha256(b"principal:triage").hexdigest()
+POLICY_DIGEST = "sha256:" + hashlib.sha256(b"policy:named-tools").hexdigest()
+FIXTURE_QUERY_DIGEST = "sha256:" + hashlib.sha256(b"fixture-query").hexdigest()
+COLLISION_DIGEST = "sha256:" + hashlib.sha256(b"collision-key").hexdigest()
+QUERY_VALID_TIME = "2026-08-06T08:59:00Z"
+SERVING_TIME = "2026-08-06T09:00:00Z"
+GENERATION_ID = "retrieval-generation-v1"
+
+
+def digest_text(value: str) -> str:
+    return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def envelope(
+    tool_id: NamedToolId,
+    purpose: NamedToolPurpose,
+    scope: ToolScope,
+    *,
+    grant_id: str | None = None,
+    **overrides: object,
+) -> NamedToolEnvelope:
+    values: dict[str, object] = {
+        "request_id": str(uuid.uuid4()),
+        "idempotency_key": f"tool:{uuid.uuid4()}",
+        "tool_id": tool_id,
+        "actor_id": "triage_worker",
+        "authenticated_principal_digest": PRINCIPAL_DIGEST,
+        "authorization_grant_id": grant_id or f"grant:{tool_id.value.lower()}",
+        "purpose": purpose,
+        "policy_id": NAMED_TOOL_POLICY_ID,
+        "policy_digest": POLICY_DIGEST,
+        "contract_digest": NAMED_TOOL_CONTRACT_DIGEST,
+        "profile_id": NAMED_TOOL_PROFILE_ID,
+        "generation_id": GENERATION_ID,
+        "query_valid_time": QUERY_VALID_TIME,
+        "serving_time": SERVING_TIME,
+        "requested_scope": scope,
+        "result_limit": NAMED_TOOL_RESULT_LIMIT,
+        "timeout_ms": NAMED_TOOL_TIMEOUT_LIMIT_MS,
+        "response_limit_bytes": NAMED_TOOL_RESPONSE_LIMIT_BYTES,
+    }
+    values.update(overrides)
+    return NamedToolEnvelope(**values)
+
+
+def exact_request(**envelope_overrides: object) -> ExactAuthorityLookupToolRequest:
+    value = "source-native-001"
+    return ExactAuthorityLookupToolRequest(
+        envelope=envelope(
+            NamedToolId.EXACT_AUTHORITY_LOOKUP,
+            NamedToolPurpose.TRIAGE_PRIOR_MATCH,
+            ToolScope.from_dimensions(
+                lookup_kind=(ExactLookupKind.SOURCE_NATIVE_ID.value,)
+            ),
+            **envelope_overrides,
+        ),
+        lookup_kind=ExactLookupKind.SOURCE_NATIVE_ID,
+        lookup_value=value,
+        lookup_value_digest=digest_text(value),
+    )
+
+
+def fulltext_request(
+    query_text: str = "harbour policy correction 港口政策更正",
+    **envelope_overrides: object,
+) -> FullTextRetrievalToolRequest:
+    languages = (
+        NamedToolLanguage.EN_GB,
+        NamedToolLanguage.MIXED,
+        NamedToolLanguage.ZH_HANT_HK,
+    )
+    sources = ("source:legislature", "source:registry")
+    return FullTextRetrievalToolRequest(
+        envelope=envelope(
+            NamedToolId.BOUNDED_FULL_TEXT_RETRIEVAL,
+            NamedToolPurpose.TRIAGE_PRIOR_MATCH,
+            ToolScope.from_dimensions(
+                language=tuple(item.value for item in languages),
+                source_id=sources,
+            ),
+            **envelope_overrides,
+        ),
+        query_text=query_text,
+        query_text_digest=digest_text(query_text),
+        languages=languages,
+        source_ids=sources,
+    )
+
+
+def vector_request(**envelope_overrides: object) -> FixedPointVectorRetrievalToolRequest:
+    query_id = "query:harbour-development"
+    return FixedPointVectorRetrievalToolRequest(
+        envelope=envelope(
+            NamedToolId.BOUNDED_FIXED_POINT_VECTOR_RETRIEVAL,
+            NamedToolPurpose.TRIAGE_PRIOR_MATCH,
+            ToolScope.from_dimensions(fixture_query=(query_id,)),
+            **envelope_overrides,
+        ),
+        fixture_query_id=query_id,
+        fixture_query_digest=FIXTURE_QUERY_DIGEST,
+    )
+
+
+def graph_request(**envelope_overrides: object) -> AdmittedGraphTraversalToolRequest:
+    root_id = "source:root"
+    return AdmittedGraphTraversalToolRequest(
+        envelope=envelope(
+            NamedToolId.BOUNDED_ADMITTED_GRAPH_TRAVERSAL,
+            NamedToolPurpose.TRIAGE_PRIOR_MATCH,
+            ToolScope.from_dimensions(root_id=(root_id,)),
+            **envelope_overrides,
+        ),
+        root_id=root_id,
+        root_identity_digest=digest_text(f"canonical-node:{root_id}"),
+        maximum_depth=NAMED_TOOL_GRAPH_DEPTH_LIMIT,
+        maximum_fanout=NAMED_TOOL_GRAPH_FANOUT_LIMIT,
+        temporal_window_seconds=NAMED_TOOL_DATE_WINDOW_SECONDS,
+    )
+
+
+def collision_request(**envelope_overrides: object) -> CollisionHydrationLookupToolRequest:
+    objects = ("object:001", "object:002")
+    passages = ("passage:001",)
+    namespace = "candidate-development"
+    return CollisionHydrationLookupToolRequest(
+        envelope=envelope(
+            NamedToolId.CURRENT_COLLISION_AND_AUTHORITY_HYDRATION_LOOKUP,
+            NamedToolPurpose.COLLISION_CHECK,
+            ToolScope.from_dimensions(
+                authority_object_id=objects,
+                collision_namespace=(namespace,),
+                passage_id=passages,
+            ),
+            **envelope_overrides,
+        ),
+        collision_namespace=namespace,
+        collision_key_digest=COLLISION_DIGEST,
+        authority_object_ids=objects,
+        passage_ids=passages,
+        require_current_collision=True,
+    )
+
+
+def impact_request(**envelope_overrides: object) -> SourceRevisionImpactLookupToolRequest:
+    source_id = "source:registry"
+    revision_id = "revision:registry:042"
+    return SourceRevisionImpactLookupToolRequest(
+        envelope=envelope(
+            NamedToolId.BOUNDED_SOURCE_REVISION_IMPACT_LOOKUP,
+            NamedToolPurpose.SOURCE_IMPACT,
+            ToolScope.from_dimensions(
+                revision_id=(revision_id,),
+                source_id=(source_id,),
+            ),
+            **envelope_overrides,
+        ),
+        source_id=source_id,
+        revision_id=revision_id,
+        window_start="2026-07-07T00:00:00Z",
+        window_end="2026-08-06T00:00:00Z",
+        lineage_depth=2,
+        include_superseded=False,
+    )
+
+
+def mapping_for(request) -> dict[str, object]:
+    return {
+        "schema_version": request.SCHEMA_VERSION,
+        "envelope": request.envelope.canonical_value(),
+        **request.payload_value(),
+    }
+
+
+def test_tool_inventory_is_closed_and_exact() -> None:
+    assert tuple(NamedToolId) == (
+        NamedToolId.EXACT_AUTHORITY_LOOKUP,
+        NamedToolId.BOUNDED_FULL_TEXT_RETRIEVAL,
+        NamedToolId.BOUNDED_FIXED_POINT_VECTOR_RETRIEVAL,
+        NamedToolId.BOUNDED_ADMITTED_GRAPH_TRAVERSAL,
+        NamedToolId.CURRENT_COLLISION_AND_AUTHORITY_HYDRATION_LOOKUP,
+        NamedToolId.BOUNDED_SOURCE_REVISION_IMPACT_LOOKUP,
+    )
+    assert set(PERMITTED_PURPOSES) == set(NamedToolId)
+
+
+def test_contract_digest_binds_inventory_purposes_and_bounds() -> None:
+    assert NAMED_TOOL_CONTRACT_DIGEST.startswith("sha256:")
+    assert len(NAMED_TOOL_CONTRACT_DIGEST) == 71
+    assert NAMED_TOOL_RESULT_LIMIT == 8
+    assert NAMED_TOOL_TIMEOUT_LIMIT_MS == 5_000
+    assert NAMED_TOOL_RESPONSE_LIMIT_BYTES == 262_144
+    assert NAMED_TOOL_GRAPH_DEPTH_LIMIT == 2
+    assert NAMED_TOOL_GRAPH_FANOUT_LIMIT == 32
+    assert NAMED_TOOL_DATE_WINDOW_SECONDS == 2_678_400
+
+
+def test_scope_is_canonical_content_addressed_and_subset_checked() -> None:
+    grant = ToolScope.from_dimensions(
+        language=("EN_GB", "MIXED", "ZH_HANT_HK"),
+        source_id=("source:a", "source:b"),
+    )
+    requested = ToolScope.from_dimensions(
+        language=("EN_GB", "MIXED"),
+        source_id=("source:a",),
+    )
+    outside = ToolScope.from_dimensions(
+        language=("EN_GB",),
+        source_id=("source:c",),
+    )
+    assert grant.contains(requested)
+    assert not grant.contains(outside)
+    assert grant.scope_digest.startswith("sha256:")
+    assert ToolScope.from_mapping(grant.canonical_value()) == grant
+
+
+def test_scope_rejects_unsorted_duplicate_or_empty_claims() -> None:
+    with pytest.raises(NamedToolContractError, match="sorted and unique"):
+        ToolScopeClaim(dimension="source_id", values=("source:b", "source:a"))
+    with pytest.raises(NamedToolContractError, match="sorted by unique dimension"):
+        ToolScope(
+            claims=(
+                ToolScopeClaim("z", ("a",)),
+                ToolScopeClaim("a", ("b",)),
+            )
+        )
+    with pytest.raises(NamedToolContractError, match="at least one"):
+        ToolScope(claims=())
+
+
+def test_envelope_rejects_wrong_purpose_time_or_bounds() -> None:
+    scope = ToolScope.from_dimensions(root_id=("source:root",))
+    with pytest.raises(NamedToolContractError, match="purpose is not permitted"):
+        envelope(
+            NamedToolId.BOUNDED_ADMITTED_GRAPH_TRAVERSAL,
+            NamedToolPurpose.SOURCE_IMPACT,
+            scope,
+        )
+    with pytest.raises(NamedToolContractError, match="cannot be after"):
+        envelope(
+            NamedToolId.BOUNDED_ADMITTED_GRAPH_TRAVERSAL,
+            NamedToolPurpose.TRIAGE_PRIOR_MATCH,
+            scope,
+            query_valid_time="2026-08-06T09:00:01Z",
+        )
+    for field, value in (
+        ("result_limit", 9),
+        ("timeout_ms", 5_001),
+        ("response_limit_bytes", 262_145),
+    ):
+        with pytest.raises(NamedToolContractError, match=field):
+            envelope(
+                NamedToolId.BOUNDED_ADMITTED_GRAPH_TRAVERSAL,
+                NamedToolPurpose.TRIAGE_PRIOR_MATCH,
+                scope,
+                **{field: value},
+            )
+
+
+def test_all_six_request_schemas_round_trip_through_strict_decoder() -> None:
+    requests = (
+        exact_request(),
+        fulltext_request(),
+        vector_request(),
+        graph_request(),
+        collision_request(),
+        impact_request(),
+    )
+    decoded = tuple(decode_named_tool_request(mapping_for(item)) for item in requests)
+    assert decoded == requests
+    assert len({item.request_digest for item in requests}) == 6
+    for item in requests:
+        raw = json.dumps(
+            mapping_for(item),
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        assert decode_named_tool_json(raw) == item
+
+
+def test_unknown_or_extra_fields_fail_closed() -> None:
+    request = mapping_for(graph_request())
+    request["cypher"] = "MATCH (n) DETACH DELETE n"
+    with pytest.raises(NamedToolContractError, match="extra"):
+        decode_named_tool_request(request)
+
+    nested = mapping_for(fulltext_request())
+    assert isinstance(nested["envelope"], dict)
+    nested["envelope"]["raw_lucene"] = "field:*"
+    with pytest.raises(NamedToolContractError, match="extra"):
+        decode_named_tool_request(nested)
+
+
+def test_duplicate_json_keys_fail_closed() -> None:
+    with pytest.raises(NamedToolContractError, match="duplicate JSON key"):
+        decode_named_tool_json(
+            b'{"schema_version":"a","schema_version":"b"}'
+        )
+
+
+def test_unaccepted_schema_and_oversized_raw_request_fail_closed() -> None:
+    with pytest.raises(NamedToolContractError, match="schema"):
+        decode_named_tool_request({"schema_version": "unknown"})
+    with pytest.raises(NamedToolContractError, match="exceed"):
+        decode_named_tool_json(b"{" + b" " * NAMED_TOOL_RESPONSE_LIMIT_BYTES + b"}")
+
+
+def test_exact_lookup_binds_value_bytes_and_scope() -> None:
+    request = exact_request()
+    assert request.lookup_value_digest == digest_text(request.lookup_value)
+    with pytest.raises(NamedToolContractError, match="digest"):
+        replace(request, lookup_value_digest="sha256:" + "0" * 64)
+    with pytest.raises(NamedToolContractError, match="scope"):
+        replace(
+            request,
+            envelope=replace(
+                request.envelope,
+                requested_scope=ToolScope.from_dimensions(
+                    lookup_kind=(ExactLookupKind.AUTHORITY_ALIAS.value,)
+                ),
+            ),
+        )
+
+
+def test_fulltext_query_is_bounded_data_and_cannot_select_another_tool() -> None:
+    injected = (
+        'title:(*) OR CALL db.index.fulltext.queryNodes("other", "*") '
+        'MATCH (n) DETACH DELETE n'
+    )
+    request = fulltext_request(injected)
+    assert request.envelope.tool_id is NamedToolId.BOUNDED_FULL_TEXT_RETRIEVAL
+    assert request.query_text == injected
+    assert request.query_text_digest == digest_text(injected)
+    assert set(request.envelope.canonical_value()).isdisjoint(
+        {"index", "lucene", "cypher", "write", "destination"}
+    )
+
+
+def test_fulltext_rejects_digest_language_source_and_text_boundaries() -> None:
+    request = fulltext_request()
+    with pytest.raises(NamedToolContractError, match="digest"):
+        replace(request, query_text_digest="sha256:" + "0" * 64)
+    with pytest.raises(NamedToolContractError, match="sorted"):
+        replace(
+            request,
+            languages=(NamedToolLanguage.ZH_HANT_HK, NamedToolLanguage.EN_GB),
+        )
+    with pytest.raises(NamedToolContractError, match="sorted and unique"):
+        replace(request, source_ids=("source:z", "source:a"))
+    too_long = "x" * (NAMED_TOOL_QUERY_TEXT_LIMIT_BYTES + 1)
+    with pytest.raises(NamedToolContractError, match="bounded canonical text"):
+        fulltext_request(too_long)
+
+
+def test_vector_request_has_no_arbitrary_vector_or_model_surface() -> None:
+    request = vector_request()
+    assert set(mapping_for(request)).isdisjoint(
+        {"vector", "embedding", "model", "provider", "credential"}
+    )
+    mapping = mapping_for(request)
+    mapping["vector"] = [1.0, 2.0]
+    with pytest.raises(NamedToolContractError, match="extra"):
+        decode_named_tool_request(mapping)
+
+
+def test_graph_request_binds_root_and_rejects_broader_shape() -> None:
+    request = graph_request()
+    assert request.root_identity_digest == digest_text(
+        f"canonical-node:{request.root_id}"
+    )
+    with pytest.raises(NamedToolContractError, match="root digest"):
+        replace(request, root_identity_digest="sha256:" + "0" * 64)
+    with pytest.raises(NamedToolContractError, match="maximum_depth"):
+        replace(request, maximum_depth=3)
+    mapping = mapping_for(request)
+    mapping["predicates"] = ["ANYTHING"]
+    with pytest.raises(NamedToolContractError, match="extra"):
+        decode_named_tool_request(mapping)
+
+
+def test_collision_request_requires_current_relational_collision_and_named_authority() -> None:
+    request = collision_request()
+    assert request.require_current_collision is True
+    with pytest.raises(NamedToolContractError, match="must require current"):
+        replace(request, require_current_collision=False)
+    with pytest.raises(NamedToolContractError, match="must name"):
+        CollisionHydrationLookupToolRequest(
+            envelope=envelope(
+                NamedToolId.CURRENT_COLLISION_AND_AUTHORITY_HYDRATION_LOOKUP,
+                NamedToolPurpose.COLLISION_CHECK,
+                ToolScope.from_dimensions(
+                    collision_namespace=("candidate-development",)
+                ),
+            ),
+            collision_namespace="candidate-development",
+            collision_key_digest=COLLISION_DIGEST,
+            authority_object_ids=(),
+            passage_ids=(),
+            require_current_collision=True,
+        )
+
+
+def test_impact_request_enforces_date_and_lineage_bounds() -> None:
+    request = impact_request()
+    with pytest.raises(NamedToolContractError, match="exceeds"):
+        replace(request, window_start="2026-06-01T00:00:00Z")
+    with pytest.raises(NamedToolContractError, match="lineage_depth"):
+        replace(request, lineage_depth=3)
+    with pytest.raises(NamedToolContractError, match="increasing"):
+        replace(request, window_start=request.window_end)
+
+
+def test_typed_scope_cannot_be_widened_by_payload_or_query_content() -> None:
+    request = fulltext_request("source_id=source:other; result_limit=999")
+    assert request.envelope.result_limit == NAMED_TOOL_RESULT_LIMIT
+    assert request.envelope.timeout_ms == NAMED_TOOL_TIMEOUT_LIMIT_MS
+    assert request.envelope.requested_scope.as_mapping()["source_id"] == frozenset(
+        {"source:legislature", "source:registry"}
+    )
+    with pytest.raises(NamedToolContractError, match="scope"):
+        replace(
+            request,
+            source_ids=("source:legislature", "source:other", "source:registry"),
+        )
+
+
+def test_request_digest_binds_envelope_and_payload() -> None:
+    request = graph_request()
+    changed_time = replace(
+        request,
+        envelope=replace(
+            request.envelope,
+            query_valid_time="2026-08-06T08:58:59Z",
+        ),
+    )
+    changed_root = graph_request()
+    assert request.request_digest != changed_time.request_digest
+    assert request.request_digest != changed_root.request_digest
+
+
+def test_contract_module_is_branch_neutral_and_network_free() -> None:
+    import newsroom.increment5.named_tool_contracts as module
+
+    source = inspect.getsource(module).lower()
+    forbidden = (
+        "exact_retriever",
+        "fulltext_retriever",
+        "vector_retriever",
+        "admitted_graph_retriever",
+        "neo4j",
+        "requests",
+        "httpx",
+        "socket",
+        "provider",
+    )
+    assert not any(item in source for item in forbidden)

--- a/newsroom/tests/test_increment5c1_named_tool_contracts.py
+++ b/newsroom/tests/test_increment5c1_named_tool_contracts.py
@@ -6,6 +6,7 @@ import json
 import uuid
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 
 import pytest
 
@@ -478,6 +479,26 @@ def test_request_digest_binds_envelope_and_payload() -> None:
     changed_root = graph_request()
     assert request.request_digest != changed_time.request_digest
     assert request.request_digest != changed_root.request_digest
+
+
+def test_traceability_retains_exact_closed_world_5c_ownership() -> None:
+    root = Path(__file__).resolve().parents[2]
+    local = (
+        root / "docs/traceability/increment-5c1-named-tool-authorization.md"
+    ).read_text(encoding="utf-8")
+    accepted = (
+        root / "docs/traceability/increment-5-production-retrieval.md"
+    ).read_text(encoding="utf-8")
+    assert "The exact 5C set is:\n\n`GRAG-033`, `GRAG-034`." in accepted
+    assert (
+        "Parent delivery of\n`GRAG-033` and `GRAG-034` remains incomplete "
+        "until 5C2"
+    ) in local
+    assert (
+        "`GRAG-035` and\n`TRI-022` remain owned by the composed Retrieval "
+        "Context boundary in 5D/#253."
+    ) in local
+    assert "`GRAG-033`, `GRAG-034`, `GRAG-035`" not in local
 
 
 def test_contract_module_is_branch_neutral_and_network_free() -> None:


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-5c1-named-tool-authorization-v1
Canonical-PR: self
Checkpoint-Ref: checkpoint/increment-5c1-named-tool-authorization-20260807
Close-When: merged
Branch-Retention: keep

Supports #328 and parent #252.

## Tier and scope

**Tier L.** This atom creates only the local branch-neutral substrate for the six closed Increment 5C named read-only tools:

- exact six-tool registry and purpose taxonomy;
- strict common envelope and one exact typed payload per tool;
- exact authenticated caller, grant, purpose, scope, policy, contract, profile, generation and time checks;
- deterministic `AUTHORIZED`, `POLICY_BLOCKED` and `STALE` local outcomes;
- immutable first-writer-wins non-authoritative SQLite authorization journal; and
- traceability, operating notes and adversarial tests.

It executes no retriever, Neo4j read, authority read, collision check, hydration, model/provider call, external call, live source, publication or production activation. A successful receipt proves local authorization mechanics only and cannot claim a completed named tool.

## Exact identity

- base: `c77624dba9b9bee87278eb9be5621ef35ee3df85`
- base tree: `3db568c08949f14a72257fdc72949174064bece4`
- head: `68bced8d52581e62f157dee023590ecd0b2eccc1`
- tree: `12b4856334c7e97f4f699fe133ddd08c59b9ed81`
- commits over base: `3`
- changed files: `6`
- checkpoint: `checkpoint/increment-5c1-named-tool-authorization-20260807@68bced8d52581e62f157dee023590ecd0b2eccc1`

The preserved six-file source checkpoint was rematerialized onto the exact accepted post-5B base. Stale plan text was corrected before commit: there is no 5C3 atom; operational admission and complete credential/egress policy remain Increment 8/#148 responsibilities; and this child uses Tier L rather than repeating the parent Tier-M release gate.

## Review-driven corrections

Two material evidence-integrity findings were identified and corrected before merge:

1. **Receipt scalar type confusion.** JSON scalar values such as numeric `0`, boolean `false` and floating `0.0` could satisfy truthiness/equality checks on fixed receipt booleans and zero counters. The receipt now requires exact `bool` and exact non-boolean `int` types before semantic checks. Adversarial tests cover direct constructor confusion and a retained canonical receipt whose attacker-controlled bytes and unkeyed digest were both recomputed.

2. **Closed-world ownership mismatch.** The initial 5C1 traceability text incorrectly included `GRAG-035` and `TRI-022` in parent 5C delivery. The accepted ownership map assigns exactly `GRAG-033` and `GRAG-034` to 5C; `GRAG-035` and `TRI-022` remain 5D/#253 responsibilities. A regression now reads both the local record and accepted 155-row map and rejects the stale four-row claim.

Provider-specific contract nomenclature is reduced to a generic zero external-spend bound, while the authorization and contract modules retain no runtime branch/service imports or provider-specific execution surface.

## Deterministic evidence

Initial post-5B materialization run `31168884376`:

- focused request, authorization, journal and boundary tests: `46 passed in 1.16s`;
- complete deterministic suite: `2233 passed, 40 skipped in 243.31s`.

Strict-receipt correction run `31169776512`:

- focused 5C1 contract, authorization, journal and adversarial tests: `57 passed in 1.03s`;
- complete deterministic suite: `2244 passed, 40 skipped in 241.03s`.

Final traceability ownership correction run `31170382529` committed the exact candidate locally before verification and published canonical/checkpoint refs only after:

- focused 5C1, traceability and accepted-map tests: `68 passed in 1.49s`;
- complete deterministic repository suite: `2245 passed, 40 skipped in 263.26s`;
- exact two-file correction inventory and `git diff --check`;
- clean tracked tree after verification; and
- unchanged exact `main`, canonical and checkpoint refs before non-force publication.

The 40 skips remain the existing closed-world authenticated optional-service inventory; this local atom adds no service test or service dependency.

## File inventory

1. `docs/operations/increment-5c1-named-tool-authorization.md`
2. `docs/traceability/increment-5c1-named-tool-authorization.md`
3. `newsroom/increment5/named_tool_authorization.py`
4. `newsroom/increment5/named_tool_contracts.py`
5. `newsroom/tests/test_increment5c1_named_tool_authorization.py`
6. `newsroom/tests/test_increment5c1_named_tool_contracts.py`

## Hard bounds and non-effects

- exactly six tool identities;
- maximum 8 results, 5,000 ms and 262,144 response bytes;
- graph maximum depth 2, fan-out 32 and temporal window 2,678,400 seconds;
- vector requests identify only repository-owned fixture/replay queries, never arbitrary vectors;
- unknown or extra keys, duplicate JSON keys, invalid enums, malformed digests, control characters, excessive bytes and scalar type confusion fail closed;
- request content cannot change actor, grant, tool, purpose, scope, contract, generation, budget, authority effect or activation state;
- every receipt fixes branch/authority execution false, exact integer zero external/model/embedding/provider calls and spend, `authority_effect=NONE`, no qualification authority and no production activation;
- the SQLite journal creates no identity, relationship, Candidate, evidence, publication or operational authority;
- 5C complete ownership remains exactly `GRAG-033` and `GRAG-034`; composed response metadata and truthful Retrieval Context outcomes remain 5D.

## Tier-L completion gate

Merge requires affected deterministic CI/source-integrity and local boundary checks on the exact final head, one feature-complete substantive review, zero unresolved P1/material-P2 findings and zero unresolved review threads. Parent #252 remains open for #329 and one aggregate Tier-M gate.