### PR TITLE
Increment 5: final corrective Tier-M closeout

### DIFF
--- a/.github/workflows/evidence.yml
+++ b/.github/workflows/evidence.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:
     inputs:
       base_sha:
-        description: Optional exact base commit for a manual comparison
-        required: false
+        description: Required exact non-head base commit for a manual comparison
+        required: true
         type: string
 
 permissions:
@@ -472,6 +472,18 @@ jobs:
             > "${RUNNER_TEMP}/decision-result.json"
           cat "${RUNNER_TEMP}/decision-result.json"
 
+      - name: Build Increment 5E2 final closeout receipt
+        if: needs.route.outputs.service_required == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m scripts.sdlc.increment5e2_closeout_receipt final \
+            --repo-root . \
+            --core-transport-bundle-root .sdlc-run/decision-input/core-transport \
+            --service-transport-bundle-root .sdlc-run/decision-input/service-transport \
+            --decision .sdlc-run/decision.json \
+            --output .sdlc-run/increment5e2-final-closeout.json
+
       - name: Upload final decision evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -481,6 +493,7 @@ jobs:
             .sdlc-run/decision-input/context.json
             .sdlc-run/decision-input/collection.json
             .sdlc-run/decision.json
+            .sdlc-run/increment5e2-final-closeout.json
           if-no-files-found: error
           retention-days: 30
           compression-level: 0

--- a/.github/workflows/evidence.yml
+++ b/.github/workflows/evidence.yml
@@ -440,6 +440,28 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Set up exact uv with shared cache
+        if: needs.route.outputs.service_required == 'true'
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: '0.8.0'
+          github-token: ''
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+          restore-cache: true
+          save-cache: false
+          cache-suffix: newsroom-py312
+          prune-cache: false
+          cache-python: false
+
+      - name: Sync locked closeout environment
+        if: needs.route.outputs.service_required == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv lock --check
+          uv sync --locked --no-dev
+
       - name: Prepare decision workspace
         shell: bash
         run: mkdir -p .sdlc-run
@@ -477,7 +499,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python -m scripts.sdlc.increment5e2_closeout_receipt final \
+          uv run --no-sync python -m scripts.sdlc.increment5e2_closeout_receipt final \
             --repo-root . \
             --core-transport-bundle-root .sdlc-run/decision-input/core-transport \
             --service-transport-bundle-root .sdlc-run/decision-input/service-transport \

--- a/.github/workflows/evidence.yml
+++ b/.github/workflows/evidence.yml
@@ -530,3 +530,200 @@ jobs:
           set -euo pipefail
           python -m scripts.sdlc.workflow_orchestrator enforce \
             --decision .sdlc-run/decision.json
+
+  signed-closeout:
+    name: signed-closeout
+    needs:
+      - route
+      - decision
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main' &&
+      needs.route.outputs.service_required == 'true' &&
+      needs.decision.result == 'success'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 6
+    permissions:
+      actions: read
+      artifact-metadata: write
+      attestations: write
+      contents: read
+      id-token: write
+    steps:
+      - name: Download exact final decision evidence
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: newsroom-sdlc-decision-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.sha }}
+          path: .sdlc-run/signed-closeout-input
+          merge-multiple: false
+          digest-mismatch: error
+
+      - name: Validate final closeout subject
+        shell: bash
+        env:
+          EXPECTED_HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          import re
+          from pathlib import Path
+
+          receipt_subject = Path(
+              '.sdlc-run/signed-closeout-input/'
+              'increment5e2-final-closeout.json'
+          )
+          decision_subject = Path(
+              '.sdlc-run/signed-closeout-input/decision.json'
+          )
+
+          def unique_object(pairs):
+              result = {}
+              for key, value in pairs:
+                  if key in result:
+                      raise ValueError(f'duplicate JSON key: {key}')
+                  result[key] = value
+              return result
+
+          def reject_constant(value):
+              raise ValueError(f'non-finite JSON value: {value}')
+
+          def load_subject(path, label):
+              if path.is_symlink():
+                  raise SystemExit(f'{label} subject must not be a symlink')
+              payload = path.read_bytes()
+              if not payload or len(payload) > 8 * 1024 * 1024:
+                  raise SystemExit(f'{label} subject size is invalid')
+              value = json.loads(
+                  payload.decode('utf-8'),
+                  object_pairs_hook=unique_object,
+                  parse_constant=reject_constant,
+              )
+              canonical = json.dumps(
+                  value,
+                  ensure_ascii=False,
+                  allow_nan=False,
+                  sort_keys=True,
+                  separators=(',', ':'),
+              ).encode('utf-8') + b'\n'
+              if payload != canonical:
+                  raise SystemExit(f'{label} subject is not canonical JSON')
+              return value
+
+          value = load_subject(receipt_subject, 'closeout')
+          if not isinstance(value, dict):
+              raise SystemExit('closeout subject must be a JSON object')
+          if value.get('schema_version') != (
+              'newsroom.increment5e2.final-closeout-receipt.v1'
+          ):
+              raise SystemExit('unexpected closeout receipt schema')
+
+          git_sha = re.compile(r'[0-9a-f]{40}')
+          expected_head = os.environ['EXPECTED_HEAD_SHA']
+          if not git_sha.fullmatch(expected_head):
+              raise SystemExit('invalid expected source head')
+          if value.get('evaluated_sha') != expected_head:
+              raise SystemExit('closeout source head does not match this run')
+          if not git_sha.fullmatch(str(value.get('evaluated_tree_sha', ''))):
+              raise SystemExit('invalid closeout source tree')
+
+          lanes = value.get('lanes')
+          if (
+              not isinstance(lanes, list)
+              or len(lanes) != 2
+              or not all(isinstance(lane, dict) for lane in lanes)
+              or {
+              lane.get('lane_id')
+              for lane in lanes
+              } != {'core', 'service'}
+          ):
+              raise SystemExit('closeout lanes are not exact')
+          inventory = value.get('inventory')
+          selected_cases = value.get('selected_cases')
+          case_count = (
+              inventory.get('case_count')
+              if isinstance(inventory, dict)
+              else None
+          )
+          if (
+              type(case_count) is not int
+              or not 1 <= case_count <= 100_000
+              or not isinstance(selected_cases, list)
+              or len(selected_cases) != case_count
+              or not all(isinstance(item, dict) for item in selected_cases)
+              or not all(
+                  isinstance(item.get('case_id'), str)
+                  and item.get('case_id')
+                  and isinstance(item.get('test_id'), str)
+                  and item.get('test_id')
+                  and item.get('outcome') == 'passed'
+                  for item in selected_cases
+              )
+              or len({item.get('case_id') for item in selected_cases})
+              != case_count
+              or len({item.get('test_id') for item in selected_cases})
+              != case_count
+              or not re.fullmatch(
+                  r'sha256:[0-9a-f]{64}',
+                  str(inventory.get('digest', '')),
+              )
+          ):
+              raise SystemExit('closeout inventory is not exact')
+
+          claimed_identity = value.get('receipt_identity')
+          unsigned = dict(value)
+          unsigned.pop('receipt_identity', None)
+          canonical = json.dumps(
+              unsigned,
+              ensure_ascii=False,
+              allow_nan=False,
+              sort_keys=True,
+              separators=(',', ':'),
+          ).encode('utf-8')
+          actual_identity = 'sha256:' + hashlib.sha256(canonical).hexdigest()
+          if claimed_identity != actual_identity:
+              raise SystemExit('closeout receipt self-hash mismatch')
+
+          decision = load_subject(decision_subject, 'decision')
+          if (
+              not isinstance(decision, dict)
+              or decision.get('schema_version')
+              != 'newsroom.sdlc.shadow-decision.v1'
+              or decision.get('result') != 'PASS'
+              or decision.get('decision_identity')
+              != value.get('decision_identity')
+          ):
+              raise SystemExit('signed decision binding differs')
+          context = decision.get('context')
+          if (
+              not isinstance(context, dict)
+              or context.get('evaluated_sha') != expected_head
+              or context.get('evaluated_tree_sha')
+              != value.get('evaluated_tree_sha')
+              or context.get('event_name') != 'workflow_dispatch'
+              or context.get('ref') != 'refs/heads/main'
+          ):
+              raise SystemExit('signed decision context differs')
+          PY
+
+      - name: Attest final decision and closeout receipt
+        id: attest
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-path: |
+            .sdlc-run/signed-closeout-input/decision.json
+            .sdlc-run/signed-closeout-input/increment5e2-final-closeout.json
+
+      - name: Retain attestation bundle
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: newsroom-sdlc-attestation-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.sha }}
+          path: ${{ steps.attest.outputs.bundle-path }}
+          if-no-files-found: error
+          retention-days: 30
+          compression-level: 0
+          overwrite: false
+          include-hidden-files: false
+          archive: true

--- a/.github/workflows/projection-b2-neo4j.yml
+++ b/.github/workflows/projection-b2-neo4j.yml
@@ -55,10 +55,12 @@ jobs:
           )"
           echo "::add-mask::${NEO4J_ADMIN_PASSWORD}"
           echo "::add-mask::${NEWSROOM_NEO4J_PROJECTOR_PASSWORD}"
-          {
-            echo "NEO4J_ADMIN_PASSWORD=${NEO4J_ADMIN_PASSWORD}"
-            echo "NEWSROOM_NEO4J_PROJECTOR_PASSWORD=${NEWSROOM_NEO4J_PROJECTOR_PASSWORD}"
-          } >> "${GITHUB_ENV}"
+          admin_file="${RUNNER_TEMP}/newsroom-b2-neo4j-admin.env"
+          projector_file="${RUNNER_TEMP}/newsroom-b2-neo4j-projector.env"
+          umask 077
+          printf 'NEO4J_ADMIN_PASSWORD=%s\n' "${NEO4J_ADMIN_PASSWORD}" > "${admin_file}"
+          printf 'NEWSROOM_NEO4J_PROJECTOR_PASSWORD=%s\n' "${NEWSROOM_NEO4J_PROJECTOR_PASSWORD}" > "${projector_file}"
+          chmod 600 "${admin_file}" "${projector_file}"
           docker run --detach \
             --name newsroom-b2-neo4j \
             --publish 127.0.0.1:7687:7687 \
@@ -67,6 +69,15 @@ jobs:
 
       - name: Wait for authenticated Neo4j and create projector identity
         run: |
+          set -euo pipefail
+          admin_file="${RUNNER_TEMP}/newsroom-b2-neo4j-admin.env"
+          projector_file="${RUNNER_TEMP}/newsroom-b2-neo4j-projector.env"
+          test -f "${admin_file}"
+          test -f "${projector_file}"
+          set -a
+          source "${admin_file}"
+          source "${projector_file}"
+          set +a
           uv run python - <<'PY'
           import os
           import time
@@ -117,6 +128,7 @@ jobs:
           finally:
               projector.close()
           PY
+          rm -f "${admin_file}"
 
       - name: Focused B1, B2, B3, C1 and complete Increment 2 tests against actual service
         id: focused
@@ -128,6 +140,15 @@ jobs:
           NEWSROOM_NEO4J_RETRIEVAL_SERVICE_REQUIRED: "1"
           NEWSROOM_NEO4J_URI: ${{ env.NEO4J_URI }}
         run: |
+          set -euo pipefail
+          projector_file="${RUNNER_TEMP}/newsroom-b2-neo4j-projector.env"
+          test -f "${projector_file}"
+          test ! -e "${RUNNER_TEMP}/newsroom-b2-neo4j-admin.env"
+          set -a
+          source "${projector_file}"
+          set +a
+          export NEWSROOM_NEO4J_USER="${NEWSROOM_NEO4J_PROJECTOR_USERNAME}"
+          export NEWSROOM_NEO4J_PASSWORD="${NEWSROOM_NEO4J_PROJECTOR_PASSWORD}"
           uv run python -m pytest -q \
             newsroom/tests/test_projection_b1_*.py \
             newsroom/tests/test_projection_b2_*.py \
@@ -137,7 +158,15 @@ jobs:
             newsroom/tests/test_retrieval_2c_neo4j_service.py \
             newsroom/tests/test_increment_2d_neo4j_service.py \
             newsroom/tests/test_increment4e_neo4j_service.py \
+            newsroom/tests/test_increment5b4_neo4j_service.py \
             --junitxml=projection-b2-b3-c1-complete-retrieval-neo4j-results.xml
+
+      - name: Remove disposable credential files
+        if: always()
+        run: |
+          rm -f \
+            "${RUNNER_TEMP}/newsroom-b2-neo4j-admin.env" \
+            "${RUNNER_TEMP}/newsroom-b2-neo4j-projector.env"
 
       - name: Prove actual-service tests executed
         if: always()
@@ -342,12 +371,22 @@ jobs:
               raise SystemExit("Increment 4E actual-service cases failed")
           PY
 
+      - name: Build Increment 5E2 actual-service closeout receipt
+        if: steps.focused.outcome == 'success'
+        run: |
+          uv run python -m scripts.sdlc.increment5e2_closeout_receipt actual-service \
+            --repo-root . \
+            --service-junit-report projection-b2-b3-c1-complete-retrieval-neo4j-results.xml \
+            --output increment5e2-actual-service-closeout.json
+
       - name: Upload B2/B3/C1, complete 2B and retrieval 2C actual-service evidence
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: projection-b2-b3-c1-complete-retrieval-neo4j-evidence
-          path: projection-b2-b3-c1-complete-retrieval-neo4j-results.xml
+          path: |
+            projection-b2-b3-c1-complete-retrieval-neo4j-results.xml
+            increment5e2-actual-service-closeout.json
           if-no-files-found: error
 
       - name: Upload complete 2B actual-service evidence alias

--- a/docs/evaluation/2026-08-09-increment-5e1-retrieval-qualification.md
+++ b/docs/evaluation/2026-08-09-increment-5e1-retrieval-qualification.md
@@ -28,7 +28,7 @@ Reports are canonical and content-addressed. A first-writer-wins SQLite journal 
 
 ## Actual-service lane
 
-The permanent Projection B2/B3/C1 Neo4j workflow automatically selects `test_projection_b2_increment5e1_qualification.py`. The test authenticates to the disposable Neo4j service, verifies the exact server edition/version and Python driver against the frozen target, binds the workflow Git tree into the Epoch, then evaluates all 500 repository fixture observations under that exact identity. It emits the Epoch digest, report digest, and complete canonical report into JUnit evidence. The service check proves the selected target identity; it does not claim that every synthetic fixture result was produced by a live graph query.
+The permanent Projection B2/B3/C1 Neo4j workflow automatically selects `test_projection_b2_increment5e2_neo4j_service.py`. The test authenticates to the disposable Neo4j service, verifies the exact server edition/version and Python driver against the frozen target, binds the workflow Git tree into the Epoch, then evaluates all 500 repository fixture observations under that exact identity. It emits the Epoch digest, report digest, complete canonical report, closed-world 5E2 case inventory digest, and declared non-effects into JUnit evidence. This 5E2 service lane reconciles the retained deterministic qualification evidence with the authenticated target; it does not claim that every synthetic fixture result was produced by a live graph query.
 
 ## Deferred ownership
 

--- a/docs/traceability/increment-5-production-retrieval.md
+++ b/docs/traceability/increment-5-production-retrieval.md
@@ -102,6 +102,11 @@ retrieval corpus, exact/full-text/vector/graph/hybrid ablation, provenance and
 temporal blockers, named-surface security, rights purge and graph/index
 recovery.
 
+The final 5E2 closed-world reconciliation is recorded in
+[`increment-5e2-final-closeout.md`](increment-5e2-final-closeout.md). Its
+content-addressed inventory binds the deterministic and authenticated
+actual-service cases required for the final Tier-M receipt.
+
 It does not claim complete human evaluation, live shadow, canary, Operational
 Profiles, scheduling, queues, backup/restore of the complete newsroom,
 capacity, licence or Operational Admission.

--- a/docs/traceability/increment-5e1-retrieval-qualification.md
+++ b/docs/traceability/increment-5e1-retrieval-qualification.md
@@ -29,7 +29,7 @@ Complete requirement credit remains at parent #254 after #333 proves final secur
 - Typed target, corpus, Epoch, observation, report, measurement, gate, evaluator, and journal modules: `newsroom/increment5/_retrieval_qualification_*.py`
 - Deterministic contract and gate tests: `newsroom/tests/test_increment5e1_retrieval_qualification.py`
 - Immutable report-history tests: `newsroom/tests/test_increment5e1_retrieval_qualification_journal.py`
-- Actual Neo4j test: `newsroom/tests/test_projection_b2_increment5e1_qualification.py`
+- Actual Neo4j test, reconciled into the final 5E2 service lane: `newsroom/tests/test_projection_b2_increment5e2_neo4j_service.py`
 - Reproducible runner: `scripts/increment5_retrieval_qualification.py`
 
 ## Non-effects

--- a/docs/traceability/increment-5e2-final-closeout.md
+++ b/docs/traceability/increment-5e2-final-closeout.md
@@ -1,0 +1,128 @@
+# Increment 5E2 final closeout traceability
+
+- **Issue:** #333
+- **Corrective blocker:** #351
+- **Parent:** #254
+- **Programme:** #145
+- **Gate:** Tier M
+- **Inventory source:** `newsroom/increment5/final_closeout.py`
+- **Inventory digest:** `sha256:7cdb2c769c4f312f0e2f670fd3c4084025d7cbe247788993d5b50841b0a5be95`
+
+## Closed boundary
+
+5E2 closes only the nine retrieval-specific requirements retained by the
+accepted Increment 5 amendment:
+
+`GRAG-050`, `GRAG-051`, `GRAG-054`, `GRAG-055`, `GRAG-056`, `GRPROD-001`,
+`GRPROD-010`, `GRPROD-015` and `GRPROD-023`.
+
+The machine inventory reconciles 64 exact pytest node identities across six
+mandatory categories: query containment, rights purge, graph/index recovery,
+failure/no-false-success, replay/retained-context integrity and qualification
+identity. Every category has deterministic repository evidence and authenticated
+actual-Neo4j evidence. The union of their requirement references is exactly the
+nine-row set above.
+
+The inventory is not evidence merely because a test name is listed. The 5E2
+receipt validator reads the retained JUnit reports, requires every selected
+node identity to occur exactly once and to pass without a skip, and records the
+canonical selected-case values and outcome. Parameterised cases retain their
+full pytest suffix, so each frozen variant is independently identified.
+
+## Corrective qualification boundary
+
+The final evaluator now:
+
+- blocks a rights residual, scope escape or successful write reported by any
+  executed system while retaining HYBRID-only quality thresholds;
+- rederives every case label, fixture, query-set, source-inventory and dataset
+  manifest identity from current content before Epoch construction, fixture
+  execution or evaluation;
+- rejects caller content that retains stale stored identities;
+- admits only the exact reviewed target and corpus-policy identity;
+- rederives and compares the complete Epoch, including source/provider,
+  adapter/parser, threshold, policy and independently supplied code-tree
+  identities, before evaluation; and
+- retains the exact Epoch and report identities in the actual-service JUnit
+  evidence.
+
+Focused adversarial regressions cover each post-merge PR #350 P1. The four
+comparative systems are all exercised for cross-system safety/rights blocking,
+and each previously omitted derived Epoch field is changed independently.
+
+## Security, rights and recovery reconciliation
+
+The inventory binds permanent implementation tests rather than duplicating
+their product paths:
+
+- strict request decoding, fixed tool routing, scope containment, principal
+  separation, wrong-credential rejection and absence of raw query/write
+  surfaces;
+- authority revocation/deletion, physical governed-byte non-resurrection,
+  exact full-text/vector removal identities, current Neo4j derivative removal
+  and tombstone non-resurrection;
+- secure deletion of retained Retrieval Context bytes in required rollback
+  journal mode, with WAL mode rejected before any success receipt; a
+  content-addressed purge receipt binds every exactly matched passage,
+  admission, blob and text identity without tombstoning an unselected sibling,
+  and the retained derivative tombstone blocks both replay and rehydration
+  under a new request identity after restart;
+- generation-scoped rebuild from retained authority, checkpoint enforcement,
+  graph-loss restart and isolated replacement; and
+- missing graph/full-text/vector, stale watermark, required gap and dead-letter
+  outcomes that cannot become a successful no-match.
+
+The Retrieval Context journal's purge is an exact identity-driven operation. It
+does not claim a scheduler or a complete operational rights-event subscriber;
+those operational controls remain outside Increment 5.
+
+## Retained receipts
+
+The authenticated 5E2 target/report case is a first-class
+`*_neo4j_service.py` test selected by both the permanent Neo4j workflow and the
+signed SDLC service lane. It is an intentional optional skip only in the core
+lane and must execute without a skip in either actual-service lane.
+
+Its JUnit properties bind:
+
+- exact source HEAD and Git tree;
+- Neo4j image, server version, edition, Python driver, database and projector
+  username, plus the service-compatibility digest;
+- exact Epoch canonical JSON and digest;
+- exact qualification-report canonical JSON and digest;
+- exact 64-case closeout inventory digest and count; and
+- the fixed non-effect inventory.
+
+`scripts/sdlc/increment5e2_closeout_receipt.py` emits two content-addressed
+receipts:
+
+1. the permanent Neo4j workflow receipt validates all selected actual-service
+   node results and the semantic identities above against the checked-out
+   source; and
+2. the signed SDLC final receipt replays the immutable core and service
+   transport bundles, validates the PASS decision and both lane receipts,
+   checks all 64 selected node results, and binds their raw JUnit digests,
+   selected-test manifest, envelope, transport and replay identities to one
+   exact source HEAD and tree.
+
+The final GitHub completion record must add the merged `main` commit and tree,
+permanent workflow run identities, signed SDLC decision and 5E2 receipt
+identities, substantive-review counts and unresolved-thread count. A
+branch-local or pre-merge receipt does not close #333, #254, #145 or #351.
+An exact-main manual SDLC run must supply an explicit, resolvable non-head
+`base_sha`; the workflow and event decoder reject a blank manual base rather
+than routing an empty R0 comparison that omits service evidence.
+
+## Non-effects and later ownership
+
+This closeout performs no live-source, provider, model or embedding call; no
+live-source or production-product credential use; no product-runtime network
+egress or spend; no live authority, Candidate or Hypothesis mutation; no
+publication; and no shadow, canary or production activation. Its authenticated
+credentials are generated for disposable loopback Neo4j only, are masked, and
+are removed before evidence finalisation. CI dependency and image retrieval is
+workflow infrastructure, not a product-runtime non-effect claim.
+
+Cross-request Hypothesis/Candidate/collision/Handoff effects remain Increment
+6/#146. Prospective human evaluation, complete operations, backup/restore,
+capacity, licence and Operational Admission remain Increment 8/#148.

--- a/docs/traceability/increment-5e2-final-closeout.md
+++ b/docs/traceability/increment-5e2-final-closeout.md
@@ -113,6 +113,11 @@ receipts:
    selected-test manifest, envelope, transport and replay identities to one
    exact source HEAD and tree.
 
+Both builders verify the tracked checkout against that HEAD before consuming
+evidence and again immediately before receipt emission. A repository-controlled
+test or transport parser that changes tracked source bytes therefore suppresses
+the receipt even when the committed HEAD and tree identities remain unchanged.
+
 The final GitHub completion record must add the merged `main` commit and tree,
 permanent workflow run identities, signed SDLC decision and 5E2 receipt
 identities, substantive-review counts and unresolved-thread count. A

--- a/docs/traceability/increment-5e2-final-closeout.md
+++ b/docs/traceability/increment-5e2-final-closeout.md
@@ -64,9 +64,17 @@ their product paths:
 - secure deletion of retained Retrieval Context bytes in required rollback
   journal mode, with WAL mode rejected before any success receipt; a
   content-addressed purge receipt binds every exactly matched passage,
-  admission, blob and text identity without tombstoning an unselected sibling,
-  and the retained derivative tombstone blocks both replay and rehydration
-  under a new request identity after restart;
+  admission, blob and text identity without tombstoning an unselected sibling.
+  The same transaction retains a canonical, digest-checked and content-free
+  per-context inventory of every sibling derivative before it deletes the raw
+  context. Purge events are append-only by purge identity: an unselected
+  sibling remains usable until its own rights withdrawal, after which a later
+  restart can locate it, retain a second exact tombstone and block replay or
+  rehydration under a new request identity. Each version-two receipt separates
+  whether that event deleted retained raw bytes from the required postcondition
+  that those bytes are absent. An empty legacy prototype table migrates
+  transactionally; a legacy table containing receipts fails closed because it
+  cannot reconstruct the lost sibling inventory;
 - generation-scoped rebuild from retained authority, checkpoint enforcement,
   graph-loss restart and isolated replacement; and
 - missing graph/full-text/vector, stale watermark, required gap and dead-letter
@@ -112,6 +120,17 @@ branch-local or pre-merge receipt does not close #333, #254, #145 or #351.
 An exact-main manual SDLC run must supply an explicit, resolvable non-head
 `base_sha`; the workflow and event decoder reject a blank manual base rather
 than routing an empty R0 comparison that omits service evidence.
+
+Only that successful service-required manual run on `refs/heads/main` advances
+to the isolated `signed-closeout` job. The job downloads the run-, attempt- and
+HEAD-scoped final decision artifact, independently checks the PASS decision,
+final receipt schema, source HEAD, source tree, lane set, inventory count,
+decision binding and content-addressed self-hash using the Python standard
+library, then requests a GitHub artifact attestation for the exact decision and
+receipt files. Its attestation bundle is retained as a separate run-scoped
+artifact. Pull-request and merge-queue runs remain
+evidence-only: they neither receive OIDC or attestation write permissions nor
+execute this signing job.
 
 ## Non-effects and later ownership
 

--- a/docs/traceability/increment-5e2-final-closeout.md
+++ b/docs/traceability/increment-5e2-final-closeout.md
@@ -65,6 +65,11 @@ their product paths:
   journal mode, with WAL mode rejected before any success receipt; a
   content-addressed purge receipt binds every exactly matched passage,
   admission, blob and text identity without tombstoning an unselected sibling.
+  The pre-hydration tombstone guard compares the complete four-field
+  derivative identity; it never promotes a matched tuple's individual blob or
+  text coordinate into a broader deletion scope. A blob- or text-scoped purge
+  still records every retained tuple selected by that digest and therefore
+  blocks each of those exact derivatives.
   The same transaction retains a canonical, digest-checked and content-free
   per-context inventory of every sibling derivative before it deletes the raw
   context. Purge events are append-only by purge identity: an unselected

--- a/newsroom/increment5/_retrieval_context_core.py
+++ b/newsroom/increment5/_retrieval_context_core.py
@@ -108,6 +108,7 @@ class RetrievalContextReason(StrEnum):
     COLLISION_CONTRADICTS_NO_MATCH = "COLLISION_CONTRADICTS_NO_MATCH"
     GOVERNED_BYTES_UNAVAILABLE = "GOVERNED_BYTES_UNAVAILABLE"
     GOVERNED_BYTES_INTEGRITY = "GOVERNED_BYTES_INTEGRITY"
+    RETAINED_CONTEXT_PURGED = "RETAINED_CONTEXT_PURGED"
     AUTHORITY_RESULT_BOUND = "AUTHORITY_RESULT_BOUND"
     CONTEXT_BYTE_BOUND = "CONTEXT_BYTE_BOUND"
 
@@ -1223,6 +1224,207 @@ class RetrievalContextReceipt:
         return _digest_bytes(self.canonical_bytes)
 
 
+@dataclass(frozen=True, slots=True)
+class RetrievalContextPurgeReceipt:
+    purge_id: str
+    idempotency_key: str
+    context_id: str
+    request_digest: str
+    prior_receipt_digest: str
+    passage_ids: tuple[str, ...]
+    admission_ids: tuple[str, ...]
+    blob_digests: tuple[str, ...]
+    text_digests: tuple[str, ...]
+    reason_code: str
+    raw_context_bytes_deleted: bool = True
+    tombstone_retained: bool = True
+    external_call_count: int = 0
+    candidate_created: bool = False
+    hypothesis_created: bool = False
+
+    def __post_init__(self) -> None:
+        _require_uuid(self.purge_id, "purge_id")
+        _require_token(self.idempotency_key, "purge_idempotency_key")
+        _require_uuid(self.context_id, "purged_context_id")
+        _require_digest(self.request_digest, "purged_request_digest")
+        _require_digest(self.prior_receipt_digest, "prior_receipt_digest")
+        _sorted_unique_text(self.passage_ids, "purged_passage_id", allow_empty=False)
+        _sorted_unique_text(
+            self.admission_ids, "purged_admission_id", allow_empty=False
+        )
+        _sorted_unique_digests(
+            self.blob_digests, "purged_blob_digest", allow_empty=False
+        )
+        _sorted_unique_digests(
+            self.text_digests, "purged_text_digest", allow_empty=False
+        )
+        _require_token(self.reason_code, "purge_reason_code")
+        if (
+            self.raw_context_bytes_deleted is not True
+            or self.tombstone_retained is not True
+            or type(self.external_call_count) is not int
+            or self.external_call_count != 0
+            or type(self.candidate_created) is not bool
+            or self.candidate_created
+            or type(self.hypothesis_created) is not bool
+            or self.hypothesis_created
+        ):
+            raise RetrievalContextError("purge receipt claims an invalid effect")
+        expected_id = str(
+            uuid.uuid5(
+                uuid.NAMESPACE_URL,
+                "|".join(
+                    (
+                        self.idempotency_key,
+                        self.context_id,
+                        self.request_digest,
+                        self.prior_receipt_digest,
+                        _digest_bytes(
+                            _canonical(
+                                {
+                                    "passage_ids": list(self.passage_ids),
+                                    "admission_ids": list(self.admission_ids),
+                                    "blob_digests": list(self.blob_digests),
+                                    "text_digests": list(self.text_digests),
+                                }
+                            )
+                        ),
+                        self.reason_code,
+                    )
+                ),
+            )
+        )
+        if self.purge_id != expected_id:
+            raise RetrievalContextError("purge identity differs from evidence")
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "schema_version": "newsroom.increment5.retrieval-context-purge.v1",
+            "purge_id": self.purge_id,
+            "idempotency_key": self.idempotency_key,
+            "context_id": self.context_id,
+            "request_digest": self.request_digest,
+            "prior_receipt_digest": self.prior_receipt_digest,
+            "passage_ids": list(self.passage_ids),
+            "admission_ids": list(self.admission_ids),
+            "blob_digests": list(self.blob_digests),
+            "text_digests": list(self.text_digests),
+            "reason_code": self.reason_code,
+            "raw_context_bytes_deleted": self.raw_context_bytes_deleted,
+            "tombstone_retained": self.tombstone_retained,
+            "external_call_count": self.external_call_count,
+            "candidate_created": self.candidate_created,
+            "hypothesis_created": self.hypothesis_created,
+        }
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return _canonical(self.canonical_value())
+
+    @property
+    def receipt_digest(self) -> str:
+        return _digest_bytes(self.canonical_bytes)
+
+    @classmethod
+    def from_canonical_bytes(cls, raw: bytes) -> "RetrievalContextPurgeReceipt":
+        value = _decode_canonical(raw, "retrieval context purge receipt")
+        required = {
+            "schema_version",
+            "purge_id",
+            "idempotency_key",
+            "context_id",
+            "request_digest",
+            "prior_receipt_digest",
+            "passage_ids",
+            "admission_ids",
+            "blob_digests",
+            "text_digests",
+            "reason_code",
+            "raw_context_bytes_deleted",
+            "tombstone_retained",
+            "external_call_count",
+            "candidate_created",
+            "hypothesis_created",
+        }
+        if set(value) != required or value["schema_version"] != (
+            "newsroom.increment5.retrieval-context-purge.v1"
+        ):
+            raise RetrievalContextError("purge receipt keys differ")
+        try:
+            return cls(
+                purge_id=value["purge_id"],
+                idempotency_key=value["idempotency_key"],
+                context_id=value["context_id"],
+                request_digest=value["request_digest"],
+                prior_receipt_digest=value["prior_receipt_digest"],
+                passage_ids=tuple(value["passage_ids"]),
+                admission_ids=tuple(value["admission_ids"]),
+                blob_digests=tuple(value["blob_digests"]),
+                text_digests=tuple(value["text_digests"]),
+                reason_code=value["reason_code"],
+                raw_context_bytes_deleted=value["raw_context_bytes_deleted"],
+                tombstone_retained=value["tombstone_retained"],
+                external_call_count=value["external_call_count"],
+                candidate_created=value["candidate_created"],
+                hypothesis_created=value["hypothesis_created"],
+            )
+        except (KeyError, TypeError) as exc:
+            raise RetrievalContextError("purge receipt values differ") from exc
+
+
+def _purge_derivative_identities(
+    raw: bytes,
+) -> tuple[str, tuple[tuple[str, str, str, str], ...]]:
+    value = _decode_canonical(raw, "retained retrieval context")
+    context_id = value.get("context_id")
+    items = value.get("items")
+    if not isinstance(context_id, str) or not isinstance(items, list):
+        raise RetrievalContextError("retained context purge evidence differs")
+    identities: set[tuple[str, str, str, str]] = set()
+    for item in items:
+        if not isinstance(item, dict) or not isinstance(item.get("passage"), dict):
+            raise RetrievalContextError("retained context purge evidence differs")
+        passage = item["passage"]
+        try:
+            identities.add(
+                (
+                    _require_text(passage["passage_id"], "purged_passage_id"),
+                    _require_text(
+                        passage["admission_id"], "purged_admission_id"
+                    ),
+                    _require_digest(
+                        passage["blob_digest"], "purged_blob_digest"
+                    ),
+                    _require_digest(
+                        passage["text_digest"], "purged_text_digest"
+                    ),
+                )
+            )
+        except KeyError as exc:
+            raise RetrievalContextError(
+                "retained context purge evidence differs"
+            ) from exc
+    return _require_uuid(context_id, "purged_context_id"), tuple(sorted(identities))
+
+
+def _retained_purge_receipt(
+    row: tuple[object, ...],
+) -> RetrievalContextPurgeReceipt:
+    if len(row) != 5 or not isinstance(row[4], bytes):
+        raise RetrievalContextError("retained purge receipt metadata differs")
+    raw = bytes(row[4])
+    if _digest_bytes(raw) != row[3]:
+        raise RetrievalContextError("retained purge receipt is corrupt")
+    purge = RetrievalContextPurgeReceipt.from_canonical_bytes(raw)
+    if (
+        purge.idempotency_key != row[0]
+        or purge.request_digest != row[1]
+        or purge.prior_receipt_digest != row[2]
+    ):
+        raise RetrievalContextError("retained purge receipt metadata differs")
+    return purge
+
+
 class RetrievalContextJournal:
     """Immutable first-writer-wins journal with deterministic replay."""
 
@@ -1241,11 +1443,43 @@ class RetrievalContextJournal:
                 )
                 """
             )
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS increment5d2_retrieval_context_purges (
+                    idempotency_key TEXT PRIMARY KEY,
+                    request_digest TEXT NOT NULL,
+                    prior_receipt_digest TEXT NOT NULL,
+                    purge_receipt_digest TEXT NOT NULL,
+                    purge_receipt_bytes BLOB NOT NULL
+                )
+                """
+            )
+
+    @staticmethod
+    def _require_purge_safe_journal(connection: sqlite3.Connection) -> None:
+        journal_mode = connection.execute("PRAGMA journal_mode").fetchone()
+        if (
+            journal_mode is None
+            or len(journal_mode) != 1
+            or str(journal_mode[0]).lower() != "delete"
+        ):
+            raise RetrievalContextError(
+                "purge-safe SQLite journal mode is unavailable"
+            )
 
     def _connect(self) -> sqlite3.Connection:
         connection = sqlite3.connect(self.path, timeout=30.0)
         connection.execute("PRAGMA foreign_keys=ON")
         connection.execute("PRAGMA busy_timeout=30000")
+        try:
+            self._require_purge_safe_journal(connection)
+        except RetrievalContextError:
+            connection.close()
+            raise
+        secure_delete = connection.execute("PRAGMA secure_delete=ON").fetchone()
+        if secure_delete != (1,):
+            connection.close()
+            raise RetrievalContextError("secure context deletion is unavailable")
         return connection
 
     def execute(self, *, idempotency_key: str, request_digest: str, producer):
@@ -1255,6 +1489,74 @@ class RetrievalContextJournal:
             raise TypeError("journal producer must be callable")
         with self._lock, self._connect() as connection:
             connection.execute("BEGIN IMMEDIATE")
+            self._require_purge_safe_journal(connection)
+
+            def derivative_was_purged(
+                *,
+                passage_ids: tuple[str, ...],
+                admission_ids: tuple[str, ...],
+                blob_digests: tuple[str, ...],
+                text_digests: tuple[str, ...],
+            ) -> bool:
+                selected_passages = frozenset(
+                    _sorted_unique_text(passage_ids, "context_passage_id")
+                )
+                selected_admissions = frozenset(
+                    _sorted_unique_text(admission_ids, "context_admission_id")
+                )
+                selected_blobs = frozenset(
+                    _sorted_unique_digests(blob_digests, "context_blob_digest")
+                )
+                selected_texts = frozenset(
+                    _sorted_unique_digests(text_digests, "context_text_digest")
+                )
+                if not any(
+                    (
+                        selected_passages,
+                        selected_admissions,
+                        selected_blobs,
+                        selected_texts,
+                    )
+                ):
+                    return False
+                rows = connection.execute(
+                    """
+                    SELECT idempotency_key,request_digest,prior_receipt_digest,
+                           purge_receipt_digest,purge_receipt_bytes
+                    FROM increment5d2_retrieval_context_purges
+                    ORDER BY idempotency_key
+                    """
+                )
+                for retained_row in rows:
+                    retained = _retained_purge_receipt(retained_row)
+                    if (
+                        selected_passages.intersection(retained.passage_ids)
+                        or selected_admissions.intersection(retained.admission_ids)
+                        or selected_blobs.intersection(retained.blob_digests)
+                        or selected_texts.intersection(retained.text_digests)
+                    ):
+                        return True
+                return False
+
+            purge_row = connection.execute(
+                """
+                SELECT idempotency_key,request_digest,prior_receipt_digest,
+                       purge_receipt_digest,purge_receipt_bytes
+                FROM increment5d2_retrieval_context_purges
+                WHERE idempotency_key=?
+                """,
+                (idempotency_key,),
+            ).fetchone()
+            if purge_row is not None:
+                purge = _retained_purge_receipt(purge_row)
+                if (
+                    purge.idempotency_key != idempotency_key
+                    or purge.request_digest != request_digest
+                ):
+                    raise RetrievalContextError(
+                        "purged idempotency key is bound to another request"
+                    )
+                raise RetrievalContextError("retrieval context was purged")
             row = connection.execute(
                 """
                 SELECT request_digest,receipt_digest,receipt_bytes
@@ -1271,7 +1573,7 @@ class RetrievalContextJournal:
                 raw = bytes(row[2])
                 if _digest_bytes(raw) != row[1]:
                     raise RetrievalContextError("retained context is corrupt")
-                expected = producer()
+                expected = producer(derivative_was_purged)
                 if (
                     not isinstance(expected, RetrievalContextReceipt)
                     or expected.request_digest != request_digest
@@ -1281,7 +1583,7 @@ class RetrievalContextJournal:
                         "retained context differs from deterministic replay"
                     )
                 return expected
-            receipt = producer()
+            receipt = producer(derivative_was_purged)
             if (
                 not isinstance(receipt, RetrievalContextReceipt)
                 or receipt.request_digest != request_digest
@@ -1303,6 +1605,161 @@ class RetrievalContextJournal:
             )
             connection.commit()
             return receipt
+
+    def purge_affected(
+        self,
+        *,
+        reason_code: str,
+        passage_ids: tuple[str, ...] = (),
+        admission_ids: tuple[str, ...] = (),
+        blob_digests: tuple[str, ...] = (),
+        text_digests: tuple[str, ...] = (),
+    ) -> tuple[RetrievalContextPurgeReceipt, ...]:
+        """Delete matching governed bytes and retain only exact purge tombstones."""
+
+        _require_token(reason_code, "purge_reason_code")
+        selected_passages = frozenset(
+            _sorted_unique_text(passage_ids, "purge_passage_id")
+        )
+        selected_admissions = frozenset(
+            _sorted_unique_text(admission_ids, "purge_admission_id")
+        )
+        selected_blobs = frozenset(
+            _sorted_unique_digests(blob_digests, "purge_blob_digest")
+        )
+        selected_texts = frozenset(
+            _sorted_unique_digests(text_digests, "purge_text_digest")
+        )
+        if not any(
+            (
+                selected_passages,
+                selected_admissions,
+                selected_blobs,
+                selected_texts,
+            )
+        ):
+            raise RetrievalContextError("purge requires an exact derivative identity")
+
+        def selected(
+            passages: tuple[str, ...],
+            admissions: tuple[str, ...],
+            blobs: tuple[str, ...],
+            texts: tuple[str, ...],
+        ) -> bool:
+            return bool(
+                selected_passages.intersection(passages)
+                or selected_admissions.intersection(admissions)
+                or selected_blobs.intersection(blobs)
+                or selected_texts.intersection(texts)
+            )
+
+        retained: list[RetrievalContextPurgeReceipt] = []
+        with self._lock, self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            self._require_purge_safe_journal(connection)
+            for row in connection.execute(
+                """
+                SELECT idempotency_key,request_digest,prior_receipt_digest,
+                       purge_receipt_digest,purge_receipt_bytes
+                FROM increment5d2_retrieval_context_purges
+                ORDER BY idempotency_key
+                """
+            ):
+                purge = _retained_purge_receipt(row)
+                if purge.reason_code == reason_code and selected(
+                    purge.passage_ids,
+                    purge.admission_ids,
+                    purge.blob_digests,
+                    purge.text_digests,
+                ):
+                    retained.append(purge)
+
+            rows = connection.execute(
+                """
+                SELECT idempotency_key,request_digest,receipt_digest,receipt_bytes
+                FROM increment5d2_retrieval_contexts
+                ORDER BY idempotency_key
+                """
+            ).fetchall()
+            for row in rows:
+                raw = bytes(row[3])
+                if _digest_bytes(raw) != row[2]:
+                    raise RetrievalContextError("retained context is corrupt")
+                context_id, identities = _purge_derivative_identities(raw)
+                passages = tuple(sorted({item[0] for item in identities}))
+                admissions = tuple(sorted({item[1] for item in identities}))
+                blobs = tuple(sorted({item[2] for item in identities}))
+                texts = tuple(sorted({item[3] for item in identities}))
+                if not selected(passages, admissions, blobs, texts):
+                    continue
+                matched = tuple(
+                    item
+                    for item in identities
+                    if selected((item[0],), (item[1],), (item[2],), (item[3],))
+                )
+                matched_passages = tuple(sorted({item[0] for item in matched}))
+                matched_admissions = tuple(sorted({item[1] for item in matched}))
+                matched_blobs = tuple(sorted({item[2] for item in matched}))
+                matched_texts = tuple(sorted({item[3] for item in matched}))
+                purge_id = str(
+                    uuid.uuid5(
+                        uuid.NAMESPACE_URL,
+                        "|".join(
+                            (
+                                row[0],
+                                context_id,
+                                row[1],
+                                row[2],
+                                _digest_bytes(
+                                    _canonical(
+                                        {
+                                            "passage_ids": list(matched_passages),
+                                            "admission_ids": list(matched_admissions),
+                                            "blob_digests": list(matched_blobs),
+                                            "text_digests": list(matched_texts),
+                                        }
+                                    )
+                                ),
+                                reason_code,
+                            )
+                        ),
+                    )
+                )
+                purge = RetrievalContextPurgeReceipt(
+                    purge_id=purge_id,
+                    idempotency_key=row[0],
+                    context_id=context_id,
+                    request_digest=row[1],
+                    prior_receipt_digest=row[2],
+                    passage_ids=matched_passages,
+                    admission_ids=matched_admissions,
+                    blob_digests=matched_blobs,
+                    text_digests=matched_texts,
+                    reason_code=reason_code,
+                )
+                connection.execute(
+                    "DELETE FROM increment5d2_retrieval_contexts "
+                    "WHERE idempotency_key=?",
+                    (row[0],),
+                )
+                connection.execute(
+                    """
+                    INSERT INTO increment5d2_retrieval_context_purges(
+                        idempotency_key,request_digest,prior_receipt_digest,
+                        purge_receipt_digest,purge_receipt_bytes
+                    ) VALUES(?,?,?,?,?)
+                    """,
+                    (
+                        row[0],
+                        row[1],
+                        row[2],
+                        purge.receipt_digest,
+                        purge.canonical_bytes,
+                    ),
+                )
+                retained.append(purge)
+            connection.commit()
+        return tuple(sorted(retained, key=lambda item: item.context_id))
 
 
 @dataclass(frozen=True, slots=True)
@@ -1460,10 +1917,12 @@ class RetrievalContextBuilder:
         return self.journal.execute(
             idempotency_key=request.idempotency_key,
             request_digest=request.request_digest,
-            producer=lambda: self._produce(request),
+            producer=lambda purge_guard: self._produce(request, purge_guard),
         )
 
-    def _produce(self, request: RetrievalContextRequest) -> RetrievalContextReceipt:
+    def _produce(
+        self, request: RetrievalContextRequest, purge_guard
+    ) -> RetrievalContextReceipt:
         composition: HybridCompositionReceipt | None = None
         try:
             composition = HybridCompositionReceipt.from_canonical_bytes(
@@ -1588,6 +2047,25 @@ class RetrievalContextBuilder:
             )
 
         try:
+            if purge_guard(
+                passage_ids=tuple(sorted(references)),
+                admission_ids=tuple(
+                    sorted({item.admission_id for item in references.values()})
+                ),
+                blob_digests=tuple(
+                    sorted({item.blob_digest for item in references.values()})
+                ),
+                text_digests=tuple(
+                    sorted({item.text_digest for item in references.values()})
+                ),
+            ):
+                return self._receipt(
+                    request,
+                    composition,
+                    authority,
+                    RetrievalContextOutcome.RIGHTS_BLOCKED,
+                    RetrievalContextReason.RETAINED_CONTEXT_PURGED,
+                )
             items = self._hydrate(request, composition, authority, planned, references)
         except GovernedBytesUnavailable:
             return self._receipt(
@@ -1982,6 +2460,7 @@ __all__ = [
     "RetrievalContextExclusionReason",
     "RetrievalContextJournal",
     "RetrievalContextOutcome",
+    "RetrievalContextPurgeReceipt",
     "RetrievalContextReason",
     "RetrievalContextReceipt",
     "RetrievalContextRequest",

--- a/newsroom/increment5/_retrieval_context_core.py
+++ b/newsroom/increment5/_retrieval_context_core.py
@@ -1762,13 +1762,11 @@ class RetrievalContextJournal:
                 *,
                 derivative_identities: tuple[_DerivativeIdentity, ...],
             ) -> bool:
-                selected = _require_derivative_identities(
-                    derivative_identities,
-                    "context_derivative_identities",
-                )
-                selected_columns = tuple(
-                    frozenset(column)
-                    for column in _derivative_identity_columns(selected)
+                selected = frozenset(
+                    _require_derivative_identities(
+                        derivative_identities,
+                        "context_derivative_identities",
+                    )
                 )
                 rows = connection.execute(
                     """
@@ -1781,19 +1779,8 @@ class RetrievalContextJournal:
                 )
                 for retained_row in rows:
                     retained = _retained_purge_receipt(retained_row)
-                    retained_columns = tuple(
-                        frozenset(column)
-                        for column in _derivative_identity_columns(
-                            retained.purged_derivative_identities
-                        )
-                    )
-                    if any(
-                        left.intersection(right)
-                        for left, right in zip(
-                            selected_columns,
-                            retained_columns,
-                            strict=True,
-                        )
+                    if selected.intersection(
+                        retained.purged_derivative_identities
                     ):
                         return True
                 return False

--- a/newsroom/increment5/_retrieval_context_core.py
+++ b/newsroom/increment5/_retrieval_context_core.py
@@ -1224,6 +1224,143 @@ class RetrievalContextReceipt:
         return _digest_bytes(self.canonical_bytes)
 
 
+_DERIVATIVE_IDENTITY_KEYS = frozenset(
+    {"passage_id", "admission_id", "blob_digest", "text_digest"}
+)
+_DerivativeIdentity = tuple[str, str, str, str]
+_PURGE_RECEIPT_SCHEMA_VERSION = "newsroom.increment5.retrieval-context-purge.v2"
+_LEGACY_PURGE_TABLE_SHAPE = (
+    ("idempotency_key", "TEXT", 0, None, 1),
+    ("request_digest", "TEXT", 1, None, 0),
+    ("prior_receipt_digest", "TEXT", 1, None, 0),
+    ("purge_receipt_digest", "TEXT", 1, None, 0),
+    ("purge_receipt_bytes", "BLOB", 1, None, 0),
+)
+_PURGE_TABLE_SHAPE = (
+    ("purge_id", "TEXT", 0, None, 1),
+    ("idempotency_key", "TEXT", 1, None, 0),
+    ("request_digest", "TEXT", 1, None, 0),
+    ("prior_receipt_digest", "TEXT", 1, None, 0),
+    ("purge_receipt_digest", "TEXT", 1, None, 0),
+    ("purge_receipt_bytes", "BLOB", 1, None, 0),
+)
+
+
+def _derivative_identity_value(
+    identity: _DerivativeIdentity,
+) -> dict[str, str]:
+    return {
+        "passage_id": identity[0],
+        "admission_id": identity[1],
+        "blob_digest": identity[2],
+        "text_digest": identity[3],
+    }
+
+
+def _require_derivative_identities(
+    value: object,
+    field: str,
+) -> tuple[_DerivativeIdentity, ...]:
+    if not isinstance(value, tuple) or not value:
+        raise RetrievalContextError(f"{field} differs")
+    identities: list[_DerivativeIdentity] = []
+    for item in value:
+        if not isinstance(item, tuple) or len(item) != 4:
+            raise RetrievalContextError(f"{field} differs")
+        identities.append(
+            (
+                _require_text(item[0], f"{field}_passage_id"),
+                _require_text(item[1], f"{field}_admission_id"),
+                _require_digest(item[2], f"{field}_blob_digest"),
+                _require_digest(item[3], f"{field}_text_digest"),
+            )
+        )
+    normalised = tuple(sorted(set(identities)))
+    if tuple(value) != normalised:
+        raise RetrievalContextError(f"{field} differs")
+    return normalised
+
+
+def _decode_derivative_identities(
+    value: object,
+    field: str,
+) -> tuple[_DerivativeIdentity, ...]:
+    if not isinstance(value, list) or not value:
+        raise RetrievalContextError(f"{field} differs")
+    identities: list[_DerivativeIdentity] = []
+    for item in value:
+        if not isinstance(item, dict) or set(item) != _DERIVATIVE_IDENTITY_KEYS:
+            raise RetrievalContextError(f"{field} differs")
+        identities.append(
+            (
+                item["passage_id"],
+                item["admission_id"],
+                item["blob_digest"],
+                item["text_digest"],
+            )
+        )
+    decoded = _require_derivative_identities(tuple(identities), field)
+    if value != [_derivative_identity_value(item) for item in decoded]:
+        raise RetrievalContextError(f"{field} differs")
+    return decoded
+
+
+def _derivative_identity_columns(
+    identities: tuple[_DerivativeIdentity, ...],
+) -> tuple[tuple[str, ...], tuple[str, ...], tuple[str, ...], tuple[str, ...]]:
+    return (
+        tuple(sorted({item[0] for item in identities})),
+        tuple(sorted({item[1] for item in identities})),
+        tuple(sorted({item[2] for item in identities})),
+        tuple(sorted({item[3] for item in identities})),
+    )
+
+
+def _retrieval_context_purge_id(
+    *,
+    idempotency_key: str,
+    context_id: str,
+    request_digest: str,
+    prior_receipt_digest: str,
+    purged_derivative_identities: tuple[_DerivativeIdentity, ...],
+    context_derivative_identities: tuple[_DerivativeIdentity, ...],
+    reason_code: str,
+    raw_context_bytes_deleted_in_event: bool,
+) -> str:
+    identity_digest = _digest_bytes(
+        _canonical(
+            {
+                "purged_derivative_identities": [
+                    _derivative_identity_value(item)
+                    for item in purged_derivative_identities
+                ],
+                "context_derivative_identities": [
+                    _derivative_identity_value(item)
+                    for item in context_derivative_identities
+                ],
+                "raw_context_bytes_deleted_in_event": (
+                    raw_context_bytes_deleted_in_event
+                ),
+            }
+        )
+    )
+    return str(
+        uuid.uuid5(
+            uuid.NAMESPACE_URL,
+            "|".join(
+                (
+                    idempotency_key,
+                    context_id,
+                    request_digest,
+                    prior_receipt_digest,
+                    identity_digest,
+                    reason_code,
+                )
+            ),
+        )
+    )
+
+
 @dataclass(frozen=True, slots=True)
 class RetrievalContextPurgeReceipt:
     purge_id: str
@@ -1235,8 +1372,11 @@ class RetrievalContextPurgeReceipt:
     admission_ids: tuple[str, ...]
     blob_digests: tuple[str, ...]
     text_digests: tuple[str, ...]
+    purged_derivative_identities: tuple[_DerivativeIdentity, ...]
+    context_derivative_identities: tuple[_DerivativeIdentity, ...]
     reason_code: str
-    raw_context_bytes_deleted: bool = True
+    raw_context_bytes_deleted_in_event: bool
+    raw_context_bytes_absent: bool = True
     tombstone_retained: bool = True
     external_call_count: int = 0
     candidate_created: bool = False
@@ -1258,9 +1398,25 @@ class RetrievalContextPurgeReceipt:
         _sorted_unique_digests(
             self.text_digests, "purged_text_digest", allow_empty=False
         )
+        purged = _require_derivative_identities(
+            self.purged_derivative_identities,
+            "purged_derivative_identities",
+        )
+        context = _require_derivative_identities(
+            self.context_derivative_identities,
+            "context_derivative_identities",
+        )
+        if not set(purged) <= set(context) or (
+            self.passage_ids,
+            self.admission_ids,
+            self.blob_digests,
+            self.text_digests,
+        ) != _derivative_identity_columns(purged):
+            raise RetrievalContextError("purged derivative identity binding differs")
         _require_token(self.reason_code, "purge_reason_code")
         if (
-            self.raw_context_bytes_deleted is not True
+            type(self.raw_context_bytes_deleted_in_event) is not bool
+            or self.raw_context_bytes_absent is not True
             or self.tombstone_retained is not True
             or type(self.external_call_count) is not int
             or self.external_call_count != 0
@@ -1270,36 +1426,24 @@ class RetrievalContextPurgeReceipt:
             or self.hypothesis_created
         ):
             raise RetrievalContextError("purge receipt claims an invalid effect")
-        expected_id = str(
-            uuid.uuid5(
-                uuid.NAMESPACE_URL,
-                "|".join(
-                    (
-                        self.idempotency_key,
-                        self.context_id,
-                        self.request_digest,
-                        self.prior_receipt_digest,
-                        _digest_bytes(
-                            _canonical(
-                                {
-                                    "passage_ids": list(self.passage_ids),
-                                    "admission_ids": list(self.admission_ids),
-                                    "blob_digests": list(self.blob_digests),
-                                    "text_digests": list(self.text_digests),
-                                }
-                            )
-                        ),
-                        self.reason_code,
-                    )
-                ),
-            )
+        expected_id = _retrieval_context_purge_id(
+            idempotency_key=self.idempotency_key,
+            context_id=self.context_id,
+            request_digest=self.request_digest,
+            prior_receipt_digest=self.prior_receipt_digest,
+            purged_derivative_identities=purged,
+            context_derivative_identities=context,
+            reason_code=self.reason_code,
+            raw_context_bytes_deleted_in_event=(
+                self.raw_context_bytes_deleted_in_event
+            ),
         )
         if self.purge_id != expected_id:
             raise RetrievalContextError("purge identity differs from evidence")
 
     def canonical_value(self) -> dict[str, object]:
         return {
-            "schema_version": "newsroom.increment5.retrieval-context-purge.v1",
+            "schema_version": _PURGE_RECEIPT_SCHEMA_VERSION,
             "purge_id": self.purge_id,
             "idempotency_key": self.idempotency_key,
             "context_id": self.context_id,
@@ -1309,8 +1453,19 @@ class RetrievalContextPurgeReceipt:
             "admission_ids": list(self.admission_ids),
             "blob_digests": list(self.blob_digests),
             "text_digests": list(self.text_digests),
+            "purged_derivative_identities": [
+                _derivative_identity_value(item)
+                for item in self.purged_derivative_identities
+            ],
+            "context_derivative_identities": [
+                _derivative_identity_value(item)
+                for item in self.context_derivative_identities
+            ],
             "reason_code": self.reason_code,
-            "raw_context_bytes_deleted": self.raw_context_bytes_deleted,
+            "raw_context_bytes_deleted_in_event": (
+                self.raw_context_bytes_deleted_in_event
+            ),
+            "raw_context_bytes_absent": self.raw_context_bytes_absent,
             "tombstone_retained": self.tombstone_retained,
             "external_call_count": self.external_call_count,
             "candidate_created": self.candidate_created,
@@ -1339,15 +1494,19 @@ class RetrievalContextPurgeReceipt:
             "admission_ids",
             "blob_digests",
             "text_digests",
+            "purged_derivative_identities",
+            "context_derivative_identities",
             "reason_code",
-            "raw_context_bytes_deleted",
+            "raw_context_bytes_deleted_in_event",
+            "raw_context_bytes_absent",
             "tombstone_retained",
             "external_call_count",
             "candidate_created",
             "hypothesis_created",
         }
-        if set(value) != required or value["schema_version"] != (
-            "newsroom.increment5.retrieval-context-purge.v1"
+        if (
+            set(value) != required
+            or value["schema_version"] != _PURGE_RECEIPT_SCHEMA_VERSION
         ):
             raise RetrievalContextError("purge receipt keys differ")
         try:
@@ -1361,8 +1520,19 @@ class RetrievalContextPurgeReceipt:
                 admission_ids=tuple(value["admission_ids"]),
                 blob_digests=tuple(value["blob_digests"]),
                 text_digests=tuple(value["text_digests"]),
+                purged_derivative_identities=_decode_derivative_identities(
+                    value["purged_derivative_identities"],
+                    "purged_derivative_identities",
+                ),
+                context_derivative_identities=_decode_derivative_identities(
+                    value["context_derivative_identities"],
+                    "context_derivative_identities",
+                ),
                 reason_code=value["reason_code"],
-                raw_context_bytes_deleted=value["raw_context_bytes_deleted"],
+                raw_context_bytes_deleted_in_event=value[
+                    "raw_context_bytes_deleted_in_event"
+                ],
+                raw_context_bytes_absent=value["raw_context_bytes_absent"],
                 tombstone_retained=value["tombstone_retained"],
                 external_call_count=value["external_call_count"],
                 candidate_created=value["candidate_created"],
@@ -1410,16 +1580,17 @@ def _purge_derivative_identities(
 def _retained_purge_receipt(
     row: tuple[object, ...],
 ) -> RetrievalContextPurgeReceipt:
-    if len(row) != 5 or not isinstance(row[4], bytes):
+    if len(row) != 6 or not isinstance(row[5], bytes):
         raise RetrievalContextError("retained purge receipt metadata differs")
-    raw = bytes(row[4])
-    if _digest_bytes(raw) != row[3]:
+    raw = bytes(row[5])
+    if _digest_bytes(raw) != row[4]:
         raise RetrievalContextError("retained purge receipt is corrupt")
     purge = RetrievalContextPurgeReceipt.from_canonical_bytes(raw)
     if (
-        purge.idempotency_key != row[0]
-        or purge.request_digest != row[1]
-        or purge.prior_receipt_digest != row[2]
+        purge.purge_id != row[0]
+        or purge.idempotency_key != row[1]
+        or purge.request_digest != row[2]
+        or purge.prior_receipt_digest != row[3]
     ):
         raise RetrievalContextError("retained purge receipt metadata differs")
     return purge
@@ -1428,11 +1599,42 @@ def _retained_purge_receipt(
 class RetrievalContextJournal:
     """Immutable first-writer-wins journal with deterministic replay."""
 
-    def __init__(self, path: Path) -> None:
-        self.path = Path(path)
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        self._lock = threading.RLock()
-        with self._connect() as connection:
+    @staticmethod
+    def _purge_table_shape(
+        connection: sqlite3.Connection,
+    ) -> tuple[tuple[object, ...], ...]:
+        return tuple(
+            (
+                row[1],
+                str(row[2]).upper(),
+                int(row[3]),
+                row[4],
+                int(row[5]),
+            )
+            for row in connection.execute(
+                "PRAGMA table_info(increment5d2_retrieval_context_purges)"
+            )
+        )
+
+    @staticmethod
+    def _create_purge_table(connection: sqlite3.Connection) -> None:
+        connection.execute(
+            """
+            CREATE TABLE increment5d2_retrieval_context_purges (
+                purge_id TEXT PRIMARY KEY,
+                idempotency_key TEXT NOT NULL,
+                request_digest TEXT NOT NULL,
+                prior_receipt_digest TEXT NOT NULL,
+                purge_receipt_digest TEXT NOT NULL,
+                purge_receipt_bytes BLOB NOT NULL
+            )
+            """
+        )
+
+    @classmethod
+    def _initialise_schema(cls, connection: sqlite3.Connection) -> None:
+        connection.execute("BEGIN IMMEDIATE")
+        try:
             connection.execute(
                 """
                 CREATE TABLE IF NOT EXISTS increment5d2_retrieval_contexts (
@@ -1443,17 +1645,82 @@ class RetrievalContextJournal:
                 )
                 """
             )
-            connection.execute(
-                """
-                CREATE TABLE IF NOT EXISTS increment5d2_retrieval_context_purges (
-                    idempotency_key TEXT PRIMARY KEY,
-                    request_digest TEXT NOT NULL,
-                    prior_receipt_digest TEXT NOT NULL,
-                    purge_receipt_digest TEXT NOT NULL,
-                    purge_receipt_bytes BLOB NOT NULL
+            objects = connection.execute(
+                "SELECT type FROM sqlite_master WHERE name=?",
+                ("increment5d2_retrieval_context_purges",),
+            ).fetchall()
+            if not objects:
+                cls._create_purge_table(connection)
+            elif objects != [("table",)]:
+                raise RetrievalContextError(
+                    "retrieval context purge journal schema differs"
                 )
-                """
+            else:
+                shape = cls._purge_table_shape(connection)
+                if shape == _LEGACY_PURGE_TABLE_SHAPE:
+                    retained = connection.execute(
+                        "SELECT COUNT(*) "
+                        "FROM increment5d2_retrieval_context_purges"
+                    ).fetchone()
+                    if retained != (0,):
+                        raise RetrievalContextError(
+                            "legacy purge journal lacks sibling identities"
+                        )
+                    connection.execute(
+                        "DROP TABLE increment5d2_retrieval_context_purges"
+                    )
+                    cls._create_purge_table(connection)
+                elif shape != _PURGE_TABLE_SHAPE:
+                    raise RetrievalContextError(
+                        "retrieval context purge journal schema differs"
+                    )
+
+            index_name = "increment5d2_retrieval_context_purges_by_key"
+            indexes = {
+                row[1]
+                for row in connection.execute(
+                    "PRAGMA index_list(increment5d2_retrieval_context_purges)"
+                )
+            }
+            if index_name not in indexes:
+                conflicting = connection.execute(
+                    "SELECT type FROM sqlite_master WHERE name=?",
+                    (index_name,),
+                ).fetchall()
+                if conflicting:
+                    raise RetrievalContextError(
+                        "retrieval context purge journal index differs"
+                    )
+                connection.execute(
+                    """
+                    CREATE INDEX increment5d2_retrieval_context_purges_by_key
+                    ON increment5d2_retrieval_context_purges(
+                        idempotency_key,purge_id
+                    )
+                    """
+                )
+            index_columns = tuple(
+                row[2]
+                for row in connection.execute(
+                    "PRAGMA index_info("
+                    "increment5d2_retrieval_context_purges_by_key)"
+                )
             )
+            if index_columns != ("idempotency_key", "purge_id"):
+                raise RetrievalContextError(
+                    "retrieval context purge journal index differs"
+                )
+            connection.commit()
+        except Exception:
+            connection.rollback()
+            raise
+
+    def __init__(self, path: Path) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.RLock()
+        with self._connect() as connection:
+            self._initialise_schema(connection)
 
     @staticmethod
     def _require_purge_safe_journal(connection: sqlite3.Connection) -> None:
@@ -1493,65 +1760,63 @@ class RetrievalContextJournal:
 
             def derivative_was_purged(
                 *,
-                passage_ids: tuple[str, ...],
-                admission_ids: tuple[str, ...],
-                blob_digests: tuple[str, ...],
-                text_digests: tuple[str, ...],
+                derivative_identities: tuple[_DerivativeIdentity, ...],
             ) -> bool:
-                selected_passages = frozenset(
-                    _sorted_unique_text(passage_ids, "context_passage_id")
+                selected = _require_derivative_identities(
+                    derivative_identities,
+                    "context_derivative_identities",
                 )
-                selected_admissions = frozenset(
-                    _sorted_unique_text(admission_ids, "context_admission_id")
+                selected_columns = tuple(
+                    frozenset(column)
+                    for column in _derivative_identity_columns(selected)
                 )
-                selected_blobs = frozenset(
-                    _sorted_unique_digests(blob_digests, "context_blob_digest")
-                )
-                selected_texts = frozenset(
-                    _sorted_unique_digests(text_digests, "context_text_digest")
-                )
-                if not any(
-                    (
-                        selected_passages,
-                        selected_admissions,
-                        selected_blobs,
-                        selected_texts,
-                    )
-                ):
-                    return False
                 rows = connection.execute(
                     """
-                    SELECT idempotency_key,request_digest,prior_receipt_digest,
+                    SELECT purge_id,idempotency_key,request_digest,
+                           prior_receipt_digest,
                            purge_receipt_digest,purge_receipt_bytes
                     FROM increment5d2_retrieval_context_purges
-                    ORDER BY idempotency_key
+                    ORDER BY purge_id
                     """
                 )
                 for retained_row in rows:
                     retained = _retained_purge_receipt(retained_row)
-                    if (
-                        selected_passages.intersection(retained.passage_ids)
-                        or selected_admissions.intersection(retained.admission_ids)
-                        or selected_blobs.intersection(retained.blob_digests)
-                        or selected_texts.intersection(retained.text_digests)
+                    retained_columns = tuple(
+                        frozenset(column)
+                        for column in _derivative_identity_columns(
+                            retained.purged_derivative_identities
+                        )
+                    )
+                    if any(
+                        left.intersection(right)
+                        for left, right in zip(
+                            selected_columns,
+                            retained_columns,
+                            strict=True,
+                        )
                     ):
                         return True
                 return False
 
-            purge_row = connection.execute(
+            purge_rows = connection.execute(
                 """
-                SELECT idempotency_key,request_digest,prior_receipt_digest,
+                SELECT purge_id,idempotency_key,request_digest,
+                       prior_receipt_digest,
                        purge_receipt_digest,purge_receipt_bytes
                 FROM increment5d2_retrieval_context_purges
                 WHERE idempotency_key=?
+                ORDER BY purge_id
                 """,
                 (idempotency_key,),
-            ).fetchone()
-            if purge_row is not None:
-                purge = _retained_purge_receipt(purge_row)
-                if (
+            ).fetchall()
+            if purge_rows:
+                purges = tuple(
+                    _retained_purge_receipt(item) for item in purge_rows
+                )
+                if any(
                     purge.idempotency_key != idempotency_key
                     or purge.request_digest != request_digest
+                    for purge in purges
                 ):
                     raise RetrievalContextError(
                         "purged idempotency key is bound to another request"
@@ -1640,37 +1905,56 @@ class RetrievalContextJournal:
         ):
             raise RetrievalContextError("purge requires an exact derivative identity")
 
-        def selected(
-            passages: tuple[str, ...],
-            admissions: tuple[str, ...],
-            blobs: tuple[str, ...],
-            texts: tuple[str, ...],
-        ) -> bool:
+        def selected(identity: _DerivativeIdentity) -> bool:
             return bool(
-                selected_passages.intersection(passages)
-                or selected_admissions.intersection(admissions)
-                or selected_blobs.intersection(blobs)
-                or selected_texts.intersection(texts)
+                identity[0] in selected_passages
+                or identity[1] in selected_admissions
+                or identity[2] in selected_blobs
+                or identity[3] in selected_texts
             )
 
         retained: list[RetrievalContextPurgeReceipt] = []
         with self._lock, self._connect() as connection:
             connection.execute("BEGIN IMMEDIATE")
             self._require_purge_safe_journal(connection)
+            inventories: dict[
+                str,
+                tuple[
+                    str,
+                    str,
+                    str,
+                    tuple[_DerivativeIdentity, ...],
+                ],
+            ] = {}
+            purged_by_context: dict[str, set[_DerivativeIdentity]] = {}
+            raw_context_keys: dict[str, str] = {}
             for row in connection.execute(
                 """
-                SELECT idempotency_key,request_digest,prior_receipt_digest,
+                SELECT purge_id,idempotency_key,request_digest,
+                       prior_receipt_digest,
                        purge_receipt_digest,purge_receipt_bytes
                 FROM increment5d2_retrieval_context_purges
-                ORDER BY idempotency_key
+                ORDER BY purge_id
                 """
             ):
                 purge = _retained_purge_receipt(row)
-                if purge.reason_code == reason_code and selected(
-                    purge.passage_ids,
-                    purge.admission_ids,
-                    purge.blob_digests,
-                    purge.text_digests,
+                inventory = (
+                    purge.idempotency_key,
+                    purge.request_digest,
+                    purge.prior_receipt_digest,
+                    purge.context_derivative_identities,
+                )
+                previous = inventories.setdefault(purge.context_id, inventory)
+                if previous != inventory:
+                    raise RetrievalContextError(
+                        "retained purge context inventory differs"
+                    )
+                purged_by_context.setdefault(purge.context_id, set()).update(
+                    purge.purged_derivative_identities
+                )
+                if purge.reason_code == reason_code and any(
+                    selected(item)
+                    for item in purge.purged_derivative_identities
                 ):
                     retained.append(purge)
 
@@ -1686,80 +1970,98 @@ class RetrievalContextJournal:
                 if _digest_bytes(raw) != row[2]:
                     raise RetrievalContextError("retained context is corrupt")
                 context_id, identities = _purge_derivative_identities(raw)
-                passages = tuple(sorted({item[0] for item in identities}))
-                admissions = tuple(sorted({item[1] for item in identities}))
-                blobs = tuple(sorted({item[2] for item in identities}))
-                texts = tuple(sorted({item[3] for item in identities}))
-                if not selected(passages, admissions, blobs, texts):
-                    continue
-                matched = tuple(
-                    item
-                    for item in identities
-                    if selected((item[0],), (item[1],), (item[2],), (item[3],))
-                )
-                matched_passages = tuple(sorted({item[0] for item in matched}))
-                matched_admissions = tuple(sorted({item[1] for item in matched}))
-                matched_blobs = tuple(sorted({item[2] for item in matched}))
-                matched_texts = tuple(sorted({item[3] for item in matched}))
-                purge_id = str(
-                    uuid.uuid5(
-                        uuid.NAMESPACE_URL,
-                        "|".join(
-                            (
-                                row[0],
-                                context_id,
-                                row[1],
-                                row[2],
-                                _digest_bytes(
-                                    _canonical(
-                                        {
-                                            "passage_ids": list(matched_passages),
-                                            "admission_ids": list(matched_admissions),
-                                            "blob_digests": list(matched_blobs),
-                                            "text_digests": list(matched_texts),
-                                        }
-                                    )
-                                ),
-                                reason_code,
-                            )
-                        ),
+                inventory = (row[0], row[1], row[2], identities)
+                previous = inventories.setdefault(context_id, inventory)
+                if previous != inventory or context_id in raw_context_keys:
+                    raise RetrievalContextError(
+                        "retained purge context inventory differs"
                     )
+                if context_id in purged_by_context:
+                    raise RetrievalContextError(
+                        "purged retrieval context bytes remain retained"
+                    )
+                raw_context_keys[context_id] = row[0]
+
+            for context_id in sorted(inventories):
+                (
+                    idempotency_key,
+                    request_digest,
+                    prior_receipt_digest,
+                    identities,
+                ) = inventories[context_id]
+                matched = tuple(item for item in identities if selected(item))
+                already_purged = purged_by_context.setdefault(context_id, set())
+                newly_purged = tuple(
+                    item for item in matched if item not in already_purged
+                )
+                if not newly_purged:
+                    continue
+                (
+                    matched_passages,
+                    matched_admissions,
+                    matched_blobs,
+                    matched_texts,
+                ) = _derivative_identity_columns(newly_purged)
+                raw_key = raw_context_keys.get(context_id)
+                deleted_in_event = raw_key is not None
+                purge_id = _retrieval_context_purge_id(
+                    idempotency_key=idempotency_key,
+                    context_id=context_id,
+                    request_digest=request_digest,
+                    prior_receipt_digest=prior_receipt_digest,
+                    purged_derivative_identities=newly_purged,
+                    context_derivative_identities=identities,
+                    reason_code=reason_code,
+                    raw_context_bytes_deleted_in_event=deleted_in_event,
                 )
                 purge = RetrievalContextPurgeReceipt(
                     purge_id=purge_id,
-                    idempotency_key=row[0],
+                    idempotency_key=idempotency_key,
                     context_id=context_id,
-                    request_digest=row[1],
-                    prior_receipt_digest=row[2],
+                    request_digest=request_digest,
+                    prior_receipt_digest=prior_receipt_digest,
                     passage_ids=matched_passages,
                     admission_ids=matched_admissions,
                     blob_digests=matched_blobs,
                     text_digests=matched_texts,
+                    purged_derivative_identities=newly_purged,
+                    context_derivative_identities=identities,
                     reason_code=reason_code,
+                    raw_context_bytes_deleted_in_event=deleted_in_event,
                 )
-                connection.execute(
-                    "DELETE FROM increment5d2_retrieval_contexts "
-                    "WHERE idempotency_key=?",
-                    (row[0],),
-                )
+                if raw_key is not None:
+                    deleted = connection.execute(
+                        "DELETE FROM increment5d2_retrieval_contexts "
+                        "WHERE idempotency_key=?",
+                        (raw_key,),
+                    )
+                    if deleted.rowcount != 1:
+                        raise RetrievalContextError(
+                            "retained context purge deletion differs"
+                        )
                 connection.execute(
                     """
                     INSERT INTO increment5d2_retrieval_context_purges(
-                        idempotency_key,request_digest,prior_receipt_digest,
+                        purge_id,idempotency_key,request_digest,
+                        prior_receipt_digest,
                         purge_receipt_digest,purge_receipt_bytes
-                    ) VALUES(?,?,?,?,?)
+                    ) VALUES(?,?,?,?,?,?)
                     """,
                     (
-                        row[0],
-                        row[1],
-                        row[2],
+                        purge.purge_id,
+                        purge.idempotency_key,
+                        purge.request_digest,
+                        purge.prior_receipt_digest,
                         purge.receipt_digest,
                         purge.canonical_bytes,
                     ),
                 )
+                already_purged.update(newly_purged)
                 retained.append(purge)
             connection.commit()
-        return tuple(sorted(retained, key=lambda item: item.context_id))
+        return tuple(
+            sorted(retained, key=lambda item: (item.context_id, item.purge_id))
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -2048,15 +2350,16 @@ class RetrievalContextBuilder:
 
         try:
             if purge_guard(
-                passage_ids=tuple(sorted(references)),
-                admission_ids=tuple(
-                    sorted({item.admission_id for item in references.values()})
-                ),
-                blob_digests=tuple(
-                    sorted({item.blob_digest for item in references.values()})
-                ),
-                text_digests=tuple(
-                    sorted({item.text_digest for item in references.values()})
+                derivative_identities=tuple(
+                    sorted(
+                        (
+                            passage_id,
+                            reference.admission_id,
+                            reference.blob_digest,
+                            reference.text_digest,
+                        )
+                        for passage_id, reference in references.items()
+                    )
                 ),
             ):
                 return self._receipt(

--- a/newsroom/increment5/_retrieval_qualification_corpus.py
+++ b/newsroom/increment5/_retrieval_qualification_corpus.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 
 from ._retrieval_qualification_common import (
@@ -20,6 +21,102 @@ from ._retrieval_qualification_contracts import (
 )
 from .decision import INCREMENT_5A_CONTRACT_DIGEST
 from .evaluation_plan import EVALUATION_PLAN_DIGEST, INCREMENT_5_EVALUATION_PLAN
+
+
+def _case_label_value(case: QualificationCase) -> dict[str, object]:
+    return {
+        "case_id": case.case_id,
+        "family_id": case.family_id,
+        "case_type": case.case_type,
+        "language": case.language,
+        "query_valid_time": case.query_valid_time,
+        "expected_root": case.expected_root,
+        "prohibited_root": case.prohibited_root,
+        "slice_labels": list(case.slice_labels),
+        "triage_labels": list(case.triage_labels),
+        "expected_candidate_count": case.expected_candidate_count,
+    }
+
+
+def _case_fixture_value(case: QualificationCase) -> dict[str, object]:
+    return {
+        "case_id": case.case_id,
+        "fixture_hits": [
+            {"mode": mode.value, "roots": list(roots)}
+            for mode, roots in case.fixture_hits
+        ],
+        "source_inventory_ids": list(case.source_inventory_ids),
+    }
+
+
+def rederive_qualification_corpus(
+    corpus: QualificationCorpus,
+) -> QualificationCorpus:
+    """Return the corpus with every content-derived identity recomputed."""
+
+    cases = tuple(
+        replace(
+            case,
+            label_digest=digest(_case_label_value(case)),
+            fixture_digest=digest(_case_fixture_value(case)),
+        )
+        for case in corpus.cases
+    )
+    source_inventory = sorted(
+        {
+            source_id
+            for case in cases
+            for source_id in case.source_inventory_ids
+        }
+    )
+    return replace(
+        corpus,
+        cases=cases,
+        query_set_digest=digest(
+            [
+                {
+                    "case_id": case.case_id,
+                    "query_valid_time": case.query_valid_time,
+                }
+                for case in cases
+            ]
+        ),
+        source_inventory_digest=digest(source_inventory),
+        dataset_manifest_digest=digest(
+            [
+                {
+                    "case_id": case.case_id,
+                    "family_id": case.family_id,
+                    "case_type": case.case_type,
+                    "language": case.language,
+                    "label_digest": case.label_digest,
+                    "fixture_digest": case.fixture_digest,
+                }
+                for case in cases
+            ]
+        ),
+    )
+
+
+def validate_qualification_corpus_content_identities(
+    corpus: QualificationCorpus,
+) -> None:
+    """Fail closed when supplied content reuses any stale stored identity."""
+
+    spec = thaw(CORPUS_SPEC)
+    if (
+        corpus.corpus_id != spec["corpus_id"]
+        or corpus.generator_version != spec["generator_version"]
+        or corpus.label_policy_digest != digest(spec["label_policy"])
+        or corpus.corpus_spec_digest != CORPUS_SPEC_DIGEST
+    ):
+        raise RetrievalQualificationError(
+            "qualification corpus policy identity differs"
+        )
+    if rederive_qualification_corpus(corpus) != corpus:
+        raise RetrievalQualificationError(
+            "qualification corpus content identities differ"
+        )
 
 
 def _candidate_count(case_type: str) -> int:
@@ -189,18 +286,6 @@ def load_qualification_corpus(
                 ).strftime("%Y-%m-%dT%H:%M:%SZ")
                 candidate_count = _candidate_count(case_type)
                 triage_labels = _triage_labels(case_type, candidate_count)
-                label = {
-                    "case_id": case_id,
-                    "family_id": family["family_id"],
-                    "case_type": case_type,
-                    "language": language,
-                    "query_valid_time": query_time,
-                    "expected_root": expected_root,
-                    "prohibited_root": prohibited_root,
-                    "slice_labels": sorted(slices),
-                    "triage_labels": list(triage_labels),
-                    "expected_candidate_count": candidate_count,
-                }
                 signals = _signals(case_type, language, sequence)
                 fixture_hits = tuple(
                     (mode, (expected_root,) if signals[mode] else ())
@@ -209,31 +294,28 @@ def load_qualification_corpus(
                 source_ids = (
                     f"fixture-source:{family['family_id'].lower()}",
                 )
-                fixture = {
-                    "case_id": case_id,
-                    "fixture_hits": [
-                        {"mode": mode.value, "roots": list(roots)}
-                        for mode, roots in fixture_hits
-                    ],
-                    "source_inventory_ids": list(source_ids),
-                }
+                case = QualificationCase(
+                    case_id=case_id,
+                    sequence=sequence,
+                    family_id=family["family_id"],
+                    case_type=case_type,
+                    language=language,
+                    query_valid_time=query_time,
+                    expected_root=expected_root,
+                    prohibited_root=prohibited_root,
+                    slice_labels=tuple(sorted(slices)),
+                    triage_labels=triage_labels,
+                    expected_candidate_count=candidate_count,
+                    fixture_hits=fixture_hits,
+                    source_inventory_ids=source_ids,
+                    label_digest="sha256:" + "0" * 64,
+                    fixture_digest="sha256:" + "0" * 64,
+                )
                 cases.append(
-                    QualificationCase(
-                        case_id=case_id,
-                        sequence=sequence,
-                        family_id=family["family_id"],
-                        case_type=case_type,
-                        language=language,
-                        query_valid_time=query_time,
-                        expected_root=expected_root,
-                        prohibited_root=prohibited_root,
-                        slice_labels=tuple(sorted(slices)),
-                        triage_labels=triage_labels,
-                        expected_candidate_count=candidate_count,
-                        fixture_hits=fixture_hits,
-                        source_inventory_ids=source_ids,
-                        label_digest=digest(label),
-                        fixture_digest=digest(fixture),
+                    replace(
+                        case,
+                        label_digest=digest(_case_label_value(case)),
+                        fixture_digest=digest(_case_fixture_value(case)),
                     )
                 )
     source_inventory = sorted(
@@ -243,7 +325,7 @@ def load_qualification_corpus(
             for source_id in case.source_inventory_ids
         }
     )
-    return QualificationCorpus(
+    corpus = QualificationCorpus(
         corpus_id=value["corpus_id"],
         generator_version=value["generator_version"],
         cases=tuple(cases),
@@ -273,3 +355,5 @@ def load_qualification_corpus(
         ),
         corpus_spec_digest=CORPUS_SPEC_DIGEST,
     )
+    validate_qualification_corpus_content_identities(corpus)
+    return corpus

--- a/newsroom/increment5/_retrieval_qualification_evaluator.py
+++ b/newsroom/increment5/_retrieval_qualification_evaluator.py
@@ -34,6 +34,14 @@ from ._retrieval_qualification_measurement import (
     _system_metrics,
 )
 from .evaluation_plan import INCREMENT_5_EVALUATION_PLAN
+from ._retrieval_qualification_run import build_qualification_epoch
+
+
+_CROSS_SYSTEM_SAFETY_OR_RIGHTS_METRICS = (
+    "rights_purge_residual_count",
+    "scope_escape_count",
+    "write_attempt_success_count",
+)
 
 
 class RetrievalQualificationEvaluator:
@@ -46,6 +54,7 @@ class RetrievalQualificationEvaluator:
         target: QualificationTarget,
         corpus: QualificationCorpus,
         epoch: QualificationEpoch,
+        code_tree_sha: str,
         observations: Sequence[QualificationObservation],
         started_at: str,
         completed_at: str,
@@ -55,18 +64,13 @@ class RetrievalQualificationEvaluator:
                 raise ValueError
         except ValueError as exc:
             raise RetrievalQualificationError("run_id must be a UUID") from exc
-        if (
-            epoch.contract_digest != target.contract_digest
-            or epoch.evaluation_plan_digest != target.evaluation_plan_digest
-            or epoch.target_manifest_digest != target.manifest_digest
-            or epoch.component_digests != target.component_digests
-            or epoch.source_inventory_digest != corpus.source_inventory_digest
-            or epoch.query_set_digest != corpus.query_set_digest
-            or epoch.dataset_manifest_digest != corpus.dataset_manifest_digest
-            or epoch.label_adjudication_policy_digest
-            != corpus.label_policy_digest
-            or epoch.generation_id != target.generation_id
-        ):
+        expected_epoch = build_qualification_epoch(
+            target=target,
+            corpus=corpus,
+            code_tree_sha=code_tree_sha,
+            epoch_id=epoch.epoch_id,
+        )
+        if epoch != expected_epoch:
             raise RetrievalQualificationError("Epoch binding differs")
         parse_utc(started_at, field="started_at")
         parse_utc(completed_at, field="completed_at")
@@ -161,13 +165,6 @@ class RetrievalQualificationEvaluator:
                     <= thresholds["p95_latency_ms_max"]
                 ),
                 "false_no_match_count": hybrid["false_no_match_count"] == 0,
-                "rights_purge_residual_count": (
-                    hybrid["rights_purge_residual_count"] == 0
-                ),
-                "scope_escape_count": hybrid["scope_escape_count"] == 0,
-                "write_attempt_success_count": (
-                    hybrid["write_attempt_success_count"] == 0
-                ),
                 "temporal_correctness_error_count": (
                     hybrid["temporal_correctness_error_count"] == 0
                 ),
@@ -179,6 +176,13 @@ class RetrievalQualificationEvaluator:
                 f"TARGET_THRESHOLD:{name}"
                 for name, passed in threshold_checks.items()
                 if not passed
+            )
+            blockers.extend(
+                "EXECUTED_SYSTEM_SAFETY_OR_RIGHTS:"
+                f"{system['system']}:{metric}"
+                for system in systems
+                for metric in _CROSS_SYSTEM_SAFETY_OR_RIGHTS_METRICS
+                if system[metric] != 0
             )
             families, slices, family_blockers = _family_metrics(
                 corpus,

--- a/newsroom/increment5/_retrieval_qualification_run.py
+++ b/newsroom/increment5/_retrieval_qualification_run.py
@@ -20,6 +20,12 @@ from ._retrieval_qualification_contracts import (
     QualificationEpoch,
     QualificationTarget,
 )
+from ._retrieval_qualification_corpus import (
+    validate_qualification_corpus_content_identities,
+)
+from ._retrieval_qualification_target import (
+    validate_qualification_target_identity,
+)
 from ._retrieval_qualification_evidence import QualificationObservation
 from .evaluation_plan import INCREMENT_5_EVALUATION_PLAN
 
@@ -30,6 +36,23 @@ def build_qualification_epoch(
     corpus: QualificationCorpus,
     code_tree_sha: str,
     epoch_id: str = "increment5-retrieval-qualification-epoch-v1",
+) -> QualificationEpoch:
+    validate_qualification_target_identity(target)
+    validate_qualification_corpus_content_identities(corpus)
+    return _derive_qualification_epoch(
+        target=target,
+        corpus=corpus,
+        code_tree_sha=code_tree_sha,
+        epoch_id=epoch_id,
+    )
+
+
+def _derive_qualification_epoch(
+    *,
+    target: QualificationTarget,
+    corpus: QualificationCorpus,
+    code_tree_sha: str,
+    epoch_id: str,
 ) -> QualificationEpoch:
     plan = thaw(INCREMENT_5_EVALUATION_PLAN)
     return QualificationEpoch(
@@ -115,6 +138,8 @@ def run_fixture_qualification(
     target: QualificationTarget,
     corpus: QualificationCorpus,
 ) -> tuple[QualificationObservation, ...]:
+    validate_qualification_target_identity(target)
+    validate_qualification_corpus_content_identities(corpus)
     system_mode = {
         QualificationSystem.EXACT_ONLY: QualificationMode.EXACT,
         QualificationSystem.FULL_TEXT_ONLY: QualificationMode.FULL_TEXT,

--- a/newsroom/increment5/_retrieval_qualification_target.py
+++ b/newsroom/increment5/_retrieval_qualification_target.py
@@ -111,3 +111,12 @@ def load_qualification_target(
         vector_scope=value["vector_scope"],
         manifest_digest=TARGET_SPEC_DIGEST,
     )
+
+
+def validate_qualification_target_identity(target: QualificationTarget) -> None:
+    """Require the exact repository-admitted v1 target at every run boundary."""
+
+    if target != load_qualification_target():
+        raise RetrievalQualificationError(
+            "qualification target identity differs from reviewed v1"
+        )

--- a/newsroom/increment5/final_closeout.py
+++ b/newsroom/increment5/final_closeout.py
@@ -1,0 +1,740 @@
+"""Closed-world evidence inventory for the final Increment 5 Tier-M gate."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from ._retrieval_qualification_common import digest, require_token
+from ._traceability_model import RETRIEVAL_QUALIFICATION_REQUIREMENTS
+
+
+class FinalCloseoutLane(StrEnum):
+    DETERMINISTIC = "DETERMINISTIC"
+    ACTUAL_NEO4J = "ACTUAL_NEO4J"
+
+
+class FinalCloseoutCategory(StrEnum):
+    QUERY_CONTAINMENT = "QUERY_CONTAINMENT"
+    RIGHTS_PURGE = "RIGHTS_PURGE"
+    GRAPH_INDEX_RECOVERY = "GRAPH_INDEX_RECOVERY"
+    FAILURE_NO_FALSE_SUCCESS = "FAILURE_NO_FALSE_SUCCESS"
+    REPLAY_CONTEXT_INTEGRITY = "REPLAY_CONTEXT_INTEGRITY"
+    QUALIFICATION_IDENTITY = "QUALIFICATION_IDENTITY"
+
+
+INCREMENT5_FINAL_REQUIREMENTS = RETRIEVAL_QUALIFICATION_REQUIREMENTS
+
+
+@dataclass(frozen=True, slots=True)
+class FinalCloseoutCase:
+    case_id: str
+    category: FinalCloseoutCategory
+    lane: FinalCloseoutLane
+    test_id: str
+    requirements: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        require_token(self.case_id, field="closeout case_id")
+        if (
+            not self.test_id.startswith("newsroom.tests.test_")
+            or "::test_" not in self.test_id
+            or len(self.test_id) > 512
+        ):
+            raise RuntimeError("closeout test identity is not canonical")
+        if (
+            self.requirements != tuple(sorted(set(self.requirements)))
+            or not self.requirements
+            or not set(self.requirements) <= INCREMENT5_FINAL_REQUIREMENTS
+        ):
+            raise RuntimeError("closeout requirement inventory differs")
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "case_id": self.case_id,
+            "category": self.category.value,
+            "lane": self.lane.value,
+            "test_id": self.test_id,
+            "requirements": list(self.requirements),
+        }
+
+
+def _case(
+    case_id: str,
+    category: FinalCloseoutCategory,
+    lane: FinalCloseoutLane,
+    module: str,
+    test_name: str,
+    *requirements: str,
+) -> FinalCloseoutCase:
+    return FinalCloseoutCase(
+        case_id=case_id,
+        category=category,
+        lane=lane,
+        test_id=f"newsroom.tests.{module}::{test_name}",
+        requirements=tuple(sorted(requirements)),
+    )
+
+
+_D = FinalCloseoutLane.DETERMINISTIC
+_A = FinalCloseoutLane.ACTUAL_NEO4J
+_Q = FinalCloseoutCategory.QUERY_CONTAINMENT
+_R = FinalCloseoutCategory.RIGHTS_PURGE
+_G = FinalCloseoutCategory.GRAPH_INDEX_RECOVERY
+_F = FinalCloseoutCategory.FAILURE_NO_FALSE_SUCCESS
+_P = FinalCloseoutCategory.REPLAY_CONTEXT_INTEGRITY
+_I = FinalCloseoutCategory.QUALIFICATION_IDENTITY
+
+
+INCREMENT5E2_FINAL_CLOSEOUT_CASES = tuple(
+    sorted(
+        (
+            # Bounded named surface, injection, scope and credential containment.
+            _case(
+                "Q01_STRICT_REQUEST",
+                _Q,
+                _D,
+                "test_increment5c1_named_tool_contracts",
+                "test_unknown_or_extra_fields_fail_closed",
+                "GRPROD-015",
+            ),
+            _case(
+                "Q02_DUPLICATE_KEYS",
+                _Q,
+                _D,
+                "test_increment5c1_named_tool_contracts",
+                "test_duplicate_json_keys_fail_closed",
+                "GRPROD-015",
+            ),
+            _case(
+                "Q03_QUERY_IS_DATA",
+                _Q,
+                _D,
+                "test_increment5c1_named_tool_contracts",
+                "test_fulltext_query_is_bounded_data_and_cannot_select_another_tool",
+                "GRPROD-015",
+                "GRPROD-023",
+            ),
+            _case(
+                "Q04_NO_MODEL_CREDENTIAL_SURFACE",
+                _Q,
+                _D,
+                "test_increment5c1_named_tool_contracts",
+                "test_vector_request_has_no_arbitrary_vector_or_model_surface",
+                "GRPROD-015",
+                "GRPROD-023",
+            ),
+            _case(
+                "Q05_SCOPE_CONTAINMENT",
+                _Q,
+                _D,
+                "test_increment5c1_named_tool_contracts",
+                "test_typed_scope_cannot_be_widened_by_payload_or_query_content",
+                "GRPROD-015",
+                "GRPROD-023",
+            ),
+            _case(
+                "Q06_AUTHORISE_BEFORE_DISPATCH",
+                _Q,
+                _D,
+                "test_increment5c2_named_tool_authority_execution",
+                "test_authorization_precedes_authority_dispatch",
+                "GRPROD-015",
+            ),
+            _case(
+                "Q07_NO_QUERY_OR_WRITE_SURFACE",
+                _Q,
+                _D,
+                "test_increment5c2_named_tool_authority_execution",
+                "test_authority_modules_expose_no_raw_query_or_write_surface",
+                "GRPROD-015",
+                "GRPROD-023",
+            ),
+            _case(
+                "Q08_PRINCIPAL_CONFUSION",
+                _Q,
+                _D,
+                "test_increment5d1_hybrid_composer",
+                "test_composition_rejects_cross_principal_receipt_mixing",
+                "GRAG-056",
+            ),
+            _case(
+                "AQ01_FIXED_READ_PORT",
+                _Q,
+                _A,
+                "test_increment5b4_neo4j_service",
+                "test_increment5b4_fixed_port_reads_only_exact_generation_and_allowed_state",
+                "GRPROD-015",
+                "GRPROD-023",
+            ),
+            _case(
+                "AQ02_WRONG_CREDENTIAL",
+                _Q,
+                _A,
+                "test_projection_b2_neo4j_service",
+                "test_actual_service_wrong_projector_credential_fails_closed_without_secret",
+                "GRPROD-015",
+            ),
+            # Current rights checks, serving-derivative purge and non-resurrection.
+            _case(
+                "R01_AUTHORITY_RIGHTS_BLOCK",
+                _R,
+                _D,
+                "test_increment5c2_named_tool_authority_execution",
+                "test_rights_or_lifecycle_block_is_explicit_policy_block",
+                "GRAG-056",
+            ),
+            _case(
+                "R02_CONTEXT_RIGHTS_WITHDRAWAL",
+                _R,
+                _D,
+                "test_increment5d2_retrieval_context",
+                "test_current_rights_withdrawal_blocks_context_before_hydration",
+                "GRAG-056",
+            ),
+            _case(
+                "R03_GOVERNED_BLOB_TAMPER",
+                _R,
+                _D,
+                "test_increment5d2_retrieval_context",
+                "test_governed_blob_tamper_is_integrity_blocked",
+                "GRAG-056",
+            ),
+            _case(
+                "R04_RETAINED_CONTEXT_PURGE",
+                _R,
+                _D,
+                "test_increment5d2_retrieval_context",
+                "test_rights_purge_removes_retained_context_and_tombstone_blocks_replay",
+                "GRAG-056",
+                "GRPROD-015",
+            ),
+            _case(
+                "R05_EXACT_INDEX_REMOVALS",
+                _R,
+                _D,
+                "test_complete_projection_2b_source_store",
+                "test_revoked_evidence_is_never_upserted_and_emits_both_index_removals",
+                "GRAG-056",
+                "GRPROD-015",
+            ),
+            _case(
+                "R06_GOVERNED_BYTES_NON_RESURRECTION",
+                _R,
+                _D,
+                "test_authority_a2b_lifecycle",
+                "test_ordered_lifecycle_events_and_deletion_non_resurrection",
+                "GRAG-056",
+                "GRPROD-015",
+            ),
+            _case(
+                "R07_DERIVATIVE_TOMBSTONE_NEW_IDENTITY",
+                _R,
+                _D,
+                "test_increment5d2_retrieval_context",
+                "test_rights_purge_blocks_new_request_identity_before_rehydration",
+                "GRAG-056",
+                "GRPROD-015",
+            ),
+            _case(
+                "R08_PURGE_SAFE_STORAGE",
+                _R,
+                _D,
+                "test_increment5d2_retrieval_context",
+                "test_rights_purge_rejects_wal_mode_without_false_success",
+                "GRAG-056",
+                "GRPROD-015",
+            ),
+            _case(
+                "R09_EXACT_DERIVATIVE_TOMBSTONE",
+                _R,
+                _D,
+                "test_increment5d2_retrieval_context",
+                "test_rights_purge_does_not_tombstone_unselected_sibling_derivative",
+                "GRAG-056",
+                "GRPROD-015",
+            ),
+            _case(
+                "AR01_RIGHTS_TOMBSTONE_PURGE",
+                _R,
+                _A,
+                "test_complete_projection_2b_neo4j_service",
+                "test_actual_service_revocation_and_tombstone_remove_current_derivatives",
+                "GRAG-056",
+            ),
+            _case(
+                "AR02_DELETION_NO_REQUALIFICATION",
+                _R,
+                _A,
+                "test_increment_2d_neo4j_service",
+                "test_actual_service_governed_deletion_purges_derivative_and_never_requalifies",
+                "GRAG-056",
+                "GRPROD-015",
+            ),
+            _case(
+                "AR03_RELATION_REVOCATION",
+                _R,
+                _A,
+                "test_increment_2d_neo4j_service",
+                "test_actual_service_relation_revocation_changes_later_context_without_rewrite",
+                "GRAG-056",
+            ),
+            _case(
+                "AR04_TOMBSTONE_NON_RESURRECTION",
+                _R,
+                _A,
+                "test_projection_b3_neo4j_service",
+                "test_actual_service_tombstone_does_not_resurrect_after_wipe_rebuild",
+                "GRAG-056",
+            ),
+            # Deterministic and actual-service graph/index replacement recovery.
+            _case(
+                "G01_AUTHORITY_ONLY_REBUILD",
+                _G,
+                _D,
+                "test_projection_b3_rebuild",
+                "test_rebuild_clears_target_and_replays_retained_authority",
+                "GRAG-056",
+                "GRPROD-015",
+            ),
+            _case(
+                "G02_REBUILD_NO_NEW_AUTHORITY",
+                _G,
+                _D,
+                "test_projection_b3_rebuild",
+                "test_exact_rebuild_replay_restores_graph_without_new_authority_events",
+                "GRAG-056",
+            ),
+            _case(
+                "G03_GENERATION_SCOPED_CLEANUP",
+                _G,
+                _D,
+                "test_projection_b3_rebuild",
+                "test_rebuild_cleanup_is_generation_scoped",
+                "GRPROD-015",
+            ),
+            _case(
+                "G04_CHECKPOINT_CONTAINMENT",
+                _G,
+                _D,
+                "test_projection_b3_rebuild",
+                "test_rebuild_target_cannot_precede_authoritative_checkpoint",
+                "GRAG-056",
+                "GRPROD-015",
+            ),
+            _case(
+                "AG01_GRAPH_LOSS_RESTART",
+                _G,
+                _A,
+                "test_projection_b3_neo4j_service",
+                "test_actual_service_graph_loss_and_process_restart_rebuild_from_authority",
+                "GRAG-056",
+                "GRPROD-015",
+            ),
+            _case(
+                "AG02_REBUILD_NAMESPACE",
+                _G,
+                _A,
+                "test_projection_b3_neo4j_service",
+                "test_actual_service_rebuild_cleanup_cannot_cross_generation_namespace",
+                "GRAG-056",
+                "GRPROD-015",
+            ),
+            _case(
+                "AG03_ISOLATED_REPLACEMENT",
+                _G,
+                _A,
+                "test_increment4e_neo4j_service",
+                "test_actual_service_increment4_graph_loss_requires_isolated_replacement",
+                "GRAG-056",
+                "GRPROD-015",
+            ),
+            _case(
+                "AG04_AUTHORITY_REPLACEMENT",
+                _G,
+                _A,
+                "test_complete_projection_2b_neo4j_service",
+                "test_actual_service_replacement_generation_recovers_from_authority_only",
+                "GRAG-056",
+                "GRPROD-015",
+            ),
+            _case(
+                "AG05_GENERATION_WATERMARK_INDEX",
+                _G,
+                _A,
+                "test_complete_projection_2b_neo4j_service",
+                "test_actual_service_wrong_watermark_generation_and_vector_dimension_fail_closed",
+                "GRPROD-001",
+                "GRPROD-015",
+            ),
+            _case(
+                "AG06_FULLTEXT_CONTRACT",
+                _G,
+                _A,
+                "test_complete_projection_2b_neo4j_service",
+                "test_actual_service_partial_or_contract_mismatched_state_fails_closed[wrong-fulltext-analyzer]",
+                "GRPROD-001",
+                "GRPROD-010",
+                "GRPROD-015",
+            ),
+            # Missing, stale, corrupt or incomplete evidence never becomes success.
+            _case(
+                "F01_MANDATORY_BRANCH_ABSENT",
+                _F,
+                _D,
+                "test_increment5d1_hybrid_composer",
+                "test_missing_mandatory_branch_is_incomplete_not_no_match",
+                "GRPROD-001",
+                "GRPROD-023",
+            ),
+            _case(
+                "F02_STALE_WATERMARK",
+                _F,
+                _D,
+                "test_increment5d2_retrieval_context",
+                "test_stale_authority_watermark_is_not_complete_or_no_match",
+                "GRAG-056",
+            ),
+            _case(
+                "F03_NO_MATCH_WITHOUT_CURRENT_COLLISION",
+                _F,
+                _D,
+                "test_increment5d2_retrieval_context",
+                "test_complete_no_match_requires_current_unoccupied_collision[False]",
+                "GRAG-056",
+                "GRPROD-001",
+            ),
+            _case(
+                "F04_NO_MATCH_WITH_CURRENT_COLLISION",
+                _F,
+                _D,
+                "test_increment5d2_retrieval_context",
+                "test_complete_no_match_requires_current_unoccupied_collision[True]",
+                "GRAG-056",
+                "GRPROD-001",
+            ),
+            _case(
+                "F05_AUTHORITY_RECEIPT_TAMPER",
+                _F,
+                _D,
+                "test_increment5d2_retrieval_context",
+                "test_tampered_authority_receipt_is_integrity_blocked",
+                "GRAG-056",
+                "GRPROD-015",
+            ),
+            _case(
+                "AF01_MISSING_FULLTEXT",
+                _F,
+                _A,
+                "test_retrieval_2c_neo4j_service",
+                "test_actual_service_missing_fulltext_index_is_unavailable_not_no_match",
+                "GRPROD-001",
+                "GRPROD-015",
+                "GRPROD-023",
+            ),
+            _case(
+                "AF02_MISSING_VECTOR",
+                _F,
+                _A,
+                "test_retrieval_2c_neo4j_service",
+                "test_actual_service_missing_vector_index_is_unavailable_not_no_match",
+                "GRPROD-001",
+                "GRPROD-015",
+                "GRPROD-023",
+            ),
+            _case(
+                "AF03_MISSING_GRAPH",
+                _F,
+                _A,
+                "test_retrieval_2c_neo4j_service",
+                "test_actual_service_missing_admitted_relation_is_incomplete_not_no_match",
+                "GRPROD-001",
+                "GRPROD-015",
+                "GRPROD-023",
+            ),
+            _case(
+                "AF04_REQUIRED_GAP",
+                _F,
+                _A,
+                "test_increment_2d_neo4j_service",
+                "test_actual_service_required_gap_blocks_complete_candidate_proof",
+                "GRAG-056",
+                "GRPROD-015",
+            ),
+            _case(
+                "AF05_DEAD_LETTER",
+                _F,
+                _A,
+                "test_increment_2d_neo4j_service",
+                "test_actual_service_dead_letter_blocks_complete_candidate_proof",
+                "GRAG-056",
+                "GRPROD-015",
+            ),
+            _case(
+                "AF06_LOST_FULLTEXT",
+                _F,
+                _A,
+                "test_increment_2d_neo4j_service",
+                "test_actual_service_complete_proof_fails_closed_when_required_surface_is_lost[fulltext]",
+                "GRPROD-001",
+                "GRPROD-015",
+            ),
+            _case(
+                "AF07_LOST_RELATION",
+                _F,
+                _A,
+                "test_increment_2d_neo4j_service",
+                "test_actual_service_complete_proof_fails_closed_when_required_surface_is_lost[relation]",
+                "GRPROD-001",
+                "GRPROD-015",
+            ),
+            _case(
+                "AF08_LOST_VECTOR",
+                _F,
+                _A,
+                "test_increment_2d_neo4j_service",
+                "test_actual_service_complete_proof_fails_closed_when_required_surface_is_lost[vector]",
+                "GRPROD-001",
+                "GRPROD-015",
+            ),
+            # Byte-identical replay, restart and retained-context integrity.
+            _case(
+                "P01_CONTEXT_REPLAY",
+                _P,
+                _D,
+                "test_increment5d2_retrieval_context",
+                "test_complete_context_replays_and_hydrates_exact_governed_bytes",
+                "GRAG-056",
+                "GRPROD-001",
+            ),
+            _case(
+                "P02_JOURNAL_RESTART",
+                _P,
+                _D,
+                "test_increment5d1_hybrid_composer",
+                "test_journal_restart_replays_exact_bytes_and_rejects_conflict",
+                "GRAG-056",
+                "GRPROD-001",
+            ),
+            _case(
+                "P03_CONTEXT_JOURNAL_RESTART",
+                _P,
+                _D,
+                "test_increment5d2_retrieval_context",
+                "test_retained_context_restart_replays_exact_bytes",
+                "GRAG-056",
+                "GRPROD-001",
+            ),
+            _case(
+                "P04_CONTEXT_JOURNAL_TAMPER",
+                _P,
+                _D,
+                "test_increment5d2_retrieval_context",
+                "test_retained_context_tamper_is_integrity_blocked",
+                "GRAG-056",
+                "GRPROD-015",
+            ),
+            _case(
+                "AP01_ACTUAL_REPLAY_RESTART",
+                _P,
+                _A,
+                "test_increment_2d_neo4j_service",
+                "test_actual_service_complete_increment_2_proof_admits_replays_and_restarts",
+                "GRAG-056",
+                "GRPROD-001",
+                "GRPROD-015",
+                "GRPROD-023",
+            ),
+            _case(
+                "AP02_RETAINED_CONTEXT_RECOVERY",
+                _P,
+                _A,
+                "test_integrated_c1_neo4j_service",
+                "test_actual_service_integrated_foundation_replay_recovery_and_tombstone",
+                "GRAG-056",
+                "GRPROD-015",
+            ),
+            # Qualification target, corpus and every derived Epoch identity.
+            _case(
+                "I01_FIVE_SYSTEM_QUALIFICATION",
+                _I,
+                _D,
+                "test_increment5e1_retrieval_qualification",
+                "test_complete_fixture_qualification_is_pass_and_ablations_are_separate",
+                "GRAG-050",
+                "GRAG-051",
+                "GRAG-054",
+                "GRAG-055",
+                "GRPROD-001",
+                "GRPROD-010",
+                "GRPROD-015",
+                "GRPROD-023",
+            ),
+            _case(
+                "I02_GRAPH_RIGHTS",
+                _I,
+                _D,
+                "test_increment5e1_retrieval_qualification",
+                "test_safety_and_rights_violations_in_any_executed_system_block[ADMITTED_GRAPH_ONLY-change0]",
+                "GRAG-056",
+            ),
+            _case(
+                "I03_EXACT_RIGHTS",
+                _I,
+                _D,
+                "test_increment5e1_retrieval_qualification",
+                "test_safety_and_rights_violations_in_any_executed_system_block[EXACT_ONLY-change1]",
+                "GRAG-056",
+            ),
+            _case(
+                "I04_FULLTEXT_RIGHTS",
+                _I,
+                _D,
+                "test_increment5e1_retrieval_qualification",
+                "test_safety_and_rights_violations_in_any_executed_system_block[FULL_TEXT_ONLY-change2]",
+                "GRAG-056",
+            ),
+            _case(
+                "I05_VECTOR_RIGHTS",
+                _I,
+                _D,
+                "test_increment5e1_retrieval_qualification",
+                "test_safety_and_rights_violations_in_any_executed_system_block[VECTOR_ONLY-change3]",
+                "GRAG-056",
+            ),
+            _case(
+                "I06_CORPUS_CONTENT_IDENTITY",
+                _I,
+                _D,
+                "test_increment5e1_retrieval_qualification",
+                "test_caller_modified_corpus_cannot_reuse_stale_content_identities",
+                "GRAG-054",
+                "GRAG-055",
+                "GRAG-056",
+            ),
+            _case(
+                "I07_SOURCE_PROVIDER_IDENTITY",
+                _I,
+                _D,
+                "test_increment5e1_retrieval_qualification",
+                "test_every_derived_epoch_identity_is_revalidated_before_evaluation[source_provider_versions_digest]",
+                "GRAG-050",
+                "GRAG-056",
+            ),
+            _case(
+                "I08_ADAPTER_PARSER_IDENTITY",
+                _I,
+                _D,
+                "test_increment5e1_retrieval_qualification",
+                "test_every_derived_epoch_identity_is_revalidated_before_evaluation[adapter_parser_versions_digest]",
+                "GRAG-050",
+                "GRAG-056",
+            ),
+            _case(
+                "I09_THRESHOLD_IDENTITY",
+                _I,
+                _D,
+                "test_increment5e1_retrieval_qualification",
+                "test_every_derived_epoch_identity_is_revalidated_before_evaluation[threshold_set_digest]",
+                "GRAG-050",
+                "GRAG-056",
+            ),
+            _case(
+                "I10_POLICY_IDENTITY",
+                _I,
+                _D,
+                "test_increment5e1_retrieval_qualification",
+                "test_every_derived_epoch_identity_is_revalidated_before_evaluation[policy_set_digest]",
+                "GRAG-050",
+                "GRAG-056",
+            ),
+            _case(
+                "I11_CODE_TREE_AND_TARGET",
+                _I,
+                _D,
+                "test_increment5e1_retrieval_qualification",
+                "test_epoch_code_tree_and_exact_target_are_independently_revalidated",
+                "GRAG-050",
+                "GRPROD-010",
+                "GRPROD-015",
+            ),
+            _case(
+                "AI01_EXACT_TARGET_REPORT",
+                _I,
+                _A,
+                "test_projection_b2_increment5e2_neo4j_service",
+                "test_actual_service_increment5e2_target_and_report",
+                *sorted(INCREMENT5_FINAL_REQUIREMENTS),
+            ),
+        ),
+        key=lambda item: item.case_id,
+    )
+)
+
+
+INCREMENT5E2_FINAL_CLOSEOUT_INVENTORY_DIGEST = digest(
+    [case.canonical_value() for case in INCREMENT5E2_FINAL_CLOSEOUT_CASES]
+)
+
+INCREMENT5E2_FINAL_NON_EFFECTS = (
+    "NO_LIVE_AUTHORITY_MUTATION",
+    "NO_LIVE_CANDIDATE_OR_HYPOTHESIS_EFFECT",
+    "NO_LIVE_SOURCE_OR_PRODUCTION_PRODUCT_CREDENTIAL_USE",
+    "NO_LIVE_SOURCE_OR_PROVIDER_CALL",
+    "NO_MODEL_OR_EMBEDDING_CALL",
+    "NO_PRODUCT_RUNTIME_NETWORK_EGRESS_OR_SPEND",
+    "NO_PUBLICATION_OR_PRODUCTION_ACTIVATION",
+    "NO_SHADOW_OR_CANARY_ACTIVATION",
+)
+
+
+def validate_increment5e2_final_closeout_inventory() -> None:
+    case_ids = tuple(case.case_id for case in INCREMENT5E2_FINAL_CLOSEOUT_CASES)
+    test_ids = tuple(case.test_id for case in INCREMENT5E2_FINAL_CLOSEOUT_CASES)
+    if (
+        case_ids != tuple(sorted(case_ids))
+        or len(case_ids) != len(set(case_ids))
+        or len(test_ids) != len(set(test_ids))
+    ):
+        raise RuntimeError("final closeout cases are not closed and unique")
+    if {case.category for case in INCREMENT5E2_FINAL_CLOSEOUT_CASES} != set(
+        FinalCloseoutCategory
+    ):
+        raise RuntimeError("final closeout category inventory differs")
+    if {case.lane for case in INCREMENT5E2_FINAL_CLOSEOUT_CASES} != set(
+        FinalCloseoutLane
+    ):
+        raise RuntimeError("final closeout lane inventory differs")
+    if {
+        requirement
+        for case in INCREMENT5E2_FINAL_CLOSEOUT_CASES
+        for requirement in case.requirements
+    } != INCREMENT5_FINAL_REQUIREMENTS:
+        raise RuntimeError("final closeout requirement coverage differs")
+    for category in FinalCloseoutCategory:
+        lanes = {
+            case.lane
+            for case in INCREMENT5E2_FINAL_CLOSEOUT_CASES
+            if case.category is category
+        }
+        if lanes != set(FinalCloseoutLane):
+            raise RuntimeError(
+                f"final closeout category lacks both evidence lanes: {category.value}"
+            )
+    if INCREMENT5E2_FINAL_NON_EFFECTS != tuple(sorted(INCREMENT5E2_FINAL_NON_EFFECTS)):
+        raise RuntimeError("final closeout non-effects are not canonical")
+
+
+validate_increment5e2_final_closeout_inventory()
+
+
+__all__ = [
+    "FinalCloseoutCase",
+    "FinalCloseoutCategory",
+    "FinalCloseoutLane",
+    "INCREMENT5E2_FINAL_CLOSEOUT_CASES",
+    "INCREMENT5E2_FINAL_CLOSEOUT_INVENTORY_DIGEST",
+    "INCREMENT5E2_FINAL_NON_EFFECTS",
+    "INCREMENT5_FINAL_REQUIREMENTS",
+    "validate_increment5e2_final_closeout_inventory",
+]

--- a/newsroom/increment5/retrieval_qualification.py
+++ b/newsroom/increment5/retrieval_qualification.py
@@ -19,7 +19,10 @@ from ._retrieval_qualification_run import (
     build_qualification_epoch,
     run_fixture_qualification,
 )
-from ._retrieval_qualification_corpus import load_qualification_corpus
+from ._retrieval_qualification_corpus import (
+    load_qualification_corpus,
+    rederive_qualification_corpus,
+)
 from ._retrieval_qualification_target import load_qualification_target
 from ._retrieval_qualification_journal import QualificationReportJournal
 from ._retrieval_qualification_evaluator import RetrievalQualificationEvaluator
@@ -67,4 +70,5 @@ __all__ = [
     "load_qualification_corpus",
     "load_qualification_target",
     "run_fixture_qualification",
+    "rederive_qualification_corpus",
 ]

--- a/newsroom/tests/test_increment5d2_retrieval_context.py
+++ b/newsroom/tests/test_increment5d2_retrieval_context.py
@@ -218,6 +218,47 @@ def _retarget_seeded_passage(
     return blob_digest
 
 
+def _retarget_seeded_passage_to_existing_blob(
+    connection: sqlite3.Connection,
+    *,
+    admission_id: str,
+    passage_id: str,
+    content: bytes,
+    blob_digest: str,
+    language: str = "ZH_HANT_HK",
+) -> None:
+    size = len(content)
+    assert connection.execute(
+        "SELECT size_bytes FROM blob_identities WHERE blob_digest=?",
+        (blob_digest,),
+    ).fetchone() == (size,)
+    connection.execute(
+        "UPDATE object_admissions SET blob_digest=? WHERE admission_id=?",
+        (blob_digest, admission_id),
+    )
+    connection.execute(
+        "UPDATE object_rights_decisions SET blob_digest=?,size_bytes=? "
+        "WHERE rights_decision_id=?",
+        (blob_digest, size, f"rights:{admission_id}"),
+    )
+    connection.execute(
+        "UPDATE object_access_decisions SET byte_offset=0,allowed_bytes=? "
+        "WHERE admission_id=?",
+        (size, admission_id),
+    )
+    connection.execute(
+        "UPDATE extraction_run_passages SET byte_offset=0,byte_length=?,"
+        "blob_digest=?,text_digest=?,language=? WHERE passage_id=?",
+        (
+            size,
+            blob_digest,
+            digest_bytes(content),
+            language,
+            passage_id,
+        ),
+    )
+
+
 def _authority_database(
     tmp_path: Path,
     *,
@@ -898,7 +939,11 @@ def test_rights_purge_does_not_tombstone_unselected_sibling_derivative(
     admission_a = "object:retained-a"
     admission_b = "object:retained-b"
     content_a = b"governed retained bytes A"
-    content_b = b"governed retained bytes B"
+    # A rights withdrawal is scoped by the selected authority identity, not by
+    # content deduplication.  A separately admitted sibling may legitimately
+    # bind the same governed bytes and must remain usable until its own scope is
+    # withdrawn.
+    content_b = content_a
     database, blob_a = _authority_database(
         tmp_path,
         name="purge-sibling",
@@ -915,11 +960,12 @@ def test_rights_purge_does_not_tombstone_unselected_sibling_derivative(
             run_id="run:purge-sibling:b",
             allowed=1,
         )
-        blob_b = _retarget_seeded_passage(
+        _retarget_seeded_passage_to_existing_blob(
             connection,
             admission_id=admission_b,
             passage_id=passage_b,
             content=content_b,
+            blob_digest=blob_a,
         )
     cas_root = _cas_root(
         tmp_path,
@@ -927,11 +973,6 @@ def test_rights_purge_does_not_tombstone_unselected_sibling_derivative(
         blob_digest=blob_a,
         content=content_a,
     )
-    digest_hex = blob_b.removeprefix("sha256:")
-    blob_b_path = cas_root / "objects" / digest_hex[:2] / digest_hex
-    blob_b_path.parent.mkdir(exist_ok=True)
-    blob_b_path.write_bytes(content_b)
-    blob_b_path.chmod(0o444)
     authority_request_ab, authority_result_ab = _authority_execution(
         tmp_path,
         name="purge-sibling-ab",
@@ -956,6 +997,10 @@ def test_rights_purge_does_not_tombstone_unselected_sibling_derivative(
     receipt_ab = builder_ab.execute(request_ab)
     assert receipt_ab.outcome is RetrievalContextOutcome.COMPLETE
     assert len(receipt_ab.items) == 2
+    assert {
+        (item.passage.blob_digest, item.passage.text_digest)
+        for item in receipt_ab.items
+    } == {(blob_a, receipt_ab.items[0].passage.text_digest)}
     item_a = next(
         item for item in receipt_ab.items if item.passage.admission_id == admission_a
     )
@@ -1005,6 +1050,44 @@ def test_rights_purge_does_not_tombstone_unselected_sibling_derivative(
     assert receipt_b.items[0].text.encode("utf-8") == content_b
 
     restarted = RetrievalContextJournal(journal.path)
+    replayed_b = RetrievalContextBuilder(
+        composition_replayer=composer_b,
+        journal=restarted,
+        hydrator=GovernedCasPassageHydrator(cas_root),
+    ).execute(request_b)
+    assert replayed_b.canonical_bytes == receipt_b.canonical_bytes
+
+    class ExplodingHydrator:
+        implementation_digest = GOVERNED_CAS_HYDRATOR_CONTRACT_DIGEST
+
+        @staticmethod
+        def read(_reference) -> bytes:
+            raise AssertionError("purged sibling bytes must not be rehydrated")
+
+    digest_journal = RetrievalContextJournal(
+        tmp_path / "context-purge-shared-blob.sqlite"
+    )
+    digest_receipt_ab = RetrievalContextBuilder(
+        composition_replayer=composer_ab,
+        journal=digest_journal,
+        hydrator=GovernedCasPassageHydrator(cas_root),
+    ).execute(request_ab)
+    assert digest_receipt_ab.outcome is RetrievalContextOutcome.COMPLETE
+    digest_purges = digest_journal.purge_affected(
+        blob_digests=(blob_a,),
+        reason_code="GOVERNED_BLOB_WITHDRAWN",
+    )
+    assert len(digest_purges) == 1
+    assert set(digest_purges[0].admission_ids) == {admission_a, admission_b}
+    assert len(digest_purges[0].purged_derivative_identities) == 2
+    digest_blocked_b = RetrievalContextBuilder(
+        composition_replayer=composer_b,
+        journal=RetrievalContextJournal(digest_journal.path),
+        hydrator=ExplodingHydrator(),
+    ).execute(request_b)
+    assert digest_blocked_b.outcome is RetrievalContextOutcome.RIGHTS_BLOCKED
+    assert digest_blocked_b.reason is RetrievalContextReason.RETAINED_CONTEXT_PURGED
+
     later_purges = restarted.purge_affected(
         admission_ids=(admission_b,),
         reason_code="RIGHTS_WITHDRAWN",
@@ -1029,13 +1112,6 @@ def test_rights_purge_does_not_tombstone_unselected_sibling_derivative(
         admission_ids=(admission_b,),
         reason_code="RIGHTS_WITHDRAWN",
     ) == later_purges
-
-    class ExplodingHydrator:
-        implementation_digest = GOVERNED_CAS_HYDRATOR_CONTRACT_DIGEST
-
-        @staticmethod
-        def read(_reference) -> bytes:
-            raise AssertionError("later-purged sibling bytes must not be rehydrated")
 
     blocked_request_b = replace(
         request_b,
@@ -1090,11 +1166,12 @@ def test_rights_purge_does_not_tombstone_unselected_sibling_derivative(
             admission_ids=(admission_b,),
             reason_code="RIGHTS_WITHDRAWN",
         )
-    for content in (content_a, content_b):
-        for suffix in ("", "-journal", "-wal", "-shm"):
-            storage_path = Path(f"{journal.path}{suffix}")
-            if storage_path.exists():
-                assert content not in storage_path.read_bytes()
+    for journal_path in (journal.path, digest_journal.path):
+        for content in {content_a, content_b}:
+            for suffix in ("", "-journal", "-wal", "-shm"):
+                storage_path = Path(f"{journal_path}{suffix}")
+                if storage_path.exists():
+                    assert content not in storage_path.read_bytes()
 
 
 def test_exact_only_root_without_authoritative_passage_fails_closed(

--- a/newsroom/tests/test_increment5d2_retrieval_context.py
+++ b/newsroom/tests/test_increment5d2_retrieval_context.py
@@ -28,8 +28,10 @@ from newsroom.increment5.retrieval_context import (
     RETRIEVAL_CONTEXT_CONTRACT_DIGEST,
     GovernedCasPassageHydrator,
     RetrievalContextBuilder,
+    RetrievalContextError,
     RetrievalContextJournal,
     RetrievalContextOutcome,
+    RetrievalContextPurgeReceipt,
     RetrievalContextReason,
     RetrievalContextRequest,
     context_collision_key_digest,
@@ -74,6 +76,29 @@ def _single_root_inputs(
         )
         for item in inputs
     )
+
+
+def _selected_passage_inputs(
+    inputs: tuple[HybridCompositionInput, ...],
+    roots_by_index: dict[int, str],
+) -> tuple[HybridCompositionInput, ...]:
+    selected: list[HybridCompositionInput] = []
+    for index, item in enumerate(inputs):
+        root = roots_by_index.get(index)
+        transform = composer_helpers._without_hits
+        if root is not None:
+            def selected_transform(receipt, root=root):
+                return _one_hit_at_root(receipt, root)
+
+            transform = selected_transform
+        selected.append(
+            composer_helpers._branch_input(
+                item.named_tool_request,
+                _branch_result(item),
+                transform=transform,
+            )
+        )
+    return tuple(selected)
 
 
 def _exact_only_inputs(
@@ -122,10 +147,14 @@ def _compose(
 
 def _selected_passage_id(composition) -> str:
     assert len(composition.candidates) == 1
+    return _candidate_passage_id(composition.candidates[0])
+
+
+def _candidate_passage_id(candidate) -> str:
     mode_order = {mode: index for index, mode in enumerate(HybridMode)}
     origins = tuple(
         origin
-        for origin in composition.candidates[0].origins
+        for origin in candidate.origins
         if origin.passage_id is not None
     )
     assert origins
@@ -363,6 +392,63 @@ def _builder(
     )
 
 
+def _retained_complete_context(
+    tmp_path: Path,
+    branch_inputs: tuple[HybridCompositionInput, ...],
+    *,
+    name: str,
+):
+    inputs = _single_root_inputs(branch_inputs)
+    composer, composition_request, composition = _compose(
+        tmp_path,
+        inputs,
+        key=f"hybrid:5d2:{name}",
+        request_id=str(uuid.uuid4()),
+    )
+    passage_id = _selected_passage_id(composition)
+    content = f"retained governed context bytes: {name}".encode("utf-8")
+    database, blob_digest = _authority_database(
+        tmp_path,
+        name=name,
+        admission_id=f"object:context-{name}",
+        passage_id=passage_id,
+        content=content,
+    )
+    assert blob_digest is not None
+    cas_root = _cas_root(
+        tmp_path,
+        name=f"cas-{name}",
+        blob_digest=blob_digest,
+        content=content,
+    )
+    authority_request, authority_result = _authority_execution(
+        tmp_path,
+        name=name,
+        database=database,
+        composition=composition,
+        passage_ids=(passage_id,),
+    )
+    request = _context_request(
+        key=name,
+        composition_request=composition_request,
+        composition=composition,
+        inputs=inputs,
+        authority_request=authority_request,
+        authority_result=authority_result,
+    )
+    journal_path = tmp_path / f"context-{name}.sqlite"
+    journal = RetrievalContextJournal(journal_path)
+    builder = RetrievalContextBuilder(
+        composition_replayer=composer,
+        journal=journal,
+        hydrator=GovernedCasPassageHydrator(cas_root),
+    )
+    receipt = builder.execute(request)
+    assert receipt.outcome is RetrievalContextOutcome.COMPLETE
+    assert len(receipt.items) == 1
+    return builder, composer, cas_root, journal, journal_path, request, receipt, content
+
+
 def test_context_contract_is_fixed_and_content_addressed() -> None:
     assert RETRIEVAL_CONTEXT_CONTRACT_DIGEST.startswith("sha256:")
     assert GOVERNED_CAS_HYDRATOR_CONTRACT_DIGEST.startswith("sha256:")
@@ -449,6 +535,341 @@ def test_complete_context_replays_and_hydrates_exact_governed_bytes(
     assert receipt.provider_spend_micros == 0
     assert len(receipt.canonical_bytes) <= CONTEXT_LIMIT_BYTES
     assert builder.execute(request) == receipt
+
+
+def test_retained_context_restart_replays_exact_bytes(
+    tmp_path: Path,
+    branch_inputs: tuple[HybridCompositionInput, ...],
+) -> None:
+    (
+        _builder_instance,
+        composer,
+        cas_root,
+        _journal,
+        journal_path,
+        request,
+        receipt,
+        _content,
+    ) = _retained_complete_context(tmp_path, branch_inputs, name="restart")
+
+    restarted = RetrievalContextBuilder(
+        composition_replayer=composer,
+        journal=RetrievalContextJournal(journal_path),
+        hydrator=GovernedCasPassageHydrator(cas_root),
+    ).execute(request)
+
+    assert restarted == receipt
+    assert restarted.canonical_bytes == receipt.canonical_bytes
+
+
+def test_retained_context_tamper_is_integrity_blocked(
+    tmp_path: Path,
+    branch_inputs: tuple[HybridCompositionInput, ...],
+) -> None:
+    (
+        builder,
+        _composer,
+        _cas_root,
+        _journal,
+        journal_path,
+        request,
+        _receipt,
+        _content,
+    ) = _retained_complete_context(tmp_path, branch_inputs, name="tamper")
+    with sqlite3.connect(journal_path) as connection:
+        connection.execute(
+            "UPDATE increment5d2_retrieval_contexts SET receipt_bytes=? "
+            "WHERE idempotency_key=?",
+            (b"{}", request.idempotency_key),
+        )
+
+    with pytest.raises(RetrievalContextError, match="retained context is corrupt"):
+        builder.execute(request)
+
+
+def test_rights_purge_removes_retained_context_and_tombstone_blocks_replay(
+    tmp_path: Path,
+    branch_inputs: tuple[HybridCompositionInput, ...],
+) -> None:
+    (
+        builder,
+        _composer,
+        _cas_root,
+        journal,
+        journal_path,
+        request,
+        receipt,
+        content,
+    ) = _retained_complete_context(tmp_path, branch_inputs, name="purge")
+    passage = receipt.items[0].passage
+
+    purges = journal.purge_affected(
+        admission_ids=(passage.admission_id,),
+        reason_code="RIGHTS_WITHDRAWN",
+    )
+
+    assert len(purges) == 1
+    purge = purges[0]
+    assert isinstance(purge, RetrievalContextPurgeReceipt)
+    assert purge.context_id == receipt.context_id
+    assert purge.request_digest == request.request_digest
+    assert purge.prior_receipt_digest == receipt.receipt_digest
+    assert purge.passage_ids == (passage.passage_id,)
+    assert purge.admission_ids == (passage.admission_id,)
+    assert purge.blob_digests == (passage.blob_digest,)
+    assert purge.text_digests == (passage.text_digest,)
+    assert content not in purge.canonical_bytes
+    with sqlite3.connect(journal_path) as connection:
+        assert (
+            connection.execute(
+                "SELECT COUNT(*) FROM increment5d2_retrieval_contexts"
+            ).fetchone()[0]
+            == 0
+        )
+        assert (
+            connection.execute(
+                "SELECT COUNT(*) FROM increment5d2_retrieval_context_purges"
+            ).fetchone()[0]
+            == 1
+        )
+    for suffix in ("", "-journal", "-wal", "-shm"):
+        storage_path = Path(f"{journal_path}{suffix}")
+        if storage_path.exists():
+            assert content not in storage_path.read_bytes()
+
+    assert journal.purge_affected(
+        admission_ids=(passage.admission_id,),
+        reason_code="RIGHTS_WITHDRAWN",
+    ) == (purge,)
+    with pytest.raises(RetrievalContextError, match="retrieval context was purged"):
+        builder.execute(request)
+
+    with sqlite3.connect(journal_path) as connection:
+        connection.execute(
+            "UPDATE increment5d2_retrieval_context_purges "
+            "SET prior_receipt_digest=? WHERE idempotency_key=?",
+            ("sha256:" + "0" * 64, request.idempotency_key),
+        )
+    with pytest.raises(RetrievalContextError, match="purge receipt metadata differs"):
+        builder.execute(request)
+
+
+def test_rights_purge_blocks_new_request_identity_before_rehydration(
+    tmp_path: Path,
+    branch_inputs: tuple[HybridCompositionInput, ...],
+) -> None:
+    (
+        _builder,
+        composer,
+        cas_root,
+        journal,
+        journal_path,
+        request,
+        receipt,
+        content,
+    ) = _retained_complete_context(tmp_path, branch_inputs, name="purge-new-key")
+    passage = receipt.items[0].passage
+    journal.purge_affected(
+        admission_ids=(passage.admission_id,),
+        reason_code="RIGHTS_WITHDRAWN",
+    )
+
+    class ExplodingHydrator:
+        implementation_digest = GOVERNED_CAS_HYDRATOR_CONTRACT_DIGEST
+
+        @staticmethod
+        def read(_reference) -> bytes:
+            raise AssertionError("purged governed bytes must not be rehydrated")
+
+    new_request = replace(
+        request,
+        request_id=str(uuid.uuid4()),
+        idempotency_key="context:purge-new-key:second-request",
+    )
+    blocked = RetrievalContextBuilder(
+        composition_replayer=composer,
+        journal=journal,
+        hydrator=ExplodingHydrator(),
+    ).execute(new_request)
+
+    assert blocked.outcome is RetrievalContextOutcome.RIGHTS_BLOCKED
+    assert blocked.reason is RetrievalContextReason.RETAINED_CONTEXT_PURGED
+    assert blocked.items == ()
+    assert content not in blocked.canonical_bytes
+    assert content not in journal_path.read_bytes()
+    assert cas_root.is_dir()
+
+
+def test_rights_purge_rejects_wal_mode_without_false_success(
+    tmp_path: Path,
+    branch_inputs: tuple[HybridCompositionInput, ...],
+) -> None:
+    (
+        _builder,
+        _composer,
+        _cas_root,
+        journal,
+        journal_path,
+        _request,
+        receipt,
+        _content,
+    ) = _retained_complete_context(tmp_path, branch_inputs, name="purge-wal")
+    passage = receipt.items[0].passage
+
+    reader = sqlite3.connect(journal_path)
+    try:
+        assert reader.execute("PRAGMA journal_mode=WAL").fetchone() == ("wal",)
+        reader.execute("BEGIN")
+        assert reader.execute(
+            "SELECT COUNT(*) FROM increment5d2_retrieval_contexts"
+        ).fetchone() == (1,)
+
+        with pytest.raises(
+            RetrievalContextError,
+            match="purge-safe SQLite journal mode is unavailable",
+        ):
+            journal.purge_affected(
+                admission_ids=(passage.admission_id,),
+                reason_code="RIGHTS_WITHDRAWN",
+            )
+    finally:
+        reader.rollback()
+        reader.close()
+
+    with sqlite3.connect(journal_path) as connection:
+        assert connection.execute(
+            "SELECT COUNT(*) FROM increment5d2_retrieval_contexts"
+        ).fetchone() == (1,)
+        assert connection.execute(
+            "SELECT COUNT(*) FROM increment5d2_retrieval_context_purges"
+        ).fetchone() == (0,)
+
+
+def test_rights_purge_does_not_tombstone_unselected_sibling_derivative(
+    tmp_path: Path,
+    branch_inputs: tuple[HybridCompositionInput, ...],
+) -> None:
+    root_a = "authority:retained-root-a"
+    root_b = "authority:retained-root-b"
+    inputs_ab = _selected_passage_inputs(branch_inputs, {1: root_a, 2: root_b})
+    composer_ab, composition_request_ab, composition_ab = _compose(
+        tmp_path,
+        inputs_ab,
+        key="hybrid:5d2:purge-sibling:ab",
+        request_id=str(uuid.uuid4()),
+    )
+    passages_by_root = {
+        candidate.dependency_root_id: _candidate_passage_id(candidate)
+        for candidate in composition_ab.candidates
+    }
+    assert set(passages_by_root) == {root_a, root_b}
+    passage_a = passages_by_root[root_a]
+    passage_b = passages_by_root[root_b]
+    passage_ids = tuple(sorted((passage_a, passage_b)))
+    admission_a = "object:retained-a"
+    admission_b = "object:retained-b"
+    content_a = b"governed retained bytes A"
+    content_b = b"governed retained bytes B"
+    database, blob_a = _authority_database(
+        tmp_path,
+        name="purge-sibling",
+        admission_id=admission_a,
+        passage_id=passage_a,
+        content=content_a,
+    )
+    assert blob_a is not None
+    with sqlite3.connect(database) as connection:
+        authority_helpers.seed_object(
+            connection,
+            admission_id=admission_b,
+            passage_id=passage_b,
+            run_id="run:purge-sibling:b",
+            allowed=1,
+        )
+        blob_b = _retarget_seeded_passage(
+            connection,
+            admission_id=admission_b,
+            passage_id=passage_b,
+            content=content_b,
+        )
+    cas_root = _cas_root(
+        tmp_path,
+        name="cas-purge-sibling",
+        blob_digest=blob_a,
+        content=content_a,
+    )
+    digest_hex = blob_b.removeprefix("sha256:")
+    blob_b_path = cas_root / "objects" / digest_hex[:2] / digest_hex
+    blob_b_path.parent.mkdir(exist_ok=True)
+    blob_b_path.write_bytes(content_b)
+    blob_b_path.chmod(0o444)
+    authority_request_ab, authority_result_ab = _authority_execution(
+        tmp_path,
+        name="purge-sibling-ab",
+        database=database,
+        composition=composition_ab,
+        passage_ids=passage_ids,
+    )
+    request_ab = _context_request(
+        key="purge-sibling:ab",
+        composition_request=composition_request_ab,
+        composition=composition_ab,
+        inputs=inputs_ab,
+        authority_request=authority_request_ab,
+        authority_result=authority_result_ab,
+    )
+    journal = RetrievalContextJournal(tmp_path / "context-purge-sibling.sqlite")
+    builder_ab = RetrievalContextBuilder(
+        composition_replayer=composer_ab,
+        journal=journal,
+        hydrator=GovernedCasPassageHydrator(cas_root),
+    )
+    receipt_ab = builder_ab.execute(request_ab)
+    assert receipt_ab.outcome is RetrievalContextOutcome.COMPLETE
+    assert len(receipt_ab.items) == 2
+    item_a = next(
+        item for item in receipt_ab.items if item.passage.admission_id == admission_a
+    )
+
+    purge = journal.purge_affected(
+        admission_ids=(admission_a,),
+        reason_code="RIGHTS_WITHDRAWN",
+    )[0]
+    assert purge.passage_ids == (item_a.passage.passage_id,)
+    assert purge.admission_ids == (admission_a,)
+
+    inputs_b = _selected_passage_inputs(branch_inputs, {2: root_b})
+    composer_b, composition_request_b, composition_b = _compose(
+        tmp_path,
+        inputs_b,
+        key="hybrid:5d2:purge-sibling:b",
+        request_id=str(uuid.uuid4()),
+    )
+    authority_request_b, authority_result_b = _authority_execution(
+        tmp_path,
+        name="purge-sibling-b",
+        database=database,
+        composition=composition_b,
+        passage_ids=(passage_b,),
+    )
+    request_b = _context_request(
+        key="purge-sibling:b",
+        composition_request=composition_request_b,
+        composition=composition_b,
+        inputs=inputs_b,
+        authority_request=authority_request_b,
+        authority_result=authority_result_b,
+    )
+    receipt_b = RetrievalContextBuilder(
+        composition_replayer=composer_b,
+        journal=journal,
+        hydrator=GovernedCasPassageHydrator(cas_root),
+    ).execute(request_b)
+
+    assert receipt_b.outcome is RetrievalContextOutcome.COMPLETE
+    assert len(receipt_b.items) == 1
+    assert receipt_b.items[0].passage.admission_id == admission_b
+    assert receipt_b.items[0].text.encode("utf-8") == content_b
 
 
 def test_exact_only_root_without_authoritative_passage_fails_closed(

--- a/newsroom/tests/test_increment5d2_retrieval_context.py
+++ b/newsroom/tests/test_increment5d2_retrieval_context.py
@@ -587,6 +587,130 @@ def test_retained_context_tamper_is_integrity_blocked(
         builder.execute(request)
 
 
+def _create_legacy_purge_journal(
+    path: Path,
+    *,
+    retained_purge: bool,
+) -> bytes:
+    retained_context = b"legacy governed context bytes"
+    with sqlite3.connect(path) as connection:
+        connection.execute(
+            """
+            CREATE TABLE increment5d2_retrieval_contexts (
+                idempotency_key TEXT PRIMARY KEY,
+                request_digest TEXT NOT NULL,
+                receipt_digest TEXT NOT NULL,
+                receipt_bytes BLOB NOT NULL
+            )
+            """
+        )
+        connection.execute(
+            """
+            CREATE TABLE increment5d2_retrieval_context_purges (
+                idempotency_key TEXT PRIMARY KEY,
+                request_digest TEXT NOT NULL,
+                prior_receipt_digest TEXT NOT NULL,
+                purge_receipt_digest TEXT NOT NULL,
+                purge_receipt_bytes BLOB NOT NULL
+            )
+            """
+        )
+        if retained_purge:
+            connection.execute(
+                """
+                INSERT INTO increment5d2_retrieval_contexts(
+                    idempotency_key,request_digest,receipt_digest,receipt_bytes
+                ) VALUES(?,?,?,?)
+                """,
+                (
+                    "context:legacy-retained",
+                    "sha256:" + "1" * 64,
+                    digest_bytes(retained_context),
+                    retained_context,
+                ),
+            )
+            legacy_purge = b"legacy purge receipt without sibling inventory"
+            connection.execute(
+                """
+                INSERT INTO increment5d2_retrieval_context_purges(
+                    idempotency_key,request_digest,prior_receipt_digest,
+                    purge_receipt_digest,purge_receipt_bytes
+                ) VALUES(?,?,?,?,?)
+                """,
+                (
+                    "context:legacy-purged",
+                    "sha256:" + "2" * 64,
+                    "sha256:" + "3" * 64,
+                    digest_bytes(legacy_purge),
+                    legacy_purge,
+                ),
+            )
+    return retained_context
+
+
+def test_empty_legacy_purge_schema_migrates_to_append_only_v2(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "legacy-empty.sqlite"
+    _create_legacy_purge_journal(path, retained_purge=False)
+
+    RetrievalContextJournal(path)
+
+    with sqlite3.connect(path) as connection:
+        columns = connection.execute(
+            "PRAGMA table_info(increment5d2_retrieval_context_purges)"
+        ).fetchall()
+        assert [row[1] for row in columns] == [
+            "purge_id",
+            "idempotency_key",
+            "request_digest",
+            "prior_receipt_digest",
+            "purge_receipt_digest",
+            "purge_receipt_bytes",
+        ]
+        assert {row[1]: row[5] for row in columns} == {
+            "purge_id": 1,
+            "idempotency_key": 0,
+            "request_digest": 0,
+            "prior_receipt_digest": 0,
+            "purge_receipt_digest": 0,
+            "purge_receipt_bytes": 0,
+        }
+
+
+def test_populated_legacy_purge_schema_fails_closed_without_mutation(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "legacy-populated.sqlite"
+    retained_context = _create_legacy_purge_journal(path, retained_purge=True)
+
+    with pytest.raises(
+        RetrievalContextError,
+        match="legacy purge journal lacks sibling identities",
+    ):
+        RetrievalContextJournal(path)
+
+    with sqlite3.connect(path) as connection:
+        assert connection.execute(
+            "SELECT COUNT(*) FROM increment5d2_retrieval_context_purges"
+        ).fetchone() == (1,)
+        assert connection.execute(
+            "SELECT receipt_bytes FROM increment5d2_retrieval_contexts"
+        ).fetchone() == (retained_context,)
+        assert [
+            row[1]
+            for row in connection.execute(
+                "PRAGMA table_info(increment5d2_retrieval_context_purges)"
+            )
+        ] == [
+            "idempotency_key",
+            "request_digest",
+            "prior_receipt_digest",
+            "purge_receipt_digest",
+            "purge_receipt_bytes",
+        ]
+
+
 def test_rights_purge_removes_retained_context_and_tombstone_blocks_replay(
     tmp_path: Path,
     branch_inputs: tuple[HybridCompositionInput, ...],
@@ -611,6 +735,11 @@ def test_rights_purge_removes_retained_context_and_tombstone_blocks_replay(
     assert len(purges) == 1
     purge = purges[0]
     assert isinstance(purge, RetrievalContextPurgeReceipt)
+    assert json.loads(purge.canonical_bytes)["schema_version"] == (
+        "newsroom.increment5.retrieval-context-purge.v2"
+    )
+    assert purge.raw_context_bytes_deleted_in_event is True
+    assert purge.raw_context_bytes_absent is True
     assert purge.context_id == receipt.context_id
     assert purge.request_digest == request.request_digest
     assert purge.prior_receipt_digest == receipt.receipt_digest
@@ -837,6 +966,10 @@ def test_rights_purge_does_not_tombstone_unselected_sibling_derivative(
     )[0]
     assert purge.passage_ids == (item_a.passage.passage_id,)
     assert purge.admission_ids == (admission_a,)
+    assert len(purge.purged_derivative_identities) == 1
+    assert len(purge.context_derivative_identities) == 2
+    assert purge.raw_context_bytes_deleted_in_event is True
+    assert purge.raw_context_bytes_absent is True
 
     inputs_b = _selected_passage_inputs(branch_inputs, {2: root_b})
     composer_b, composition_request_b, composition_b = _compose(
@@ -870,6 +1003,98 @@ def test_rights_purge_does_not_tombstone_unselected_sibling_derivative(
     assert len(receipt_b.items) == 1
     assert receipt_b.items[0].passage.admission_id == admission_b
     assert receipt_b.items[0].text.encode("utf-8") == content_b
+
+    restarted = RetrievalContextJournal(journal.path)
+    later_purges = restarted.purge_affected(
+        admission_ids=(admission_b,),
+        reason_code="RIGHTS_WITHDRAWN",
+    )
+
+    assert len(later_purges) == 2
+    assert {item.context_id for item in later_purges} == {
+        receipt_ab.context_id,
+        receipt_b.context_id,
+    }
+    assert all(item.passage_ids == (passage_b,) for item in later_purges)
+    assert all(item.admission_ids == (admission_b,) for item in later_purges)
+    later_by_context = {item.context_id: item for item in later_purges}
+    assert later_by_context[receipt_ab.context_id].raw_context_bytes_deleted_in_event is (
+        False
+    )
+    assert later_by_context[receipt_b.context_id].raw_context_bytes_deleted_in_event is (
+        True
+    )
+    assert all(item.raw_context_bytes_absent is True for item in later_purges)
+    assert restarted.purge_affected(
+        admission_ids=(admission_b,),
+        reason_code="RIGHTS_WITHDRAWN",
+    ) == later_purges
+
+    class ExplodingHydrator:
+        implementation_digest = GOVERNED_CAS_HYDRATOR_CONTRACT_DIGEST
+
+        @staticmethod
+        def read(_reference) -> bytes:
+            raise AssertionError("later-purged sibling bytes must not be rehydrated")
+
+    blocked_request_b = replace(
+        request_b,
+        request_id=str(uuid.uuid4()),
+        idempotency_key="context:purge-sibling:b-after-withdrawal",
+    )
+    post_purge_restart = RetrievalContextJournal(journal.path)
+    blocked_b = RetrievalContextBuilder(
+        composition_replayer=composer_b,
+        journal=post_purge_restart,
+        hydrator=ExplodingHydrator(),
+    ).execute(blocked_request_b)
+    assert blocked_b.outcome is RetrievalContextOutcome.RIGHTS_BLOCKED
+    assert blocked_b.reason is RetrievalContextReason.RETAINED_CONTEXT_PURGED
+    assert blocked_b.items == ()
+
+    with sqlite3.connect(journal.path) as connection:
+        assert connection.execute(
+            "SELECT COUNT(*) FROM increment5d2_retrieval_contexts"
+        ).fetchone() == (1,)
+        assert connection.execute(
+            "SELECT COUNT(*) FROM increment5d2_retrieval_context_purges"
+        ).fetchone() == (3,)
+        primary_keys = {
+            row[1]: row[5]
+            for row in connection.execute(
+                "PRAGMA table_info(increment5d2_retrieval_context_purges)"
+            )
+        }
+        assert primary_keys["purge_id"] == 1
+        assert primary_keys["idempotency_key"] == 0
+        rows = connection.execute(
+            "SELECT purge_receipt_digest,purge_receipt_bytes "
+            "FROM increment5d2_retrieval_context_purges ORDER BY purge_id"
+        ).fetchall()
+        retained_values = [json.loads(bytes(row[1])) for row in rows]
+        assert all(
+            len(value["context_derivative_identities"]) == 2
+            for value in retained_values
+            if value["context_id"] == receipt_ab.context_id
+        )
+        tampered = retained_values[0]
+        tampered["context_derivative_identities"][0]["passage_id"] = "tampered"
+        connection.execute(
+            "UPDATE increment5d2_retrieval_context_purges "
+            "SET purge_receipt_bytes=? WHERE purge_receipt_digest=?",
+            (canonical_json_bytes(tampered), rows[0][0]),
+        )
+
+    with pytest.raises(RetrievalContextError, match="retained purge receipt is corrupt"):
+        restarted.purge_affected(
+            admission_ids=(admission_b,),
+            reason_code="RIGHTS_WITHDRAWN",
+        )
+    for content in (content_a, content_b):
+        for suffix in ("", "-journal", "-wal", "-shm"):
+            storage_path = Path(f"{journal.path}{suffix}")
+            if storage_path.exists():
+                assert content not in storage_path.read_bytes()
 
 
 def test_exact_only_root_without_authoritative_passage_fails_closed(

--- a/newsroom/tests/test_increment5e1_retrieval_qualification.py
+++ b/newsroom/tests/test_increment5e1_retrieval_qualification.py
@@ -27,6 +27,7 @@ from newsroom.increment5.retrieval_qualification import (
     build_qualification_epoch,
     load_qualification_corpus,
     load_qualification_target,
+    rederive_qualification_corpus,
     run_fixture_qualification,
 )
 
@@ -46,6 +47,7 @@ def _evaluate(observations=None, *, tree: str = TREE):
         target=QUALIFICATION_TARGET,
         corpus=QUALIFICATION_CORPUS,
         epoch=epoch,
+        code_tree_sha=tree,
         observations=(
             run_fixture_qualification(
                 target=QUALIFICATION_TARGET,
@@ -69,6 +71,17 @@ def _replace_first_hybrid(observations, **changes):
     )
     values[index] = replace(values[index], **changes)
     return tuple(values), QUALIFICATION_CORPUS.cases[0]
+
+
+def _replace_first_system(observations, system, **changes):
+    values = list(observations)
+    index = next(
+        index
+        for index, item in enumerate(values)
+        if item.system is system
+    )
+    values[index] = replace(values[index], **changes)
+    return tuple(values)
 
 
 
@@ -169,6 +182,38 @@ def test_rights_temporal_scope_write_and_rebuild_violations_fail_closed() -> Non
         _, report = _evaluate(modified)
         assert report.decision is QualificationDecision.FAIL
         assert report.blockers
+
+
+@pytest.mark.parametrize(
+    ("system", "change"),
+    [
+        (
+            QualificationSystem.ADMITTED_GRAPH_ONLY,
+            {"rights_purge_residual_count": 1},
+        ),
+        (QualificationSystem.EXACT_ONLY, {"scope_escape_count": 1}),
+        (
+            QualificationSystem.FULL_TEXT_ONLY,
+            {"write_attempt_success_count": 1},
+        ),
+        (
+            QualificationSystem.VECTOR_ONLY,
+            {"rights_purge_residual_count": 1},
+        ),
+    ],
+)
+def test_safety_and_rights_violations_in_any_executed_system_block(
+    system,
+    change,
+) -> None:
+    observations = run_fixture_qualification(
+        target=QUALIFICATION_TARGET,
+        corpus=QUALIFICATION_CORPUS,
+    )
+    modified = _replace_first_system(observations, system, **change)
+    _, report = _evaluate(modified)
+    assert report.decision is QualificationDecision.FAIL
+    assert any(system.value in blocker for blocker in report.blockers)
 
 
 def test_false_no_match_false_merge_and_candidate_disposition_fail() -> None:
@@ -327,7 +372,9 @@ def test_family_required_slice_underexposure_is_not_evaluated() -> None:
             label for label in cases[index].slice_labels if label != "EN_GB"
         ),
     )
-    corpus = replace(QUALIFICATION_CORPUS, cases=tuple(cases))
+    corpus = rederive_qualification_corpus(
+        replace(QUALIFICATION_CORPUS, cases=tuple(cases))
+    )
     epoch = build_qualification_epoch(
         target=QUALIFICATION_TARGET,
         corpus=corpus,
@@ -338,6 +385,7 @@ def test_family_required_slice_underexposure_is_not_evaluated() -> None:
         target=QUALIFICATION_TARGET,
         corpus=corpus,
         epoch=epoch,
+        code_tree_sha=TREE,
         observations=observations,
         started_at=START,
         completed_at=END,
@@ -384,7 +432,10 @@ def test_epoch_identity_changes_with_code_tree_and_mismatch_is_rejected() -> Non
         target=QUALIFICATION_TARGET,
         corpus=QUALIFICATION_CORPUS,
     )
-    with pytest.raises(RetrievalQualificationError, match="Epoch binding"):
+    with pytest.raises(
+        RetrievalQualificationError,
+        match="target identity|Epoch binding",
+    ):
         RetrievalQualificationEvaluator().evaluate(
             run_id=str(uuid.uuid4()),
             target=replace(
@@ -393,9 +444,121 @@ def test_epoch_identity_changes_with_code_tree_and_mismatch_is_rejected() -> Non
             ),
             corpus=QUALIFICATION_CORPUS,
             epoch=first,
+            code_tree_sha=TREE,
             observations=observations,
             started_at=START,
             completed_at=END,
+        )
+
+
+def test_caller_modified_corpus_cannot_reuse_stale_content_identities() -> None:
+    cases = list(QUALIFICATION_CORPUS.cases)
+    case = cases[0]
+    changed_root = "authority-root:caller-modified"
+    cases[0] = replace(
+        case,
+        expected_root=changed_root,
+        fixture_hits=tuple(
+            (mode, (changed_root,) if roots else ())
+            for mode, roots in case.fixture_hits
+        ),
+    )
+    changed = replace(QUALIFICATION_CORPUS, cases=tuple(cases))
+
+    with pytest.raises(RetrievalQualificationError, match="content identities"):
+        build_qualification_epoch(
+            target=QUALIFICATION_TARGET,
+            corpus=changed,
+            code_tree_sha=TREE,
+        )
+    with pytest.raises(RetrievalQualificationError, match="content identities"):
+        run_fixture_qualification(
+            target=QUALIFICATION_TARGET,
+            corpus=changed,
+        )
+
+    rederived = rederive_qualification_corpus(changed)
+    assert rederived.dataset_manifest_digest != (
+        QUALIFICATION_CORPUS.dataset_manifest_digest
+    )
+    assert rederived.cases[0].label_digest != case.label_digest
+    assert rederived.cases[0].fixture_digest != case.fixture_digest
+    changed_epoch = build_qualification_epoch(
+        target=QUALIFICATION_TARGET,
+        corpus=rederived,
+        code_tree_sha=TREE,
+    )
+    assert changed_epoch.dataset_manifest_digest == (
+        rederived.dataset_manifest_digest
+    )
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "source_provider_versions_digest",
+        "adapter_parser_versions_digest",
+        "threshold_set_digest",
+        "policy_set_digest",
+    ],
+)
+def test_every_derived_epoch_identity_is_revalidated_before_evaluation(
+    field: str,
+) -> None:
+    epoch = build_qualification_epoch(
+        target=QUALIFICATION_TARGET,
+        corpus=QUALIFICATION_CORPUS,
+        code_tree_sha=TREE,
+    )
+    changed = replace(epoch, **{field: "sha256:" + "b" * 64})
+    observations = run_fixture_qualification(
+        target=QUALIFICATION_TARGET,
+        corpus=QUALIFICATION_CORPUS,
+    )
+    with pytest.raises(RetrievalQualificationError, match="Epoch binding"):
+        RetrievalQualificationEvaluator().evaluate(
+            run_id=str(uuid.uuid4()),
+            target=QUALIFICATION_TARGET,
+            corpus=QUALIFICATION_CORPUS,
+            epoch=changed,
+            code_tree_sha=TREE,
+            observations=observations,
+            started_at=START,
+            completed_at=END,
+        )
+
+
+def test_epoch_code_tree_and_exact_target_are_independently_revalidated() -> None:
+    epoch = build_qualification_epoch(
+        target=QUALIFICATION_TARGET,
+        corpus=QUALIFICATION_CORPUS,
+        code_tree_sha=TREE,
+    )
+    observations = run_fixture_qualification(
+        target=QUALIFICATION_TARGET,
+        corpus=QUALIFICATION_CORPUS,
+    )
+    with pytest.raises(RetrievalQualificationError, match="Epoch binding"):
+        RetrievalQualificationEvaluator().evaluate(
+            run_id=str(uuid.uuid4()),
+            target=QUALIFICATION_TARGET,
+            corpus=QUALIFICATION_CORPUS,
+            epoch=replace(epoch, code_tree_sha="b" * 40),
+            code_tree_sha=TREE,
+            observations=observations,
+            started_at=START,
+            completed_at=END,
+        )
+
+    changed_target = replace(
+        QUALIFICATION_TARGET,
+        profile_id="CALLER_SELECTED_TARGET",
+    )
+    with pytest.raises(RetrievalQualificationError, match="target identity"):
+        build_qualification_epoch(
+            target=changed_target,
+            corpus=QUALIFICATION_CORPUS,
+            code_tree_sha=TREE,
         )
 
 

--- a/newsroom/tests/test_increment5e1_retrieval_qualification_journal.py
+++ b/newsroom/tests/test_increment5e1_retrieval_qualification_journal.py
@@ -35,6 +35,7 @@ def _evaluate(observations=None, *, tree: str = TREE):
         target=QUALIFICATION_TARGET,
         corpus=QUALIFICATION_CORPUS,
         epoch=epoch,
+        code_tree_sha=tree,
         observations=(
             run_fixture_qualification(
                 target=QUALIFICATION_TARGET,
@@ -140,6 +141,7 @@ def test_report_journal_is_first_writer_wins_and_detects_corruption(tmp_path: Pa
         target=QUALIFICATION_TARGET,
         corpus=QUALIFICATION_CORPUS,
         epoch=epoch,
+        code_tree_sha=TREE,
         observations=tuple(observations),
         started_at=START,
         completed_at=END,

--- a/newsroom/tests/test_increment5e2_closeout_receipt.py
+++ b/newsroom/tests/test_increment5e2_closeout_receipt.py
@@ -327,6 +327,35 @@ def test_junit_parser_preserves_exact_parameter_node_ids(tmp_path: Path) -> None
     )
 
 
+def test_junit_parser_accepts_bounded_long_unselected_parameter_id(
+    tmp_path: Path,
+) -> None:
+    parameter = "x" * (16 * 1024)
+    path = tmp_path / "long-parameter.xml"
+    path.write_text(
+        '<testsuite><testcase classname="newsroom.tests.test_example" '
+        f'name="test_exact[{parameter}]"/></testsuite>',
+        encoding="utf-8",
+    )
+
+    parsed = _parse_junit(path)
+
+    assert parsed.cases[0].test_id.endswith(f"test_exact[{parameter}]")
+
+
+def test_junit_parser_rejects_unbounded_parameter_id(tmp_path: Path) -> None:
+    parameter = "x" * (64 * 1024)
+    path = tmp_path / "unbounded-parameter.xml"
+    path.write_text(
+        '<testsuite><testcase classname="newsroom.tests.test_example" '
+        f'name="test_exact[{parameter}]"/></testsuite>',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(Increment5E2CloseoutReceiptError, match="test_name"):
+        _parse_junit(path)
+
+
 def test_junit_parser_rejects_utf16_dtd_and_entity(tmp_path: Path) -> None:
     path = tmp_path / "utf16-entity.xml"
     path.write_bytes(

--- a/newsroom/tests/test_increment5e2_closeout_receipt.py
+++ b/newsroom/tests/test_increment5e2_closeout_receipt.py
@@ -1,0 +1,437 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import uuid
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from newsroom.increment5.final_closeout import (
+    INCREMENT5E2_FINAL_CLOSEOUT_CASES,
+    INCREMENT5E2_FINAL_CLOSEOUT_INVENTORY_DIGEST,
+    INCREMENT5E2_FINAL_NON_EFFECTS,
+    FinalCloseoutLane,
+)
+from newsroom.increment5.retrieval_qualification import (
+    QUALIFICATION_CORPUS,
+    QUALIFICATION_TARGET,
+    RetrievalQualificationEvaluator,
+    build_qualification_epoch,
+    run_fixture_qualification,
+)
+from newsroom.projection.neo4j import (
+    NEO4J_B2_DRIVER_VERSION,
+    NEO4J_B2_IMAGE,
+    NEO4J_B2_SERVER_VERSION,
+)
+from scripts.sdlc.emit_evidence import sha256_identity
+from scripts.sdlc.increment5e2_closeout_receipt import (
+    Increment5E2CloseoutReceiptError,
+    _parse_junit,
+    build_actual_service_receipt,
+    build_final_receipt,
+)
+from scripts.sdlc.workflow_lane import service_compatibility_digest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _tree() -> str:
+    return subprocess.check_output(
+        ["git", "rev-parse", "HEAD^{tree}"], cwd=ROOT, text=True
+    ).strip()
+
+
+@pytest.fixture(scope="module")
+def target_properties() -> dict[str, str]:
+    head = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=ROOT, text=True
+    ).strip()
+    tree = _tree()
+    epoch = build_qualification_epoch(
+        target=QUALIFICATION_TARGET,
+        corpus=QUALIFICATION_CORPUS,
+        code_tree_sha=tree,
+    )
+    report = RetrievalQualificationEvaluator().evaluate(
+        run_id=str(uuid.uuid5(uuid.NAMESPACE_URL, epoch.epoch_digest)),
+        target=QUALIFICATION_TARGET,
+        corpus=QUALIFICATION_CORPUS,
+        epoch=epoch,
+        code_tree_sha=tree,
+        observations=run_fixture_qualification(
+            target=QUALIFICATION_TARGET,
+            corpus=QUALIFICATION_CORPUS,
+        ),
+        started_at="2026-08-08T20:00:00Z",
+        completed_at="2026-08-08T20:01:00Z",
+    )
+    return {
+        "increment5e2_epoch_digest": epoch.epoch_digest,
+        "increment5e2_epoch_json": json.dumps(
+            epoch.canonical_value(), sort_keys=True, separators=(",", ":")
+        ),
+        "increment5e2_report_digest": report.report_digest,
+        "increment5e2_report_json": report.canonical_bytes.decode("utf-8"),
+        "increment5e2_closeout_inventory_digest": (
+            INCREMENT5E2_FINAL_CLOSEOUT_INVENTORY_DIGEST
+        ),
+        "increment5e2_closeout_case_count": str(len(INCREMENT5E2_FINAL_CLOSEOUT_CASES)),
+        "increment5e2_non_effects": ",".join(INCREMENT5E2_FINAL_NON_EFFECTS),
+        "increment5e2_source_head_sha": head,
+        "increment5e2_source_tree_sha": tree,
+        "increment5e2_neo4j_image": NEO4J_B2_IMAGE,
+        "increment5e2_neo4j_server_version": NEO4J_B2_SERVER_VERSION,
+        "increment5e2_neo4j_edition": "community",
+        "increment5e2_neo4j_driver_version": NEO4J_B2_DRIVER_VERSION,
+        "increment5e2_neo4j_database": "neo4j",
+        "increment5e2_neo4j_projector_username": "newsroom_projector",
+        "increment5e2_service_compatibility_digest": service_compatibility_digest(),
+    }
+
+
+def _junit(
+    path: Path,
+    lane: FinalCloseoutLane,
+    properties: dict[str, str],
+    *,
+    omitted: str | None = None,
+    skipped: str | None = None,
+) -> Path:
+    suite = ET.Element("testsuite")
+    for case in INCREMENT5E2_FINAL_CLOSEOUT_CASES:
+        if case.lane is not lane or case.test_id == omitted:
+            continue
+        owner, name = case.test_id.split("::", 1)
+        element = ET.SubElement(suite, "testcase", classname=owner, name=name)
+        if case.test_id == skipped:
+            ET.SubElement(element, "skipped")
+        if name == "test_actual_service_increment5e2_target_and_report":
+            container = ET.SubElement(element, "properties")
+            for key, value in properties.items():
+                ET.SubElement(container, "property", name=key, value=value)
+    path.write_bytes(ET.tostring(suite, encoding="utf-8", xml_declaration=True))
+    return path
+
+
+def test_actual_service_receipt_binds_exact_report_and_semantics(
+    tmp_path: Path, target_properties: dict[str, str]
+) -> None:
+    report = _junit(
+        tmp_path / "service.xml",
+        FinalCloseoutLane.ACTUAL_NEO4J,
+        target_properties,
+    )
+
+    receipt = build_actual_service_receipt(repo_root=ROOT, service_junit_report=report)
+
+    expected_digest = "sha256:" + hashlib.sha256(report.read_bytes()).hexdigest()
+    assert receipt["junit_report"]["digest"] == expected_digest
+    assert len(receipt["selected_cases"]) == len(
+        [
+            case
+            for case in INCREMENT5E2_FINAL_CLOSEOUT_CASES
+            if case.lane is FinalCloseoutLane.ACTUAL_NEO4J
+        ]
+    )
+    assert receipt["service"]["compatibility_digest"] == (
+        service_compatibility_digest()
+    )
+    unsigned = dict(receipt)
+    assert unsigned.pop("receipt_identity") == sha256_identity(unsigned)
+
+
+def test_actual_service_rejects_missing_skipped_and_tampered_properties(
+    tmp_path: Path, target_properties: dict[str, str]
+) -> None:
+    cases = [
+        case
+        for case in INCREMENT5E2_FINAL_CLOSEOUT_CASES
+        if case.lane is FinalCloseoutLane.ACTUAL_NEO4J
+    ]
+    missing = _junit(
+        tmp_path / "missing.xml",
+        FinalCloseoutLane.ACTUAL_NEO4J,
+        target_properties,
+        omitted=cases[0].test_id,
+    )
+    with pytest.raises(Increment5E2CloseoutReceiptError, match="selected_test_missing"):
+        build_actual_service_receipt(repo_root=ROOT, service_junit_report=missing)
+
+    skipped = _junit(
+        tmp_path / "skipped.xml",
+        FinalCloseoutLane.ACTUAL_NEO4J,
+        target_properties,
+        skipped=cases[0].test_id,
+    )
+    with pytest.raises(Increment5E2CloseoutReceiptError, match="not_passed"):
+        build_actual_service_receipt(repo_root=ROOT, service_junit_report=skipped)
+
+    changed = dict(target_properties)
+    changed["increment5e2_epoch_digest"] = "sha256:" + "0" * 64
+    tampered = _junit(
+        tmp_path / "tampered.xml",
+        FinalCloseoutLane.ACTUAL_NEO4J,
+        changed,
+    )
+    with pytest.raises(Increment5E2CloseoutReceiptError, match="epoch_identity"):
+        build_actual_service_receipt(repo_root=ROOT, service_junit_report=tampered)
+
+    unexpected = dict(target_properties)
+    unexpected["increment5e2_unreviewed_property"] = "unexpected"
+    extra = _junit(
+        tmp_path / "extra.xml",
+        FinalCloseoutLane.ACTUAL_NEO4J,
+        unexpected,
+    )
+    with pytest.raises(Increment5E2CloseoutReceiptError, match="target_properties"):
+        build_actual_service_receipt(repo_root=ROOT, service_junit_report=extra)
+
+
+@pytest.mark.parametrize("outcome", ("failure", "error"))
+def test_actual_service_rejects_unselected_failure_or_error(
+    tmp_path: Path,
+    target_properties: dict[str, str],
+    outcome: str,
+) -> None:
+    report = _junit(
+        tmp_path / f"extra-{outcome}.xml",
+        FinalCloseoutLane.ACTUAL_NEO4J,
+        target_properties,
+    )
+    suite = ET.fromstring(report.read_bytes())
+    extra = ET.SubElement(
+        suite,
+        "testcase",
+        classname="newsroom.tests.test_unselected",
+        name="test_extra",
+    )
+    ET.SubElement(extra, outcome)
+    report.write_bytes(ET.tostring(suite, encoding="utf-8", xml_declaration=True))
+
+    with pytest.raises(
+        Increment5E2CloseoutReceiptError,
+        match="unselected_test_not_passed",
+    ):
+        build_actual_service_receipt(repo_root=ROOT, service_junit_report=report)
+
+
+@pytest.mark.parametrize(
+    ("property_name", "property_value", "expected_error"),
+    (
+        ("increment5e2_source_head_sha", "0" * 40, "service_identity"),
+        ("increment5e2_source_tree_sha", "0" * 40, "service_identity"),
+        ("increment5e2_neo4j_image", "neo4j:changed", "service_identity"),
+        ("increment5e2_closeout_case_count", "0", "closeout_inventory"),
+    ),
+)
+def test_actual_service_rejects_changed_checkout_service_or_inventory_identity(
+    tmp_path: Path,
+    target_properties: dict[str, str],
+    property_name: str,
+    property_value: str,
+    expected_error: str,
+) -> None:
+    changed = dict(target_properties)
+    changed[property_name] = property_value
+    report = _junit(
+        tmp_path / f"{property_name}.xml",
+        FinalCloseoutLane.ACTUAL_NEO4J,
+        changed,
+    )
+
+    with pytest.raises(Increment5E2CloseoutReceiptError, match=expected_error):
+        build_actual_service_receipt(repo_root=ROOT, service_junit_report=report)
+
+
+def test_actual_service_rejects_self_consistent_forged_qualification_report(
+    tmp_path: Path, target_properties: dict[str, str]
+) -> None:
+    forged_value = json.loads(target_properties["increment5e2_report_json"])
+    forged_value.update(
+        {
+            "target_manifest_digest": "sha256:" + "1" * 64,
+            "corpus_spec_digest": "sha256:" + "2" * 64,
+            "dataset_manifest_digest": "sha256:" + "3" * 64,
+            "vector_quality_scope": "FABRICATED_VECTOR_SCOPE",
+        }
+    )
+    for name in (
+        "systems",
+        "mandatory_families",
+        "required_slices",
+        "triage_error_classes",
+        "branch_contributions",
+    ):
+        forged_value["metrics"][name] = []
+    evidence = {
+        "metrics": forged_value["metrics"],
+        "blockers": forged_value["blockers"],
+        "observation_count": forged_value["observation_count"],
+        "expected_observation_count": forged_value["expected_observation_count"],
+    }
+    evidence_payload = json.dumps(
+        evidence, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    evidence_digest = "sha256:" + hashlib.sha256(evidence_payload).hexdigest()
+    forged_value["report_id"] = str(
+        uuid.uuid5(
+            uuid.NAMESPACE_URL,
+            "|".join(
+                (
+                    forged_value["run_id"],
+                    forged_value["epoch_digest"],
+                    forged_value["decision"],
+                    forged_value["reason"],
+                    evidence_digest,
+                )
+            ),
+        )
+    )
+    forged_text = json.dumps(forged_value, sort_keys=True, separators=(",", ":"))
+    forged = dict(target_properties)
+    forged["increment5e2_report_json"] = forged_text
+    forged["increment5e2_report_digest"] = (
+        "sha256:" + hashlib.sha256(forged_text.encode("utf-8")).hexdigest()
+    )
+    report = _junit(
+        tmp_path / "forged-report.xml",
+        FinalCloseoutLane.ACTUAL_NEO4J,
+        forged,
+    )
+
+    with pytest.raises(
+        Increment5E2CloseoutReceiptError,
+        match="qualification_report_semantics",
+    ):
+        build_actual_service_receipt(repo_root=ROOT, service_junit_report=report)
+
+
+def test_junit_parser_preserves_exact_parameter_node_ids(tmp_path: Path) -> None:
+    path = tmp_path / "parameter.xml"
+    path.write_text(
+        '<testsuite><testcase classname="newsroom.tests.test_example" '
+        'name="test_exact[node-a]"/></testsuite>',
+        encoding="utf-8",
+    )
+
+    parsed = _parse_junit(path)
+
+    assert parsed.cases[0].test_id == (
+        "newsroom.tests.test_example::test_exact[node-a]"
+    )
+
+
+def test_junit_parser_rejects_utf16_dtd_and_entity(tmp_path: Path) -> None:
+    path = tmp_path / "utf16-entity.xml"
+    path.write_bytes(
+        (
+            '<!DOCTYPE testsuite [<!ENTITY owner "newsroom.tests.test_example">]>'
+            '<testsuite><testcase classname="&owner;" name="test_exact"/>'
+            "</testsuite>"
+        ).encode("utf-16")
+    )
+
+    with pytest.raises(
+        Increment5E2CloseoutReceiptError,
+        match="junit_xml_encoding",
+    ):
+        _parse_junit(path)
+
+
+@dataclass(frozen=True)
+class _RawReport:
+    path: str
+    size_bytes: int
+    digest: str
+
+
+def test_final_receipt_binds_validated_decision_transports_and_both_lanes(
+    tmp_path: Path,
+    target_properties: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    head = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=ROOT, text=True
+    ).strip()
+    tree = _tree()
+    lane_inputs = {}
+    lanes = []
+    for lane_id, inventory_lane in (
+        ("core", FinalCloseoutLane.DETERMINISTIC),
+        ("service", FinalCloseoutLane.ACTUAL_NEO4J),
+    ):
+        artifact = tmp_path / lane_id
+        artifact.mkdir()
+        report_path = _junit(artifact / "report.xml", inventory_lane, target_properties)
+        payload = report_path.read_bytes()
+        replay = SimpleNamespace(
+            head_sha=head, replay_identity=f"sha256:{lane_id[0] * 64}"
+        )
+        raw = _RawReport(
+            "report.xml",
+            len(payload),
+            "sha256:" + hashlib.sha256(payload).hexdigest(),
+        )
+        receipt = SimpleNamespace(
+            evaluated_sha=head,
+            evaluated_tree_sha=tree,
+            raw_reports=(raw,),
+            route=SimpleNamespace(selected_test_manifest_digest="sha256:" + "a" * 64),
+            receipt_identity="sha256:" + ("b" if lane_id == "core" else "c") * 64,
+            envelope_identity="sha256:" + ("d" if lane_id == "core" else "e") * 64,
+        )
+        lane = SimpleNamespace(
+            lane_id=lane_id,
+            replay=replay,
+            receipt=receipt,
+            lane_identity="sha256:" + ("f" if lane_id == "core" else "9") * 64,
+        )
+        verified = SimpleNamespace(
+            replay=replay,
+            artifact_root=artifact,
+            bundle=SimpleNamespace(
+                transport_identity="sha256:" + ("1" if lane_id == "core" else "2") * 64
+            ),
+        )
+        lanes.append(lane)
+        lane_inputs[lane_id] = verified
+    decision = SimpleNamespace(
+        result="PASS",
+        lanes=tuple(lanes),
+        context=SimpleNamespace(evaluated_sha=head, evaluated_tree_sha=tree),
+        decision_identity="sha256:" + "3" * 64,
+    )
+    monkeypatch.setattr(
+        "scripts.sdlc.increment5e2_closeout_receipt.load_contract",
+        lambda _root: object(),
+    )
+    monkeypatch.setattr(
+        "scripts.sdlc.increment5e2_closeout_receipt.validate_shadow_decision",
+        lambda _value, contract: decision,
+    )
+    monkeypatch.setattr(
+        "scripts.sdlc.increment5e2_closeout_receipt.load_verified_transport",
+        lambda path: lane_inputs[Path(path).name],
+    )
+    decision_path = tmp_path / "decision.json"
+    decision_path.write_text("{}", encoding="utf-8")
+
+    receipt = build_final_receipt(
+        repo_root=ROOT,
+        core_transport_bundle_root=tmp_path / "core",
+        service_transport_bundle_root=tmp_path / "service",
+        decision_path=decision_path,
+    )
+
+    assert receipt["decision_identity"] == decision.decision_identity
+    assert len(receipt["selected_cases"]) == len(INCREMENT5E2_FINAL_CLOSEOUT_CASES)
+    assert {lane["lane_id"] for lane in receipt["lanes"]} == {"core", "service"}
+    assert receipt["inventory"]["digest"] == (
+        INCREMENT5E2_FINAL_CLOSEOUT_INVENTORY_DIGEST
+    )

--- a/newsroom/tests/test_increment5e2_closeout_receipt.py
+++ b/newsroom/tests/test_increment5e2_closeout_receipt.py
@@ -41,18 +41,32 @@ from scripts.sdlc.workflow_lane import service_compatibility_digest
 ROOT = Path(__file__).resolve().parents[2]
 
 
-def _tree() -> str:
+def _tree(root: Path) -> str:
     return subprocess.check_output(
-        ["git", "rev-parse", "HEAD^{tree}"], cwd=ROOT, text=True
+        ["git", "rev-parse", "HEAD^{tree}"], cwd=root, text=True
     ).strip()
+
+
+def _clean_clone(tmp_path: Path, name: str) -> Path:
+    clone = tmp_path / name
+    subprocess.run(
+        ["git", "clone", "--quiet", "--no-local", str(ROOT), str(clone)],
+        check=True,
+    )
+    return clone
 
 
 @pytest.fixture(scope="module")
-def target_properties() -> dict[str, str]:
+def clean_repo(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    return _clean_clone(tmp_path_factory.mktemp("clean-closeout-repo"), "repository")
+
+
+@pytest.fixture(scope="module")
+def target_properties(clean_repo: Path) -> dict[str, str]:
     head = subprocess.check_output(
-        ["git", "rev-parse", "HEAD"], cwd=ROOT, text=True
+        ["git", "rev-parse", "HEAD"], cwd=clean_repo, text=True
     ).strip()
-    tree = _tree()
+    tree = _tree(clean_repo)
     epoch = build_qualification_epoch(
         target=QUALIFICATION_TARGET,
         corpus=QUALIFICATION_CORPUS,
@@ -120,7 +134,9 @@ def _junit(
 
 
 def test_actual_service_receipt_binds_exact_report_and_semantics(
-    tmp_path: Path, target_properties: dict[str, str]
+    tmp_path: Path,
+    target_properties: dict[str, str],
+    clean_repo: Path,
 ) -> None:
     report = _junit(
         tmp_path / "service.xml",
@@ -128,7 +144,10 @@ def test_actual_service_receipt_binds_exact_report_and_semantics(
         target_properties,
     )
 
-    receipt = build_actual_service_receipt(repo_root=ROOT, service_junit_report=report)
+    receipt = build_actual_service_receipt(
+        repo_root=clean_repo,
+        service_junit_report=report,
+    )
 
     expected_digest = "sha256:" + hashlib.sha256(report.read_bytes()).hexdigest()
     assert receipt["junit_report"]["digest"] == expected_digest
@@ -146,8 +165,98 @@ def test_actual_service_receipt_binds_exact_report_and_semantics(
     assert unsigned.pop("receipt_identity") == sha256_identity(unsigned)
 
 
+def test_actual_service_rejects_tracked_checkout_drift_before_emission(
+    tmp_path: Path,
+    target_properties: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clone = _clean_clone(tmp_path, "actual-service-dirty")
+    report = _junit(
+        tmp_path / "dirty-service.xml",
+        FinalCloseoutLane.ACTUAL_NEO4J,
+        target_properties,
+    )
+
+    def parse_then_dirty(path: Path) -> object:
+        parsed = _parse_junit(path)
+        tracked = clone / "README.md"
+        tracked.write_text(
+            tracked.read_text(encoding="utf-8") + "\ntracked receipt drift\n",
+            encoding="utf-8",
+        )
+        return parsed
+
+    monkeypatch.setattr(
+        "scripts.sdlc.increment5e2_closeout_receipt._parse_junit",
+        parse_then_dirty,
+    )
+
+    with pytest.raises(
+        Increment5E2CloseoutReceiptError,
+        match="tracked_checkout_dirty",
+    ):
+        build_actual_service_receipt(
+            repo_root=clone,
+            service_junit_report=report,
+        )
+
+
+@pytest.mark.parametrize("builder", ("actual-service", "final"))
+def test_receipt_builders_reject_initial_tracked_checkout_drift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    builder: str,
+) -> None:
+    clone = _clean_clone(tmp_path, f"initial-dirty-{builder}")
+    tracked = clone / "README.md"
+    tracked.write_text(
+        tracked.read_text(encoding="utf-8") + "\ninitial tracked drift\n",
+        encoding="utf-8",
+    )
+
+    if builder == "actual-service":
+        def must_not_parse(_path: Path) -> object:
+            raise AssertionError(
+                "dirty checkout must fail before JUnit parsing"
+            )
+
+        monkeypatch.setattr(
+            "scripts.sdlc.increment5e2_closeout_receipt._parse_junit",
+            must_not_parse,
+        )
+    else:
+        def must_not_load(_root: Path) -> object:
+            raise AssertionError(
+                "dirty checkout must fail before contract loading"
+            )
+
+        monkeypatch.setattr(
+            "scripts.sdlc.increment5e2_closeout_receipt.load_contract",
+            must_not_load,
+        )
+
+    with pytest.raises(
+        Increment5E2CloseoutReceiptError,
+        match="tracked_checkout_dirty",
+    ):
+        if builder == "actual-service":
+            build_actual_service_receipt(
+                repo_root=clone,
+                service_junit_report=tmp_path / "missing.xml",
+            )
+        else:
+            build_final_receipt(
+                repo_root=clone,
+                core_transport_bundle_root=tmp_path / "missing-core",
+                service_transport_bundle_root=tmp_path / "missing-service",
+                decision_path=tmp_path / "missing-decision.json",
+            )
+
+
 def test_actual_service_rejects_missing_skipped_and_tampered_properties(
-    tmp_path: Path, target_properties: dict[str, str]
+    tmp_path: Path,
+    target_properties: dict[str, str],
+    clean_repo: Path,
 ) -> None:
     cases = [
         case
@@ -161,7 +270,10 @@ def test_actual_service_rejects_missing_skipped_and_tampered_properties(
         omitted=cases[0].test_id,
     )
     with pytest.raises(Increment5E2CloseoutReceiptError, match="selected_test_missing"):
-        build_actual_service_receipt(repo_root=ROOT, service_junit_report=missing)
+        build_actual_service_receipt(
+            repo_root=clean_repo,
+            service_junit_report=missing,
+        )
 
     skipped = _junit(
         tmp_path / "skipped.xml",
@@ -170,7 +282,10 @@ def test_actual_service_rejects_missing_skipped_and_tampered_properties(
         skipped=cases[0].test_id,
     )
     with pytest.raises(Increment5E2CloseoutReceiptError, match="not_passed"):
-        build_actual_service_receipt(repo_root=ROOT, service_junit_report=skipped)
+        build_actual_service_receipt(
+            repo_root=clean_repo,
+            service_junit_report=skipped,
+        )
 
     changed = dict(target_properties)
     changed["increment5e2_epoch_digest"] = "sha256:" + "0" * 64
@@ -180,7 +295,10 @@ def test_actual_service_rejects_missing_skipped_and_tampered_properties(
         changed,
     )
     with pytest.raises(Increment5E2CloseoutReceiptError, match="epoch_identity"):
-        build_actual_service_receipt(repo_root=ROOT, service_junit_report=tampered)
+        build_actual_service_receipt(
+            repo_root=clean_repo,
+            service_junit_report=tampered,
+        )
 
     unexpected = dict(target_properties)
     unexpected["increment5e2_unreviewed_property"] = "unexpected"
@@ -190,13 +308,17 @@ def test_actual_service_rejects_missing_skipped_and_tampered_properties(
         unexpected,
     )
     with pytest.raises(Increment5E2CloseoutReceiptError, match="target_properties"):
-        build_actual_service_receipt(repo_root=ROOT, service_junit_report=extra)
+        build_actual_service_receipt(
+            repo_root=clean_repo,
+            service_junit_report=extra,
+        )
 
 
 @pytest.mark.parametrize("outcome", ("failure", "error"))
 def test_actual_service_rejects_unselected_failure_or_error(
     tmp_path: Path,
     target_properties: dict[str, str],
+    clean_repo: Path,
     outcome: str,
 ) -> None:
     report = _junit(
@@ -218,7 +340,10 @@ def test_actual_service_rejects_unselected_failure_or_error(
         Increment5E2CloseoutReceiptError,
         match="unselected_test_not_passed",
     ):
-        build_actual_service_receipt(repo_root=ROOT, service_junit_report=report)
+        build_actual_service_receipt(
+            repo_root=clean_repo,
+            service_junit_report=report,
+        )
 
 
 @pytest.mark.parametrize(
@@ -233,6 +358,7 @@ def test_actual_service_rejects_unselected_failure_or_error(
 def test_actual_service_rejects_changed_checkout_service_or_inventory_identity(
     tmp_path: Path,
     target_properties: dict[str, str],
+    clean_repo: Path,
     property_name: str,
     property_value: str,
     expected_error: str,
@@ -246,11 +372,16 @@ def test_actual_service_rejects_changed_checkout_service_or_inventory_identity(
     )
 
     with pytest.raises(Increment5E2CloseoutReceiptError, match=expected_error):
-        build_actual_service_receipt(repo_root=ROOT, service_junit_report=report)
+        build_actual_service_receipt(
+            repo_root=clean_repo,
+            service_junit_report=report,
+        )
 
 
 def test_actual_service_rejects_self_consistent_forged_qualification_report(
-    tmp_path: Path, target_properties: dict[str, str]
+    tmp_path: Path,
+    target_properties: dict[str, str],
+    clean_repo: Path,
 ) -> None:
     forged_value = json.loads(target_properties["increment5e2_report_json"])
     forged_value.update(
@@ -309,7 +440,10 @@ def test_actual_service_rejects_self_consistent_forged_qualification_report(
         Increment5E2CloseoutReceiptError,
         match="qualification_report_semantics",
     ):
-        build_actual_service_receipt(repo_root=ROOT, service_junit_report=report)
+        build_actual_service_receipt(
+            repo_root=clean_repo,
+            service_junit_report=report,
+        )
 
 
 def test_junit_parser_preserves_exact_parameter_node_ids(tmp_path: Path) -> None:
@@ -380,16 +514,17 @@ class _RawReport:
     digest: str
 
 
-def test_final_receipt_binds_validated_decision_transports_and_both_lanes(
+def _final_receipt_stubs(
     tmp_path: Path,
     target_properties: dict[str, str],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+    *,
+    repo_root: Path,
+) -> tuple[SimpleNamespace, dict[str, SimpleNamespace]]:
     head = subprocess.check_output(
-        ["git", "rev-parse", "HEAD"], cwd=ROOT, text=True
+        ["git", "rev-parse", "HEAD"], cwd=repo_root, text=True
     ).strip()
-    tree = _tree()
-    lane_inputs = {}
+    tree = _tree(repo_root)
+    lane_inputs: dict[str, SimpleNamespace] = {}
     lanes = []
     for lane_id, inventory_lane in (
         ("core", FinalCloseoutLane.DETERMINISTIC),
@@ -436,6 +571,14 @@ def test_final_receipt_binds_validated_decision_transports_and_both_lanes(
         context=SimpleNamespace(evaluated_sha=head, evaluated_tree_sha=tree),
         decision_identity="sha256:" + "3" * 64,
     )
+    return decision, lane_inputs
+
+
+def _stub_final_receipt_inputs(
+    monkeypatch: pytest.MonkeyPatch,
+    decision: SimpleNamespace,
+    lane_inputs: dict[str, SimpleNamespace],
+) -> None:
     monkeypatch.setattr(
         "scripts.sdlc.increment5e2_closeout_receipt.load_contract",
         lambda _root: object(),
@@ -448,11 +591,25 @@ def test_final_receipt_binds_validated_decision_transports_and_both_lanes(
         "scripts.sdlc.increment5e2_closeout_receipt.load_verified_transport",
         lambda path: lane_inputs[Path(path).name],
     )
+
+
+def test_final_receipt_binds_validated_decision_transports_and_both_lanes(
+    tmp_path: Path,
+    target_properties: dict[str, str],
+    clean_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    decision, lane_inputs = _final_receipt_stubs(
+        tmp_path,
+        target_properties,
+        repo_root=clean_repo,
+    )
+    _stub_final_receipt_inputs(monkeypatch, decision, lane_inputs)
     decision_path = tmp_path / "decision.json"
     decision_path.write_text("{}", encoding="utf-8")
 
     receipt = build_final_receipt(
-        repo_root=ROOT,
+        repo_root=clean_repo,
         core_transport_bundle_root=tmp_path / "core",
         service_transport_bundle_root=tmp_path / "service",
         decision_path=decision_path,
@@ -464,3 +621,53 @@ def test_final_receipt_binds_validated_decision_transports_and_both_lanes(
     assert receipt["inventory"]["digest"] == (
         INCREMENT5E2_FINAL_CLOSEOUT_INVENTORY_DIGEST
     )
+
+
+def test_final_receipt_rejects_tracked_checkout_drift_before_emission(
+    tmp_path: Path,
+    target_properties: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clone = _clean_clone(tmp_path, "final-dirty")
+    decision, lane_inputs = _final_receipt_stubs(
+        tmp_path,
+        target_properties,
+        repo_root=clone,
+    )
+    monkeypatch.setattr(
+        "scripts.sdlc.increment5e2_closeout_receipt.load_contract",
+        lambda _root: object(),
+    )
+    monkeypatch.setattr(
+        "scripts.sdlc.increment5e2_closeout_receipt.validate_shadow_decision",
+        lambda _value, contract: decision,
+    )
+
+    def load_then_dirty(path: Path) -> SimpleNamespace:
+        selected = lane_inputs[Path(path).name]
+        if Path(path).name == "service":
+            tracked = clone / "README.md"
+            tracked.write_text(
+                tracked.read_text(encoding="utf-8")
+                + "\ntracked final receipt drift\n",
+                encoding="utf-8",
+            )
+        return selected
+
+    monkeypatch.setattr(
+        "scripts.sdlc.increment5e2_closeout_receipt.load_verified_transport",
+        load_then_dirty,
+    )
+    decision_path = tmp_path / "dirty-decision.json"
+    decision_path.write_text("{}", encoding="utf-8")
+
+    with pytest.raises(
+        Increment5E2CloseoutReceiptError,
+        match="tracked_checkout_dirty",
+    ):
+        build_final_receipt(
+            repo_root=clone,
+            core_transport_bundle_root=tmp_path / "core",
+            service_transport_bundle_root=tmp_path / "service",
+            decision_path=decision_path,
+        )

--- a/newsroom/tests/test_increment5e2_final_closeout.py
+++ b/newsroom/tests/test_increment5e2_final_closeout.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import importlib
+import re
+from pathlib import Path
+
+from newsroom.increment5._traceability_model import (
+    RETRIEVAL_QUALIFICATION_REQUIREMENTS,
+)
+from newsroom.increment5.final_closeout import (
+    INCREMENT5_FINAL_REQUIREMENTS,
+    INCREMENT5E2_FINAL_CLOSEOUT_CASES,
+    INCREMENT5E2_FINAL_CLOSEOUT_INVENTORY_DIGEST,
+    INCREMENT5E2_FINAL_NON_EFFECTS,
+    FinalCloseoutCategory,
+    FinalCloseoutLane,
+    validate_increment5e2_final_closeout_inventory,
+)
+from scripts.sdlc.workflow_lane import (
+    _OPTIONAL_CORE_TEST_IDS,
+    _repository_service_tests,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_final_closeout_inventory_is_content_addressed_and_exact() -> None:
+    validate_increment5e2_final_closeout_inventory()
+    assert len(INCREMENT5E2_FINAL_CLOSEOUT_CASES) == 64
+    assert INCREMENT5E2_FINAL_CLOSEOUT_INVENTORY_DIGEST == (
+        "sha256:7cdb2c769c4f312f0e2f670fd3c4084025d7cbe247788993d5b50841b0a5be95"
+    )
+    assert {
+        requirement
+        for case in INCREMENT5E2_FINAL_CLOSEOUT_CASES
+        for requirement in case.requirements
+    } == INCREMENT5_FINAL_REQUIREMENTS
+    assert INCREMENT5_FINAL_REQUIREMENTS is RETRIEVAL_QUALIFICATION_REQUIREMENTS
+    assert INCREMENT5E2_FINAL_NON_EFFECTS == tuple(
+        sorted(INCREMENT5E2_FINAL_NON_EFFECTS)
+    )
+
+
+def test_every_closeout_category_has_deterministic_and_actual_service_proof() -> None:
+    for category in FinalCloseoutCategory:
+        assert {
+            case.lane
+            for case in INCREMENT5E2_FINAL_CLOSEOUT_CASES
+            if case.category is category
+        } == set(FinalCloseoutLane)
+
+
+def test_closeout_test_functions_are_permanent_repository_tests() -> None:
+    for case in INCREMENT5E2_FINAL_CLOSEOUT_CASES:
+        module_name, function_name = case.test_id.split("::", 1)
+        function_name = function_name.split("[", 1)[0]
+        module = importlib.import_module(module_name)
+        assert callable(getattr(module, function_name))
+
+
+def test_actual_service_closeout_cases_are_closed_world_sdlc_cases() -> None:
+    actual = {
+        case.test_id
+        for case in INCREMENT5E2_FINAL_CLOSEOUT_CASES
+        if case.lane is FinalCloseoutLane.ACTUAL_NEO4J
+    }
+    assert actual <= set(_OPTIONAL_CORE_TEST_IDS)
+
+    selected_files = set(_repository_service_tests(ROOT))
+    for test_id in actual:
+        module_name = test_id.split("::", 1)[0]
+        relative = module_name.replace(".", "/") + ".py"
+        assert relative in selected_files
+
+
+def test_permanent_neo4j_workflow_selects_every_actual_closeout_module() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "projection-b2-neo4j.yml").read_text(
+        encoding="utf-8"
+    )
+    patterns = set(re.findall(r"newsroom/tests/test_[^\\\s]+\.py", workflow))
+    selected = {
+        path.relative_to(ROOT).as_posix()
+        for pattern in patterns
+        for path in ROOT.glob(pattern)
+    }
+    required = {
+        case.test_id.split("::", 1)[0].replace(".", "/") + ".py"
+        for case in INCREMENT5E2_FINAL_CLOSEOUT_CASES
+        if case.lane is FinalCloseoutLane.ACTUAL_NEO4J
+    }
+    assert required <= selected
+
+
+def test_final_actual_service_receipt_binds_every_frozen_identity() -> None:
+    source = (
+        ROOT / "newsroom" / "tests" / "test_projection_b2_increment5e2_neo4j_service.py"
+    ).read_text(encoding="utf-8")
+    for identity in (
+        "increment5e2_epoch_json",
+        "increment5e2_epoch_digest",
+        "increment5e2_report_json",
+        "increment5e2_report_digest",
+        "increment5e2_closeout_inventory_digest",
+        "increment5e2_closeout_case_count",
+        "increment5e2_non_effects",
+        "increment5e2_source_head_sha",
+        "increment5e2_source_tree_sha",
+        "increment5e2_neo4j_image",
+        "increment5e2_neo4j_server_version",
+        "increment5e2_neo4j_edition",
+        "increment5e2_neo4j_driver_version",
+        "increment5e2_neo4j_database",
+        "increment5e2_neo4j_projector_username",
+        "increment5e2_service_compatibility_digest",
+    ):
+        assert identity in source

--- a/newsroom/tests/test_integrated_c1_sdlc_contract.py
+++ b/newsroom/tests/test_integrated_c1_sdlc_contract.py
@@ -40,6 +40,7 @@ def test_increment_1c_native_graph_paths_require_actual_service_evidence() -> No
         "newsroom/tests/test_increment5b4_neo4j_service.py",
         "newsroom/tests/test_increment_2d_neo4j_service.py",
         _INTEGRATED_SERVICE_TEST,
+        "newsroom/tests/test_projection_b2_increment5e2_neo4j_service.py",
         "newsroom/tests/test_projection_b2_neo4j_service.py",
         "newsroom/tests/test_projection_b3_neo4j_service.py",
         "newsroom/tests/test_retrieval_2c_neo4j_service.py",
@@ -112,13 +113,17 @@ def test_complete_actual_service_cases_are_optional_only_in_core() -> None:
         'newsroom.tests.test_retrieval_2c_neo4j_service::test_actual_service_missing_vector_index_is_unavailable_not_no_match',
     }
     assert _INTEGRATED_SERVICE_TEST_ID in optional
+    assert (
+        "newsroom.tests.test_projection_b2_increment5e2_neo4j_service::"
+        "test_actual_service_increment5e2_target_and_report"
+    ) in optional
     assert {
         "newsroom.tests.test_projection_b3_neo4j_service::test_actual_service_3e_projects_complete_lineage_and_recovers_graph_loss",
         "newsroom.tests.test_projection_b3_neo4j_service::test_actual_service_3e_replacement_generation_becomes_only_active_lineage",
     } <= set(optional)
     assert complete <= set(optional)
     assert optional == tuple(sorted(optional))
-    assert len(optional) == 40
+    assert len(optional) == 41
 
     route = _route("newsroom/projection/neo4j/_complete_adapter.py")
     assert route["service_required"] is True

--- a/newsroom/tests/test_integrated_c1_workflow_contract.py
+++ b/newsroom/tests/test_integrated_c1_workflow_contract.py
@@ -54,3 +54,26 @@ def test_permanent_neo4j_gate_executes_every_b3_and_3e_actual_service_case() -> 
     )
     for statement in required:
         assert text.count(statement) == 1
+
+
+def test_permanent_neo4j_gate_retains_increment5e2_closed_world_receipt() -> None:
+    text = _WORKFLOW.read_text(encoding="utf-8")
+    required = (
+        "newsroom/tests/test_projection_b2_*.py",
+        "newsroom/tests/test_increment5b4_neo4j_service.py",
+        "scripts.sdlc.increment5e2_closeout_receipt actual-service",
+        "--service-junit-report projection-b2-b3-c1-complete-retrieval-neo4j-results.xml",
+        "--output increment5e2-actual-service-closeout.json",
+        "increment5e2-actual-service-closeout.json",
+        "Remove disposable credential files",
+        '${RUNNER_TEMP}/newsroom-b2-neo4j-admin.env',
+        '${RUNNER_TEMP}/newsroom-b2-neo4j-projector.env',
+        'export NEWSROOM_NEO4J_PASSWORD="${NEWSROOM_NEO4J_PROJECTOR_PASSWORD}"',
+    )
+    for statement in required:
+        assert statement in text
+    assert "GITHUB_ENV" not in text
+    assert text.index("Remove disposable credential files") < text.index(
+        "Build Increment 5E2 actual-service closeout receipt"
+    )
+    assert "if: steps.focused.outcome == 'success'" in text

--- a/newsroom/tests/test_projection_b2_boundaries.py
+++ b/newsroom/tests/test_projection_b2_boundaries.py
@@ -168,7 +168,10 @@ def test_actual_service_workflow_masks_runtime_credentials() -> None:
     assert "secrets.token_urlsafe" in workflow
     assert 'echo "::add-mask::${NEO4J_ADMIN_PASSWORD}"' in workflow
     assert 'echo "::add-mask::${NEWSROOM_NEO4J_PROJECTOR_PASSWORD}"' in workflow
-    assert '>> "${GITHUB_ENV}"' in workflow
+    assert "GITHUB_ENV" not in workflow
+    assert '${RUNNER_TEMP}/newsroom-b2-neo4j-admin.env' in workflow
+    assert '${RUNNER_TEMP}/newsroom-b2-neo4j-projector.env' in workflow
+    assert 'chmod 600 "${admin_file}" "${projector_file}"' in workflow
     assert "docker run --detach" in workflow
     assert "--publish 127.0.0.1:7687:7687" in workflow
     assert "docker rm --force newsroom-b2-neo4j" in workflow

--- a/newsroom/tests/test_projection_b2_increment5e1_qualification.py
+++ b/newsroom/tests/test_projection_b2_increment5e1_qualification.py
@@ -61,6 +61,7 @@ def test_actual_service_increment5e1_target_and_report(
         target=QUALIFICATION_TARGET,
         corpus=QUALIFICATION_CORPUS,
         epoch=epoch,
+        code_tree_sha=tree,
         observations=run_fixture_qualification(
             target=QUALIFICATION_TARGET,
             corpus=QUALIFICATION_CORPUS,

--- a/newsroom/tests/test_projection_b2_increment5e2_neo4j_service.py
+++ b/newsroom/tests/test_projection_b2_increment5e2_neo4j_service.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import uuid
 
+import pytest
 
+from newsroom.increment5.final_closeout import (
+    INCREMENT5E2_FINAL_CLOSEOUT_CASES,
+    INCREMENT5E2_FINAL_CLOSEOUT_INVENTORY_DIGEST,
+    INCREMENT5E2_FINAL_NON_EFFECTS,
+)
 from newsroom.increment5.retrieval_qualification import (
     QUALIFICATION_CORPUS,
     QUALIFICATION_TARGET,
@@ -20,21 +27,19 @@ from newsroom.projection.neo4j import (
     Neo4jProjectorConfig,
 )
 from newsroom.projection.neo4j._adapter import _open_neo4j_adapter
+from scripts.sdlc.workflow_lane import service_compatibility_digest
 
 
 _REQUIRED_FLAG = "NEWSROOM_NEO4J_SERVICE_REQUIRED"
 
 
-def test_actual_service_increment5e1_target_and_report(
+def test_actual_service_increment5e2_target_and_report(
     record_property,
 ) -> None:
     assert QUALIFICATION_TARGET.graph_engine_image == NEO4J_B2_IMAGE
-    assert (
-        QUALIFICATION_TARGET.graph_driver_version
-        == NEO4J_B2_DRIVER_VERSION
-    )
+    assert QUALIFICATION_TARGET.graph_driver_version == NEO4J_B2_DRIVER_VERSION
     if os.environ.get(_REQUIRED_FLAG) != "1":
-        return
+        pytest.skip("authenticated Neo4j service is not required")
 
     config = Neo4jProjectorConfig.from_environment()
     adapter = _open_neo4j_adapter(config)
@@ -46,6 +51,10 @@ def test_actual_service_increment5e1_target_and_report(
     assert compatibility.server_version == NEO4J_B2_SERVER_VERSION
     assert compatibility.edition == "community"
     assert compatibility.driver_version == NEO4J_B2_DRIVER_VERSION
+    head = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"],
+        text=True,
+    ).strip()
     tree = subprocess.check_output(
         ["git", "rev-parse", "HEAD^{tree}"],
         text=True,
@@ -77,9 +86,41 @@ def test_actual_service_increment5e1_target_and_report(
     assert report.authority_effect == "NONE"
     assert report.production_activation_authorized is False
 
-    record_property("increment5e1_epoch_digest", epoch.epoch_digest)
-    record_property("increment5e1_report_digest", report.report_digest)
+    record_property("increment5e2_source_head_sha", head)
+    record_property("increment5e2_source_tree_sha", tree)
+    record_property("increment5e2_neo4j_image", NEO4J_B2_IMAGE)
+    record_property("increment5e2_neo4j_server_version", compatibility.server_version)
+    record_property("increment5e2_neo4j_edition", compatibility.edition)
+    record_property("increment5e2_neo4j_driver_version", compatibility.driver_version)
+    record_property("increment5e2_neo4j_database", config.database)
+    record_property("increment5e2_neo4j_projector_username", config.username)
     record_property(
-        "increment5e1_report_json",
+        "increment5e2_service_compatibility_digest",
+        service_compatibility_digest(),
+    )
+    record_property("increment5e2_epoch_digest", epoch.epoch_digest)
+    record_property(
+        "increment5e2_epoch_json",
+        json.dumps(
+            epoch.canonical_value(),
+            sort_keys=True,
+            separators=(",", ":"),
+        ),
+    )
+    record_property("increment5e2_report_digest", report.report_digest)
+    record_property(
+        "increment5e2_report_json",
         report.canonical_bytes.decode("utf-8"),
+    )
+    record_property(
+        "increment5e2_closeout_inventory_digest",
+        INCREMENT5E2_FINAL_CLOSEOUT_INVENTORY_DIGEST,
+    )
+    record_property(
+        "increment5e2_closeout_case_count",
+        str(len(INCREMENT5E2_FINAL_CLOSEOUT_CASES)),
+    )
+    record_property(
+        "increment5e2_non_effects",
+        ",".join(INCREMENT5E2_FINAL_NON_EFFECTS),
     )

--- a/newsroom/tests/test_sdlc_classifier.py
+++ b/newsroom/tests/test_sdlc_classifier.py
@@ -96,6 +96,7 @@ def test_classifier_source_tests_policy_and_workflows_require_service() -> None:
         "newsroom/tests/test_increment5b4_neo4j_service.py",
             "newsroom/tests/test_increment_2d_neo4j_service.py",
             "newsroom/tests/test_integrated_c1_neo4j_service.py",
+            "newsroom/tests/test_projection_b2_increment5e2_neo4j_service.py",
             "newsroom/tests/test_projection_b2_neo4j_service.py",
             "newsroom/tests/test_projection_b3_neo4j_service.py",
             "newsroom/tests/test_retrieval_2c_neo4j_service.py",

--- a/newsroom/tests/test_sdlc_evidence_workflow.py
+++ b/newsroom/tests/test_sdlc_evidence_workflow.py
@@ -155,7 +155,7 @@ def test_every_action_is_release_pinned_to_an_exact_sha() -> None:
     assert set(observed) == allowed
     assert observed.count(CHECKOUT) == 4
     assert observed.count(SETUP_PYTHON) == 4
-    assert observed.count(SETUP_UV) == 2
+    assert observed.count(SETUP_UV) == 3
     assert observed.count(UPLOAD) == 4
     assert observed.count(DOWNLOAD) == 2
 
@@ -179,7 +179,8 @@ def test_each_job_checks_out_the_exact_evaluated_head_without_credentials() -> N
 def test_uv_cache_is_exact_observable_and_untrusted_prs_cannot_save() -> None:
     core = _uses_steps("core", SETUP_UV)
     service = _uses_steps("service", SETUP_UV)
-    assert len(core) == len(service) == 1
+    decision = _uses_steps("decision", SETUP_UV)
+    assert len(core) == len(service) == len(decision) == 1
     common = {
         "version": "0.8.0",
         "github-token": "",
@@ -195,8 +196,11 @@ def test_uv_cache_is_exact_observable_and_untrusted_prs_cannot_save() -> None:
         "save-cache": "${{ github.event_name != 'pull_request' }}",
     }
     assert service[0]["with"] == {**common, "save-cache": "false"}
+    assert decision[0]["with"] == {**common, "save-cache": "false"}
+    assert decision[0]["if"] == (
+        "needs.route.outputs.service_required == 'true'"
+    )
     assert not _uses_steps("route", SETUP_UV)
-    assert not _uses_steps("decision", SETUP_UV)
 
     expected_cache_env = {
         "NEWSROOM_SDLC_CACHE_KEY": "${{ steps.setup_uv.outputs.cache-key }}",
@@ -307,6 +311,27 @@ def test_core_bootstrap_precompiles_exact_source_before_timed_lane() -> None:
     assert "compileall" not in _step(
         "service", "Sync locked environment"
     )["run"]
+
+
+def test_decision_bootstraps_locked_runtime_before_closeout_receipt() -> None:
+    sync_step = _step("decision", "Sync locked closeout environment")
+    assert sync_step["if"] == "needs.route.outputs.service_required == 'true'"
+    sync = sync_step["run"]
+    assert sync.splitlines() == [
+        "set -euo pipefail",
+        "uv lock --check",
+        "uv sync --locked --no-dev",
+    ]
+    closeout = _step("decision", "Build Increment 5E2 final closeout receipt")
+    invocation = (
+        "uv run --no-sync python -m "
+        "scripts.sdlc.increment5e2_closeout_receipt final"
+    )
+    assert invocation in closeout["run"]
+    names = [step["name"] for step in _steps("decision")]
+    assert names.index("Sync locked closeout environment") < names.index(
+        "Build Increment 5E2 final closeout receipt"
+    )
 
 
 def test_service_boundary_is_exact_authenticated_loopback_and_bounded() -> None:
@@ -436,7 +461,7 @@ def test_workflow_never_invokes_prohibited_product_runtime() -> None:
 
 
 def test_setup_uv_never_receives_the_github_token() -> None:
-    for job_id in ("core", "service"):
+    for job_id in ("core", "service", "decision"):
         setup = _uses_steps(job_id, SETUP_UV)
         assert len(setup) == 1
         assert setup[0]["with"]["github-token"] == ""

--- a/newsroom/tests/test_sdlc_evidence_workflow.py
+++ b/newsroom/tests/test_sdlc_evidence_workflow.py
@@ -15,6 +15,7 @@ SETUP_PYTHON = "actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1"
 SETUP_UV = "astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b"
 UPLOAD = "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
 DOWNLOAD = "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c"
+ATTEST = "actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6"
 EVALUATED_SHA = (
     "${{ github.event.pull_request.head.sha || "
     "github.event.merge_group.head_sha || github.sha }}"
@@ -104,16 +105,24 @@ def test_shadow_workflow_has_exact_nonprivileged_event_surface() -> None:
 
 def test_job_graph_is_exact_and_decision_always_reports() -> None:
     jobs = _jobs()
-    assert set(jobs) == {"route", "core", "service", "decision"}
+    assert set(jobs) == {
+        "route",
+        "core",
+        "service",
+        "decision",
+        "signed-closeout",
+    }
     assert {job_id: jobs[job_id]["name"] for job_id in jobs} == {
         "route": "route",
         "core": "core",
         "service": "service",
         "decision": "decision",
+        "signed-closeout": "signed-closeout",
     }
     assert jobs["core"]["needs"] == ["route"]
     assert jobs["service"]["needs"] == ["route"]
     assert jobs["decision"]["needs"] == ["route", "core", "service"]
+    assert jobs["signed-closeout"]["needs"] == ["route", "decision"]
     assert jobs["core"]["if"] == "needs.route.result == 'success'"
     assert jobs["service"]["if"] == (
         "needs.route.result == 'success' && "
@@ -123,6 +132,19 @@ def test_job_graph_is_exact_and_decision_always_reports() -> None:
     assert jobs["decision"]["permissions"] == {
         "actions": "read",
         "contents": "read",
+    }
+    assert jobs["signed-closeout"]["if"] == (
+        "github.event_name == 'workflow_dispatch' && "
+        "github.ref == 'refs/heads/main' && "
+        "needs.route.outputs.service_required == 'true' && "
+        "needs.decision.result == 'success'"
+    )
+    assert jobs["signed-closeout"]["permissions"] == {
+        "actions": "read",
+        "artifact-metadata": "write",
+        "attestations": "write",
+        "contents": "read",
+        "id-token": "write",
     }
     assert jobs["route"]["outputs"] == {
         "service_required": "${{ steps.route_output.outputs.service_required }}"
@@ -134,12 +156,13 @@ def test_job_graph_is_exact_and_decision_always_reports() -> None:
         "core": "10",
         "service": "10",
         "decision": "10",
+        "signed-closeout": "6",
     }
 
 
 def test_every_action_is_release_pinned_to_an_exact_sha() -> None:
     workflow = _workflow()
-    allowed = {CHECKOUT, SETUP_PYTHON, SETUP_UV, UPLOAD, DOWNLOAD}
+    allowed = {CHECKOUT, SETUP_PYTHON, SETUP_UV, UPLOAD, DOWNLOAD, ATTEST}
     observed: list[str] = []
     for job_id in _jobs():
         for step in _steps(job_id):
@@ -156,12 +179,13 @@ def test_every_action_is_release_pinned_to_an_exact_sha() -> None:
     assert observed.count(CHECKOUT) == 4
     assert observed.count(SETUP_PYTHON) == 4
     assert observed.count(SETUP_UV) == 3
-    assert observed.count(UPLOAD) == 4
-    assert observed.count(DOWNLOAD) == 2
+    assert observed.count(UPLOAD) == 5
+    assert observed.count(DOWNLOAD) == 3
+    assert observed.count(ATTEST) == 1
 
 
-def test_each_job_checks_out_the_exact_evaluated_head_without_credentials() -> None:
-    for job_id in _jobs():
+def test_execution_jobs_check_out_the_exact_evaluated_head_without_credentials() -> None:
+    for job_id in ("route", "core", "service", "decision"):
         checkouts = _uses_steps(job_id, CHECKOUT)
         assert len(checkouts) == 1
         assert _steps(job_id)[0] == checkouts[0]
@@ -174,6 +198,8 @@ def test_each_job_checks_out_the_exact_evaluated_head_without_credentials() -> N
         python = _uses_steps(job_id, SETUP_PYTHON)
         assert len(python) == 1
         assert python[0]["with"] == {"python-version": "3.12"}
+    assert not _uses_steps("signed-closeout", CHECKOUT)
+    assert not _uses_steps("signed-closeout", SETUP_PYTHON)
 
 
 def test_uv_cache_is_exact_observable_and_untrusted_prs_cannot_save() -> None:
@@ -279,6 +305,84 @@ def test_lane_and_decision_artifacts_are_compact_immutable_and_attempt_scoped() 
                 ".sdlc-run/decision.json",
                 ".sdlc-run/increment5e2-final-closeout.json",
             ]
+
+
+def test_signed_closeout_attests_only_the_validated_exact_main_receipt() -> None:
+    job = _jobs()["signed-closeout"]
+    download = _step("signed-closeout", "Download exact final decision evidence")
+    assert download["uses"] == DOWNLOAD
+    assert download["with"] == {
+        "name": (
+            "newsroom-sdlc-decision-${{ github.run_id }}-"
+            "${{ github.run_attempt }}-${{ github.sha }}"
+        ),
+        "path": ".sdlc-run/signed-closeout-input",
+        "merge-multiple": "false",
+        "digest-mismatch": "error",
+    }
+
+    validate = _step("signed-closeout", "Validate final closeout subject")
+    assert validate["env"] == {"EXPECTED_HEAD_SHA": "${{ github.sha }}"}
+    validation = validate["run"]
+    for expected in (
+        "newsroom.increment5e2.final-closeout-receipt.v1",
+        "receipt_identity",
+        "evaluated_sha",
+        "EXPECTED_HEAD_SHA",
+        "hashlib.sha256",
+        "allow_nan=False",
+        "object_pairs_hook=unique_object",
+        "newsroom.sdlc.shadow-decision.v1",
+        "workflow_dispatch",
+        "refs/heads/main",
+        "signed decision binding differs",
+    ):
+        assert expected in validation
+
+    attest = _step(
+        "signed-closeout",
+        "Attest final decision and closeout receipt",
+    )
+    assert attest["uses"] == ATTEST
+    assert attest["with"]["subject-path"].splitlines() == [
+        ".sdlc-run/signed-closeout-input/decision.json",
+        (
+            ".sdlc-run/signed-closeout-input/"
+            "increment5e2-final-closeout.json"
+        ),
+    ]
+    upload = _step("signed-closeout", "Retain attestation bundle")
+    assert upload["uses"] == UPLOAD
+    assert upload["with"] == {
+        "name": (
+            "newsroom-sdlc-attestation-${{ github.run_id }}-"
+            "${{ github.run_attempt }}-${{ github.sha }}"
+        ),
+        "path": "${{ steps.attest.outputs.bundle-path }}",
+        "if-no-files-found": "error",
+        "retention-days": "30",
+        "compression-level": "0",
+        "overwrite": "false",
+        "include-hidden-files": "false",
+        "archive": "true",
+    }
+    assert job["steps"][-1] == upload
+
+
+def test_only_signed_closeout_receives_oidc_and_attestation_permissions() -> None:
+    jobs = _jobs()
+    for job_id, job in jobs.items():
+        permissions = job.get("permissions", _workflow()["permissions"])
+        if job_id == "signed-closeout":
+            continue
+        assert permissions.get("id-token") != "write"
+        assert permissions.get("attestations") != "write"
+        assert permissions.get("artifact-metadata") != "write"
+
+    rendered = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert rendered.count("id-token: write") == 1
+    assert rendered.count("attestations: write") == 1
+    assert rendered.count("artifact-metadata: write") == 1
 
 
 def test_lane_step_names_match_jobs_api_telemetry_contract() -> None:

--- a/newsroom/tests/test_sdlc_evidence_workflow.py
+++ b/newsroom/tests/test_sdlc_evidence_workflow.py
@@ -81,7 +81,10 @@ def test_shadow_workflow_has_exact_nonprivileged_event_surface() -> None:
     assert events["merge_group"] == {"types": ["checks_requested"]}
     manual = events["workflow_dispatch"]
     assert isinstance(manual, dict)
-    assert manual["inputs"]["base_sha"]["required"] == "false"
+    assert manual["inputs"]["base_sha"]["required"] == "true"
+    assert manual["inputs"]["base_sha"]["description"] == (
+        "Required exact non-head base commit for a manual comparison"
+    )
     assert manual["inputs"]["base_sha"]["type"] == "string"
 
     assert workflow["permissions"] == {"contents": "read"}
@@ -270,6 +273,7 @@ def test_lane_and_decision_artifacts_are_compact_immutable_and_attempt_scoped() 
                 ".sdlc-run/decision-input/context.json",
                 ".sdlc-run/decision-input/collection.json",
                 ".sdlc-run/decision.json",
+                ".sdlc-run/increment5e2-final-closeout.json",
             ]
 
 
@@ -390,6 +394,16 @@ def test_repository_owned_gate_budgets_drive_route_lane_and_decision() -> None:
     finalize = _step("decision", "Finalize decision")
     assert finalize["if"] == "always()"
     assert "scripts.sdlc.workflow_orchestrator decide" in finalize["run"]
+    closeout = _step("decision", "Build Increment 5E2 final closeout receipt")
+    assert closeout["if"] == "needs.route.outputs.service_required == 'true'"
+    for expected in (
+        "scripts.sdlc.increment5e2_closeout_receipt final",
+        "--core-transport-bundle-root .sdlc-run/decision-input/core-transport",
+        "--service-transport-bundle-root .sdlc-run/decision-input/service-transport",
+        "--decision .sdlc-run/decision.json",
+        "--output .sdlc-run/increment5e2-final-closeout.json",
+    ):
+        assert expected in closeout["run"]
     report = _step("decision", "Report decision")
     assert report["if"] == "always()"
     assert "scripts.sdlc.workflow_orchestrator enforce" in report["run"]

--- a/newsroom/tests/test_sdlc_workflow_event.py
+++ b/newsroom/tests/test_sdlc_workflow_event.py
@@ -169,18 +169,30 @@ def test_merge_group_and_push_bases_are_exact(
     assert event.evaluated_sha == head
 
 
-def test_workflow_dispatch_defaults_to_head_or_accepts_exact_base(tmp_path: Path) -> None:
-    repo, base, _, head, head_tree = _repository(tmp_path)
+def test_workflow_dispatch_requires_and_accepts_exact_base(tmp_path: Path) -> None:
+    repo, base, _, head, _head_tree = _repository(tmp_path)
 
-    defaulted = derive_workflow_event(
-        repo,
-        _environment(
+    with pytest.raises(WorkflowEvidenceError, match="event_base_sha"):
+        derive_workflow_event(
             repo,
-            event_name="workflow_dispatch",
-            base=base,
-            head=head,
-        ),
-    )
+            _environment(
+                repo,
+                event_name="workflow_dispatch",
+                base=base,
+                head=head,
+            ),
+        )
+    with pytest.raises(WorkflowEvidenceError, match="event_base_matches_head"):
+        derive_workflow_event(
+            repo,
+            _environment(
+                repo,
+                event_name="workflow_dispatch",
+                base=base,
+                head=head,
+                dispatch_base=head,
+            ),
+        )
     selected = derive_workflow_event(
         repo,
         _environment(
@@ -192,8 +204,6 @@ def test_workflow_dispatch_defaults_to_head_or_accepts_exact_base(tmp_path: Path
         ),
     )
 
-    assert defaulted.base_sha == head
-    assert defaulted.base_tree_sha == head_tree
     assert selected.base_sha == base
 
 

--- a/newsroom/tests/test_sdlc_workflow_lane.py
+++ b/newsroom/tests/test_sdlc_workflow_lane.py
@@ -687,6 +687,7 @@ def test_optional_core_skips_are_exact_actual_service_cases() -> None:
         'newsroom.tests.test_increment_2d_neo4j_service::test_actual_service_replacement_generation_deduplicates_candidate_authority',
         'newsroom.tests.test_increment_2d_neo4j_service::test_actual_service_required_gap_blocks_complete_candidate_proof',
         'newsroom.tests.test_integrated_c1_neo4j_service::test_actual_service_integrated_foundation_replay_recovery_and_tombstone',
+        'newsroom.tests.test_projection_b2_increment5e2_neo4j_service::test_actual_service_increment5e2_target_and_report',
         'newsroom.tests.test_projection_b2_neo4j_service::test_actual_service_private_adapter_exact_duplicate_and_digest_conflict',
         'newsroom.tests.test_projection_b2_neo4j_service::test_actual_service_public_round_trip_duplicate_and_generation_isolation',
         'newsroom.tests.test_projection_b2_neo4j_service::test_actual_service_requires_explicit_authentication_configuration',

--- a/scripts/increment5_retrieval_qualification.py
+++ b/scripts/increment5_retrieval_qualification.py
@@ -60,6 +60,7 @@ def main(argv: list[str] | None = None) -> int:
             target=QUALIFICATION_TARGET,
             corpus=QUALIFICATION_CORPUS,
             epoch=epoch,
+            code_tree_sha=epoch.code_tree_sha,
             observations=observations,
             started_at=arguments.started_at,
             completed_at=arguments.completed_at,

--- a/scripts/sdlc/increment5e2_closeout_receipt.py
+++ b/scripts/sdlc/increment5e2_closeout_receipt.py
@@ -36,7 +36,12 @@ from newsroom.projection.neo4j import (
     NEO4J_B2_SERVER_VERSION,
 )
 from scripts.sdlc.contracts import ContractError, load_contract
-from scripts.sdlc.emit_evidence import canonical_json_bytes, sha256_identity
+from scripts.sdlc.emit_evidence import (
+    EvidenceError,
+    canonical_json_bytes,
+    sha256_identity,
+    verify_tracked_checkout,
+)
 from scripts.sdlc.shadow_decision import (
     ShadowDecisionError,
     validate_shadow_decision,
@@ -304,6 +309,12 @@ def _require_git_identity(root: Path, head: str, tree: str) -> None:
     _same_root, current_head, current_tree = _git_identity(root)
     if (current_head, current_tree) != (head, tree):
         raise Increment5E2CloseoutReceiptError("stale_checkout_identity")
+    try:
+        verify_tracked_checkout(root, head)
+    except EvidenceError as exc:
+        raise Increment5E2CloseoutReceiptError(
+            "tracked_checkout_dirty"
+        ) from exc
 
 
 def _selected_cases(
@@ -472,6 +483,7 @@ def build_actual_service_receipt(
     *, repo_root: str | Path, service_junit_report: str | Path
 ) -> dict[str, object]:
     _root, head, tree = _git_identity(repo_root)
+    _require_git_identity(_root, head, tree)
     report = _parse_junit(service_junit_report)
     _reject_unselected_failures((report,), FinalCloseoutLane.ACTUAL_NEO4J)
     selected, properties = _selected_cases((report,), FinalCloseoutLane.ACTUAL_NEO4J)
@@ -521,6 +533,7 @@ def build_final_receipt(
     decision_path: str | Path,
 ) -> dict[str, object]:
     root, head, tree = _git_identity(repo_root)
+    _require_git_identity(root, head, tree)
     try:
         contract = load_contract(root)
         decision = validate_shadow_decision(

--- a/scripts/sdlc/increment5e2_closeout_receipt.py
+++ b/scripts/sdlc/increment5e2_closeout_receipt.py
@@ -1,0 +1,673 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import stat
+import subprocess
+import sys
+import uuid
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Sequence
+
+from newsroom.increment5.final_closeout import (
+    INCREMENT5_FINAL_REQUIREMENTS,
+    INCREMENT5E2_FINAL_CLOSEOUT_CASES,
+    INCREMENT5E2_FINAL_CLOSEOUT_INVENTORY_DIGEST,
+    INCREMENT5E2_FINAL_NON_EFFECTS,
+    FinalCloseoutLane,
+)
+from newsroom.increment5.retrieval_qualification import (
+    QUALIFICATION_CORPUS,
+    QUALIFICATION_TARGET,
+    QualificationDecision,
+    QualificationReport,
+    RetrievalQualificationError,
+    RetrievalQualificationEvaluator,
+    build_qualification_epoch,
+    run_fixture_qualification,
+)
+from newsroom.projection.neo4j import (
+    NEO4J_B2_DRIVER_VERSION,
+    NEO4J_B2_IMAGE,
+    NEO4J_B2_SERVER_VERSION,
+)
+from scripts.sdlc.contracts import ContractError, load_contract
+from scripts.sdlc.emit_evidence import canonical_json_bytes, sha256_identity
+from scripts.sdlc.shadow_decision import (
+    ShadowDecisionError,
+    validate_shadow_decision,
+)
+from scripts.sdlc.transport_replay import (
+    TransportReplayError,
+    load_verified_transport,
+)
+from scripts.sdlc.workflow_lane import service_compatibility_digest
+
+ACTUAL_SERVICE_SCHEMA_VERSION = (
+    "newsroom.increment5e2.actual-service-closeout-receipt.v1"
+)
+FINAL_SCHEMA_VERSION = "newsroom.increment5e2.final-closeout-receipt.v1"
+_MAX_REPORT_BYTES = 16 * 1024 * 1024
+_MAX_DECISION_BYTES = 8 * 1024 * 1024
+_MAX_TESTS = 100_000
+_QUALIFICATION_STARTED_AT = "2026-08-08T20:00:00Z"
+_QUALIFICATION_COMPLETED_AT = "2026-08-08T20:01:00Z"
+_TARGET_TEST_ID = (
+    "newsroom.tests.test_projection_b2_increment5e2_neo4j_service::"
+    "test_actual_service_increment5e2_target_and_report"
+)
+_TARGET_PROPERTIES = {
+    "increment5e2_epoch_digest",
+    "increment5e2_epoch_json",
+    "increment5e2_report_digest",
+    "increment5e2_report_json",
+    "increment5e2_closeout_inventory_digest",
+    "increment5e2_closeout_case_count",
+    "increment5e2_non_effects",
+    "increment5e2_source_head_sha",
+    "increment5e2_source_tree_sha",
+    "increment5e2_neo4j_image",
+    "increment5e2_neo4j_server_version",
+    "increment5e2_neo4j_edition",
+    "increment5e2_neo4j_driver_version",
+    "increment5e2_neo4j_database",
+    "increment5e2_neo4j_projector_username",
+    "increment5e2_service_compatibility_digest",
+}
+
+
+class Increment5E2CloseoutReceiptError(ValueError):
+    """Raised when closed-world Increment 5E2 evidence is not exact."""
+
+
+@dataclass(frozen=True, slots=True)
+class _JUnitCase:
+    test_id: str
+    outcome: str
+    properties: Mapping[str, str]
+
+
+@dataclass(frozen=True, slots=True)
+class _ParsedReport:
+    path: Path
+    payload: bytes
+    digest: str
+    cases: tuple[_JUnitCase, ...]
+
+
+def _digest(payload: bytes) -> str:
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def _unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise Increment5E2CloseoutReceiptError("duplicate_json_key")
+        result[key] = value
+    return result
+
+
+def _json(payload: bytes | str, code: str) -> object:
+    try:
+        raw = payload if isinstance(payload, bytes) else payload.encode("utf-8")
+        value = json.loads(
+            raw.decode("utf-8"),
+            object_pairs_hook=_unique_object,
+            parse_constant=lambda _value: (_ for _ in ()).throw(
+                Increment5E2CloseoutReceiptError(code)
+            ),
+        )
+        pending = [(value, 0)]
+        nodes = 0
+        while pending:
+            item, depth = pending.pop()
+            nodes += 1
+            if depth > 64 or nodes > 100_000:
+                raise Increment5E2CloseoutReceiptError(f"{code}_bounds")
+            if isinstance(item, dict):
+                pending.extend((child, depth + 1) for child in item.values())
+            elif isinstance(item, list):
+                pending.extend((child, depth + 1) for child in item)
+        return value
+    except Increment5E2CloseoutReceiptError:
+        raise
+    except (UnicodeError, json.JSONDecodeError, RecursionError) as exc:
+        raise Increment5E2CloseoutReceiptError(code) from exc
+
+
+def _safe_file(path: str | Path, *, maximum: int, code: str) -> tuple[Path, bytes]:
+    candidate = Path(path)
+    absolute = candidate if candidate.is_absolute() else candidate.absolute()
+    current = Path(absolute.anchor)
+    for part in absolute.parts[1:]:
+        current /= part
+        if current.is_symlink():
+            raise Increment5E2CloseoutReceiptError(f"{code}_symlink")
+    try:
+        initial = os.lstat(absolute)
+    except OSError as exc:
+        raise Increment5E2CloseoutReceiptError(code) from exc
+    if (
+        not stat.S_ISREG(initial.st_mode)
+        or initial.st_size <= 0
+        or initial.st_size > maximum
+    ):
+        raise Increment5E2CloseoutReceiptError(code)
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_NONBLOCK", 0)
+    )
+    descriptor = -1
+    try:
+        descriptor = os.open(absolute, flags)
+        opened = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or opened.st_dev != initial.st_dev
+            or opened.st_ino != initial.st_ino
+            or opened.st_size != initial.st_size
+        ):
+            raise Increment5E2CloseoutReceiptError(code)
+        with os.fdopen(descriptor, "rb", closefd=True) as stream:
+            descriptor = -1
+            payload = stream.read(maximum + 1)
+    except Increment5E2CloseoutReceiptError:
+        raise
+    except OSError as exc:
+        raise Increment5E2CloseoutReceiptError(code) from exc
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    if len(payload) != initial.st_size or len(payload) > maximum:
+        raise Increment5E2CloseoutReceiptError(code)
+    return absolute, payload
+
+
+def _local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def _field(value: str | None, code: str, *, maximum: int = 2 * 1024 * 1024) -> str:
+    text = value or ""
+    if not text or len(text) > maximum or "\x00" in text:
+        raise Increment5E2CloseoutReceiptError(code)
+    return text
+
+
+def _parse_properties(case: ET.Element) -> Mapping[str, str]:
+    values: dict[str, str] = {}
+    containers = [child for child in case if _local_name(child.tag) == "properties"]
+    if len(containers) > 1:
+        raise Increment5E2CloseoutReceiptError("duplicate_properties")
+    if not containers:
+        return values
+    children = list(containers[0])
+    if len(children) > 128:
+        raise Increment5E2CloseoutReceiptError("property_count")
+    for child in children:
+        if _local_name(child.tag) != "property":
+            raise Increment5E2CloseoutReceiptError("property_shape")
+        name = _field(child.attrib.get("name"), "property_name", maximum=256)
+        if name in values:
+            raise Increment5E2CloseoutReceiptError("duplicate_property")
+        if "value" in child.attrib:
+            value = child.attrib["value"]
+            if child.text and child.text.strip():
+                raise Increment5E2CloseoutReceiptError("property_shape")
+        else:
+            value = child.text or ""
+        if len(value) > 2 * 1024 * 1024 or "\x00" in value:
+            raise Increment5E2CloseoutReceiptError("property_value")
+        values[name] = value
+    return values
+
+
+def _parse_junit(path: str | Path) -> _ParsedReport:
+    absolute, payload = _safe_file(path, maximum=_MAX_REPORT_BYTES, code="junit_report")
+    try:
+        decoded = payload.decode("utf-8-sig")
+    except UnicodeDecodeError as exc:
+        raise Increment5E2CloseoutReceiptError("junit_xml_encoding") from exc
+    upper = decoded.upper()
+    if "<!DOCTYPE" in upper or "<!ENTITY" in upper:
+        raise Increment5E2CloseoutReceiptError("junit_xml_declaration")
+    try:
+        root = ET.fromstring(payload)
+    except ET.ParseError as exc:
+        raise Increment5E2CloseoutReceiptError("junit_xml") from exc
+    if _local_name(root.tag) not in {"testsuite", "testsuites"}:
+        raise Increment5E2CloseoutReceiptError("junit_root")
+    cases: list[_JUnitCase] = []
+    seen: set[str] = set()
+    for element in root.iter():
+        if _local_name(element.tag) != "testcase":
+            continue
+        name = _field(element.attrib.get("name"), "test_name", maximum=1024).strip()
+        owner = (element.attrib.get("classname") or "").strip() or (
+            element.attrib.get("file") or ""
+        ).strip()
+        owner = _field(owner, "test_owner", maximum=1024)
+        test_id = f"{owner}::{name}"
+        if test_id in seen:
+            raise Increment5E2CloseoutReceiptError("duplicate_test_id")
+        seen.add(test_id)
+        terminals = [
+            child
+            for child in element
+            if _local_name(child.tag) in {"failure", "error", "skipped"}
+        ]
+        if len(terminals) > 1:
+            raise Increment5E2CloseoutReceiptError("conflicting_test_outcome")
+        outcome = _local_name(terminals[0].tag) if terminals else "passed"
+        cases.append(_JUnitCase(test_id, outcome, _parse_properties(element)))
+        if len(cases) > _MAX_TESTS:
+            raise Increment5E2CloseoutReceiptError("junit_test_count")
+    if not cases:
+        raise Increment5E2CloseoutReceiptError("junit_no_tests")
+    return _ParsedReport(absolute, payload, _digest(payload), tuple(cases))
+
+
+def _git_identity(repo_root: str | Path) -> tuple[Path, str, str]:
+    root = Path(repo_root).resolve()
+    if not root.is_dir():
+        raise Increment5E2CloseoutReceiptError("repo_root")
+    try:
+        output = subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel", "HEAD", "HEAD^{tree}"],
+            cwd=root,
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).splitlines()
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise Increment5E2CloseoutReceiptError("git_identity") from exc
+    if len(output) != 3 or Path(output[0]).resolve() != root:
+        raise Increment5E2CloseoutReceiptError("repo_root")
+    head, tree = output[1:]
+    if any(len(value) != 40 or value.lower() != value for value in (head, tree)):
+        raise Increment5E2CloseoutReceiptError("git_identity")
+    return root, head, tree
+
+
+def _require_git_identity(root: Path, head: str, tree: str) -> None:
+    _same_root, current_head, current_tree = _git_identity(root)
+    if (current_head, current_tree) != (head, tree):
+        raise Increment5E2CloseoutReceiptError("stale_checkout_identity")
+
+
+def _selected_cases(
+    reports: Sequence[_ParsedReport], lane: FinalCloseoutLane
+) -> tuple[list[dict[str, object]], Mapping[str, str]]:
+    all_cases: dict[str, _JUnitCase] = {}
+    for report in reports:
+        for case in report.cases:
+            if case.test_id in all_cases:
+                raise Increment5E2CloseoutReceiptError("duplicate_test_id")
+            all_cases[case.test_id] = case
+    selected: list[dict[str, object]] = []
+    target_properties: Mapping[str, str] = {}
+    for item in INCREMENT5E2_FINAL_CLOSEOUT_CASES:
+        if item.lane is not lane:
+            continue
+        case = all_cases.get(item.test_id)
+        if case is None:
+            raise Increment5E2CloseoutReceiptError(
+                f"selected_test_missing:{item.case_id}"
+            )
+        if case.outcome != "passed":
+            raise Increment5E2CloseoutReceiptError(
+                f"selected_test_not_passed:{item.case_id}:{case.outcome}"
+            )
+        selected.append({**item.canonical_value(), "outcome": "passed"})
+        if item.test_id == _TARGET_TEST_ID:
+            target_properties = case.properties
+    return selected, target_properties
+
+
+def _reject_unselected_failures(
+    reports: Sequence[_ParsedReport], lane: FinalCloseoutLane
+) -> None:
+    selected_test_ids = {
+        item.test_id for item in INCREMENT5E2_FINAL_CLOSEOUT_CASES if item.lane is lane
+    }
+    for report in reports:
+        for case in report.cases:
+            if case.test_id not in selected_test_ids and case.outcome in {
+                "failure",
+                "error",
+            }:
+                raise Increment5E2CloseoutReceiptError(
+                    f"unselected_test_not_passed:{case.test_id}:{case.outcome}"
+                )
+
+
+def _semantic_identities(
+    properties: Mapping[str, str], head: str, tree: str
+) -> dict[str, object]:
+    missing = _TARGET_PROPERTIES - properties.keys()
+    extra = properties.keys() - _TARGET_PROPERTIES
+    if missing or extra:
+        raise Increment5E2CloseoutReceiptError("target_properties")
+    expected_epoch = build_qualification_epoch(
+        target=QUALIFICATION_TARGET,
+        corpus=QUALIFICATION_CORPUS,
+        code_tree_sha=tree,
+    )
+    epoch_value = _json(properties["increment5e2_epoch_json"], "epoch_json")
+    if (
+        epoch_value != expected_epoch.canonical_value()
+        or properties["increment5e2_epoch_json"]
+        != canonical_json_bytes(epoch_value).decode("utf-8")
+        or properties["increment5e2_epoch_digest"] != expected_epoch.epoch_digest
+    ):
+        raise Increment5E2CloseoutReceiptError("epoch_identity")
+    report_text = properties["increment5e2_report_json"]
+    _json(report_text, "report_json")
+    try:
+        report = QualificationReport.from_canonical_bytes(report_text.encode("utf-8"))
+    except RetrievalQualificationError as exc:
+        raise Increment5E2CloseoutReceiptError("qualification_report") from exc
+    expected_report = RetrievalQualificationEvaluator().evaluate(
+        run_id=str(uuid.uuid5(uuid.NAMESPACE_URL, expected_epoch.epoch_digest)),
+        target=QUALIFICATION_TARGET,
+        corpus=QUALIFICATION_CORPUS,
+        epoch=expected_epoch,
+        code_tree_sha=tree,
+        observations=run_fixture_qualification(
+            target=QUALIFICATION_TARGET,
+            corpus=QUALIFICATION_CORPUS,
+        ),
+        started_at=_QUALIFICATION_STARTED_AT,
+        completed_at=_QUALIFICATION_COMPLETED_AT,
+    )
+    if (
+        properties["increment5e2_report_digest"] != report.report_digest
+        or report.canonical_bytes != expected_report.canonical_bytes
+        or report.epoch_digest != expected_epoch.epoch_digest
+        or report.code_tree_sha != tree
+        or report.decision is not QualificationDecision.PASS
+        or report.observation_count != 500
+        or report.expected_observation_count != 500
+        or report.external_call_count != 0
+        or report.provider_spend_micros != 0
+        or report.authority_effect != "NONE"
+        or report.candidate_created
+        or report.hypothesis_created
+        or report.production_activation_authorized
+    ):
+        raise Increment5E2CloseoutReceiptError("qualification_report_semantics")
+    if (
+        properties["increment5e2_closeout_inventory_digest"]
+        != INCREMENT5E2_FINAL_CLOSEOUT_INVENTORY_DIGEST
+        or properties["increment5e2_closeout_case_count"]
+        != str(len(INCREMENT5E2_FINAL_CLOSEOUT_CASES))
+        or properties["increment5e2_non_effects"]
+        != ",".join(INCREMENT5E2_FINAL_NON_EFFECTS)
+    ):
+        raise Increment5E2CloseoutReceiptError("closeout_inventory")
+    expected_service = {
+        "increment5e2_source_head_sha": head,
+        "increment5e2_source_tree_sha": tree,
+        "increment5e2_neo4j_image": NEO4J_B2_IMAGE,
+        "increment5e2_neo4j_server_version": NEO4J_B2_SERVER_VERSION,
+        "increment5e2_neo4j_edition": "community",
+        "increment5e2_neo4j_driver_version": NEO4J_B2_DRIVER_VERSION,
+        "increment5e2_neo4j_database": "neo4j",
+        "increment5e2_neo4j_projector_username": "newsroom_projector",
+        "increment5e2_service_compatibility_digest": service_compatibility_digest(),
+    }
+    if any(properties[name] != value for name, value in expected_service.items()):
+        raise Increment5E2CloseoutReceiptError("service_identity")
+    return {
+        "epoch": {
+            "epoch_id": expected_epoch.epoch_id,
+            "epoch_digest": expected_epoch.epoch_digest,
+            "code_tree_sha": tree,
+        },
+        "qualification_report": {
+            "report_id": report.report_id,
+            "report_digest": report.report_digest,
+            "epoch_digest": report.epoch_digest,
+            "code_tree_sha": report.code_tree_sha,
+            "decision": report.decision.value,
+            "observation_count": report.observation_count,
+        },
+        "service": {
+            "image": NEO4J_B2_IMAGE,
+            "server_version": NEO4J_B2_SERVER_VERSION,
+            "edition": "community",
+            "driver_version": NEO4J_B2_DRIVER_VERSION,
+            "database": "neo4j",
+            "projector_username": "newsroom_projector",
+            "compatibility_digest": service_compatibility_digest(),
+        },
+    }
+
+
+def _inventory() -> dict[str, object]:
+    return {
+        "digest": INCREMENT5E2_FINAL_CLOSEOUT_INVENTORY_DIGEST,
+        "case_count": len(INCREMENT5E2_FINAL_CLOSEOUT_CASES),
+        "requirements": sorted(INCREMENT5_FINAL_REQUIREMENTS),
+        "non_effects": list(INCREMENT5E2_FINAL_NON_EFFECTS),
+    }
+
+
+def _with_identity(value: dict[str, object]) -> dict[str, object]:
+    return {**value, "receipt_identity": sha256_identity(value)}
+
+
+def build_actual_service_receipt(
+    *, repo_root: str | Path, service_junit_report: str | Path
+) -> dict[str, object]:
+    _root, head, tree = _git_identity(repo_root)
+    report = _parse_junit(service_junit_report)
+    _reject_unselected_failures((report,), FinalCloseoutLane.ACTUAL_NEO4J)
+    selected, properties = _selected_cases((report,), FinalCloseoutLane.ACTUAL_NEO4J)
+    identities = _semantic_identities(properties, head, tree)
+    _require_git_identity(_root, head, tree)
+    return _with_identity(
+        {
+            "schema_version": ACTUAL_SERVICE_SCHEMA_VERSION,
+            "evaluated_sha": head,
+            "evaluated_tree_sha": tree,
+            "junit_report": {
+                "path": report.path.name,
+                "size_bytes": len(report.payload),
+                "digest": report.digest,
+            },
+            "selected_cases": selected,
+            "inventory": _inventory(),
+            **identities,
+        }
+    )
+
+
+def _decision_payload(path: str | Path) -> object:
+    _path, payload = _safe_file(path, maximum=_MAX_DECISION_BYTES, code="decision")
+    return _json(payload, "decision_json")
+
+
+def _lane_reports(verified: object, lane: object) -> tuple[_ParsedReport, ...]:
+    if verified.replay != lane.replay:
+        raise Increment5E2CloseoutReceiptError("transport_replay_identity")
+    reports = []
+    for raw in lane.receipt.raw_reports:
+        report = _parse_junit(verified.artifact_root / raw.path)
+        if len(report.payload) != raw.size_bytes or report.digest != raw.digest:
+            raise Increment5E2CloseoutReceiptError("receipt_report_digest")
+        reports.append(report)
+    if not reports:
+        raise Increment5E2CloseoutReceiptError("receipt_reports_missing")
+    return tuple(reports)
+
+
+def build_final_receipt(
+    *,
+    repo_root: str | Path,
+    core_transport_bundle_root: str | Path,
+    service_transport_bundle_root: str | Path,
+    decision_path: str | Path,
+) -> dict[str, object]:
+    root, head, tree = _git_identity(repo_root)
+    try:
+        contract = load_contract(root)
+        decision = validate_shadow_decision(
+            _decision_payload(decision_path), contract=contract
+        )
+        core_transport = load_verified_transport(core_transport_bundle_root)
+        service_transport = load_verified_transport(service_transport_bundle_root)
+    except (ContractError, ShadowDecisionError, TransportReplayError) as exc:
+        raise Increment5E2CloseoutReceiptError("validated_input") from exc
+    if decision.result != "PASS" or {lane.lane_id for lane in decision.lanes} != {
+        "core",
+        "service",
+    }:
+        raise Increment5E2CloseoutReceiptError("decision_not_exact_pass")
+    if (
+        decision.context.evaluated_sha != head
+        or decision.context.evaluated_tree_sha != tree
+    ):
+        raise Increment5E2CloseoutReceiptError("checkout_identity")
+    lane_map = {lane.lane_id: lane for lane in decision.lanes}
+    transports = {"core": core_transport, "service": service_transport}
+    selected_all: list[dict[str, object]] = []
+    report_values: dict[str, list[dict[str, object]]] = {}
+    identities: dict[str, object] | None = None
+    lane_values: list[dict[str, object]] = []
+    manifest_digests: set[str] = set()
+    for lane_id, inventory_lane in (
+        ("core", FinalCloseoutLane.DETERMINISTIC),
+        ("service", FinalCloseoutLane.ACTUAL_NEO4J),
+    ):
+        lane = lane_map[lane_id]
+        verified = transports[lane_id]
+        if (
+            lane.receipt.evaluated_sha != head
+            or lane.receipt.evaluated_tree_sha != tree
+            or verified.replay.head_sha != head
+        ):
+            raise Increment5E2CloseoutReceiptError("lane_checkout_identity")
+        reports = _lane_reports(verified, lane)
+        selected, properties = _selected_cases(reports, inventory_lane)
+        selected_all.extend(selected)
+        if inventory_lane is FinalCloseoutLane.ACTUAL_NEO4J:
+            identities = _semantic_identities(properties, head, tree)
+        report_values[lane_id] = [
+            {
+                "path": raw.path,
+                "size_bytes": raw.size_bytes,
+                "digest": raw.digest,
+            }
+            for raw in lane.receipt.raw_reports
+        ]
+        manifest_digests.add(lane.receipt.route.selected_test_manifest_digest)
+        lane_values.append(
+            {
+                "lane_id": lane_id,
+                "lane_identity": lane.lane_identity,
+                "receipt_identity": lane.receipt.receipt_identity,
+                "envelope_identity": lane.receipt.envelope_identity,
+                "transport_identity": verified.bundle.transport_identity,
+                "replay_identity": verified.replay.replay_identity,
+            }
+        )
+    if identities is None or len(manifest_digests) != 1:
+        raise Increment5E2CloseoutReceiptError("selected_test_manifest")
+    _require_git_identity(root, head, tree)
+    return _with_identity(
+        {
+            "schema_version": FINAL_SCHEMA_VERSION,
+            "decision_identity": decision.decision_identity,
+            "evaluated_sha": head,
+            "evaluated_tree_sha": tree,
+            "selected_test_manifest_digest": manifest_digests.pop(),
+            "lanes": lane_values,
+            "junit_reports": report_values,
+            "selected_cases": sorted(
+                selected_all, key=lambda item: str(item["case_id"])
+            ),
+            "inventory": _inventory(),
+            **identities,
+        }
+    )
+
+
+def _write_output(path: str | Path, receipt: Mapping[str, object]) -> None:
+    output = Path(path)
+    absolute = output if output.is_absolute() else output.absolute()
+    current = Path(absolute.anchor)
+    for part in absolute.parts[1:-1]:
+        current /= part
+        if current.is_symlink():
+            raise Increment5E2CloseoutReceiptError("output_path")
+    if (
+        not absolute.parent.is_dir()
+        or absolute.suffix != ".json"
+        or absolute.is_symlink()
+    ):
+        raise Increment5E2CloseoutReceiptError("output_path")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0)
+    try:
+        descriptor = os.open(absolute, flags, 0o600)
+    except FileExistsError as exc:
+        raise Increment5E2CloseoutReceiptError("output_exists") from exc
+    except OSError as exc:
+        raise Increment5E2CloseoutReceiptError("output_open") from exc
+    with os.fdopen(descriptor, "wb") as stream:
+        stream.write(canonical_json_bytes(dict(receipt)) + b"\n")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    raw = list(sys.argv[1:] if argv is None else argv)
+    if raw and raw[0] in {"actual-service", "final"}:
+        raw = ["--mode", raw[0], *raw[1:]]
+    parser = argparse.ArgumentParser(
+        description="Emit exact Increment 5E2 closeout receipts"
+    )
+    parser.add_argument("--mode", required=True, choices=("actual-service", "final"))
+    parser.add_argument("--repo-root", required=True)
+    parser.add_argument("--service-junit-report", "--report")
+    parser.add_argument("--core-transport-bundle-root", "--core-transport-root")
+    parser.add_argument("--service-transport-bundle-root", "--service-transport-root")
+    parser.add_argument("--decision", "--validated-decision")
+    parser.add_argument("--output", required=True)
+    arguments = parser.parse_args(raw)
+    try:
+        if arguments.mode == "actual-service":
+            if not arguments.service_junit_report:
+                raise Increment5E2CloseoutReceiptError("service_junit_report")
+            receipt = build_actual_service_receipt(
+                repo_root=arguments.repo_root,
+                service_junit_report=arguments.service_junit_report,
+            )
+        else:
+            if not all(
+                (
+                    arguments.core_transport_bundle_root,
+                    arguments.service_transport_bundle_root,
+                    arguments.decision,
+                )
+            ):
+                raise Increment5E2CloseoutReceiptError("final_inputs")
+            receipt = build_final_receipt(
+                repo_root=arguments.repo_root,
+                core_transport_bundle_root=arguments.core_transport_bundle_root,
+                service_transport_bundle_root=arguments.service_transport_bundle_root,
+                decision_path=arguments.decision,
+            )
+        _write_output(arguments.output, receipt)
+    except Increment5E2CloseoutReceiptError as exc:
+        print(f"EVIDENCE_MISMATCH:increment5e2-closeout:{exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sdlc/increment5e2_closeout_receipt.py
+++ b/scripts/sdlc/increment5e2_closeout_receipt.py
@@ -54,6 +54,7 @@ FINAL_SCHEMA_VERSION = "newsroom.increment5e2.final-closeout-receipt.v1"
 _MAX_REPORT_BYTES = 16 * 1024 * 1024
 _MAX_DECISION_BYTES = 8 * 1024 * 1024
 _MAX_TESTS = 100_000
+_MAX_TEST_NAME_CHARS = 64 * 1024
 _QUALIFICATION_STARTED_AT = "2026-08-08T20:00:00Z"
 _QUALIFICATION_COMPLETED_AT = "2026-08-08T20:01:00Z"
 _TARGET_TEST_ID = (
@@ -249,7 +250,11 @@ def _parse_junit(path: str | Path) -> _ParsedReport:
     for element in root.iter():
         if _local_name(element.tag) != "testcase":
             continue
-        name = _field(element.attrib.get("name"), "test_name", maximum=1024).strip()
+        name = _field(
+            element.attrib.get("name"),
+            "test_name",
+            maximum=_MAX_TEST_NAME_CHARS,
+        ).strip()
         owner = (element.attrib.get("classname") or "").strip() or (
             element.attrib.get("file") or ""
         ).strip()

--- a/scripts/sdlc/workflow_event.py
+++ b/scripts/sdlc/workflow_event.py
@@ -365,12 +365,14 @@ def _base_identity(
             raise WorkflowEvidenceError("event_base_unavailable")
         return before
     if context.event_name == "workflow_dispatch":
-        inputs = event.get("inputs")
-        if inputs is None:
-            return context.evaluated_sha
-        mapping = _mapping(inputs, "event_inputs")
+        mapping = _mapping(event.get("inputs"), "event_inputs")
         value = mapping.get("base_sha")
-        return context.evaluated_sha if value in {None, ""} else _sha(value, "event_base_sha")
+        if value in {None, ""}:
+            raise WorkflowEvidenceError("event_base_sha")
+        base = _sha(value, "event_base_sha")
+        if base == context.evaluated_sha:
+            raise WorkflowEvidenceError("event_base_matches_head")
+        return base
     raise WorkflowEvidenceError("event_name")
 
 

--- a/scripts/sdlc/workflow_lane.py
+++ b/scripts/sdlc/workflow_lane.py
@@ -76,6 +76,7 @@ _OPTIONAL_CORE_TEST_IDS = (
     'newsroom.tests.test_increment_2d_neo4j_service::test_actual_service_replacement_generation_deduplicates_candidate_authority',
     'newsroom.tests.test_increment_2d_neo4j_service::test_actual_service_required_gap_blocks_complete_candidate_proof',
     'newsroom.tests.test_integrated_c1_neo4j_service::test_actual_service_integrated_foundation_replay_recovery_and_tombstone',
+    'newsroom.tests.test_projection_b2_increment5e2_neo4j_service::test_actual_service_increment5e2_target_and_report',
     'newsroom.tests.test_projection_b2_neo4j_service::test_actual_service_private_adapter_exact_duplicate_and_digest_conflict',
     'newsroom.tests.test_projection_b2_neo4j_service::test_actual_service_public_round_trip_duplicate_and_generation_isolation',
     'newsroom.tests.test_projection_b2_neo4j_service::test_actual_service_requires_explicit_authentication_configuration',


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-5-final-corrective-closeout-v1
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

## Scope

Close the three post-merge Increment 5 P1s from #351 and add the genuine 5E2/Tier-M closed-world closeout path for #333, #254 and #145.

- rederive corpus, dataset, target and every Epoch identity from current source before qualification;
- enforce cross-system safety/rights blockers without widening HYBRID-only quality claims;
- purge retained Retrieval Context bytes with exact derivative tombstones, new-request non-resurrection, sibling precision, sequential-withdrawal support and purge-safe SQLite storage;
- bind 64 exact pytest node identities across deterministic and authenticated Neo4j lanes;
- emit actual-service and final receipts bound to exact JUnit, report, Epoch, service, Git, tracked-checkout and transport identities;
- reject tracked source drift before consuming evidence and again immediately before receipt emission;
- require an explicit non-head base for manual signed-SDLC comparisons;
- provision the service-required decision job from the exact locked production environment;
- attest both the exact-main decision and final receipt in an isolated, main-only, manually dispatched job with job-scoped OIDC and attestation permissions.

Supports #351, #332, #333, #254 and #145. This PR deliberately does not auto-close those issues; exact-main receipts, verified attestations and completion records remain post-merge gates.

## Exact state

```text
base: 4cdb1b94f9038a2d82ecd1adc71632eb2966a90d
head: 2596fd2a9fe5b18500c7c83655fcc9f2ae9661bf
tree: bd0245042f5f70e5d356b8071d2a44e05ee3b360
commits over base: 7
changed files: 30
```

## Verification

- Track A focused/integration suite: 174 passed, 1 intentional local Neo4j skip on the exact head/tree.
- Track B lifecycle integration: 42 passed; combined focused proof is 216 passed, 1 skip.
- Closed-world inventory: 64/64 exact node identities; local result 41 passed and 23 intentional actual-Neo4j skips.
- Critical blocker selectors: 14 passed, covering sequential sibling purge, shared-content exact-tuple scope, restart/tombstone behaviour, legacy journal handling, physical byte deletion, signed-closeout isolation and dirty-checkout rejection.
- Independent true-clone receipt probes: clean checkout accepted; staged and unstaged tracked drift rejected as `tracked_checkout_dirty`; actual-service and final CLIs return non-zero and emit no receipt under drift.
- Production-only isolated decision runtime imports locked `jsonschema==4.26.0`, `neo4j==6.2.0` and the closeout CLI.
- Whole repository on macOS at the exact head/tree: 2486 passed, 41 skipped, 20 known platform-boundary failures (16 trusted `/usr/bin/python3`, 3 Linux `renameat2`, 1 `/bin/true` watchdog); Ubuntu CI is the completion gate.
- `uv lock --check`, YAML parsing, filtered actionlint, compilation and `git diff --check`: pass. Raw actionlint reports only the three pre-existing dynamic `source` SC1090 warnings.
- Independent exact-head direction, completeness and simplicity reviews: 0 P1 / 0 P2.
- Required before merge: all exact-head GitHub checks green, a fresh substantive PR review and zero unresolved review threads.
- Required after merge: permanent authenticated Neo4j evidence, exact-main signed Tier-M final receipt and successful `gh attestation verify` for both attested subjects.

## Non-effects

No live source/provider/model/embedding call; no production-product credential use; no product-runtime network egress or spend; no live authority, Candidate or Hypothesis mutation; no publication; and no shadow, canary or production activation. Workflow credentials are generated only for disposable loopback Neo4j and removed before evidence finalisation. OIDC and attestation write permissions exist only in the isolated exact-main signed-closeout job.
