### PR TITLE
Increment 5E2: restore exact-main source-integrity closeout

### DIFF
--- a/newsroom/increment5/_retrieval_qualification_gates.py
+++ b/newsroom/increment5/_retrieval_qualification_gates.py
@@ -236,5 +236,3 @@ def _branch_contributions(
             }
         )
     return results
-
-

--- a/newsroom/increment5/_retrieval_qualification_measurement.py
+++ b/newsroom/increment5/_retrieval_qualification_measurement.py
@@ -219,5 +219,3 @@ def _exposure_metrics(
     ].items():
         add("SLICE", slice_id, slice_counts[slice_id], required)
     return rows, blockers
-
-


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-5-source-integrity-closeout-v1
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

## Summary
- remove the two blank EOF lines reported by the exact-main `source-integrity` gate
- restore `git diff --check` for the accepted Increment 5 closeout range
- keep the correction limited to source formatting; no runtime behaviour changes

## Failure evidence
- exact-main workflow run: https://github.com/fol2/newsroom/actions/runs/31313646233
- source gate: `FAIL:source-integrity:source:exit=2`
- reported paths:
  - `newsroom/increment5/_retrieval_qualification_gates.py:239`
  - `newsroom/increment5/_retrieval_qualification_measurement.py:222`

## Exact state

```text
base: fcd5cd485e59799e679796eabf54f2596285aaba
head: 409888751c4f2db8f5d63bfc85b4da22d819659c
tree: 069f19698f8bfe6d0f8453219ccd961c89be94c4
commits over base: 1
changed files: 2
```

## Local verification
- `uv run --no-sync python -m scripts.sdlc.workflow_lane source-check --repo-root . --base-sha fda53b723c7f27c9fc0d5e9bc204721d254332dd --head-sha 409888751c4f2db8f5d63bfc85b4da22d819659c`
- 26 relevant qualification tests passed
- `uv lock --check`
- committed worktree clean

## Non-effects
Formatting-only deletion of four blank EOF lines. No schemas, receipts, gates, runtime decisions, purge semantics, Neo4j behaviour, or user-facing behaviour change.
