### PR TITLE
Increment 6F1: complete evaluation Handoff authority

### DIFF
--- a/newsroom/authority/_event_store_base.py
+++ b/newsroom/authority/_event_store_base.py
@@ -19,6 +19,7 @@ from .migrations import (
     EXPECTED_SCHEMA_FINGERPRINT,
     SCHEMA_VERSION,
     apply_pending_migrations,
+    prepare_pending_migration_backup,
     schema_fingerprint,
 )
 from .models import CommittedCommandIdentity
@@ -183,6 +184,7 @@ class _EventStoreBase:
                 "refusing to adopt a non-empty unversioned authority database"
             )
         if version < SCHEMA_VERSION:
+            prepare_pending_migration_backup(conn)
             apply_pending_migrations(
                 conn, applied_at=self._clock().to_text()
             )

--- a/newsroom/authority/_object_store_base.py
+++ b/newsroom/authority/_object_store_base.py
@@ -46,7 +46,11 @@ class _ObjectStoreBase:
     def _migrate_or_validate(self) -> None:
         """Apply A2a/A2b migrations, retain exact object contracts, then validate."""
 
-        from .migrations import SCHEMA_VERSION, apply_pending_migrations
+        from .migrations import (
+            SCHEMA_VERSION,
+            apply_pending_migrations,
+            prepare_pending_migration_backup,
+        )
         from .persistence import AuthoritySchemaError
 
         conn = self._connection
@@ -61,6 +65,7 @@ class _ObjectStoreBase:
                 "refusing to adopt a non-empty unversioned authority database"
             )
         if version < SCHEMA_VERSION:
+            prepare_pending_migration_backup(conn)
             apply_pending_migrations(conn, applied_at=self._clock().to_text())
         try:
             conn.execute("BEGIN IMMEDIATE")

--- a/newsroom/authority/evaluation_handoff_migrations.py
+++ b/newsroom/authority/evaluation_handoff_migrations.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .canonical import digest_canonical
+
+
+EVALUATION_HANDOFF_SCHEMA_VERSION = 17
+EVALUATION_HANDOFF_MIGRATION_NAME = "evaluation_handoff_authority_v17"
+
+
+@dataclass(frozen=True, slots=True)
+class EvaluationHandoffMigrationRecord:
+    version: int
+    name: str
+    checksum: str
+
+
+EVALUATION_HANDOFF_MIGRATION_STATEMENTS: tuple[str, ...] = (
+    """CREATE TABLE evaluation_handoffs(
+        handoff_id TEXT PRIMARY KEY,
+        schema_identity TEXT NOT NULL
+            CHECK(schema_identity='newsroom.increment6.evaluation-handoff.v1'),
+        candidate_version_id TEXT NOT NULL,
+        governing_manifest_digest TEXT NOT NULL,
+        sink_id TEXT NOT NULL CHECK(sink_id LIKE 'evaluation-sink:%'),
+        max_attempts INTEGER NOT NULL CHECK(max_attempts BETWEEN 1 AND 100),
+        transport_state TEXT NOT NULL
+            CHECK(transport_state IN('pending','acknowledged','rejected','ambiguous','retry')),
+        retry_exhausted INTEGER NOT NULL CHECK(retry_exhausted IN(0,1)),
+        ambiguity_reason TEXT,
+        evaluation_only INTEGER NOT NULL CHECK(evaluation_only=1),
+        publication_authority INTEGER NOT NULL CHECK(publication_authority=0),
+        evidence_authority INTEGER NOT NULL CHECK(evidence_authority=0),
+        UNIQUE(candidate_version_id,governing_manifest_digest,sink_id),
+        CHECK(substr(governing_manifest_digest,1,7)='sha256:'
+              AND length(governing_manifest_digest)=71
+              AND substr(governing_manifest_digest,8)
+                  NOT GLOB '*[^0-9a-f]*'),
+        CHECK((retry_exhausted=0) OR transport_state='ambiguous')
+    ) STRICT""",
+    """CREATE TABLE evaluation_handoff_attempts(
+        attempt_id TEXT PRIMARY KEY,
+        schema_identity TEXT NOT NULL
+            CHECK(schema_identity='newsroom.increment6.evaluation-handoff-attempt.v1'),
+        handoff_id TEXT NOT NULL REFERENCES evaluation_handoffs(handoff_id),
+        attempt_number INTEGER NOT NULL CHECK(attempt_number>0),
+        semantic_idempotency_key TEXT NOT NULL,
+        persisted_before_send INTEGER NOT NULL CHECK(persisted_before_send=1),
+        sent INTEGER NOT NULL CHECK(sent IN(0,1)),
+        ambiguous INTEGER NOT NULL CHECK(ambiguous IN(0,1)),
+        UNIQUE(handoff_id,attempt_number),
+        UNIQUE(attempt_id,handoff_id),
+        CHECK(semantic_idempotency_key=handoff_id),
+        CHECK(ambiguous=0 OR sent=1)
+    ) STRICT""",
+    """CREATE TABLE evaluation_handoff_acknowledgements(
+        acknowledgement_id TEXT PRIMARY KEY,
+        schema_identity TEXT NOT NULL
+            CHECK(schema_identity='newsroom.increment6.evaluation-handoff-acknowledgement.v1'),
+        recorded_handoff_id TEXT NOT NULL
+            REFERENCES evaluation_handoffs(handoff_id),
+        handoff_id TEXT NOT NULL,
+        attempt_id TEXT NOT NULL,
+        candidate_version_id TEXT NOT NULL,
+        governing_manifest_digest TEXT NOT NULL,
+        sink_id TEXT NOT NULL,
+        outcome TEXT NOT NULL CHECK(outcome IN('acknowledged','rejected')),
+        response_digest TEXT NOT NULL,
+        UNIQUE(recorded_handoff_id,acknowledgement_id),
+        CHECK(substr(governing_manifest_digest,1,7)='sha256:'
+              AND length(governing_manifest_digest)=71
+              AND substr(governing_manifest_digest,8)
+                  NOT GLOB '*[^0-9a-f]*'),
+        CHECK(substr(response_digest,1,7)='sha256:'
+              AND length(response_digest)=71
+              AND substr(response_digest,8) NOT GLOB '*[^0-9a-f]*')
+    ) STRICT""",
+    """CREATE TRIGGER evaluation_handoff_identity_guard
+        BEFORE UPDATE ON evaluation_handoffs
+        WHEN NEW.handoff_id!=OLD.handoff_id
+          OR NEW.schema_identity!=OLD.schema_identity
+          OR NEW.candidate_version_id!=OLD.candidate_version_id
+          OR NEW.governing_manifest_digest!=OLD.governing_manifest_digest
+          OR NEW.sink_id!=OLD.sink_id
+          OR NEW.max_attempts!=OLD.max_attempts
+          OR NEW.evaluation_only!=OLD.evaluation_only
+          OR NEW.publication_authority!=OLD.publication_authority
+          OR NEW.evidence_authority!=OLD.evidence_authority
+        BEGIN SELECT RAISE(ABORT,'immutable evaluation Handoff identity'); END""",
+    """CREATE TRIGGER evaluation_handoff_state_guard
+        BEFORE UPDATE ON evaluation_handoffs
+        WHEN NOT (
+            NEW.transport_state=OLD.transport_state
+            OR (OLD.transport_state='pending'
+                AND NEW.transport_state IN('ambiguous','acknowledged','rejected'))
+            OR (OLD.transport_state='ambiguous'
+                AND NEW.transport_state IN('retry','acknowledged','rejected'))
+            OR (OLD.transport_state='retry'
+                AND NEW.transport_state IN('pending','acknowledged','rejected'))
+            OR (OLD.transport_state IN('acknowledged','rejected')
+                AND NEW.transport_state='ambiguous')
+        )
+        OR (
+            NEW.transport_state IN('acknowledged','rejected')
+            AND NOT EXISTS(
+                SELECT 1
+                FROM evaluation_handoff_acknowledgements AS k
+                JOIN evaluation_handoff_attempts AS a
+                  ON a.attempt_id=k.attempt_id
+                 AND a.handoff_id=NEW.handoff_id
+                WHERE k.recorded_handoff_id=NEW.handoff_id
+                  AND k.handoff_id=NEW.handoff_id
+                  AND k.candidate_version_id=NEW.candidate_version_id
+                  AND k.governing_manifest_digest=NEW.governing_manifest_digest
+                  AND k.sink_id=NEW.sink_id
+                  AND k.outcome=NEW.transport_state
+                  AND a.sent=1
+            )
+        )
+        BEGIN SELECT RAISE(ABORT,'invalid evaluation Handoff state transition'); END""",
+    """CREATE TRIGGER evaluation_handoff_attempt_insert_guard
+        BEFORE INSERT ON evaluation_handoff_attempts
+        WHEN NOT EXISTS(
+            SELECT 1 FROM evaluation_handoffs AS h
+            WHERE h.handoff_id=NEW.handoff_id
+              AND NEW.attempt_number=(
+                  SELECT COUNT(*)+1 FROM evaluation_handoff_attempts
+                  WHERE handoff_id=NEW.handoff_id
+              )
+              AND NEW.attempt_number<=h.max_attempts
+        )
+        BEGIN SELECT RAISE(ABORT,'invalid evaluation Handoff attempt sequence'); END""",
+    """CREATE TRIGGER evaluation_handoff_attempt_update_guard
+        BEFORE UPDATE ON evaluation_handoff_attempts
+        WHEN NEW.attempt_id!=OLD.attempt_id
+          OR NEW.schema_identity!=OLD.schema_identity
+          OR NEW.handoff_id!=OLD.handoff_id
+          OR NEW.attempt_number!=OLD.attempt_number
+          OR NEW.semantic_idempotency_key!=OLD.semantic_idempotency_key
+          OR NEW.persisted_before_send!=OLD.persisted_before_send
+          OR NEW.sent<OLD.sent OR NEW.ambiguous<OLD.ambiguous
+        BEGIN SELECT RAISE(ABORT,'immutable evaluation Handoff attempt identity'); END""",
+    *tuple(
+        statement
+        for table in (
+            "evaluation_handoffs",
+            "evaluation_handoff_attempts",
+            "evaluation_handoff_acknowledgements",
+        )
+        for statement in (
+            f"CREATE TRIGGER retained_{table}_delete BEFORE DELETE ON {table} "
+            f"BEGIN SELECT RAISE(ABORT,'retained {table}'); END",
+        )
+    ),
+    """CREATE TRIGGER immutable_evaluation_handoff_acknowledgements_update
+        BEFORE UPDATE ON evaluation_handoff_acknowledgements
+        BEGIN SELECT RAISE(ABORT,'immutable evaluation Handoff acknowledgement'); END""",
+)
+
+
+EVALUATION_HANDOFF_MIGRATION_CHECKSUM = digest_canonical(
+    {
+        "version": EVALUATION_HANDOFF_SCHEMA_VERSION,
+        "name": EVALUATION_HANDOFF_MIGRATION_NAME,
+        "statements": list(EVALUATION_HANDOFF_MIGRATION_STATEMENTS),
+    }
+)
+EVALUATION_HANDOFF_MIGRATION = EvaluationHandoffMigrationRecord(
+    version=EVALUATION_HANDOFF_SCHEMA_VERSION,
+    name=EVALUATION_HANDOFF_MIGRATION_NAME,
+    checksum=EVALUATION_HANDOFF_MIGRATION_CHECKSUM,
+)
+
+
+__all__ = [
+    "EVALUATION_HANDOFF_MIGRATION",
+    "EVALUATION_HANDOFF_MIGRATION_CHECKSUM",
+    "EVALUATION_HANDOFF_MIGRATION_NAME",
+    "EVALUATION_HANDOFF_MIGRATION_STATEMENTS",
+    "EVALUATION_HANDOFF_SCHEMA_VERSION",
+]

--- a/newsroom/authority/evaluation_handoff_migrations.py
+++ b/newsroom/authority/evaluation_handoff_migrations.py
@@ -252,6 +252,7 @@ EVALUATION_HANDOFF_MIGRATION_STATEMENTS: tuple[str, ...] = (
         sink_id TEXT NOT NULL,
         outcome TEXT NOT NULL CHECK(outcome IN('acknowledged','rejected')),
         response_digest TEXT NOT NULL,
+        state_authority INTEGER NOT NULL CHECK(state_authority IN(0,1)),
         PRIMARY KEY(recorded_handoff_id,acknowledgement_id),
         CHECK(substr(governing_manifest_digest,1,7)='sha256:'
               AND length(governing_manifest_digest)=71
@@ -314,6 +315,20 @@ EVALUATION_HANDOFF_MIGRATION_STATEMENTS: tuple[str, ...] = (
                   WHERE handoff_id=NEW.handoff_id
               )
               AND NEW.attempt_number<=h.max_attempts
+              AND (
+                  (NEW.attempt_number=1 AND h.transport_state='pending')
+                  OR (
+                      NEW.attempt_number>1
+                      AND h.transport_state='retry'
+                      AND EXISTS(
+                          SELECT 1 FROM evaluation_handoff_attempts AS previous
+                          WHERE previous.handoff_id=NEW.handoff_id
+                            AND previous.attempt_number=NEW.attempt_number-1
+                            AND previous.sent=1
+                            AND previous.ambiguous=1
+                      )
+                  )
+              )
         )
         BEGIN SELECT RAISE(ABORT,'invalid evaluation Handoff attempt sequence'); END""",
     """CREATE TRIGGER evaluation_handoff_attempt_update_guard
@@ -341,6 +356,13 @@ EVALUATION_HANDOFF_MIGRATION_STATEMENTS: tuple[str, ...] = (
     """CREATE TRIGGER immutable_evaluation_handoff_acknowledgements_update
         BEFORE UPDATE ON evaluation_handoff_acknowledgements
         BEGIN SELECT RAISE(ABORT,'immutable evaluation Handoff acknowledgement'); END""",
+    """CREATE TRIGGER evaluation_handoff_ack_state_authority_guard
+        BEFORE INSERT ON evaluation_handoff_acknowledgements
+        WHEN NEW.state_authority=1 AND NOT EXISTS(
+            SELECT 1 FROM evaluation_handoff_attempts
+            WHERE handoff_id=NEW.recorded_handoff_id AND sent=1
+        )
+        BEGIN SELECT RAISE(ABORT,'invalid acknowledgement state authority'); END""",
 )
 
 

--- a/newsroom/authority/evaluation_handoff_migrations.py
+++ b/newsroom/authority/evaluation_handoff_migrations.py
@@ -252,7 +252,6 @@ EVALUATION_HANDOFF_MIGRATION_STATEMENTS: tuple[str, ...] = (
         sink_id TEXT NOT NULL,
         outcome TEXT NOT NULL CHECK(outcome IN('acknowledged','rejected')),
         response_digest TEXT NOT NULL,
-        state_authority INTEGER NOT NULL CHECK(state_authority IN(0,1)),
         PRIMARY KEY(recorded_handoff_id,acknowledgement_id),
         CHECK(substr(governing_manifest_digest,1,7)='sha256:'
               AND length(governing_manifest_digest)=71
@@ -286,6 +285,37 @@ EVALUATION_HANDOFF_MIGRATION_STATEMENTS: tuple[str, ...] = (
                 AND NEW.transport_state IN('pending','acknowledged','rejected'))
             OR (OLD.transport_state IN('acknowledged','rejected')
                 AND NEW.transport_state='ambiguous')
+            OR (OLD.transport_state IN('acknowledged','rejected')
+                AND NEW.transport_state='pending'
+                AND EXISTS(
+                    SELECT 1 FROM evaluation_handoff_attempts AS active
+                    WHERE active.handoff_id=NEW.handoff_id
+                      AND active.attempt_number=(
+                          SELECT MAX(attempt_number)
+                          FROM evaluation_handoff_attempts
+                          WHERE handoff_id=NEW.handoff_id
+                      )
+                      AND active.attempt_number>1
+                      AND active.ambiguous=0
+                      AND NOT EXISTS(
+                          SELECT 1
+                          FROM evaluation_handoff_acknowledgements AS current_ack
+                          WHERE current_ack.recorded_handoff_id=NEW.handoff_id
+                            AND current_ack.attempt_id=active.attempt_id
+                      )
+                      AND EXISTS(
+                          SELECT 1
+                          FROM evaluation_handoff_acknowledgements
+                          WHERE recorded_handoff_id=NEW.handoff_id
+                            AND outcome='acknowledged'
+                      )
+                      AND EXISTS(
+                          SELECT 1
+                          FROM evaluation_handoff_acknowledgements
+                          WHERE recorded_handoff_id=NEW.handoff_id
+                            AND outcome='rejected'
+                      )
+                ))
         )
         OR (
             NEW.transport_state IN('acknowledged','rejected')
@@ -356,13 +386,22 @@ EVALUATION_HANDOFF_MIGRATION_STATEMENTS: tuple[str, ...] = (
     """CREATE TRIGGER immutable_evaluation_handoff_acknowledgements_update
         BEFORE UPDATE ON evaluation_handoff_acknowledgements
         BEGIN SELECT RAISE(ABORT,'immutable evaluation Handoff acknowledgement'); END""",
-    """CREATE TRIGGER evaluation_handoff_ack_state_authority_guard
+    """CREATE TRIGGER evaluation_handoff_ack_correlation_guard
         BEFORE INSERT ON evaluation_handoff_acknowledgements
-        WHEN NEW.state_authority=1 AND NOT EXISTS(
-            SELECT 1 FROM evaluation_handoff_attempts
-            WHERE handoff_id=NEW.recorded_handoff_id AND sent=1
+        WHEN NOT EXISTS(
+            SELECT 1
+            FROM evaluation_handoffs AS h
+            JOIN evaluation_handoff_attempts AS a
+              ON a.handoff_id=h.handoff_id
+             AND a.attempt_id=NEW.attempt_id
+            WHERE h.handoff_id=NEW.recorded_handoff_id
+              AND NEW.handoff_id=h.handoff_id
+              AND NEW.candidate_version_id=h.candidate_version_id
+              AND NEW.governing_manifest_digest=h.governing_manifest_digest
+              AND NEW.sink_id=h.sink_id
+              AND a.sent=1
         )
-        BEGIN SELECT RAISE(ABORT,'invalid acknowledgement state authority'); END""",
+        BEGIN SELECT RAISE(ABORT,'invalid acknowledgement correlation'); END""",
 )
 
 

--- a/newsroom/authority/evaluation_handoff_migrations.py
+++ b/newsroom/authority/evaluation_handoff_migrations.py
@@ -1,12 +1,30 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import hashlib
+from pathlib import Path
+import sqlite3
 
 from .canonical import digest_canonical
 
 
 EVALUATION_HANDOFF_SCHEMA_VERSION = 17
 EVALUATION_HANDOFF_MIGRATION_NAME = "evaluation_handoff_authority_v17"
+EVALUATION_HANDOFF_PREDECESSOR_FINGERPRINT = (
+    "sha256:b5a6d2afc78838cdeb648e7cd34b66452f2e0a0f7dab4773dd17a4cc28e3b5d8"
+)
+
+
+class EvaluationHandoffBackupError(sqlite3.DatabaseError):
+    """The exact retained v16 backup boundary is absent or differs."""
+
+
+@dataclass(frozen=True, slots=True)
+class EvaluationHandoffBackupReceipt:
+    backup_path: Path
+    digest_path: Path
+    backup_digest: str
+    logical_digest: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -14,6 +32,171 @@ class EvaluationHandoffMigrationRecord:
     version: int
     name: str
     checksum: str
+
+
+def evaluation_handoff_backup_paths(database: str | Path) -> tuple[Path, Path]:
+    source = Path(database)
+    backup = source.with_name(source.name + ".pre-v17.sqlite3")
+    return backup, backup.with_name(backup.name + ".sha256")
+
+
+def _logical_database_digest(connection: sqlite3.Connection) -> str:
+    return digest_canonical(list(connection.iterdump()))
+
+
+def _file_digest(path: Path) -> str:
+    return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _schema_fingerprint(connection: sqlite3.Connection) -> str:
+    rows = connection.execute(
+        "SELECT type,name,tbl_name,sql FROM sqlite_master "
+        "WHERE name NOT LIKE 'sqlite_%' ORDER BY type,name"
+    ).fetchall()
+    return digest_canonical(
+        [
+            [str(row[0]), str(row[1]), str(row[2]), " ".join(str(row[3] or "").split())]
+            for row in rows
+        ]
+    )
+
+
+def prepare_evaluation_handoff_backup(
+    connection: sqlite3.Connection,
+    backup_path: Path,
+) -> EvaluationHandoffBackupReceipt:
+    """Retain an exact v16 SQLite backup and digest before the v17 upgrade."""
+    if connection.in_transaction:
+        raise EvaluationHandoffBackupError("backup requires no active transaction")
+    if connection.execute("PRAGMA user_version").fetchone()[0] != 16:
+        raise EvaluationHandoffBackupError("backup requires exact schema v16")
+    if (
+        _schema_fingerprint(connection)
+        != EVALUATION_HANDOFF_PREDECESSOR_FINGERPRINT
+    ):
+        raise EvaluationHandoffBackupError("backup requires checked v16 schema")
+    if not isinstance(backup_path, Path) or not backup_path.is_absolute():
+        raise EvaluationHandoffBackupError("backup path must be absolute")
+    source_path = Path(
+        next(
+            row[2]
+            for row in connection.execute("PRAGMA database_list").fetchall()
+            if row[1] == "main"
+        )
+    )
+    if not source_path or source_path.resolve() == backup_path.resolve():
+        raise EvaluationHandoffBackupError("backup path must differ from source")
+    digest_path = backup_path.with_name(backup_path.name + ".sha256")
+    source_logical_digest = _logical_database_digest(connection)
+    if backup_path.exists() != digest_path.exists():
+        raise EvaluationHandoffBackupError("backup receipt is incomplete")
+    if backup_path.exists():
+        backup_digest = _file_digest(backup_path)
+        if digest_path.read_text(encoding="ascii") != backup_digest + "\n":
+            raise EvaluationHandoffBackupError("retained backup digest differs")
+        backup_connection = sqlite3.connect(
+            f"file:{backup_path}?mode=ro", uri=True, isolation_level=None
+        )
+        try:
+            backup_logical_digest = _logical_database_digest(backup_connection)
+            backup_version = backup_connection.execute(
+                "PRAGMA user_version"
+            ).fetchone()[0]
+            backup_fingerprint = _schema_fingerprint(backup_connection)
+        finally:
+            backup_connection.close()
+        if (
+            backup_version != 16
+            or backup_fingerprint != EVALUATION_HANDOFF_PREDECESSOR_FINGERPRINT
+            or backup_logical_digest != source_logical_digest
+        ):
+            raise EvaluationHandoffBackupError("retained backup differs from source")
+    else:
+        backup_path.open("xb").close()
+        backup_connection = sqlite3.connect(backup_path, isolation_level=None)
+        try:
+            connection.backup(backup_connection)
+            backup_logical_digest = _logical_database_digest(backup_connection)
+        finally:
+            backup_connection.close()
+        if backup_logical_digest != source_logical_digest:
+            raise EvaluationHandoffBackupError("backup differs from source snapshot")
+        backup_digest = _file_digest(backup_path)
+        with digest_path.open("x", encoding="ascii") as receipt_file:
+            receipt_file.write(backup_digest + "\n")
+    connection.execute(
+        "CREATE TEMP TABLE IF NOT EXISTS evaluation_handoff_backup_gate("
+        "backup_path TEXT PRIMARY KEY,backup_digest TEXT NOT NULL,"
+        "logical_digest TEXT NOT NULL) STRICT"
+    )
+    connection.execute("DELETE FROM evaluation_handoff_backup_gate")
+    connection.execute(
+        "INSERT INTO evaluation_handoff_backup_gate VALUES(?,?,?)",
+        (str(backup_path), backup_digest, source_logical_digest),
+    )
+    return EvaluationHandoffBackupReceipt(
+        backup_path=backup_path,
+        digest_path=digest_path,
+        backup_digest=backup_digest,
+        logical_digest=source_logical_digest,
+    )
+
+
+def require_evaluation_handoff_backup(
+    connection: sqlite3.Connection,
+    *,
+    expected_history: tuple[tuple[int, str, str], ...],
+) -> EvaluationHandoffBackupReceipt:
+    """Validate the prepared backup while the upgrade holds its exclusive lock."""
+    try:
+        row = connection.execute(
+            "SELECT backup_path,backup_digest,logical_digest "
+            "FROM temp.evaluation_handoff_backup_gate"
+        ).fetchone()
+    except sqlite3.OperationalError as exc:
+        raise EvaluationHandoffBackupError(
+            "v16 to v17 upgrade requires a prepared backup"
+        ) from exc
+    if row is None:
+        raise EvaluationHandoffBackupError(
+            "v16 to v17 upgrade requires a prepared backup"
+        )
+    backup_path = Path(str(row[0]))
+    digest_path = backup_path.with_name(backup_path.name + ".sha256")
+    backup_digest = str(row[1])
+    logical_digest = str(row[2])
+    if (
+        not backup_path.is_file()
+        or not digest_path.is_file()
+        or _file_digest(backup_path) != backup_digest
+        or digest_path.read_text(encoding="ascii") != backup_digest + "\n"
+        or _logical_database_digest(connection) != logical_digest
+    ):
+        raise EvaluationHandoffBackupError("prepared backup identity differs")
+    backup_connection = sqlite3.connect(
+        f"file:{backup_path}?mode=ro", uri=True, isolation_level=None
+    )
+    try:
+        if (
+            backup_connection.execute("PRAGMA user_version").fetchone()[0] != 16
+            or _schema_fingerprint(backup_connection)
+            != EVALUATION_HANDOFF_PREDECESSOR_FINGERPRINT
+            or _logical_database_digest(backup_connection) != logical_digest
+            or backup_connection.execute(
+                "SELECT version,name,checksum FROM authority_migrations "
+                "ORDER BY version"
+            ).fetchall()
+            != list(expected_history)
+        ):
+            raise EvaluationHandoffBackupError("prepared backup is not exact v16")
+    finally:
+        backup_connection.close()
+    return EvaluationHandoffBackupReceipt(
+        backup_path=backup_path,
+        digest_path=digest_path,
+        backup_digest=backup_digest,
+        logical_digest=logical_digest,
+    )
 
 
 EVALUATION_HANDOFF_MIGRATION_STATEMENTS: tuple[str, ...] = (
@@ -55,7 +238,7 @@ EVALUATION_HANDOFF_MIGRATION_STATEMENTS: tuple[str, ...] = (
         CHECK(ambiguous=0 OR sent=1)
     ) STRICT""",
     """CREATE TABLE evaluation_handoff_acknowledgements(
-        acknowledgement_id TEXT PRIMARY KEY,
+        acknowledgement_id TEXT NOT NULL,
         schema_identity TEXT NOT NULL
             CHECK(schema_identity='newsroom.increment6.evaluation-handoff-acknowledgement.v1'),
         recorded_handoff_id TEXT NOT NULL
@@ -67,7 +250,7 @@ EVALUATION_HANDOFF_MIGRATION_STATEMENTS: tuple[str, ...] = (
         sink_id TEXT NOT NULL,
         outcome TEXT NOT NULL CHECK(outcome IN('acknowledged','rejected')),
         response_digest TEXT NOT NULL,
-        UNIQUE(recorded_handoff_id,acknowledgement_id),
+        PRIMARY KEY(recorded_handoff_id,acknowledgement_id),
         CHECK(substr(governing_manifest_digest,1,7)='sha256:'
               AND length(governing_manifest_digest)=71
               AND substr(governing_manifest_digest,8)
@@ -75,7 +258,7 @@ EVALUATION_HANDOFF_MIGRATION_STATEMENTS: tuple[str, ...] = (
         CHECK(substr(response_digest,1,7)='sha256:'
               AND length(response_digest)=71
               AND substr(response_digest,8) NOT GLOB '*[^0-9a-f]*')
-    ) STRICT""",
+    ) WITHOUT ROWID, STRICT""",
     """CREATE TRIGGER evaluation_handoff_identity_guard
         BEFORE UPDATE ON evaluation_handoffs
         WHEN NEW.handoff_id!=OLD.handoff_id
@@ -174,9 +357,14 @@ EVALUATION_HANDOFF_MIGRATION = EvaluationHandoffMigrationRecord(
 
 
 __all__ = [
+    "EvaluationHandoffBackupError",
+    "EvaluationHandoffBackupReceipt",
     "EVALUATION_HANDOFF_MIGRATION",
     "EVALUATION_HANDOFF_MIGRATION_CHECKSUM",
     "EVALUATION_HANDOFF_MIGRATION_NAME",
     "EVALUATION_HANDOFF_MIGRATION_STATEMENTS",
     "EVALUATION_HANDOFF_SCHEMA_VERSION",
+    "evaluation_handoff_backup_paths",
+    "prepare_evaluation_handoff_backup",
+    "require_evaluation_handoff_backup",
 ]

--- a/newsroom/authority/evaluation_handoff_migrations.py
+++ b/newsroom/authority/evaluation_handoff_migrations.py
@@ -134,6 +134,8 @@ def prepare_evaluation_handoff_backup(
         "INSERT INTO evaluation_handoff_backup_gate VALUES(?,?,?)",
         (str(backup_path), backup_digest, source_logical_digest),
     )
+    if connection.in_transaction:
+        connection.commit()
     return EvaluationHandoffBackupReceipt(
         backup_path=backup_path,
         digest_path=digest_path,

--- a/newsroom/authority/evaluation_handoff_migrations.py
+++ b/newsroom/authority/evaluation_handoff_migrations.py
@@ -331,7 +331,16 @@ EVALUATION_HANDOFF_MIGRATION_STATEMENTS: tuple[str, ...] = (
                   AND k.governing_manifest_digest=NEW.governing_manifest_digest
                   AND k.sink_id=NEW.sink_id
                   AND k.outcome=NEW.transport_state
-                  AND a.sent=1
+                AND a.sent=1
+            )
+        )
+        OR (
+            NEW.transport_state IN('acknowledged','rejected')
+            AND EXISTS(
+                SELECT 1
+                FROM evaluation_handoff_acknowledgements AS conflict
+                WHERE conflict.recorded_handoff_id=NEW.handoff_id
+                  AND conflict.outcome!=NEW.transport_state
             )
         )
         BEGIN SELECT RAISE(ABORT,'invalid evaluation Handoff state transition'); END""",

--- a/newsroom/authority/migrations.py
+++ b/newsroom/authority/migrations.py
@@ -53,6 +53,8 @@ from .evaluation_handoff_migrations import (
     EVALUATION_HANDOFF_MIGRATION_NAME,
     EVALUATION_HANDOFF_MIGRATION_STATEMENTS,
     EVALUATION_HANDOFF_SCHEMA_VERSION,
+    evaluation_handoff_backup_paths,
+    prepare_evaluation_handoff_backup,
     require_evaluation_handoff_backup,
 )
 from .extraction_migrations import (
@@ -838,7 +840,24 @@ def apply_pending_migrations(
             )
             current = GRAPHITI_ADAPTER_SCHEMA_VERSION
         if current == GRAPHITI_ADAPTER_SCHEMA_VERSION:
-            if starting_version == GRAPHITI_ADAPTER_SCHEMA_VERSION:
+            if 0 < starting_version < GRAPHITI_ADAPTER_SCHEMA_VERSION:
+                conn.execute(
+                    f"PRAGMA user_version={GRAPHITI_ADAPTER_SCHEMA_VERSION}"
+                )
+                conn.execute("COMMIT")
+                database_path = next(
+                    str(row[2])
+                    for row in conn.execute("PRAGMA database_list").fetchall()
+                    if row[1] == "main"
+                )
+                if not database_path:
+                    raise sqlite3.DatabaseError(
+                        "existing multihop upgrade requires a file-backed database"
+                    )
+                backup_path, _ = evaluation_handoff_backup_paths(database_path)
+                prepare_evaluation_handoff_backup(conn, backup_path)
+                conn.execute("BEGIN EXCLUSIVE")
+            if starting_version != 0:
                 require_evaluation_handoff_backup(
                     conn,
                     expected_history=EXPECTED_MIGRATION_HISTORY[:-1],

--- a/newsroom/authority/migrations.py
+++ b/newsroom/authority/migrations.py
@@ -48,6 +48,7 @@ from .graphiti_adapter_migrations import (
     GRAPHITI_ADAPTER_SCHEMA_VERSION,
 )
 from .evaluation_handoff_migrations import (
+    EvaluationHandoffBackupReceipt,
     EVALUATION_HANDOFF_MIGRATION,
     EVALUATION_HANDOFF_MIGRATION_CHECKSUM,
     EVALUATION_HANDOFF_MIGRATION_NAME,
@@ -561,6 +562,25 @@ def schema_fingerprint(conn: sqlite3.Connection) -> str:
             for row in rows
         ]
     )
+
+
+def prepare_pending_migration_backup(
+    conn: sqlite3.Connection,
+) -> EvaluationHandoffBackupReceipt | None:
+    """Prepare the exact retained backup required by an existing v16 store."""
+    if int(conn.execute("PRAGMA user_version").fetchone()[0]) != 16:
+        return None
+    database_path = next(
+        str(row[2])
+        for row in conn.execute("PRAGMA database_list").fetchall()
+        if row[1] == "main"
+    )
+    if not database_path:
+        raise sqlite3.DatabaseError(
+            "existing v16 upgrade requires a file-backed database"
+        )
+    backup_path, _ = evaluation_handoff_backup_paths(database_path)
+    return prepare_evaluation_handoff_backup(conn, backup_path)
 
 
 def apply_migration(

--- a/newsroom/authority/migrations.py
+++ b/newsroom/authority/migrations.py
@@ -53,6 +53,7 @@ from .evaluation_handoff_migrations import (
     EVALUATION_HANDOFF_MIGRATION_NAME,
     EVALUATION_HANDOFF_MIGRATION_STATEMENTS,
     EVALUATION_HANDOFF_SCHEMA_VERSION,
+    require_evaluation_handoff_backup,
 )
 from .extraction_migrations import (
     EXTRACTION_AUTHORITY_MIGRATION,
@@ -592,9 +593,16 @@ def apply_pending_migrations(
     migration. Existing databases upgrade through checked extraction v13,
     entity-resolution v14, editorial-relation v15, isolated Graphiti
     proposal-adapter v16 and evaluation-Handoff authority v17.
+
+    An exact retained v16 database must first call
+    ``evaluation_handoff_migrations.prepare_evaluation_handoff_backup`` with a
+    durable backup path.
+    The v17 transaction revalidates that backup, its digest sidecar, the exact
+    predecessor schema and migration history while holding its exclusive lock.
     """
 
     current = int(conn.execute("PRAGMA user_version").fetchone()[0])
+    starting_version = current
     if current > SCHEMA_VERSION:
         raise sqlite3.DatabaseError(
             f"database schema {current} is newer than supported {SCHEMA_VERSION}"
@@ -830,6 +838,11 @@ def apply_pending_migrations(
             )
             current = GRAPHITI_ADAPTER_SCHEMA_VERSION
         if current == GRAPHITI_ADAPTER_SCHEMA_VERSION:
+            if starting_version == GRAPHITI_ADAPTER_SCHEMA_VERSION:
+                require_evaluation_handoff_backup(
+                    conn,
+                    expected_history=EXPECTED_MIGRATION_HISTORY[:-1],
+                )
             for statement in EVALUATION_HANDOFF_MIGRATION_STATEMENTS:
                 conn.execute(statement)
             conn.execute(

--- a/newsroom/authority/migrations.py
+++ b/newsroom/authority/migrations.py
@@ -47,6 +47,13 @@ from .graphiti_adapter_migrations import (
     GRAPHITI_ADAPTER_MIGRATION_STATEMENTS,
     GRAPHITI_ADAPTER_SCHEMA_VERSION,
 )
+from .evaluation_handoff_migrations import (
+    EVALUATION_HANDOFF_MIGRATION,
+    EVALUATION_HANDOFF_MIGRATION_CHECKSUM,
+    EVALUATION_HANDOFF_MIGRATION_NAME,
+    EVALUATION_HANDOFF_MIGRATION_STATEMENTS,
+    EVALUATION_HANDOFF_SCHEMA_VERSION,
+)
 from .extraction_migrations import (
     EXTRACTION_AUTHORITY_MIGRATION,
     EXTRACTION_AUTHORITY_MIGRATION_CHECKSUM,
@@ -113,7 +120,7 @@ from .source_registry_migrations import (
 )
 
 BASE_SCHEMA_VERSION = 1
-SCHEMA_VERSION = GRAPHITI_ADAPTER_SCHEMA_VERSION
+SCHEMA_VERSION = EVALUATION_HANDOFF_SCHEMA_VERSION
 MIGRATION_NAME = "authority_event_foundation_v1"
 
 
@@ -583,8 +590,8 @@ def apply_pending_migrations(
 
     Fresh schema creation is all-or-nothing across every retained authority
     migration. Existing databases upgrade through checked extraction v13,
-    entity-resolution v14, editorial-relation v15 and isolated Graphiti
-    proposal-adapter v16.
+    entity-resolution v14, editorial-relation v15, isolated Graphiti
+    proposal-adapter v16 and evaluation-Handoff authority v17.
     """
 
     current = int(conn.execute("PRAGMA user_version").fetchone()[0])
@@ -822,6 +829,21 @@ def apply_pending_migrations(
                 ),
             )
             current = GRAPHITI_ADAPTER_SCHEMA_VERSION
+        if current == GRAPHITI_ADAPTER_SCHEMA_VERSION:
+            for statement in EVALUATION_HANDOFF_MIGRATION_STATEMENTS:
+                conn.execute(statement)
+            conn.execute(
+                "INSERT INTO authority_migrations("
+                "version,name,checksum,applied_at) "
+                "VALUES(?,?,?,?)",
+                (
+                    EVALUATION_HANDOFF_SCHEMA_VERSION,
+                    EVALUATION_HANDOFF_MIGRATION_NAME,
+                    EVALUATION_HANDOFF_MIGRATION_CHECKSUM,
+                    applied_at,
+                ),
+            )
+            current = EVALUATION_HANDOFF_SCHEMA_VERSION
         conn.execute(f"PRAGMA user_version={current}")
         conn.execute("COMMIT")
     except Exception:
@@ -847,6 +869,7 @@ MIGRATIONS: tuple[MigrationRecord | object, ...] = (
     ENTITY_AUTHORITY_MIGRATION,
     EDITORIAL_RELATION_MIGRATION,
     GRAPHITI_ADAPTER_MIGRATION,
+    EVALUATION_HANDOFF_MIGRATION,
 )
 
 def _expected_fingerprint() -> str:
@@ -934,5 +957,10 @@ EXPECTED_MIGRATION_HISTORY: tuple[tuple[int, str, str], ...] = (
         GRAPHITI_ADAPTER_SCHEMA_VERSION,
         GRAPHITI_ADAPTER_MIGRATION_NAME,
         GRAPHITI_ADAPTER_MIGRATION_CHECKSUM,
+    ),
+    (
+        EVALUATION_HANDOFF_SCHEMA_VERSION,
+        EVALUATION_HANDOFF_MIGRATION_NAME,
+        EVALUATION_HANDOFF_MIGRATION_CHECKSUM,
     ),
 )

--- a/newsroom/increment6/handoffs.py
+++ b/newsroom/increment6/handoffs.py
@@ -203,7 +203,6 @@ class Handoff:
     state: HandoffState = HandoffState.PENDING
     attempts: tuple[HandoffAttempt, ...] = ()
     acknowledgements: tuple[Acknowledgement, ...] = ()
-    causal_acknowledgement_ids: tuple[str, ...] = ()
     retry_exhausted: bool = False
     ambiguity_reason: str | None = None
     evaluation_only: bool = True
@@ -253,26 +252,11 @@ class Handoff:
             for item in self.acknowledgements
         ):
             raise HandoffContractError("acknowledgements")
-        if any(
-            not isinstance(item, str)
-            or _ACKNOWLEDGEMENT_ID.fullmatch(item) is None
-            for item in self.causal_acknowledgement_ids
-        ):
-            raise HandoffContractError("causal_acknowledgement_ids")
-        if tuple(sorted(set(self.causal_acknowledgement_ids))) != (
-            self.causal_acknowledgement_ids
-        ):
-            raise HandoffContractError("causal_acknowledgement_ids")
-        if not set(self.causal_acknowledgement_ids) <= {
+        acknowledgement_ids = tuple(
             item.acknowledgement_id for item in self.acknowledgements
-        }:
-            raise HandoffContractError("causal_acknowledgement_ids")
-        if self.causal_acknowledgement_ids and not any(
-            attempt.sent for attempt in self.attempts
-        ):
-            raise HandoffContractError(
-                "causal acknowledgement requires a sent attempt"
-            )
+        )
+        if acknowledgement_ids != tuple(sorted(set(acknowledgement_ids))):
+            raise HandoffContractError("acknowledgement records")
         expected_numbers = tuple(range(1, len(self.attempts) + 1))
         if tuple(item.attempt_number for item in self.attempts) != expected_numbers:
             raise HandoffContractError("attempt sequence")
@@ -453,29 +437,19 @@ def _ack_mismatch(handoff: Handoff, acknowledgement: Acknowledgement) -> str | N
 def _derived_ack_state(
     handoff: Handoff,
 ) -> tuple[HandoffState, str | None] | None:
-    authoritative = tuple(
-        item
-        for item in handoff.acknowledgements
-        if item.acknowledgement_id in handoff.causal_acknowledgement_ids
-    )
-    if not authoritative:
+    if not handoff.acknowledgements:
         return None
+    if any(
+        _ack_mismatch(handoff, item) is not None
+        for item in handoff.acknowledgements
+    ):
+        raise HandoffContractError("uncorrelated acknowledgement record")
     correlated = {
         item.outcome
-        for item in authoritative
-        if _ack_mismatch(handoff, item) is None
+        for item in handoff.acknowledgements
     }
-    mismatches = sorted(
-        {
-            mismatch
-            for item in authoritative
-            if (mismatch := _ack_mismatch(handoff, item)) is not None
-        }
-    )
     if len(correlated) > 1:
         return HandoffState.AMBIGUOUS, "conflicting_acknowledgements"
-    if mismatches:
-        return HandoffState.AMBIGUOUS, mismatches[0]
     if correlated == {AcknowledgementOutcome.ACKNOWLEDGED}:
         return HandoffState.ACKNOWLEDGED, None
     if correlated == {AcknowledgementOutcome.REJECTED}:
@@ -537,6 +511,8 @@ def correlate_acknowledgement(
     handoff: Handoff, acknowledgement: Acknowledgement
 ) -> Handoff:
     """Correlate an untrusted response to its exact persisted and sent attempt."""
+    if _ack_mismatch(handoff, acknowledgement) is not None:
+        return handoff
     existing = next(
         (
             item
@@ -556,44 +532,34 @@ def correlate_acknowledgement(
             key=lambda item: item.acknowledgement_id,
         )
     )
-    causal_ids = handoff.causal_acknowledgement_ids
-    if any(attempt.sent for attempt in handoff.attempts):
-        causal_ids = tuple(
-            sorted(set(causal_ids) | {acknowledgement.acknowledgement_id})
-        )
-    if acknowledgement.acknowledgement_id not in causal_ids:
-        return replace(handoff, acknowledgements=acknowledgements)
     correlated_outcomes = {
         item.outcome
         for item in acknowledgements
-        if item.acknowledgement_id in causal_ids
-        and _ack_mismatch(handoff, item) is None
     }
     if len(correlated_outcomes) > 1:
+        latest = handoff.attempts[-1] if handoff.attempts else None
+        if (
+            latest is not None
+            and len(handoff.attempts) >= 2
+            and not latest.ambiguous
+            and all(
+                item.attempt_id != latest.attempt_id
+                for item in acknowledgements
+            )
+        ):
+            return replace(
+                handoff,
+                state=HandoffState.PENDING,
+                acknowledgements=acknowledgements,
+                retry_exhausted=False,
+                ambiguity_reason=None,
+            )
         return replace(
             handoff,
             state=HandoffState.AMBIGUOUS,
             acknowledgements=acknowledgements,
-            causal_acknowledgement_ids=causal_ids,
             retry_exhausted=len(handoff.attempts) >= handoff.max_attempts,
             ambiguity_reason="conflicting_acknowledgements",
-        )
-    mismatches = sorted(
-        {
-            mismatch
-            for item in acknowledgements
-            if item.acknowledgement_id in causal_ids
-            and (mismatch := _ack_mismatch(handoff, item)) is not None
-        }
-    )
-    if mismatches:
-        return replace(
-            handoff,
-            state=HandoffState.AMBIGUOUS,
-            acknowledgements=acknowledgements,
-            causal_acknowledgement_ids=causal_ids,
-            retry_exhausted=len(handoff.attempts) >= handoff.max_attempts,
-            ambiguity_reason=mismatches[0],
         )
     if not correlated_outcomes:
         raise HandoffContractError("acknowledgement correlation produced no outcome")
@@ -607,7 +573,6 @@ def correlate_acknowledgement(
         handoff,
         state=state,
         acknowledgements=acknowledgements,
-        causal_acknowledgement_ids=causal_ids,
         retry_exhausted=False,
         ambiguity_reason=None,
     )
@@ -780,7 +745,7 @@ class EvaluationHandoffStore:
         acknowledgement_rows = self._connection.execute(
             "SELECT schema_identity,acknowledgement_id,handoff_id,attempt_id,"
             "candidate_version_id,governing_manifest_digest,sink_id,outcome,"
-            "response_digest,state_authority "
+            "response_digest "
             "FROM evaluation_handoff_acknowledgements "
             "WHERE recorded_handoff_id=? ORDER BY acknowledgement_id",
             (handoff_id,),
@@ -799,9 +764,6 @@ class EvaluationHandoffStore:
             for item in acknowledgement_rows
             if self._require_schema(item[0], HANDOFF_ACKNOWLEDGEMENT)
         )
-        causal_acknowledgement_ids = tuple(
-            str(item[1]) for item in acknowledgement_rows if bool(item[9])
-        )
         return Handoff(
             handoff_id=handoff_id,
             candidate_version_id=str(row[1]),
@@ -811,7 +773,6 @@ class EvaluationHandoffStore:
             state=HandoffState(str(row[5])),
             attempts=attempts,
             acknowledgements=acknowledgements,
-            causal_acknowledgement_ids=causal_acknowledgement_ids,
             retry_exhausted=bool(row[6]),
             ambiguity_reason=None if row[7] is None else str(row[7]),
             evaluation_only=bool(row[8]),
@@ -858,8 +819,8 @@ class EvaluationHandoffStore:
                 "INSERT INTO evaluation_handoff_acknowledgements("
                 "acknowledgement_id,schema_identity,recorded_handoff_id,"
                 "handoff_id,attempt_id,candidate_version_id,"
-                "governing_manifest_digest,sink_id,outcome,response_digest,"
-                "state_authority) VALUES(?,?,?,?,?,?,?,?,?,?,?) "
+                "governing_manifest_digest,sink_id,outcome,response_digest) "
+                "VALUES(?,?,?,?,?,?,?,?,?,?) "
                 "ON CONFLICT(recorded_handoff_id,acknowledgement_id) DO NOTHING",
                 (
                     acknowledgement.acknowledgement_id,
@@ -872,16 +833,11 @@ class EvaluationHandoffStore:
                     acknowledgement.sink_id,
                     acknowledgement.outcome.value,
                     acknowledgement.response_digest,
-                    int(
-                        acknowledgement.acknowledgement_id
-                        in handoff.causal_acknowledgement_ids
-                    ),
                 ),
             )
             retained = self._connection.execute(
                 "SELECT handoff_id,attempt_id,candidate_version_id,"
-                "governing_manifest_digest,sink_id,outcome,response_digest,"
-                "state_authority "
+                "governing_manifest_digest,sink_id,outcome,response_digest "
                 "FROM evaluation_handoff_acknowledgements "
                 "WHERE recorded_handoff_id=? AND acknowledgement_id=?",
                 (handoff.handoff_id, acknowledgement.acknowledgement_id),
@@ -894,10 +850,6 @@ class EvaluationHandoffStore:
                 acknowledgement.sink_id,
                 acknowledgement.outcome.value,
                 acknowledgement.response_digest,
-                int(
-                    acknowledgement.acknowledgement_id
-                    in handoff.causal_acknowledgement_ids
-                ),
             )
             if retained != expected:
                 raise HandoffContractError(

--- a/newsroom/increment6/handoffs.py
+++ b/newsroom/increment6/handoffs.py
@@ -1,7 +1,8 @@
 """Pure contracts for evaluation-only Candidate Version handoffs.
 
-This module deliberately owns no persistence or transport adapter.  It models the
-records that those later integrations must durably store before external I/O.
+The SQLite store is deliberately transport-agnostic: it durably records each
+attempt before a caller performs external I/O and grants no publication or
+evidence authority.
 """
 
 from __future__ import annotations
@@ -11,11 +12,27 @@ from enum import Enum
 import hashlib
 import json
 import re
+import sqlite3
+from typing import Callable, ClassVar
 
 
 _DIGEST = re.compile(r"sha256:[0-9a-f]{64}")
 _HANDOFF_ID = re.compile(r"handoff:sha256:[0-9a-f]{64}")
 _ATTEMPT_ID = re.compile(r"attempt:sha256:[0-9a-f]{64}")
+_ACKNOWLEDGEMENT_ID = re.compile(r"acknowledgement:sha256:[0-9a-f]{64}")
+
+EVALUATION_HANDOFF = "newsroom.increment6.evaluation-handoff.v1"
+HANDOFF_ATTEMPT = "newsroom.increment6.evaluation-handoff-attempt.v1"
+HANDOFF_ACKNOWLEDGEMENT = (
+    "newsroom.increment6.evaluation-handoff-acknowledgement.v1"
+)
+HANDOFF_TRANSPORT_STATE = (
+    "pending",
+    "acknowledged",
+    "rejected",
+    "ambiguous",
+    "retry",
+)
 
 
 class HandoffContractError(ValueError):
@@ -62,6 +79,7 @@ def _identity(prefix: str, value: object) -> str:
 
 @dataclass(frozen=True)
 class HandoffAttempt:
+    schema_identity: ClassVar[str] = HANDOFF_ATTEMPT
     attempt_id: str
     handoff_id: str
     attempt_number: int
@@ -95,6 +113,7 @@ class HandoffAttempt:
 
 @dataclass(frozen=True)
 class Acknowledgement:
+    schema_identity: ClassVar[str] = HANDOFF_ACKNOWLEDGEMENT
     acknowledgement_id: str
     handoff_id: str
     attempt_id: str
@@ -105,7 +124,11 @@ class Acknowledgement:
     response_digest: str
 
     def __post_init__(self) -> None:
-        _text(self.acknowledgement_id, "acknowledgement_id")
+        _matches(
+            self.acknowledgement_id,
+            _ACKNOWLEDGEMENT_ID,
+            "acknowledgement_id",
+        )
         _matches(self.handoff_id, _HANDOFF_ID, "handoff_id")
         _matches(self.attempt_id, _ATTEMPT_ID, "attempt_id")
         _text(self.candidate_version_id, "candidate_version_id")
@@ -118,12 +141,25 @@ class Acknowledgement:
         if not isinstance(self.outcome, AcknowledgementOutcome):
             raise HandoffContractError("outcome")
         _matches(self.response_digest, _DIGEST, "response_digest")
+        expected = _identity(
+            "acknowledgement",
+            {
+                "handoff_id": self.handoff_id,
+                "attempt_id": self.attempt_id,
+                "candidate_version_id": self.candidate_version_id,
+                "governing_manifest_digest": self.governing_manifest_digest,
+                "sink_id": self.sink_id,
+                "outcome": self.outcome.value,
+                "response_digest": self.response_digest,
+            },
+        )
+        if self.acknowledgement_id != expected:
+            raise HandoffContractError("acknowledgement_id")
 
     @classmethod
     def create(
         cls,
         *,
-        acknowledgement_id: str,
         handoff_id: str,
         attempt_id: str,
         candidate_version_id: str,
@@ -132,6 +168,18 @@ class Acknowledgement:
         outcome: AcknowledgementOutcome,
         response_digest: str,
     ) -> Acknowledgement:
+        acknowledgement_id = _identity(
+            "acknowledgement",
+            {
+                "handoff_id": handoff_id,
+                "attempt_id": attempt_id,
+                "candidate_version_id": candidate_version_id,
+                "governing_manifest_digest": governing_manifest_digest,
+                "sink_id": sink_id,
+                "outcome": outcome.value,
+                "response_digest": response_digest,
+            },
+        )
         return cls(
             acknowledgement_id=acknowledgement_id,
             handoff_id=handoff_id,
@@ -146,6 +194,7 @@ class Acknowledgement:
 
 @dataclass(frozen=True)
 class Handoff:
+    schema_identity: ClassVar[str] = EVALUATION_HANDOFF
     handoff_id: str
     candidate_version_id: str
     governing_manifest_digest: str
@@ -326,7 +375,11 @@ def request_retry(handoff: Handoff) -> Handoff:
 def _ack_mismatch(handoff: Handoff, acknowledgement: Acknowledgement) -> str | None:
     comparisons = (
         ("handoff_id", acknowledgement.handoff_id, handoff.handoff_id),
-        ("candidate_version_id", acknowledgement.candidate_version_id, handoff.candidate_version_id),
+        (
+            "candidate_version_id",
+            acknowledgement.candidate_version_id,
+            handoff.candidate_version_id,
+        ),
         (
             "governing_manifest_digest",
             acknowledgement.governing_manifest_digest,
@@ -401,9 +454,281 @@ def correlate_acknowledgement(
     )
 
 
+class EvaluationHandoffStore:
+    """Sole-transaction SQLite store for evaluation-only Handoffs.
+
+    Transport callers persist an attempt through this store, commit, and only
+    then send it. Every transition reloads the aggregate inside ``BEGIN
+    IMMEDIATE`` so concurrent replays serialize to the same logical Handoff.
+    """
+
+    def __init__(self, connection: sqlite3.Connection) -> None:
+        if not isinstance(connection, sqlite3.Connection):
+            raise TypeError("connection must be sqlite3.Connection")
+        if connection.in_transaction:
+            raise HandoffContractError("connection has an active transaction")
+        connection.execute("PRAGMA foreign_keys=ON")
+        if connection.execute("PRAGMA foreign_keys").fetchone()[0] != 1:
+            raise HandoffContractError("foreign keys must be enabled")
+        self._connection = connection
+
+    def register(self, handoff: Handoff) -> Handoff:
+        """Create or idempotently replay one exact logical Handoff."""
+        pristine = create_handoff(
+            handoff.candidate_version_id,
+            handoff.governing_manifest_digest,
+            handoff.sink_id,
+            max_attempts=handoff.max_attempts,
+        )
+        if handoff != pristine:
+            raise HandoffContractError("registration requires a pristine Handoff")
+        self._begin()
+        try:
+            self._connection.execute(
+                "INSERT OR IGNORE INTO evaluation_handoffs("
+                "handoff_id,schema_identity,candidate_version_id,"
+                "governing_manifest_digest,sink_id,max_attempts,transport_state,"
+                "retry_exhausted,ambiguity_reason,evaluation_only,"
+                "publication_authority,evidence_authority) "
+                "VALUES(?,?,?,?,?,?,?,?,?,?,?,?)",
+                (
+                    handoff.handoff_id,
+                    EVALUATION_HANDOFF,
+                    handoff.candidate_version_id,
+                    handoff.governing_manifest_digest,
+                    handoff.sink_id,
+                    handoff.max_attempts,
+                    handoff.state.value,
+                    int(handoff.retry_exhausted),
+                    handoff.ambiguity_reason,
+                    1,
+                    0,
+                    0,
+                ),
+            )
+            retained = self._load(handoff.handoff_id)
+            if (
+                retained.candidate_version_id != handoff.candidate_version_id
+                or retained.governing_manifest_digest
+                != handoff.governing_manifest_digest
+                or retained.sink_id != handoff.sink_id
+                or retained.max_attempts != handoff.max_attempts
+            ):
+                raise HandoffContractError("Handoff replay conflicts with authority")
+            self._connection.execute("COMMIT")
+            return retained
+        except Exception:
+            self._rollback()
+            raise
+
+    def load(self, handoff_id: str) -> Handoff:
+        _matches(handoff_id, _HANDOFF_ID, "handoff_id")
+        self._begin()
+        try:
+            retained = self._load(handoff_id)
+            self._connection.execute("COMMIT")
+            return retained
+        except Exception:
+            self._rollback()
+            raise
+
+    def persist_attempt(self, handoff_id: str) -> Handoff:
+        return self._transition(handoff_id, persist_attempt)
+
+    def mark_attempt_sent(self, handoff_id: str, attempt_id: str) -> Handoff:
+        return self._transition(
+            handoff_id, lambda value: mark_attempt_sent(value, attempt_id)
+        )
+
+    def mark_attempt_ambiguous(
+        self, handoff_id: str, attempt_id: str
+    ) -> Handoff:
+        return self._transition(
+            handoff_id, lambda value: mark_attempt_ambiguous(value, attempt_id)
+        )
+
+    def request_retry(self, handoff_id: str) -> Handoff:
+        return self._transition(handoff_id, request_retry)
+
+    def correlate_acknowledgement(
+        self, handoff_id: str, acknowledgement: Acknowledgement
+    ) -> Handoff:
+        return self._transition(
+            handoff_id,
+            lambda value: correlate_acknowledgement(value, acknowledgement),
+        )
+
+    def _begin(self) -> None:
+        if self._connection.in_transaction:
+            raise HandoffContractError("connection has an active transaction")
+        self._connection.execute("BEGIN IMMEDIATE")
+
+    def _rollback(self) -> None:
+        if self._connection.in_transaction:
+            self._connection.execute("ROLLBACK")
+
+    def _transition(
+        self, handoff_id: str, operation: Callable[[Handoff], Handoff]
+    ) -> Handoff:
+        _matches(handoff_id, _HANDOFF_ID, "handoff_id")
+        self._begin()
+        try:
+            before = self._load(handoff_id)
+            after = operation(before)
+            self._write(after)
+            retained = self._load(handoff_id)
+            if retained != after:
+                raise HandoffContractError("persisted Handoff differs from transition")
+            self._connection.execute("COMMIT")
+            return retained
+        except Exception:
+            self._rollback()
+            raise
+
+    def _load(self, handoff_id: str) -> Handoff:
+        row = self._connection.execute(
+            "SELECT schema_identity,candidate_version_id,"
+            "governing_manifest_digest,sink_id,max_attempts,transport_state,"
+            "retry_exhausted,ambiguity_reason,evaluation_only,"
+            "publication_authority,evidence_authority "
+            "FROM evaluation_handoffs WHERE handoff_id=?",
+            (handoff_id,),
+        ).fetchone()
+        if row is None:
+            raise HandoffContractError("unknown Handoff")
+        if row[0] != EVALUATION_HANDOFF:
+            raise HandoffContractError("Handoff schema identity")
+        attempt_rows = self._connection.execute(
+            "SELECT schema_identity,attempt_id,attempt_number,"
+            "semantic_idempotency_key,persisted_before_send,sent,ambiguous "
+            "FROM evaluation_handoff_attempts WHERE handoff_id=? "
+            "ORDER BY attempt_number",
+            (handoff_id,),
+        ).fetchall()
+        attempts = tuple(
+            HandoffAttempt(
+                attempt_id=str(item[1]),
+                handoff_id=handoff_id,
+                attempt_number=int(item[2]),
+                semantic_idempotency_key=str(item[3]),
+                persisted_before_send=bool(item[4]),
+                sent=bool(item[5]),
+                ambiguous=bool(item[6]),
+            )
+            for item in attempt_rows
+            if self._require_schema(item[0], HANDOFF_ATTEMPT)
+        )
+        acknowledgement_rows = self._connection.execute(
+            "SELECT schema_identity,acknowledgement_id,handoff_id,attempt_id,"
+            "candidate_version_id,governing_manifest_digest,sink_id,outcome,"
+            "response_digest FROM evaluation_handoff_acknowledgements "
+            "WHERE recorded_handoff_id=? ORDER BY rowid",
+            (handoff_id,),
+        ).fetchall()
+        acknowledgements = tuple(
+            Acknowledgement(
+                acknowledgement_id=str(item[1]),
+                handoff_id=str(item[2]),
+                attempt_id=str(item[3]),
+                candidate_version_id=str(item[4]),
+                governing_manifest_digest=str(item[5]),
+                sink_id=str(item[6]),
+                outcome=AcknowledgementOutcome(str(item[7])),
+                response_digest=str(item[8]),
+            )
+            for item in acknowledgement_rows
+            if self._require_schema(item[0], HANDOFF_ACKNOWLEDGEMENT)
+        )
+        return Handoff(
+            handoff_id=handoff_id,
+            candidate_version_id=str(row[1]),
+            governing_manifest_digest=str(row[2]),
+            sink_id=str(row[3]),
+            max_attempts=int(row[4]),
+            state=HandoffState(str(row[5])),
+            attempts=attempts,
+            acknowledgements=acknowledgements,
+            retry_exhausted=bool(row[6]),
+            ambiguity_reason=None if row[7] is None else str(row[7]),
+            evaluation_only=bool(row[8]),
+            publication_authority=bool(row[9]),
+            evidence_authority=bool(row[10]),
+        )
+
+    @staticmethod
+    def _require_schema(actual: object, expected: str) -> bool:
+        if actual != expected:
+            raise HandoffContractError("record schema identity")
+        return True
+
+    def _write(self, handoff: Handoff) -> None:
+        for attempt in handoff.attempts:
+            exists = self._connection.execute(
+                "SELECT 1 FROM evaluation_handoff_attempts WHERE attempt_id=?",
+                (attempt.attempt_id,),
+            ).fetchone()
+            if exists is None:
+                self._connection.execute(
+                    "INSERT INTO evaluation_handoff_attempts("
+                    "attempt_id,schema_identity,handoff_id,attempt_number,"
+                    "semantic_idempotency_key,persisted_before_send,sent,ambiguous) "
+                    "VALUES(?,?,?,?,?,?,?,?)",
+                    (
+                        attempt.attempt_id,
+                        HANDOFF_ATTEMPT,
+                        attempt.handoff_id,
+                        attempt.attempt_number,
+                        attempt.semantic_idempotency_key,
+                        1,
+                        int(attempt.sent),
+                        int(attempt.ambiguous),
+                    ),
+                )
+            self._connection.execute(
+                "UPDATE evaluation_handoff_attempts SET sent=?,ambiguous=? "
+                "WHERE attempt_id=?",
+                (int(attempt.sent), int(attempt.ambiguous), attempt.attempt_id),
+            )
+        for acknowledgement in handoff.acknowledgements:
+            self._connection.execute(
+                "INSERT OR IGNORE INTO evaluation_handoff_acknowledgements("
+                "acknowledgement_id,schema_identity,recorded_handoff_id,"
+                "handoff_id,attempt_id,candidate_version_id,"
+                "governing_manifest_digest,sink_id,outcome,response_digest) "
+                "VALUES(?,?,?,?,?,?,?,?,?,?)",
+                (
+                    acknowledgement.acknowledgement_id,
+                    HANDOFF_ACKNOWLEDGEMENT,
+                    handoff.handoff_id,
+                    acknowledgement.handoff_id,
+                    acknowledgement.attempt_id,
+                    acknowledgement.candidate_version_id,
+                    acknowledgement.governing_manifest_digest,
+                    acknowledgement.sink_id,
+                    acknowledgement.outcome.value,
+                    acknowledgement.response_digest,
+                ),
+            )
+        self._connection.execute(
+            "UPDATE evaluation_handoffs SET transport_state=?,"
+            "retry_exhausted=?,ambiguity_reason=? WHERE handoff_id=?",
+            (
+                handoff.state.value,
+                int(handoff.retry_exhausted),
+                handoff.ambiguity_reason,
+                handoff.handoff_id,
+            ),
+        )
+
+
 __all__ = [
     "Acknowledgement",
     "AcknowledgementOutcome",
+    "EVALUATION_HANDOFF",
+    "EvaluationHandoffStore",
+    "HANDOFF_ACKNOWLEDGEMENT",
+    "HANDOFF_ATTEMPT",
+    "HANDOFF_TRANSPORT_STATE",
     "Handoff",
     "HandoffAttempt",
     "HandoffContractError",

--- a/newsroom/increment6/handoffs.py
+++ b/newsroom/increment6/handoffs.py
@@ -484,6 +484,10 @@ def _validate_handoff_state(handoff: Handoff) -> None:
                 and len(handoff.attempts) >= 2
                 and latest is not None
                 and not latest.ambiguous
+                and all(
+                    item.attempt_id != latest.attempt_id
+                    for item in handoff.acknowledgements
+                )
             ):
                 return
         raise HandoffContractError("Handoff state differs from records")

--- a/newsroom/increment6/handoffs.py
+++ b/newsroom/increment6/handoffs.py
@@ -203,6 +203,7 @@ class Handoff:
     state: HandoffState = HandoffState.PENDING
     attempts: tuple[HandoffAttempt, ...] = ()
     acknowledgements: tuple[Acknowledgement, ...] = ()
+    causal_acknowledgement_ids: tuple[str, ...] = ()
     retry_exhausted: bool = False
     ambiguity_reason: str | None = None
     evaluation_only: bool = True
@@ -252,11 +253,36 @@ class Handoff:
             for item in self.acknowledgements
         ):
             raise HandoffContractError("acknowledgements")
+        if any(
+            not isinstance(item, str)
+            or _ACKNOWLEDGEMENT_ID.fullmatch(item) is None
+            for item in self.causal_acknowledgement_ids
+        ):
+            raise HandoffContractError("causal_acknowledgement_ids")
+        if tuple(sorted(set(self.causal_acknowledgement_ids))) != (
+            self.causal_acknowledgement_ids
+        ):
+            raise HandoffContractError("causal_acknowledgement_ids")
+        if not set(self.causal_acknowledgement_ids) <= {
+            item.acknowledgement_id for item in self.acknowledgements
+        }:
+            raise HandoffContractError("causal_acknowledgement_ids")
+        if self.causal_acknowledgement_ids and not any(
+            attempt.sent for attempt in self.attempts
+        ):
+            raise HandoffContractError(
+                "causal acknowledgement requires a sent attempt"
+            )
         expected_numbers = tuple(range(1, len(self.attempts) + 1))
         if tuple(item.attempt_number for item in self.attempts) != expected_numbers:
             raise HandoffContractError("attempt sequence")
         if any(item.handoff_id != self.handoff_id for item in self.attempts):
             raise HandoffContractError("attempt handoff_id")
+        if any(
+            not previous.sent or not previous.ambiguous
+            for previous in self.attempts[:-1]
+        ):
+            raise HandoffContractError("attempt history")
         if len(self.attempts) > self.max_attempts:
             raise HandoffContractError("attempt limit")
         if self.retry_exhausted and self.state is not HandoffState.AMBIGUOUS:
@@ -348,16 +374,23 @@ def mark_attempt_ambiguous(handoff: Handoff, attempt_id: str) -> Handoff:
         raise HandoffContractError("ambiguous attempt was not sent")
     if attempt.ambiguous:
         return handoff
-    if handoff.state is not HandoffState.PENDING:
-        raise HandoffContractError("ambiguous transition requires pending state")
     attempts = list(handoff.attempts)
     attempts[index] = replace(attempt, ambiguous=True)
+    if index < len(attempts) - 1:
+        return replace(handoff, attempts=tuple(attempts))
     reason = "target_outcome_unknown"
-    if handoff.acknowledgements:
-        derived = _derived_ack_state(handoff)
-        if derived is None or derived[0] is not HandoffState.AMBIGUOUS:
-            raise HandoffContractError("retry timeout acknowledgement state")
-        reason = derived[1]
+    derived = _derived_ack_state(handoff)
+    if derived is not None:
+        return replace(
+            handoff,
+            state=derived[0],
+            attempts=tuple(attempts),
+            retry_exhausted=(
+                derived[0] is HandoffState.AMBIGUOUS
+                and len(attempts) >= handoff.max_attempts
+            ),
+            ambiguity_reason=derived[1],
+        )
     return replace(
         handoff,
         state=HandoffState.AMBIGUOUS,
@@ -377,7 +410,17 @@ def request_retry(handoff: Handoff) -> Handoff:
         raise HandoffContractError("retry requires ambiguous state")
     if len(handoff.attempts) >= handoff.max_attempts:
         return replace(handoff, retry_exhausted=True)
-    return replace(handoff, state=HandoffState.RETRY, ambiguity_reason=None)
+    if not handoff.attempts or not handoff.attempts[-1].sent:
+        raise HandoffContractError("retry requires a sent attempt")
+    attempts = handoff.attempts[:-1] + (
+        replace(handoff.attempts[-1], ambiguous=True),
+    )
+    return replace(
+        handoff,
+        state=HandoffState.RETRY,
+        attempts=attempts,
+        ambiguity_reason=None,
+    )
 
 
 def _ack_mismatch(handoff: Handoff, acknowledgement: Acknowledgement) -> str | None:
@@ -410,17 +453,22 @@ def _ack_mismatch(handoff: Handoff, acknowledgement: Acknowledgement) -> str | N
 def _derived_ack_state(
     handoff: Handoff,
 ) -> tuple[HandoffState, str | None] | None:
-    if not handoff.acknowledgements:
+    authoritative = tuple(
+        item
+        for item in handoff.acknowledgements
+        if item.acknowledgement_id in handoff.causal_acknowledgement_ids
+    )
+    if not authoritative:
         return None
     correlated = {
         item.outcome
-        for item in handoff.acknowledgements
+        for item in authoritative
         if _ack_mismatch(handoff, item) is None
     }
     mismatches = sorted(
         {
             mismatch
-            for item in handoff.acknowledgements
+            for item in authoritative
             if (mismatch := _ack_mismatch(handoff, item)) is not None
         }
     )
@@ -451,6 +499,8 @@ def _validate_handoff_state(handoff: Handoff) -> None:
             if (
                 handoff.state is HandoffState.RETRY
                 and handoff.ambiguity_reason is None
+                and latest is not None
+                and latest.ambiguous
                 and len(handoff.attempts) < handoff.max_attempts
             ):
                 return
@@ -506,16 +556,25 @@ def correlate_acknowledgement(
             key=lambda item: item.acknowledgement_id,
         )
     )
+    causal_ids = handoff.causal_acknowledgement_ids
+    if any(attempt.sent for attempt in handoff.attempts):
+        causal_ids = tuple(
+            sorted(set(causal_ids) | {acknowledgement.acknowledgement_id})
+        )
+    if acknowledgement.acknowledgement_id not in causal_ids:
+        return replace(handoff, acknowledgements=acknowledgements)
     correlated_outcomes = {
         item.outcome
         for item in acknowledgements
-        if _ack_mismatch(handoff, item) is None
+        if item.acknowledgement_id in causal_ids
+        and _ack_mismatch(handoff, item) is None
     }
     if len(correlated_outcomes) > 1:
         return replace(
             handoff,
             state=HandoffState.AMBIGUOUS,
             acknowledgements=acknowledgements,
+            causal_acknowledgement_ids=causal_ids,
             retry_exhausted=len(handoff.attempts) >= handoff.max_attempts,
             ambiguity_reason="conflicting_acknowledgements",
         )
@@ -523,7 +582,8 @@ def correlate_acknowledgement(
         {
             mismatch
             for item in acknowledgements
-            if (mismatch := _ack_mismatch(handoff, item)) is not None
+            if item.acknowledgement_id in causal_ids
+            and (mismatch := _ack_mismatch(handoff, item)) is not None
         }
     )
     if mismatches:
@@ -531,6 +591,7 @@ def correlate_acknowledgement(
             handoff,
             state=HandoffState.AMBIGUOUS,
             acknowledgements=acknowledgements,
+            causal_acknowledgement_ids=causal_ids,
             retry_exhausted=len(handoff.attempts) >= handoff.max_attempts,
             ambiguity_reason=mismatches[0],
         )
@@ -546,6 +607,7 @@ def correlate_acknowledgement(
         handoff,
         state=state,
         acknowledgements=acknowledgements,
+        causal_acknowledgement_ids=causal_ids,
         retry_exhausted=False,
         ambiguity_reason=None,
     )
@@ -718,7 +780,8 @@ class EvaluationHandoffStore:
         acknowledgement_rows = self._connection.execute(
             "SELECT schema_identity,acknowledgement_id,handoff_id,attempt_id,"
             "candidate_version_id,governing_manifest_digest,sink_id,outcome,"
-            "response_digest FROM evaluation_handoff_acknowledgements "
+            "response_digest,state_authority "
+            "FROM evaluation_handoff_acknowledgements "
             "WHERE recorded_handoff_id=? ORDER BY acknowledgement_id",
             (handoff_id,),
         ).fetchall()
@@ -736,6 +799,9 @@ class EvaluationHandoffStore:
             for item in acknowledgement_rows
             if self._require_schema(item[0], HANDOFF_ACKNOWLEDGEMENT)
         )
+        causal_acknowledgement_ids = tuple(
+            str(item[1]) for item in acknowledgement_rows if bool(item[9])
+        )
         return Handoff(
             handoff_id=handoff_id,
             candidate_version_id=str(row[1]),
@@ -745,6 +811,7 @@ class EvaluationHandoffStore:
             state=HandoffState(str(row[5])),
             attempts=attempts,
             acknowledgements=acknowledgements,
+            causal_acknowledgement_ids=causal_acknowledgement_ids,
             retry_exhausted=bool(row[6]),
             ambiguity_reason=None if row[7] is None else str(row[7]),
             evaluation_only=bool(row[8]),
@@ -791,8 +858,8 @@ class EvaluationHandoffStore:
                 "INSERT INTO evaluation_handoff_acknowledgements("
                 "acknowledgement_id,schema_identity,recorded_handoff_id,"
                 "handoff_id,attempt_id,candidate_version_id,"
-                "governing_manifest_digest,sink_id,outcome,response_digest) "
-                "VALUES(?,?,?,?,?,?,?,?,?,?) "
+                "governing_manifest_digest,sink_id,outcome,response_digest,"
+                "state_authority) VALUES(?,?,?,?,?,?,?,?,?,?,?) "
                 "ON CONFLICT(recorded_handoff_id,acknowledgement_id) DO NOTHING",
                 (
                     acknowledgement.acknowledgement_id,
@@ -805,11 +872,16 @@ class EvaluationHandoffStore:
                     acknowledgement.sink_id,
                     acknowledgement.outcome.value,
                     acknowledgement.response_digest,
+                    int(
+                        acknowledgement.acknowledgement_id
+                        in handoff.causal_acknowledgement_ids
+                    ),
                 ),
             )
             retained = self._connection.execute(
                 "SELECT handoff_id,attempt_id,candidate_version_id,"
-                "governing_manifest_digest,sink_id,outcome,response_digest "
+                "governing_manifest_digest,sink_id,outcome,response_digest,"
+                "state_authority "
                 "FROM evaluation_handoff_acknowledgements "
                 "WHERE recorded_handoff_id=? AND acknowledgement_id=?",
                 (handoff.handoff_id, acknowledgement.acknowledgement_id),
@@ -822,6 +894,10 @@ class EvaluationHandoffStore:
                 acknowledgement.sink_id,
                 acknowledgement.outcome.value,
                 acknowledgement.response_digest,
+                int(
+                    acknowledgement.acknowledgement_id
+                    in handoff.causal_acknowledgement_ids
+                ),
             )
             if retained != expected:
                 raise HandoffContractError(

--- a/newsroom/increment6/handoffs.py
+++ b/newsroom/increment6/handoffs.py
@@ -416,23 +416,18 @@ def correlate_acknowledgement(
             raise HandoffContractError("acknowledgement identity conflict")
         return handoff
 
-    acknowledgements = handoff.acknowledgements + (acknowledgement,)
-    mismatch = _ack_mismatch(handoff, acknowledgement)
-    if mismatch is not None:
-        return replace(
-            handoff,
-            state=HandoffState.AMBIGUOUS,
-            acknowledgements=acknowledgements,
-            retry_exhausted=False,
-            ambiguity_reason=mismatch,
+    acknowledgements = tuple(
+        sorted(
+            handoff.acknowledgements + (acknowledgement,),
+            key=lambda item: item.acknowledgement_id,
         )
-
+    )
     correlated_outcomes = {
         item.outcome
-        for item in handoff.acknowledgements
+        for item in acknowledgements
         if _ack_mismatch(handoff, item) is None
     }
-    if correlated_outcomes and acknowledgement.outcome not in correlated_outcomes:
+    if len(correlated_outcomes) > 1:
         return replace(
             handoff,
             state=HandoffState.AMBIGUOUS,
@@ -440,9 +435,27 @@ def correlate_acknowledgement(
             retry_exhausted=False,
             ambiguity_reason="conflicting_acknowledgements",
         )
+    mismatches = sorted(
+        {
+            mismatch
+            for item in acknowledgements
+            if (mismatch := _ack_mismatch(handoff, item)) is not None
+        }
+    )
+    if mismatches:
+        return replace(
+            handoff,
+            state=HandoffState.AMBIGUOUS,
+            acknowledgements=acknowledgements,
+            retry_exhausted=False,
+            ambiguity_reason=mismatches[0],
+        )
+    if not correlated_outcomes:
+        raise HandoffContractError("acknowledgement correlation produced no outcome")
+    outcome = next(iter(correlated_outcomes))
     state = (
         HandoffState.ACKNOWLEDGED
-        if acknowledgement.outcome is AcknowledgementOutcome.ACKNOWLEDGED
+        if outcome is AcknowledgementOutcome.ACKNOWLEDGED
         else HandoffState.REJECTED
     )
     return replace(
@@ -622,7 +635,7 @@ class EvaluationHandoffStore:
             "SELECT schema_identity,acknowledgement_id,handoff_id,attempt_id,"
             "candidate_version_id,governing_manifest_digest,sink_id,outcome,"
             "response_digest FROM evaluation_handoff_acknowledgements "
-            "WHERE recorded_handoff_id=? ORDER BY rowid",
+            "WHERE recorded_handoff_id=? ORDER BY acknowledgement_id",
             (handoff_id,),
         ).fetchall()
         acknowledgements = tuple(
@@ -639,7 +652,7 @@ class EvaluationHandoffStore:
             for item in acknowledgement_rows
             if self._require_schema(item[0], HANDOFF_ACKNOWLEDGEMENT)
         )
-        return Handoff(
+        retained = Handoff(
             handoff_id=handoff_id,
             candidate_version_id=str(row[1]),
             governing_manifest_digest=str(row[2]),
@@ -654,6 +667,87 @@ class EvaluationHandoffStore:
             publication_authority=bool(row[9]),
             evidence_authority=bool(row[10]),
         )
+        self._validate_retained_state(retained)
+        return retained
+
+    @staticmethod
+    def _validate_retained_state(handoff: Handoff) -> None:
+        if handoff.acknowledgements:
+            correlated = {
+                item.outcome
+                for item in handoff.acknowledgements
+                if _ack_mismatch(handoff, item) is None
+            }
+            mismatches = sorted(
+                {
+                    mismatch
+                    for item in handoff.acknowledgements
+                    if (mismatch := _ack_mismatch(handoff, item)) is not None
+                }
+            )
+            if len(correlated) > 1:
+                expected = (
+                    HandoffState.AMBIGUOUS,
+                    "conflicting_acknowledgements",
+                )
+            elif mismatches:
+                expected = (HandoffState.AMBIGUOUS, mismatches[0])
+            elif correlated == {AcknowledgementOutcome.ACKNOWLEDGED}:
+                expected = (HandoffState.ACKNOWLEDGED, None)
+            elif correlated == {AcknowledgementOutcome.REJECTED}:
+                expected = (HandoffState.REJECTED, None)
+            else:
+                raise HandoffContractError("retained Handoff acknowledgement state")
+            valid_exhaustion = not handoff.retry_exhausted or (
+                expected[0] is HandoffState.AMBIGUOUS
+                and len(handoff.attempts) >= handoff.max_attempts
+            )
+            derived_state_matches = (
+                handoff.state,
+                handoff.ambiguity_reason,
+            ) == expected and valid_exhaustion
+            latest = handoff.attempts[-1] if handoff.attempts else None
+            active_retry = (
+                expected[0] is HandoffState.AMBIGUOUS
+                and not handoff.retry_exhausted
+                and handoff.ambiguity_reason is None
+                and (
+                    (
+                        handoff.state is HandoffState.RETRY
+                        and len(handoff.attempts) < handoff.max_attempts
+                    )
+                    or (
+                        handoff.state is HandoffState.PENDING
+                        and len(handoff.attempts) >= 2
+                        and latest is not None
+                        and not latest.ambiguous
+                    )
+                )
+            )
+            if not derived_state_matches and not active_retry:
+                raise HandoffContractError("retained Handoff state differs from records")
+            return
+        latest = handoff.attempts[-1] if handoff.attempts else None
+        valid = (
+            handoff.state is HandoffState.PENDING
+            and handoff.ambiguity_reason is None
+            and not handoff.retry_exhausted
+            and (latest is None or not latest.ambiguous)
+        ) or (
+            handoff.state is HandoffState.AMBIGUOUS
+            and handoff.ambiguity_reason == "target_outcome_unknown"
+            and latest is not None
+            and latest.ambiguous
+        ) or (
+            handoff.state is HandoffState.RETRY
+            and handoff.ambiguity_reason is None
+            and not handoff.retry_exhausted
+            and latest is not None
+            and latest.ambiguous
+            and len(handoff.attempts) < handoff.max_attempts
+        )
+        if not valid:
+            raise HandoffContractError("retained Handoff state differs from records")
 
     @staticmethod
     def _require_schema(actual: object, expected: str) -> bool:
@@ -691,11 +785,12 @@ class EvaluationHandoffStore:
             )
         for acknowledgement in handoff.acknowledgements:
             self._connection.execute(
-                "INSERT OR IGNORE INTO evaluation_handoff_acknowledgements("
+                "INSERT INTO evaluation_handoff_acknowledgements("
                 "acknowledgement_id,schema_identity,recorded_handoff_id,"
                 "handoff_id,attempt_id,candidate_version_id,"
                 "governing_manifest_digest,sink_id,outcome,response_digest) "
-                "VALUES(?,?,?,?,?,?,?,?,?,?)",
+                "VALUES(?,?,?,?,?,?,?,?,?,?) "
+                "ON CONFLICT(recorded_handoff_id,acknowledgement_id) DO NOTHING",
                 (
                     acknowledgement.acknowledgement_id,
                     HANDOFF_ACKNOWLEDGEMENT,
@@ -709,6 +804,26 @@ class EvaluationHandoffStore:
                     acknowledgement.response_digest,
                 ),
             )
+            retained = self._connection.execute(
+                "SELECT handoff_id,attempt_id,candidate_version_id,"
+                "governing_manifest_digest,sink_id,outcome,response_digest "
+                "FROM evaluation_handoff_acknowledgements "
+                "WHERE recorded_handoff_id=? AND acknowledgement_id=?",
+                (handoff.handoff_id, acknowledgement.acknowledgement_id),
+            ).fetchone()
+            expected = (
+                acknowledgement.handoff_id,
+                acknowledgement.attempt_id,
+                acknowledgement.candidate_version_id,
+                acknowledgement.governing_manifest_digest,
+                acknowledgement.sink_id,
+                acknowledgement.outcome.value,
+                acknowledgement.response_digest,
+            )
+            if retained != expected:
+                raise HandoffContractError(
+                    "acknowledgement association conflicts with authority"
+                )
         self._connection.execute(
             "UPDATE evaluation_handoffs SET transport_state=?,"
             "retry_exhausted=?,ambiguity_reason=? WHERE handoff_id=?",

--- a/newsroom/increment6/handoffs.py
+++ b/newsroom/increment6/handoffs.py
@@ -1,0 +1,417 @@
+"""Pure contracts for evaluation-only Candidate Version handoffs.
+
+This module deliberately owns no persistence or transport adapter.  It models the
+records that those later integrations must durably store before external I/O.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from enum import Enum
+import hashlib
+import json
+import re
+
+
+_DIGEST = re.compile(r"sha256:[0-9a-f]{64}")
+_HANDOFF_ID = re.compile(r"handoff:sha256:[0-9a-f]{64}")
+_ATTEMPT_ID = re.compile(r"attempt:sha256:[0-9a-f]{64}")
+
+
+class HandoffContractError(ValueError):
+    """Raised when an evaluation Handoff contract would become untruthful."""
+
+
+class HandoffState(str, Enum):
+    PENDING = "pending"
+    ACKNOWLEDGED = "acknowledged"
+    REJECTED = "rejected"
+    AMBIGUOUS = "ambiguous"
+    RETRY = "retry"
+
+
+class AcknowledgementOutcome(str, Enum):
+    ACKNOWLEDGED = "acknowledged"
+    REJECTED = "rejected"
+
+
+def _text(value: object, field: str, *, maximum: int = 512) -> str:
+    if not isinstance(value, str) or not value or len(value.encode("utf-8")) > maximum:
+        raise HandoffContractError(field)
+    if any(ord(character) < 32 or ord(character) == 127 for character in value):
+        raise HandoffContractError(field)
+    return value
+
+
+def _matches(value: object, pattern: re.Pattern[str], field: str) -> str:
+    text = _text(value, field)
+    if pattern.fullmatch(text) is None:
+        raise HandoffContractError(field)
+    return text
+
+
+def _identity(prefix: str, value: object) -> str:
+    canonical = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return f"{prefix}:sha256:{hashlib.sha256(canonical).hexdigest()}"
+
+
+@dataclass(frozen=True)
+class HandoffAttempt:
+    attempt_id: str
+    handoff_id: str
+    attempt_number: int
+    semantic_idempotency_key: str
+    persisted_before_send: bool = True
+    sent: bool = False
+    ambiguous: bool = False
+
+    def __post_init__(self) -> None:
+        _matches(self.attempt_id, _ATTEMPT_ID, "attempt_id")
+        _matches(self.handoff_id, _HANDOFF_ID, "handoff_id")
+        if (
+            isinstance(self.attempt_number, bool)
+            or not isinstance(self.attempt_number, int)
+            or self.attempt_number < 1
+        ):
+            raise HandoffContractError("attempt_number")
+        if self.semantic_idempotency_key != self.handoff_id:
+            raise HandoffContractError("semantic_idempotency_key")
+        if self.persisted_before_send is not True:
+            raise HandoffContractError("persisted_before_send")
+        if self.ambiguous and not self.sent:
+            raise HandoffContractError("ambiguous attempt was not sent")
+        expected = _identity(
+            "attempt",
+            {"handoff_id": self.handoff_id, "attempt_number": self.attempt_number},
+        )
+        if self.attempt_id != expected:
+            raise HandoffContractError("attempt_id")
+
+
+@dataclass(frozen=True)
+class Acknowledgement:
+    acknowledgement_id: str
+    handoff_id: str
+    attempt_id: str
+    candidate_version_id: str
+    governing_manifest_digest: str
+    sink_id: str
+    outcome: AcknowledgementOutcome
+    response_digest: str
+
+    def __post_init__(self) -> None:
+        _text(self.acknowledgement_id, "acknowledgement_id")
+        _matches(self.handoff_id, _HANDOFF_ID, "handoff_id")
+        _matches(self.attempt_id, _ATTEMPT_ID, "attempt_id")
+        _text(self.candidate_version_id, "candidate_version_id")
+        _matches(
+            self.governing_manifest_digest,
+            _DIGEST,
+            "governing_manifest_digest",
+        )
+        _text(self.sink_id, "sink_id")
+        if not isinstance(self.outcome, AcknowledgementOutcome):
+            raise HandoffContractError("outcome")
+        _matches(self.response_digest, _DIGEST, "response_digest")
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        acknowledgement_id: str,
+        handoff_id: str,
+        attempt_id: str,
+        candidate_version_id: str,
+        governing_manifest_digest: str,
+        sink_id: str,
+        outcome: AcknowledgementOutcome,
+        response_digest: str,
+    ) -> Acknowledgement:
+        return cls(
+            acknowledgement_id=acknowledgement_id,
+            handoff_id=handoff_id,
+            attempt_id=attempt_id,
+            candidate_version_id=candidate_version_id,
+            governing_manifest_digest=governing_manifest_digest,
+            sink_id=sink_id,
+            outcome=outcome,
+            response_digest=response_digest,
+        )
+
+
+@dataclass(frozen=True)
+class Handoff:
+    handoff_id: str
+    candidate_version_id: str
+    governing_manifest_digest: str
+    sink_id: str
+    max_attempts: int
+    state: HandoffState = HandoffState.PENDING
+    attempts: tuple[HandoffAttempt, ...] = ()
+    acknowledgements: tuple[Acknowledgement, ...] = ()
+    retry_exhausted: bool = False
+    ambiguity_reason: str | None = None
+    evaluation_only: bool = True
+    publication_authority: bool = False
+    evidence_authority: bool = False
+
+    def __post_init__(self) -> None:
+        _matches(self.handoff_id, _HANDOFF_ID, "handoff_id")
+        candidate_version_id = _text(
+            self.candidate_version_id, "candidate_version_id"
+        )
+        manifest_digest = _matches(
+            self.governing_manifest_digest,
+            _DIGEST,
+            "governing_manifest_digest",
+        )
+        sink_id = _text(self.sink_id, "sink_id")
+        if not sink_id.startswith("evaluation-sink:"):
+            raise HandoffContractError("sink_id must identify an evaluation sink")
+        if isinstance(self.max_attempts, bool) or not isinstance(self.max_attempts, int):
+            raise HandoffContractError("max_attempts")
+        if self.max_attempts < 1 or self.max_attempts > 100:
+            raise HandoffContractError("max_attempts")
+        if not isinstance(self.state, HandoffState):
+            raise HandoffContractError("state")
+        if self.evaluation_only is not True:
+            raise HandoffContractError("evaluation_only")
+        if self.publication_authority is not False:
+            raise HandoffContractError("publication_authority")
+        if self.evidence_authority is not False:
+            raise HandoffContractError("evidence_authority")
+        expected = _identity(
+            "handoff",
+            {
+                "candidate_version_id": candidate_version_id,
+                "governing_manifest_digest": manifest_digest,
+                "sink_id": sink_id,
+                "authority": "evaluation-only",
+            },
+        )
+        if self.handoff_id != expected:
+            raise HandoffContractError("handoff_id")
+        if any(not isinstance(item, HandoffAttempt) for item in self.attempts):
+            raise HandoffContractError("attempts")
+        if any(
+            not isinstance(item, Acknowledgement)
+            for item in self.acknowledgements
+        ):
+            raise HandoffContractError("acknowledgements")
+        expected_numbers = tuple(range(1, len(self.attempts) + 1))
+        if tuple(item.attempt_number for item in self.attempts) != expected_numbers:
+            raise HandoffContractError("attempt sequence")
+        if any(item.handoff_id != self.handoff_id for item in self.attempts):
+            raise HandoffContractError("attempt handoff_id")
+        if len(self.attempts) > self.max_attempts:
+            raise HandoffContractError("attempt limit")
+        if self.retry_exhausted and self.state is not HandoffState.AMBIGUOUS:
+            raise HandoffContractError("retry_exhausted")
+        if self.ambiguity_reason is not None:
+            _text(self.ambiguity_reason, "ambiguity_reason")
+
+
+def create_handoff(
+    candidate_version_id: str,
+    governing_manifest_digest: str,
+    sink_id: str,
+    *,
+    max_attempts: int = 3,
+) -> Handoff:
+    """Create or replay one stable logical Handoff without side effects."""
+    handoff_id = _identity(
+        "handoff",
+        {
+            "candidate_version_id": candidate_version_id,
+            "governing_manifest_digest": governing_manifest_digest,
+            "sink_id": sink_id,
+            "authority": "evaluation-only",
+        },
+    )
+    return Handoff(
+        handoff_id=handoff_id,
+        candidate_version_id=candidate_version_id,
+        governing_manifest_digest=governing_manifest_digest,
+        sink_id=sink_id,
+        max_attempts=max_attempts,
+    )
+
+
+def persist_attempt(handoff: Handoff) -> Handoff:
+    """Return the attempt record that a repository must commit before sending."""
+    if handoff.state is HandoffState.AMBIGUOUS and handoff.retry_exhausted:
+        return handoff
+    if handoff.state not in (HandoffState.PENDING, HandoffState.RETRY):
+        raise HandoffContractError("attempt persistence requires pending or retry state")
+    if handoff.attempts and handoff.state is HandoffState.PENDING:
+        return handoff
+    attempt_number = len(handoff.attempts) + 1
+    if attempt_number > handoff.max_attempts:
+        raise HandoffContractError("attempt limit")
+    attempt = HandoffAttempt(
+        attempt_id=_identity(
+            "attempt",
+            {"handoff_id": handoff.handoff_id, "attempt_number": attempt_number},
+        ),
+        handoff_id=handoff.handoff_id,
+        attempt_number=attempt_number,
+        semantic_idempotency_key=handoff.handoff_id,
+    )
+    return replace(
+        handoff,
+        state=HandoffState.PENDING,
+        attempts=handoff.attempts + (attempt,),
+        ambiguity_reason=None,
+    )
+
+
+def _attempt_index(handoff: Handoff, attempt_id: str) -> int:
+    for index, attempt in enumerate(handoff.attempts):
+        if attempt.attempt_id == attempt_id:
+            return index
+    raise HandoffContractError("unknown attempt")
+
+
+def mark_attempt_sent(handoff: Handoff, attempt_id: str) -> Handoff:
+    """Record sending only after the exact attempt has been persisted."""
+    index = _attempt_index(handoff, attempt_id)
+    attempt = handoff.attempts[index]
+    if handoff.state is not HandoffState.PENDING:
+        raise HandoffContractError("send requires pending state")
+    if attempt.sent:
+        return handoff
+    attempts = list(handoff.attempts)
+    attempts[index] = replace(attempt, sent=True)
+    return replace(handoff, attempts=tuple(attempts))
+
+
+def mark_attempt_ambiguous(handoff: Handoff, attempt_id: str) -> Handoff:
+    """Record a lost, delayed or otherwise indeterminate target response."""
+    index = _attempt_index(handoff, attempt_id)
+    attempt = handoff.attempts[index]
+    if not attempt.sent:
+        raise HandoffContractError("ambiguous attempt was not sent")
+    if attempt.ambiguous:
+        return handoff
+    if handoff.state is not HandoffState.PENDING:
+        raise HandoffContractError("ambiguous transition requires pending state")
+    attempts = list(handoff.attempts)
+    attempts[index] = replace(attempt, ambiguous=True)
+    return replace(
+        handoff,
+        state=HandoffState.AMBIGUOUS,
+        attempts=tuple(attempts),
+        ambiguity_reason="target_outcome_unknown",
+    )
+
+
+def request_retry(handoff: Handoff) -> Handoff:
+    """Request a bounded retry without allocating a second logical Handoff."""
+    if handoff.state in (HandoffState.ACKNOWLEDGED, HandoffState.REJECTED):
+        raise HandoffContractError("terminal handoff cannot retry")
+    if handoff.state is HandoffState.RETRY:
+        return handoff
+    if handoff.state is not HandoffState.AMBIGUOUS:
+        raise HandoffContractError("retry requires ambiguous state")
+    if len(handoff.attempts) >= handoff.max_attempts:
+        return replace(handoff, retry_exhausted=True)
+    return replace(handoff, state=HandoffState.RETRY, ambiguity_reason=None)
+
+
+def _ack_mismatch(handoff: Handoff, acknowledgement: Acknowledgement) -> str | None:
+    comparisons = (
+        ("handoff_id", acknowledgement.handoff_id, handoff.handoff_id),
+        ("candidate_version_id", acknowledgement.candidate_version_id, handoff.candidate_version_id),
+        (
+            "governing_manifest_digest",
+            acknowledgement.governing_manifest_digest,
+            handoff.governing_manifest_digest,
+        ),
+        ("sink_id", acknowledgement.sink_id, handoff.sink_id),
+    )
+    for field, actual, expected in comparisons:
+        if actual != expected:
+            return f"acknowledgement_{field}_mismatch"
+    matching_attempt = next(
+        (item for item in handoff.attempts if item.attempt_id == acknowledgement.attempt_id),
+        None,
+    )
+    if matching_attempt is None or not matching_attempt.sent:
+        return "acknowledgement_attempt_id_mismatch"
+    return None
+
+
+def correlate_acknowledgement(
+    handoff: Handoff, acknowledgement: Acknowledgement
+) -> Handoff:
+    """Correlate an untrusted response to its exact persisted and sent attempt."""
+    existing = next(
+        (
+            item
+            for item in handoff.acknowledgements
+            if item.acknowledgement_id == acknowledgement.acknowledgement_id
+        ),
+        None,
+    )
+    if existing is not None:
+        if existing != acknowledgement:
+            raise HandoffContractError("acknowledgement identity conflict")
+        return handoff
+
+    acknowledgements = handoff.acknowledgements + (acknowledgement,)
+    mismatch = _ack_mismatch(handoff, acknowledgement)
+    if mismatch is not None:
+        return replace(
+            handoff,
+            state=HandoffState.AMBIGUOUS,
+            acknowledgements=acknowledgements,
+            retry_exhausted=False,
+            ambiguity_reason=mismatch,
+        )
+
+    correlated_outcomes = {
+        item.outcome
+        for item in handoff.acknowledgements
+        if _ack_mismatch(handoff, item) is None
+    }
+    if correlated_outcomes and acknowledgement.outcome not in correlated_outcomes:
+        return replace(
+            handoff,
+            state=HandoffState.AMBIGUOUS,
+            acknowledgements=acknowledgements,
+            retry_exhausted=False,
+            ambiguity_reason="conflicting_acknowledgements",
+        )
+    state = (
+        HandoffState.ACKNOWLEDGED
+        if acknowledgement.outcome is AcknowledgementOutcome.ACKNOWLEDGED
+        else HandoffState.REJECTED
+    )
+    return replace(
+        handoff,
+        state=state,
+        acknowledgements=acknowledgements,
+        retry_exhausted=False,
+        ambiguity_reason=None,
+    )
+
+
+__all__ = [
+    "Acknowledgement",
+    "AcknowledgementOutcome",
+    "Handoff",
+    "HandoffAttempt",
+    "HandoffContractError",
+    "HandoffState",
+    "correlate_acknowledgement",
+    "create_handoff",
+    "mark_attempt_ambiguous",
+    "mark_attempt_sent",
+    "persist_attempt",
+    "request_retry",
+]

--- a/newsroom/increment6/handoffs.py
+++ b/newsroom/increment6/handoffs.py
@@ -263,6 +263,7 @@ class Handoff:
             raise HandoffContractError("retry_exhausted")
         if self.ambiguity_reason is not None:
             _text(self.ambiguity_reason, "ambiguity_reason")
+        _validate_handoff_state(self)
 
 
 def create_handoff(
@@ -351,11 +352,18 @@ def mark_attempt_ambiguous(handoff: Handoff, attempt_id: str) -> Handoff:
         raise HandoffContractError("ambiguous transition requires pending state")
     attempts = list(handoff.attempts)
     attempts[index] = replace(attempt, ambiguous=True)
+    reason = "target_outcome_unknown"
+    if handoff.acknowledgements:
+        derived = _derived_ack_state(handoff)
+        if derived is None or derived[0] is not HandoffState.AMBIGUOUS:
+            raise HandoffContractError("retry timeout acknowledgement state")
+        reason = derived[1]
     return replace(
         handoff,
         state=HandoffState.AMBIGUOUS,
         attempts=tuple(attempts),
-        ambiguity_reason="target_outcome_unknown",
+        retry_exhausted=len(attempts) >= handoff.max_attempts,
+        ambiguity_reason=reason,
     )
 
 
@@ -399,6 +407,82 @@ def _ack_mismatch(handoff: Handoff, acknowledgement: Acknowledgement) -> str | N
     return None
 
 
+def _derived_ack_state(
+    handoff: Handoff,
+) -> tuple[HandoffState, str | None] | None:
+    if not handoff.acknowledgements:
+        return None
+    correlated = {
+        item.outcome
+        for item in handoff.acknowledgements
+        if _ack_mismatch(handoff, item) is None
+    }
+    mismatches = sorted(
+        {
+            mismatch
+            for item in handoff.acknowledgements
+            if (mismatch := _ack_mismatch(handoff, item)) is not None
+        }
+    )
+    if len(correlated) > 1:
+        return HandoffState.AMBIGUOUS, "conflicting_acknowledgements"
+    if mismatches:
+        return HandoffState.AMBIGUOUS, mismatches[0]
+    if correlated == {AcknowledgementOutcome.ACKNOWLEDGED}:
+        return HandoffState.ACKNOWLEDGED, None
+    if correlated == {AcknowledgementOutcome.REJECTED}:
+        return HandoffState.REJECTED, None
+    raise HandoffContractError("Handoff acknowledgement state")
+
+
+def _validate_handoff_state(handoff: Handoff) -> None:
+    latest = handoff.attempts[-1] if handoff.attempts else None
+    derived_ack = _derived_ack_state(handoff)
+    exact_exhaustion = (
+        handoff.state is HandoffState.AMBIGUOUS
+        and len(handoff.attempts) >= handoff.max_attempts
+    )
+    if handoff.retry_exhausted != exact_exhaustion:
+        raise HandoffContractError("Handoff state retry exhaustion differs")
+    if derived_ack is not None:
+        if (handoff.state, handoff.ambiguity_reason) == derived_ack:
+            return
+        if derived_ack[0] is HandoffState.AMBIGUOUS:
+            if (
+                handoff.state is HandoffState.RETRY
+                and handoff.ambiguity_reason is None
+                and len(handoff.attempts) < handoff.max_attempts
+            ):
+                return
+            if (
+                handoff.state is HandoffState.PENDING
+                and handoff.ambiguity_reason is None
+                and len(handoff.attempts) >= 2
+                and latest is not None
+                and not latest.ambiguous
+            ):
+                return
+        raise HandoffContractError("Handoff state differs from records")
+    valid = (
+        handoff.state is HandoffState.PENDING
+        and handoff.ambiguity_reason is None
+        and (latest is None or not latest.ambiguous)
+    ) or (
+        handoff.state is HandoffState.AMBIGUOUS
+        and handoff.ambiguity_reason == "target_outcome_unknown"
+        and latest is not None
+        and latest.ambiguous
+    ) or (
+        handoff.state is HandoffState.RETRY
+        and handoff.ambiguity_reason is None
+        and latest is not None
+        and latest.ambiguous
+        and len(handoff.attempts) < handoff.max_attempts
+    )
+    if not valid:
+        raise HandoffContractError("Handoff state differs from records")
+
+
 def correlate_acknowledgement(
     handoff: Handoff, acknowledgement: Acknowledgement
 ) -> Handoff:
@@ -432,7 +516,7 @@ def correlate_acknowledgement(
             handoff,
             state=HandoffState.AMBIGUOUS,
             acknowledgements=acknowledgements,
-            retry_exhausted=False,
+            retry_exhausted=len(handoff.attempts) >= handoff.max_attempts,
             ambiguity_reason="conflicting_acknowledgements",
         )
     mismatches = sorted(
@@ -447,7 +531,7 @@ def correlate_acknowledgement(
             handoff,
             state=HandoffState.AMBIGUOUS,
             acknowledgements=acknowledgements,
-            retry_exhausted=False,
+            retry_exhausted=len(handoff.attempts) >= handoff.max_attempts,
             ambiguity_reason=mismatches[0],
         )
     if not correlated_outcomes:
@@ -652,7 +736,7 @@ class EvaluationHandoffStore:
             for item in acknowledgement_rows
             if self._require_schema(item[0], HANDOFF_ACKNOWLEDGEMENT)
         )
-        retained = Handoff(
+        return Handoff(
             handoff_id=handoff_id,
             candidate_version_id=str(row[1]),
             governing_manifest_digest=str(row[2]),
@@ -667,87 +751,6 @@ class EvaluationHandoffStore:
             publication_authority=bool(row[9]),
             evidence_authority=bool(row[10]),
         )
-        self._validate_retained_state(retained)
-        return retained
-
-    @staticmethod
-    def _validate_retained_state(handoff: Handoff) -> None:
-        if handoff.acknowledgements:
-            correlated = {
-                item.outcome
-                for item in handoff.acknowledgements
-                if _ack_mismatch(handoff, item) is None
-            }
-            mismatches = sorted(
-                {
-                    mismatch
-                    for item in handoff.acknowledgements
-                    if (mismatch := _ack_mismatch(handoff, item)) is not None
-                }
-            )
-            if len(correlated) > 1:
-                expected = (
-                    HandoffState.AMBIGUOUS,
-                    "conflicting_acknowledgements",
-                )
-            elif mismatches:
-                expected = (HandoffState.AMBIGUOUS, mismatches[0])
-            elif correlated == {AcknowledgementOutcome.ACKNOWLEDGED}:
-                expected = (HandoffState.ACKNOWLEDGED, None)
-            elif correlated == {AcknowledgementOutcome.REJECTED}:
-                expected = (HandoffState.REJECTED, None)
-            else:
-                raise HandoffContractError("retained Handoff acknowledgement state")
-            valid_exhaustion = not handoff.retry_exhausted or (
-                expected[0] is HandoffState.AMBIGUOUS
-                and len(handoff.attempts) >= handoff.max_attempts
-            )
-            derived_state_matches = (
-                handoff.state,
-                handoff.ambiguity_reason,
-            ) == expected and valid_exhaustion
-            latest = handoff.attempts[-1] if handoff.attempts else None
-            active_retry = (
-                expected[0] is HandoffState.AMBIGUOUS
-                and not handoff.retry_exhausted
-                and handoff.ambiguity_reason is None
-                and (
-                    (
-                        handoff.state is HandoffState.RETRY
-                        and len(handoff.attempts) < handoff.max_attempts
-                    )
-                    or (
-                        handoff.state is HandoffState.PENDING
-                        and len(handoff.attempts) >= 2
-                        and latest is not None
-                        and not latest.ambiguous
-                    )
-                )
-            )
-            if not derived_state_matches and not active_retry:
-                raise HandoffContractError("retained Handoff state differs from records")
-            return
-        latest = handoff.attempts[-1] if handoff.attempts else None
-        valid = (
-            handoff.state is HandoffState.PENDING
-            and handoff.ambiguity_reason is None
-            and not handoff.retry_exhausted
-            and (latest is None or not latest.ambiguous)
-        ) or (
-            handoff.state is HandoffState.AMBIGUOUS
-            and handoff.ambiguity_reason == "target_outcome_unknown"
-            and latest is not None
-            and latest.ambiguous
-        ) or (
-            handoff.state is HandoffState.RETRY
-            and handoff.ambiguity_reason is None
-            and not handoff.retry_exhausted
-            and latest is not None
-            and latest.ambiguous
-            and len(handoff.attempts) < handoff.max_attempts
-        )
-        if not valid:
-            raise HandoffContractError("retained Handoff state differs from records")
 
     @staticmethod
     def _require_schema(actual: object, expected: str) -> bool:

--- a/newsroom/tests/graphiti_adapter_4d_migration_helpers.py
+++ b/newsroom/tests/graphiti_adapter_4d_migration_helpers.py
@@ -6,13 +6,17 @@ from pathlib import Path
 from newsroom.authority.graphiti_adapter_migrations import (
     GRAPHITI_ADAPTER_SCHEMA_VERSION,
 )
+from newsroom.authority.evaluation_handoff_migrations import (
+    EVALUATION_HANDOFF_SCHEMA_VERSION,
+)
 
 
 def downgrade_empty_graphiti_adapter_schema_to_v15(database: Path) -> None:
     """Remove only the empty v16 Graphiti-adapter schema from a checked test DB.
 
-    This helper is test-only. It preserves all v1-v15 authority rows and restores
-    the migration-history delete guard after removing the v16 history record.
+    This helper is test-only. It first removes the empty additive v17 successor,
+    preserves all v1-v15 authority rows, and restores the migration-history
+    delete guard after removing the v16+ history records.
     """
 
     conn = sqlite3.connect(database, isolation_level=None)
@@ -27,6 +31,20 @@ def downgrade_empty_graphiti_adapter_schema_to_v15(database: Path) -> None:
         ).fetchone()
         assert delete_trigger is not None and delete_trigger[0]
         conn.execute("DROP TRIGGER immutable_authority_migrations_delete")
+
+        if current >= EVALUATION_HANDOFF_SCHEMA_VERSION:
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='trigger' "
+                "AND (name LIKE '%evaluation_handoff%' "
+                "OR tbl_name LIKE 'evaluation_handoff%') ORDER BY name DESC"
+            ).fetchall():
+                conn.execute(f'DROP TRIGGER "{row[0]}"')
+            for table in (
+                "evaluation_handoff_acknowledgements",
+                "evaluation_handoff_attempts",
+                "evaluation_handoffs",
+            ):
+                conn.execute(f'DROP TABLE "{table}"')
 
         for row in conn.execute(
             "SELECT name FROM sqlite_master WHERE type='view' "

--- a/newsroom/tests/test_editorial_relation_4c_migrations.py
+++ b/newsroom/tests/test_editorial_relation_4c_migrations.py
@@ -77,7 +77,7 @@ def test_fresh_schema_v15_history_registry_tables_and_view_are_exact(
     conn = sqlite3.connect(state.extraction.database)
     try:
         assert EDITORIAL_RELATION_SCHEMA_VERSION == 15
-        assert SCHEMA_VERSION == 16
+        assert SCHEMA_VERSION == 17
         assert conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
         assert schema_fingerprint(conn) == EXPECTED_SCHEMA_FINGERPRINT
         assert conn.execute(

--- a/newsroom/tests/test_entity_4b_migrations.py
+++ b/newsroom/tests/test_entity_4b_migrations.py
@@ -118,7 +118,7 @@ def test_current_schema_retains_exact_v14_history_tables_and_view(
     conn = sqlite3.connect(state.database)
     try:
         assert ENTITY_AUTHORITY_SCHEMA_VERSION == 14
-        assert SCHEMA_VERSION == 16
+        assert SCHEMA_VERSION == 17
         assert conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
         assert schema_fingerprint(conn) == EXPECTED_SCHEMA_FINGERPRINT
         assert conn.execute(

--- a/newsroom/tests/test_graphiti_adapter_4d_migrations.py
+++ b/newsroom/tests/test_graphiti_adapter_4d_migrations.py
@@ -75,8 +75,9 @@ def test_fresh_schema_v16_history_policies_tables_and_triggers_are_exact(
     state = seed_extraction_fixture(tmp_path)
     conn = sqlite3.connect(state.database)
     try:
-        assert GRAPHITI_ADAPTER_SCHEMA_VERSION == SCHEMA_VERSION == 16
-        assert conn.execute("PRAGMA user_version").fetchone()[0] == 16
+        assert GRAPHITI_ADAPTER_SCHEMA_VERSION == 16
+        assert SCHEMA_VERSION == 17
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
         assert schema_fingerprint(conn) == EXPECTED_SCHEMA_FINGERPRINT
         assert conn.execute(
             "SELECT name,checksum FROM authority_migrations WHERE version=?",
@@ -181,6 +182,10 @@ def test_checked_v15_to_v16_upgrade_preserves_retained_extraction_authority(
             "SELECT COUNT(*) FROM sqlite_master WHERE type='table' "
             "AND name='graphiti_adapter_attempts'"
         ).fetchone()[0] == 0
+        assert downgraded.execute(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' "
+            "AND name='evaluation_handoffs'"
+        ).fetchone()[0] == 0
     finally:
         downgraded.close()
 
@@ -189,7 +194,7 @@ def test_checked_v15_to_v16_upgrade_preserves_retained_extraction_authority(
 
     after = sqlite3.connect(state.database)
     try:
-        assert after.execute("PRAGMA user_version").fetchone()[0] == 16
+        assert after.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
         assert schema_fingerprint(after) == EXPECTED_SCHEMA_FINGERPRINT
         assert {
             table: after.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]

--- a/newsroom/tests/test_increment6f1_handoff_migrations.py
+++ b/newsroom/tests/test_increment6f1_handoff_migrations.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from newsroom.authority.evaluation_handoff_migrations import (
+    EVALUATION_HANDOFF_MIGRATION_CHECKSUM,
+    EVALUATION_HANDOFF_MIGRATION_NAME,
+    EVALUATION_HANDOFF_SCHEMA_VERSION,
+)
+from newsroom.authority.migrations import (
+    EXPECTED_MIGRATION_HISTORY,
+    EXPECTED_SCHEMA_FINGERPRINT,
+    SCHEMA_VERSION,
+    apply_pending_migrations,
+    schema_fingerprint,
+)
+from newsroom.increment6.handoffs import (
+    Acknowledgement,
+    AcknowledgementOutcome,
+    EvaluationHandoffStore,
+    HandoffState,
+    create_handoff,
+)
+
+
+CANDIDATE_VERSION_ID = "candidate-version:01JZX7V7G8Q6XKNR4M8J5TH9WD"
+MANIFEST_DIGEST = "sha256:" + "a" * 64
+SINK_ID = "evaluation-sink:fixture-v1"
+
+
+def _handoff(*, max_attempts: int = 3):
+    return create_handoff(
+        CANDIDATE_VERSION_ID,
+        MANIFEST_DIGEST,
+        SINK_ID,
+        max_attempts=max_attempts,
+    )
+
+
+def _open(database: str | Path) -> sqlite3.Connection:
+    connection = sqlite3.connect(database, isolation_level=None, timeout=10)
+    connection.execute("PRAGMA foreign_keys=ON")
+    return connection
+
+
+def _fresh(database: str | Path = ":memory:") -> sqlite3.Connection:
+    connection = _open(database)
+    apply_pending_migrations(
+        connection, applied_at="2042-03-12T10:00:00.000000Z"
+    )
+    return connection
+
+
+def _downgrade_empty_v17_to_v16(connection: sqlite3.Connection) -> None:
+    connection.execute("PRAGMA foreign_keys=OFF")
+    delete_guard = connection.execute(
+        "SELECT sql FROM sqlite_master WHERE type='trigger' "
+        "AND name='immutable_authority_migrations_delete'"
+    ).fetchone()[0]
+    connection.execute("DROP TRIGGER immutable_authority_migrations_delete")
+    for row in connection.execute(
+        "SELECT name FROM sqlite_master WHERE type='trigger' "
+        "AND (name LIKE '%evaluation_handoff%') ORDER BY name DESC"
+    ).fetchall():
+        connection.execute(f'DROP TRIGGER "{row[0]}"')
+    for table in (
+        "evaluation_handoff_acknowledgements",
+        "evaluation_handoff_attempts",
+        "evaluation_handoffs",
+    ):
+        connection.execute(f'DROP TABLE "{table}"')
+    connection.execute("DELETE FROM authority_migrations WHERE version=17")
+    connection.execute(delete_guard)
+    connection.execute("PRAGMA user_version=16")
+    connection.execute("PRAGMA foreign_keys=ON")
+
+
+def test_fresh_v17_schema_history_fingerprint_and_integrity_are_exact() -> None:
+    connection = _fresh()
+    try:
+        assert SCHEMA_VERSION == EVALUATION_HANDOFF_SCHEMA_VERSION == 17
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 17
+        assert connection.execute(
+            "SELECT version,name,checksum FROM authority_migrations "
+            "ORDER BY version"
+        ).fetchall() == list(EXPECTED_MIGRATION_HISTORY)
+        assert connection.execute(
+            "SELECT name,checksum FROM authority_migrations WHERE version=17"
+        ).fetchone() == (
+            EVALUATION_HANDOFF_MIGRATION_NAME,
+            EVALUATION_HANDOFF_MIGRATION_CHECKSUM,
+        )
+        assert schema_fingerprint(connection) == EXPECTED_SCHEMA_FINGERPRINT
+        assert {
+            row[0]
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name LIKE 'evaluation_handoff%'"
+            )
+        } == {
+            "evaluation_handoffs",
+            "evaluation_handoff_attempts",
+            "evaluation_handoff_acknowledgements",
+        }
+        assert connection.execute("PRAGMA foreign_key_check").fetchall() == []
+        assert connection.execute("PRAGMA quick_check").fetchone()[0] == "ok"
+    finally:
+        connection.close()
+
+
+def test_exact_v16_upgrade_is_additive_and_failure_rolls_back_exclusively() -> None:
+    connection = _fresh()
+    try:
+        retained_v16_history = connection.execute(
+            "SELECT version,name,checksum FROM authority_migrations "
+            "WHERE version<=16 ORDER BY version"
+        ).fetchall()
+        _downgrade_empty_v17_to_v16(connection)
+        apply_pending_migrations(
+            connection, applied_at="2042-03-12T10:00:01.000000Z"
+        )
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 17
+        assert connection.execute(
+            "SELECT version,name,checksum FROM authority_migrations "
+            "WHERE version<=16 ORDER BY version"
+        ).fetchall() == retained_v16_history
+
+        _downgrade_empty_v17_to_v16(connection)
+        connection.execute("CREATE TABLE evaluation_handoffs(conflict TEXT) STRICT")
+        with pytest.raises(sqlite3.OperationalError, match="already exists"):
+            apply_pending_migrations(
+                connection, applied_at="2042-03-12T10:00:02.000000Z"
+            )
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 16
+        assert connection.execute(
+            "SELECT COUNT(*) FROM authority_migrations WHERE version=17"
+        ).fetchone()[0] == 0
+        assert connection.execute(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' "
+            "AND name='evaluation_handoff_attempts'"
+        ).fetchone()[0] == 0
+    finally:
+        connection.close()
+
+
+def test_store_persists_before_send_and_survives_restart_replay(tmp_path: Path) -> None:
+    database = tmp_path / "handoffs.sqlite3"
+    connection = _fresh(database)
+    store = EvaluationHandoffStore(connection)
+    initial = store.register(_handoff())
+    with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+        connection.execute(
+            "UPDATE evaluation_handoffs SET publication_authority=1 "
+            "WHERE handoff_id=?",
+            (initial.handoff_id,),
+        )
+    with pytest.raises(sqlite3.IntegrityError, match="state transition"):
+        connection.execute(
+            "UPDATE evaluation_handoffs SET transport_state='acknowledged' "
+            "WHERE handoff_id=?",
+            (initial.handoff_id,),
+        )
+    persisted = store.persist_attempt(initial.handoff_id)
+    attempt = persisted.attempts[0]
+    assert attempt.persisted_before_send is True
+    assert attempt.sent is False
+    connection.close()
+
+    connection = _open(database)
+    store = EvaluationHandoffStore(connection)
+    assert store.register(_handoff()) == persisted
+    sent = store.mark_attempt_sent(initial.handoff_id, attempt.attempt_id)
+    acknowledgement = Acknowledgement.create(
+        handoff_id=sent.handoff_id,
+        attempt_id=attempt.attempt_id,
+        candidate_version_id=sent.candidate_version_id,
+        governing_manifest_digest=sent.governing_manifest_digest,
+        sink_id=sent.sink_id,
+        outcome=AcknowledgementOutcome.ACKNOWLEDGED,
+        response_digest="sha256:" + "b" * 64,
+    )
+    acknowledged = store.correlate_acknowledgement(
+        sent.handoff_id, acknowledgement
+    )
+    assert acknowledged.state is HandoffState.ACKNOWLEDGED
+    assert store.correlate_acknowledgement(
+        sent.handoff_id, acknowledgement
+    ) == acknowledged
+    connection.close()
+
+    connection = _open(database)
+    try:
+        assert EvaluationHandoffStore(connection).load(initial.handoff_id) == acknowledged
+        assert connection.execute("PRAGMA foreign_key_check").fetchall() == []
+    finally:
+        connection.close()
+
+
+def test_store_retains_ambiguous_ack_and_bounds_retry(tmp_path: Path) -> None:
+    connection = _fresh(tmp_path / "ambiguous.sqlite3")
+    store = EvaluationHandoffStore(connection)
+    handoff = store.register(_handoff(max_attempts=1))
+    handoff = store.persist_attempt(handoff.handoff_id)
+    attempt = handoff.attempts[0]
+    handoff = store.mark_attempt_sent(handoff.handoff_id, attempt.attempt_id)
+    mismatched = Acknowledgement.create(
+        handoff_id="handoff:sha256:" + "0" * 64,
+        attempt_id=attempt.attempt_id,
+        candidate_version_id=handoff.candidate_version_id,
+        governing_manifest_digest=handoff.governing_manifest_digest,
+        sink_id=handoff.sink_id,
+        outcome=AcknowledgementOutcome.ACKNOWLEDGED,
+        response_digest="sha256:" + "c" * 64,
+    )
+    ambiguous = store.correlate_acknowledgement(handoff.handoff_id, mismatched)
+    assert ambiguous.state is HandoffState.AMBIGUOUS
+    assert ambiguous.ambiguity_reason == "acknowledgement_handoff_id_mismatch"
+    exhausted = store.request_retry(handoff.handoff_id)
+    assert exhausted.retry_exhausted is True
+    assert store.persist_attempt(handoff.handoff_id) == exhausted
+    connection.close()
+
+
+def test_store_correlates_delayed_ack_after_lost_response_and_retry(
+    tmp_path: Path,
+) -> None:
+    connection = _fresh(tmp_path / "delayed.sqlite3")
+    store = EvaluationHandoffStore(connection)
+    handoff = store.persist_attempt(store.register(_handoff()).handoff_id)
+    first = handoff.attempts[0]
+    handoff = store.mark_attempt_sent(handoff.handoff_id, first.attempt_id)
+    handoff = store.mark_attempt_ambiguous(handoff.handoff_id, first.attempt_id)
+    handoff = store.request_retry(handoff.handoff_id)
+    handoff = store.persist_attempt(handoff.handoff_id)
+    handoff = store.mark_attempt_sent(
+        handoff.handoff_id, handoff.attempts[1].attempt_id
+    )
+    delayed = Acknowledgement.create(
+        handoff_id=handoff.handoff_id,
+        attempt_id=first.attempt_id,
+        candidate_version_id=handoff.candidate_version_id,
+        governing_manifest_digest=handoff.governing_manifest_digest,
+        sink_id=handoff.sink_id,
+        outcome=AcknowledgementOutcome.ACKNOWLEDGED,
+        response_digest="sha256:" + "d" * 64,
+    )
+
+    result = store.correlate_acknowledgement(handoff.handoff_id, delayed)
+
+    assert result.state is HandoffState.ACKNOWLEDGED
+    assert result.handoff_id == handoff.handoff_id
+    assert len(result.attempts) == 2
+    connection.close()
+
+
+def test_concurrent_replay_allocates_one_logical_handoff_and_attempt(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "concurrent.sqlite3"
+    _fresh(database).close()
+
+    def persist() -> tuple[str, str]:
+        connection = _open(database)
+        try:
+            store = EvaluationHandoffStore(connection)
+            registered = store.register(_handoff())
+            result = store.persist_attempt(registered.handoff_id)
+            return result.handoff_id, result.attempts[0].attempt_id
+        finally:
+            connection.close()
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        results = list(pool.map(lambda _: persist(), range(8)))
+
+    assert len(set(results)) == 1
+    connection = _open(database)
+    try:
+        assert connection.execute(
+            "SELECT COUNT(*) FROM evaluation_handoffs"
+        ).fetchone()[0] == 1
+        assert connection.execute(
+            "SELECT COUNT(*) FROM evaluation_handoff_attempts"
+        ).fetchone()[0] == 1
+    finally:
+        connection.close()

--- a/newsroom/tests/test_increment6f1_handoff_migrations.py
+++ b/newsroom/tests/test_increment6f1_handoff_migrations.py
@@ -28,6 +28,10 @@ from newsroom.increment6.handoffs import (
     HandoffContractError,
     HandoffState,
     create_handoff,
+    mark_attempt_ambiguous,
+    mark_attempt_sent,
+    persist_attempt,
+    request_retry,
 )
 
 from .graphiti_adapter_4d_migration_helpers import (
@@ -456,6 +460,195 @@ def test_retry_timeout_after_wrong_ack_uses_one_deterministic_reason(
     assert timed_out.ambiguity_reason == "acknowledgement_handoff_id_mismatch"
     assert timed_out.retry_exhausted is True
     assert store.load(handoff.handoff_id) == timed_out
+
+
+def test_store_delayed_old_timeout_preserves_active_sent_retry(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "delayed-old-timeout.sqlite3"
+    connection = _fresh(database)
+    store = EvaluationHandoffStore(connection)
+    handoff = store.persist_attempt(store.register(_handoff()).handoff_id)
+    first = handoff.attempts[0]
+    handoff = store.mark_attempt_sent(handoff.handoff_id, first.attempt_id)
+    wrong = Acknowledgement.create(
+        handoff_id="handoff:sha256:" + "0" * 64,
+        attempt_id=first.attempt_id,
+        candidate_version_id=handoff.candidate_version_id,
+        governing_manifest_digest=handoff.governing_manifest_digest,
+        sink_id=handoff.sink_id,
+        outcome=AcknowledgementOutcome.ACKNOWLEDGED,
+        response_digest="sha256:" + "5" * 64,
+    )
+    handoff = store.correlate_acknowledgement(handoff.handoff_id, wrong)
+    handoff = store.persist_attempt(store.request_retry(handoff.handoff_id).handoff_id)
+    second = handoff.attempts[1]
+    handoff = store.mark_attempt_sent(handoff.handoff_id, second.attempt_id)
+
+    retained = store.mark_attempt_ambiguous(handoff.handoff_id, first.attempt_id)
+
+    assert retained.state is HandoffState.PENDING
+    assert retained.attempts[1].sent is True
+    assert store.persist_attempt(handoff.handoff_id) == retained
+    assert store.load(handoff.handoff_id) == retained
+    connection.close()
+
+
+def test_database_and_restart_reject_premature_second_attempt(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "premature-attempt.sqlite3"
+    connection = _fresh(database)
+    store = EvaluationHandoffStore(connection)
+    handoff = store.persist_attempt(store.register(_handoff()).handoff_id)
+    handoff = store.mark_attempt_sent(
+        handoff.handoff_id, handoff.attempts[0].attempt_id
+    )
+    valid = persist_attempt(_handoff())
+    valid = mark_attempt_sent(valid, valid.attempts[0].attempt_id)
+    valid = mark_attempt_ambiguous(valid, valid.attempts[0].attempt_id)
+    valid = persist_attempt(request_retry(valid))
+    second = valid.attempts[1]
+    with pytest.raises(sqlite3.IntegrityError, match="attempt sequence"):
+        connection.execute(
+            "INSERT INTO evaluation_handoff_attempts VALUES(?,?,?,?,?,?,?,?)",
+            (
+                second.attempt_id,
+                second.schema_identity,
+                handoff.handoff_id,
+                2,
+                handoff.handoff_id,
+                1,
+                0,
+                0,
+            ),
+        )
+
+    connection.execute("DROP TRIGGER evaluation_handoff_attempt_insert_guard")
+    connection.execute(
+        "INSERT INTO evaluation_handoff_attempts VALUES(?,?,?,?,?,?,?,?)",
+        (
+            second.attempt_id,
+            second.schema_identity,
+            handoff.handoff_id,
+            2,
+            handoff.handoff_id,
+            1,
+            0,
+            0,
+        ),
+    )
+    connection.close()
+    connection = _open(database)
+    with pytest.raises(HandoffContractError, match="attempt history"):
+        EvaluationHandoffStore(connection).load(handoff.handoff_id)
+    connection.close()
+
+
+def test_store_pristine_wrong_ack_remains_inert_across_restart_and_send(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "pristine-wrong-ack.sqlite3"
+    connection = _fresh(database)
+    store = EvaluationHandoffStore(connection)
+    handoff = store.register(_handoff())
+    wrong = Acknowledgement.create(
+        handoff_id="handoff:sha256:" + "0" * 64,
+        attempt_id="attempt:sha256:" + "0" * 64,
+        candidate_version_id=handoff.candidate_version_id,
+        governing_manifest_digest=handoff.governing_manifest_digest,
+        sink_id=handoff.sink_id,
+        outcome=AcknowledgementOutcome.ACKNOWLEDGED,
+        response_digest="sha256:" + "4" * 64,
+    )
+    retained = store.correlate_acknowledgement(handoff.handoff_id, wrong)
+    assert retained.state is HandoffState.PENDING
+    assert store.correlate_acknowledgement(handoff.handoff_id, wrong) == retained
+    connection.close()
+
+    connection = _open(database)
+    store = EvaluationHandoffStore(connection)
+    retained = store.load(handoff.handoff_id)
+    assert retained.state is HandoffState.PENDING
+    retained = store.persist_attempt(handoff.handoff_id)
+    retained = store.mark_attempt_sent(
+        handoff.handoff_id, retained.attempts[0].attempt_id
+    )
+    assert store.correlate_acknowledgement(handoff.handoff_id, wrong) == retained
+    connection.close()
+
+
+def test_database_rejects_pristine_ack_retry_authority(tmp_path: Path) -> None:
+    connection = _fresh(tmp_path / "pristine-ack-authority.sqlite3")
+    handoff = EvaluationHandoffStore(connection).register(_handoff())
+    wrong = Acknowledgement.create(
+        handoff_id="handoff:sha256:" + "0" * 64,
+        attempt_id="attempt:sha256:" + "0" * 64,
+        candidate_version_id=handoff.candidate_version_id,
+        governing_manifest_digest=handoff.governing_manifest_digest,
+        sink_id=handoff.sink_id,
+        outcome=AcknowledgementOutcome.ACKNOWLEDGED,
+        response_digest="sha256:" + "2" * 64,
+    )
+
+    with pytest.raises(sqlite3.IntegrityError, match="state authority"):
+        connection.execute(
+            "INSERT INTO evaluation_handoff_acknowledgements VALUES(?,?,?,?,?,?,?,?,?,?,?)",
+            (
+                wrong.acknowledgement_id,
+                wrong.schema_identity,
+                handoff.handoff_id,
+                wrong.handoff_id,
+                wrong.attempt_id,
+                wrong.candidate_version_id,
+                wrong.governing_manifest_digest,
+                wrong.sink_id,
+                wrong.outcome.value,
+                wrong.response_digest,
+                1,
+            ),
+        )
+    connection.close()
+
+def test_concurrent_pristine_ack_and_attempt_persistence_remain_retry_inert(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "concurrent-pristine-ack.sqlite3"
+    connection = _fresh(database)
+    handoff = EvaluationHandoffStore(connection).register(_handoff())
+    connection.close()
+    wrong = Acknowledgement.create(
+        handoff_id="handoff:sha256:" + "0" * 64,
+        attempt_id="attempt:sha256:" + "0" * 64,
+        candidate_version_id=handoff.candidate_version_id,
+        governing_manifest_digest=handoff.governing_manifest_digest,
+        sink_id=handoff.sink_id,
+        outcome=AcknowledgementOutcome.ACKNOWLEDGED,
+        response_digest="sha256:" + "3" * 64,
+    )
+
+    def observe_or_persist(observe: bool) -> None:
+        local = _open(database)
+        try:
+            store = EvaluationHandoffStore(local)
+            if observe:
+                store.correlate_acknowledgement(handoff.handoff_id, wrong)
+            else:
+                store.persist_attempt(handoff.handoff_id)
+        finally:
+            local.close()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        list(pool.map(observe_or_persist, (True, False)))
+
+    connection = _open(database)
+    try:
+        retained = EvaluationHandoffStore(connection).load(handoff.handoff_id)
+        assert retained.state is HandoffState.PENDING
+        assert len(retained.attempts) == 1
+        assert retained.acknowledgements == (wrong,)
+    finally:
+        connection.close()
 
 
 def test_restart_rejects_premature_retry_exhaustion_sql_tamper(

--- a/newsroom/tests/test_increment6f1_handoff_migrations.py
+++ b/newsroom/tests/test_increment6f1_handoff_migrations.py
@@ -33,6 +33,8 @@ from newsroom.increment6.handoffs import (
 from .graphiti_adapter_4d_migration_helpers import (
     downgrade_empty_graphiti_adapter_schema_to_v15,
 )
+from .authority_event_helpers import open_test_system
+from .extraction_4a_helpers import open_extraction_system, seed_extraction_fixture
 
 
 CANDIDATE_VERSION_ID = "candidate-version:01JZX7V7G8Q6XKNR4M8J5TH9WD"
@@ -236,6 +238,49 @@ def test_exact_v16_upgrade_rejects_changed_backup_digest(tmp_path: Path) -> None
         connection.close()
 
 
+def test_standard_sqlite_connection_backup_preflight_leaves_no_transaction(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "standard-connection.sqlite3"
+    initial = _fresh(database)
+    _downgrade_empty_v17_to_v16(initial)
+    initial.close()
+    connection = sqlite3.connect(database)
+    try:
+        prepare_evaluation_handoff_backup(
+            connection, evaluation_handoff_backup_paths(database)[0]
+        )
+        assert connection.in_transaction is False
+        apply_pending_migrations(
+            connection, applied_at="2042-03-12T10:00:01.000000Z"
+        )
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 17
+    finally:
+        connection.close()
+
+
+def test_actual_service_event_and_object_open_preflight_exact_v16_backup(
+    tmp_path: Path,
+) -> None:
+    event_database = tmp_path / "event" / "authority.sqlite3"
+    with open_test_system(event_database):
+        pass
+    event_connection = _open(event_database)
+    _downgrade_empty_v17_to_v16(event_connection)
+    event_connection.close()
+    with open_test_system(event_database):
+        pass
+    assert evaluation_handoff_backup_paths(event_database)[0].is_file()
+
+    extraction = seed_extraction_fixture(tmp_path / "object")
+    object_connection = _open(extraction.database)
+    _downgrade_empty_v17_to_v16(object_connection)
+    object_connection.close()
+    with open_extraction_system(extraction):
+        pass
+    assert evaluation_handoff_backup_paths(extraction.database)[0].is_file()
+
+
 def test_failed_v17_upgrade_rolls_back_exclusively_after_backup(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -381,6 +426,62 @@ def test_store_can_persist_bounded_retry_after_ambiguous_ack(tmp_path: Path) -> 
     connection.close()
 
 
+def test_retry_timeout_after_wrong_ack_uses_one_deterministic_reason(
+    tmp_path: Path,
+) -> None:
+    connection = _fresh(tmp_path / "retry-timeout.sqlite3")
+    store = EvaluationHandoffStore(connection)
+    handoff = store.persist_attempt(
+        store.register(_handoff(max_attempts=2)).handoff_id
+    )
+    first = handoff.attempts[0]
+    handoff = store.mark_attempt_sent(handoff.handoff_id, first.attempt_id)
+    wrong = Acknowledgement.create(
+        handoff_id="handoff:sha256:" + "0" * 64,
+        attempt_id=first.attempt_id,
+        candidate_version_id=handoff.candidate_version_id,
+        governing_manifest_digest=handoff.governing_manifest_digest,
+        sink_id=handoff.sink_id,
+        outcome=AcknowledgementOutcome.ACKNOWLEDGED,
+        response_digest="sha256:" + "6" * 64,
+    )
+    handoff = store.correlate_acknowledgement(handoff.handoff_id, wrong)
+    handoff = store.persist_attempt(store.request_retry(handoff.handoff_id).handoff_id)
+    second = handoff.attempts[1]
+    handoff = store.mark_attempt_sent(handoff.handoff_id, second.attempt_id)
+
+    timed_out = store.mark_attempt_ambiguous(handoff.handoff_id, second.attempt_id)
+
+    assert timed_out.state is HandoffState.AMBIGUOUS
+    assert timed_out.ambiguity_reason == "acknowledgement_handoff_id_mismatch"
+    assert timed_out.retry_exhausted is True
+    assert store.load(handoff.handoff_id) == timed_out
+
+
+def test_restart_rejects_premature_retry_exhaustion_sql_tamper(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "exhaustion-tamper.sqlite3"
+    connection = _fresh(database)
+    store = EvaluationHandoffStore(connection)
+    handoff = store.persist_attempt(
+        store.register(_handoff(max_attempts=3)).handoff_id
+    )
+    attempt = handoff.attempts[0]
+    handoff = store.mark_attempt_sent(handoff.handoff_id, attempt.attempt_id)
+    handoff = store.mark_attempt_ambiguous(handoff.handoff_id, attempt.attempt_id)
+    connection.execute(
+        "UPDATE evaluation_handoffs SET retry_exhausted=1 WHERE handoff_id=?",
+        (handoff.handoff_id,),
+    )
+    connection.close()
+
+    connection = _open(database)
+    with pytest.raises(HandoffContractError, match="Handoff state"):
+        EvaluationHandoffStore(connection).load(handoff.handoff_id)
+    connection.close()
+
+
 def test_store_correlates_delayed_ack_after_lost_response_and_retry(
     tmp_path: Path,
 ) -> None:
@@ -482,7 +583,7 @@ def test_restart_rederives_state_and_rejects_terminal_to_ambiguous_tamper(
     connection.close()
 
     connection = _open(tmp_path / "state-tamper.sqlite3")
-    with pytest.raises(HandoffContractError, match="retained Handoff state"):
+    with pytest.raises(HandoffContractError, match="Handoff state"):
         EvaluationHandoffStore(connection).load(handoff.handoff_id)
     connection.close()
 

--- a/newsroom/tests/test_increment6f1_handoff_migrations.py
+++ b/newsroom/tests/test_increment6f1_handoff_migrations.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
+import hashlib
 import sqlite3
 from pathlib import Path
 
@@ -10,6 +11,8 @@ from newsroom.authority.evaluation_handoff_migrations import (
     EVALUATION_HANDOFF_MIGRATION_CHECKSUM,
     EVALUATION_HANDOFF_MIGRATION_NAME,
     EVALUATION_HANDOFF_SCHEMA_VERSION,
+    evaluation_handoff_backup_paths,
+    prepare_evaluation_handoff_backup,
 )
 from newsroom.authority.migrations import (
     EXPECTED_MIGRATION_HISTORY,
@@ -22,6 +25,7 @@ from newsroom.increment6.handoffs import (
     Acknowledgement,
     AcknowledgementOutcome,
     EvaluationHandoffStore,
+    HandoffContractError,
     HandoffState,
     create_handoff,
 )
@@ -112,26 +116,114 @@ def test_fresh_v17_schema_history_fingerprint_and_integrity_are_exact() -> None:
         connection.close()
 
 
-def test_exact_v16_upgrade_is_additive_and_failure_rolls_back_exclusively() -> None:
-    connection = _fresh()
+def test_exact_v16_upgrade_requires_and_retains_exact_backup_digest(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "upgrade.sqlite3"
+    connection = _fresh(database)
     try:
         retained_v16_history = connection.execute(
             "SELECT version,name,checksum FROM authority_migrations "
             "WHERE version<=16 ORDER BY version"
         ).fetchall()
         _downgrade_empty_v17_to_v16(connection)
+        prepare_evaluation_handoff_backup(
+            connection, evaluation_handoff_backup_paths(database)[0]
+        )
+        connection.close()
+        connection = _open(database)
+        replayed_receipt = prepare_evaluation_handoff_backup(
+            connection, evaluation_handoff_backup_paths(database)[0]
+        )
         apply_pending_migrations(
             connection, applied_at="2042-03-12T10:00:01.000000Z"
         )
+        backup, digest_file = evaluation_handoff_backup_paths(database)
+        digest = "sha256:" + hashlib.sha256(backup.read_bytes()).hexdigest()
+        assert backup.is_file()
+        assert replayed_receipt.backup_path == backup
+        assert digest_file.read_text(encoding="ascii") == digest + "\n"
+        backup_connection = _open(backup)
+        try:
+            assert backup_connection.execute("PRAGMA user_version").fetchone()[0] == 16
+            assert backup_connection.execute(
+                "SELECT version,name,checksum FROM authority_migrations "
+                "ORDER BY version"
+            ).fetchall() == retained_v16_history
+        finally:
+            backup_connection.close()
         assert connection.execute("PRAGMA user_version").fetchone()[0] == 17
         assert connection.execute(
             "SELECT version,name,checksum FROM authority_migrations "
             "WHERE version<=16 ORDER BY version"
         ).fetchall() == retained_v16_history
 
+    finally:
+        connection.close()
+
+
+def test_exact_v16_upgrade_without_prepared_backup_fails_closed(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "missing-backup.sqlite3"
+    connection = _fresh(database)
+    try:
         _downgrade_empty_v17_to_v16(connection)
-        connection.execute("CREATE TABLE evaluation_handoffs(conflict TEXT) STRICT")
-        with pytest.raises(sqlite3.OperationalError, match="already exists"):
+        with pytest.raises(sqlite3.DatabaseError, match="requires a prepared backup"):
+            apply_pending_migrations(
+                connection, applied_at="2042-03-12T10:00:01.000000Z"
+            )
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 16
+        assert connection.execute(
+            "SELECT COUNT(*) FROM authority_migrations WHERE version=17"
+        ).fetchone()[0] == 0
+        assert not evaluation_handoff_backup_paths(database)[0].exists()
+    finally:
+        connection.close()
+
+
+def test_exact_v16_upgrade_rejects_changed_backup_digest(tmp_path: Path) -> None:
+    database = tmp_path / "changed-backup.sqlite3"
+    connection = _fresh(database)
+    try:
+        _downgrade_empty_v17_to_v16(connection)
+        backup, digest_path = evaluation_handoff_backup_paths(database)
+        prepare_evaluation_handoff_backup(connection, backup)
+        digest_path.write_text("sha256:" + "0" * 64 + "\n", encoding="ascii")
+
+        with pytest.raises(sqlite3.DatabaseError, match="identity differs"):
+            apply_pending_migrations(
+                connection, applied_at="2042-03-12T10:00:01.000000Z"
+            )
+
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 16
+        assert connection.execute(
+            "SELECT COUNT(*) FROM authority_migrations WHERE version=17"
+        ).fetchone()[0] == 0
+    finally:
+        connection.close()
+
+
+def test_failed_v17_upgrade_rolls_back_exclusively_after_backup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database = tmp_path / "failed-upgrade.sqlite3"
+    connection = _fresh(database)
+    try:
+        _downgrade_empty_v17_to_v16(connection)
+        prepare_evaluation_handoff_backup(
+            connection, evaluation_handoff_backup_paths(database)[0]
+        )
+        from newsroom.authority import migrations
+
+        monkeypatch.setattr(
+            migrations,
+            "EVALUATION_HANDOFF_MIGRATION_STATEMENTS",
+            migrations.EVALUATION_HANDOFF_MIGRATION_STATEMENTS
+            + ("CREATE TABLE injected_failure(",),
+        )
+        with pytest.raises(sqlite3.OperationalError):
             apply_pending_migrations(
                 connection, applied_at="2042-03-12T10:00:02.000000Z"
             )
@@ -139,6 +231,9 @@ def test_exact_v16_upgrade_is_additive_and_failure_rolls_back_exclusively() -> N
         assert connection.execute(
             "SELECT COUNT(*) FROM authority_migrations WHERE version=17"
         ).fetchone()[0] == 0
+        backup, digest_file = evaluation_handoff_backup_paths(database)
+        assert backup.is_file()
+        assert digest_file.is_file()
         assert connection.execute(
             "SELECT COUNT(*) FROM sqlite_master WHERE type='table' "
             "AND name='evaluation_handoff_attempts'"
@@ -225,6 +320,35 @@ def test_store_retains_ambiguous_ack_and_bounds_retry(tmp_path: Path) -> None:
     connection.close()
 
 
+def test_store_can_persist_bounded_retry_after_ambiguous_ack(tmp_path: Path) -> None:
+    connection = _fresh(tmp_path / "ambiguous-retry.sqlite3")
+    store = EvaluationHandoffStore(connection)
+    handoff = store.persist_attempt(
+        store.register(_handoff(max_attempts=2)).handoff_id
+    )
+    attempt = handoff.attempts[0]
+    handoff = store.mark_attempt_sent(handoff.handoff_id, attempt.attempt_id)
+    mismatched = Acknowledgement.create(
+        handoff_id="handoff:sha256:" + "0" * 64,
+        attempt_id=attempt.attempt_id,
+        candidate_version_id=handoff.candidate_version_id,
+        governing_manifest_digest=handoff.governing_manifest_digest,
+        sink_id=handoff.sink_id,
+        outcome=AcknowledgementOutcome.ACKNOWLEDGED,
+        response_digest="sha256:" + "7" * 64,
+    )
+    handoff = store.correlate_acknowledgement(handoff.handoff_id, mismatched)
+
+    retry = store.request_retry(handoff.handoff_id)
+    pending = store.persist_attempt(handoff.handoff_id)
+
+    assert retry.state is HandoffState.RETRY
+    assert pending.state is HandoffState.PENDING
+    assert len(pending.attempts) == 2
+    assert store.load(handoff.handoff_id) == pending
+    connection.close()
+
+
 def test_store_correlates_delayed_ack_after_lost_response_and_retry(
     tmp_path: Path,
 ) -> None:
@@ -254,6 +378,80 @@ def test_store_correlates_delayed_ack_after_lost_response_and_retry(
     assert result.state is HandoffState.ACKNOWLEDGED
     assert result.handoff_id == handoff.handoff_id
     assert len(result.attempts) == 2
+    connection.close()
+
+
+def test_wrong_handoff_observation_cannot_poison_rightful_ack_correlation(
+    tmp_path: Path,
+) -> None:
+    connection = _fresh(tmp_path / "ack-association.sqlite3")
+    store = EvaluationHandoffStore(connection)
+    first = store.persist_attempt(store.register(_handoff()).handoff_id)
+    first = store.mark_attempt_sent(first.handoff_id, first.attempts[0].attempt_id)
+    second_request = create_handoff(
+        CANDIDATE_VERSION_ID + ":second",
+        MANIFEST_DIGEST,
+        SINK_ID,
+    )
+    second = store.persist_attempt(store.register(second_request).handoff_id)
+    second = store.mark_attempt_sent(
+        second.handoff_id, second.attempts[0].attempt_id
+    )
+    acknowledgement = Acknowledgement.create(
+        handoff_id=second.handoff_id,
+        attempt_id=second.attempts[0].attempt_id,
+        candidate_version_id=second.candidate_version_id,
+        governing_manifest_digest=second.governing_manifest_digest,
+        sink_id=second.sink_id,
+        outcome=AcknowledgementOutcome.ACKNOWLEDGED,
+        response_digest="sha256:" + "f" * 64,
+    )
+
+    poisoned = store.correlate_acknowledgement(first.handoff_id, acknowledgement)
+    rightful = store.correlate_acknowledgement(second.handoff_id, acknowledgement)
+
+    assert poisoned.state is HandoffState.AMBIGUOUS
+    assert rightful.state is HandoffState.ACKNOWLEDGED
+    assert store.correlate_acknowledgement(
+        second.handoff_id, acknowledgement
+    ) == rightful
+    assert connection.execute(
+        "SELECT recorded_handoff_id FROM evaluation_handoff_acknowledgements "
+        "WHERE acknowledgement_id=? ORDER BY recorded_handoff_id",
+        (acknowledgement.acknowledgement_id,),
+    ).fetchall() == sorted([(first.handoff_id,), (second.handoff_id,)])
+    connection.close()
+
+
+def test_restart_rederives_state_and_rejects_terminal_to_ambiguous_tamper(
+    tmp_path: Path,
+) -> None:
+    connection = _fresh(tmp_path / "state-tamper.sqlite3")
+    store = EvaluationHandoffStore(connection)
+    handoff = store.persist_attempt(store.register(_handoff()).handoff_id)
+    handoff = store.mark_attempt_sent(
+        handoff.handoff_id, handoff.attempts[0].attempt_id
+    )
+    acknowledgement = Acknowledgement.create(
+        handoff_id=handoff.handoff_id,
+        attempt_id=handoff.attempts[0].attempt_id,
+        candidate_version_id=handoff.candidate_version_id,
+        governing_manifest_digest=handoff.governing_manifest_digest,
+        sink_id=handoff.sink_id,
+        outcome=AcknowledgementOutcome.ACKNOWLEDGED,
+        response_digest="sha256:" + "9" * 64,
+    )
+    handoff = store.correlate_acknowledgement(handoff.handoff_id, acknowledgement)
+    connection.execute(
+        "UPDATE evaluation_handoffs SET transport_state='ambiguous',"
+        "ambiguity_reason='target_outcome_unknown' WHERE handoff_id=?",
+        (handoff.handoff_id,),
+    )
+    connection.close()
+
+    connection = _open(tmp_path / "state-tamper.sqlite3")
+    with pytest.raises(HandoffContractError, match="retained Handoff state"):
+        EvaluationHandoffStore(connection).load(handoff.handoff_id)
     connection.close()
 
 

--- a/newsroom/tests/test_increment6f1_handoff_migrations.py
+++ b/newsroom/tests/test_increment6f1_handoff_migrations.py
@@ -376,7 +376,7 @@ def test_store_persists_before_send_and_survives_restart_replay(tmp_path: Path) 
         connection.close()
 
 
-def test_store_retains_ambiguous_ack_and_bounds_retry(tmp_path: Path) -> None:
+def test_store_bounds_retry_after_exact_timeout(tmp_path: Path) -> None:
     connection = _fresh(tmp_path / "ambiguous.sqlite3")
     store = EvaluationHandoffStore(connection)
     handoff = store.register(_handoff(max_attempts=1))
@@ -392,16 +392,19 @@ def test_store_retains_ambiguous_ack_and_bounds_retry(tmp_path: Path) -> None:
         outcome=AcknowledgementOutcome.ACKNOWLEDGED,
         response_digest="sha256:" + "c" * 64,
     )
-    ambiguous = store.correlate_acknowledgement(handoff.handoff_id, mismatched)
+    assert store.correlate_acknowledgement(handoff.handoff_id, mismatched) == handoff
+    ambiguous = store.mark_attempt_ambiguous(handoff.handoff_id, attempt.attempt_id)
     assert ambiguous.state is HandoffState.AMBIGUOUS
-    assert ambiguous.ambiguity_reason == "acknowledgement_handoff_id_mismatch"
+    assert ambiguous.ambiguity_reason == "target_outcome_unknown"
     exhausted = store.request_retry(handoff.handoff_id)
     assert exhausted.retry_exhausted is True
     assert store.persist_attempt(handoff.handoff_id) == exhausted
     connection.close()
 
 
-def test_store_can_persist_bounded_retry_after_ambiguous_ack(tmp_path: Path) -> None:
+def test_store_can_persist_bounded_retry_after_wrong_response_and_timeout(
+    tmp_path: Path,
+) -> None:
     connection = _fresh(tmp_path / "ambiguous-retry.sqlite3")
     store = EvaluationHandoffStore(connection)
     handoff = store.persist_attempt(
@@ -419,6 +422,7 @@ def test_store_can_persist_bounded_retry_after_ambiguous_ack(tmp_path: Path) -> 
         response_digest="sha256:" + "7" * 64,
     )
     handoff = store.correlate_acknowledgement(handoff.handoff_id, mismatched)
+    handoff = store.mark_attempt_ambiguous(handoff.handoff_id, attempt.attempt_id)
 
     retry = store.request_retry(handoff.handoff_id)
     pending = store.persist_attempt(handoff.handoff_id)
@@ -450,6 +454,7 @@ def test_retry_timeout_after_wrong_ack_uses_one_deterministic_reason(
         response_digest="sha256:" + "6" * 64,
     )
     handoff = store.correlate_acknowledgement(handoff.handoff_id, wrong)
+    handoff = store.mark_attempt_ambiguous(handoff.handoff_id, first.attempt_id)
     handoff = store.persist_attempt(store.request_retry(handoff.handoff_id).handoff_id)
     second = handoff.attempts[1]
     handoff = store.mark_attempt_sent(handoff.handoff_id, second.attempt_id)
@@ -457,7 +462,7 @@ def test_retry_timeout_after_wrong_ack_uses_one_deterministic_reason(
     timed_out = store.mark_attempt_ambiguous(handoff.handoff_id, second.attempt_id)
 
     assert timed_out.state is HandoffState.AMBIGUOUS
-    assert timed_out.ambiguity_reason == "acknowledgement_handoff_id_mismatch"
+    assert timed_out.ambiguity_reason == "target_outcome_unknown"
     assert timed_out.retry_exhausted is True
     assert store.load(handoff.handoff_id) == timed_out
 
@@ -481,6 +486,7 @@ def test_store_delayed_old_timeout_preserves_active_sent_retry(
         response_digest="sha256:" + "5" * 64,
     )
     handoff = store.correlate_acknowledgement(handoff.handoff_id, wrong)
+    handoff = store.mark_attempt_ambiguous(handoff.handoff_id, first.attempt_id)
     handoff = store.persist_attempt(store.request_retry(handoff.handoff_id).handoff_id)
     second = handoff.attempts[1]
     handoff = store.mark_attempt_sent(handoff.handoff_id, second.attempt_id)
@@ -562,7 +568,8 @@ def test_store_pristine_wrong_ack_remains_inert_across_restart_and_send(
         response_digest="sha256:" + "4" * 64,
     )
     retained = store.correlate_acknowledgement(handoff.handoff_id, wrong)
-    assert retained.state is HandoffState.PENDING
+    assert retained == handoff
+    assert retained.acknowledgements == ()
     assert store.correlate_acknowledgement(handoff.handoff_id, wrong) == retained
     connection.close()
 
@@ -578,7 +585,7 @@ def test_store_pristine_wrong_ack_remains_inert_across_restart_and_send(
     connection.close()
 
 
-def test_database_rejects_pristine_ack_retry_authority(tmp_path: Path) -> None:
+def test_database_rejects_ack_without_exact_sent_attempt(tmp_path: Path) -> None:
     connection = _fresh(tmp_path / "pristine-ack-authority.sqlite3")
     handoff = EvaluationHandoffStore(connection).register(_handoff())
     wrong = Acknowledgement.create(
@@ -591,9 +598,9 @@ def test_database_rejects_pristine_ack_retry_authority(tmp_path: Path) -> None:
         response_digest="sha256:" + "2" * 64,
     )
 
-    with pytest.raises(sqlite3.IntegrityError, match="state authority"):
+    with pytest.raises(sqlite3.IntegrityError, match="correlation"):
         connection.execute(
-            "INSERT INTO evaluation_handoff_acknowledgements VALUES(?,?,?,?,?,?,?,?,?,?,?)",
+            "INSERT INTO evaluation_handoff_acknowledgements VALUES(?,?,?,?,?,?,?,?,?,?)",
             (
                 wrong.acknowledgement_id,
                 wrong.schema_identity,
@@ -605,9 +612,176 @@ def test_database_rejects_pristine_ack_retry_authority(tmp_path: Path) -> None:
                 wrong.sink_id,
                 wrong.outcome.value,
                 wrong.response_digest,
-                1,
             ),
         )
+    connection.close()
+
+
+def test_sql_exact_sent_ack_has_no_suppression_seam(tmp_path: Path) -> None:
+    connection = _fresh(tmp_path / "exact-sql-ack.sqlite3")
+    store = EvaluationHandoffStore(connection)
+    handoff = store.persist_attempt(store.register(_handoff()).handoff_id)
+    handoff = store.mark_attempt_sent(
+        handoff.handoff_id, handoff.attempts[0].attempt_id
+    )
+    acknowledgement = Acknowledgement.create(
+        handoff_id=handoff.handoff_id,
+        attempt_id=handoff.attempts[0].attempt_id,
+        candidate_version_id=handoff.candidate_version_id,
+        governing_manifest_digest=handoff.governing_manifest_digest,
+        sink_id=handoff.sink_id,
+        outcome=AcknowledgementOutcome.ACKNOWLEDGED,
+        response_digest="sha256:" + "1" * 64,
+    )
+    assert "state_authority" not in {
+        row[1]
+        for row in connection.execute(
+            "PRAGMA table_info(evaluation_handoff_acknowledgements)"
+        )
+    }
+    connection.execute(
+        "INSERT INTO evaluation_handoff_acknowledgements VALUES(?,?,?,?,?,?,?,?,?,?)",
+        (
+            acknowledgement.acknowledgement_id,
+            acknowledgement.schema_identity,
+            handoff.handoff_id,
+            acknowledgement.handoff_id,
+            acknowledgement.attempt_id,
+            acknowledgement.candidate_version_id,
+            acknowledgement.governing_manifest_digest,
+            acknowledgement.sink_id,
+            acknowledgement.outcome.value,
+            acknowledgement.response_digest,
+        ),
+    )
+    connection.execute(
+        "UPDATE evaluation_handoffs SET transport_state='acknowledged' "
+        "WHERE handoff_id=?",
+        (handoff.handoff_id,),
+    )
+    assert EvaluationHandoffStore(connection).load(handoff.handoff_id).state is (
+        HandoffState.ACKNOWLEDGED
+    )
+    connection.close()
+
+
+def test_store_future_response_is_inert_until_exact_attempt_is_sent(
+    tmp_path: Path,
+) -> None:
+    connection = _fresh(tmp_path / "future-response.sqlite3")
+    store = EvaluationHandoffStore(connection)
+    handoff = store.persist_attempt(store.register(_handoff()).handoff_id)
+    handoff = store.mark_attempt_sent(
+        handoff.handoff_id, handoff.attempts[0].attempt_id
+    )
+    handoff = store.mark_attempt_ambiguous(
+        handoff.handoff_id, handoff.attempts[0].attempt_id
+    )
+    future = persist_attempt(request_retry(handoff))
+    response = Acknowledgement.create(
+        handoff_id=future.handoff_id,
+        attempt_id=future.attempts[1].attempt_id,
+        candidate_version_id=future.candidate_version_id,
+        governing_manifest_digest=future.governing_manifest_digest,
+        sink_id=future.sink_id,
+        outcome=AcknowledgementOutcome.ACKNOWLEDGED,
+        response_digest="sha256:" + "0" * 64,
+    )
+
+    assert store.correlate_acknowledgement(handoff.handoff_id, response) == handoff
+    pending = store.persist_attempt(store.request_retry(handoff.handoff_id).handoff_id)
+    assert store.correlate_acknowledgement(handoff.handoff_id, response) == pending
+    sent = store.mark_attempt_sent(
+        handoff.handoff_id, pending.attempts[1].attempt_id
+    )
+    assert store.correlate_acknowledgement(
+        handoff.handoff_id, response
+    ).state is HandoffState.ACKNOWLEDGED
+    connection.close()
+
+
+def test_store_wrong_response_preserves_unsent_retry_for_rightful_ack(
+    tmp_path: Path,
+) -> None:
+    connection = _fresh(tmp_path / "wrong-active-retry.sqlite3")
+    store = EvaluationHandoffStore(connection)
+    handoff = store.persist_attempt(store.register(_handoff()).handoff_id)
+    handoff = store.mark_attempt_sent(
+        handoff.handoff_id, handoff.attempts[0].attempt_id
+    )
+    handoff = store.mark_attempt_ambiguous(
+        handoff.handoff_id, handoff.attempts[0].attempt_id
+    )
+    pending = store.persist_attempt(store.request_retry(handoff.handoff_id).handoff_id)
+    wrong = Acknowledgement.create(
+        handoff_id="handoff:sha256:" + "0" * 64,
+        attempt_id=pending.attempts[1].attempt_id,
+        candidate_version_id=pending.candidate_version_id,
+        governing_manifest_digest=pending.governing_manifest_digest,
+        sink_id=pending.sink_id,
+        outcome=AcknowledgementOutcome.ACKNOWLEDGED,
+        response_digest="sha256:" + "8" * 64,
+    )
+
+    assert store.correlate_acknowledgement(pending.handoff_id, wrong) == pending
+    sent = store.mark_attempt_sent(pending.handoff_id, pending.attempts[1].attempt_id)
+    rightful = Acknowledgement.create(
+        handoff_id=sent.handoff_id,
+        attempt_id=sent.attempts[1].attempt_id,
+        candidate_version_id=sent.candidate_version_id,
+        governing_manifest_digest=sent.governing_manifest_digest,
+        sink_id=sent.sink_id,
+        outcome=AcknowledgementOutcome.ACKNOWLEDGED,
+        response_digest="sha256:" + "7" * 64,
+    )
+    assert store.correlate_acknowledgement(
+        sent.handoff_id, rightful
+    ).state is HandoffState.ACKNOWLEDGED
+    connection.close()
+
+
+def test_store_conflicting_old_acks_preserve_active_retry_across_restart(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "old-conflict-active-retry.sqlite3"
+    connection = _fresh(database)
+    store = EvaluationHandoffStore(connection)
+    handoff = store.persist_attempt(store.register(_handoff()).handoff_id)
+    first = handoff.attempts[0]
+    handoff = store.mark_attempt_sent(handoff.handoff_id, first.attempt_id)
+    handoff = store.mark_attempt_ambiguous(handoff.handoff_id, first.attempt_id)
+    pending = store.persist_attempt(store.request_retry(handoff.handoff_id).handoff_id)
+    accepted = Acknowledgement.create(
+        handoff_id=pending.handoff_id,
+        attempt_id=first.attempt_id,
+        candidate_version_id=pending.candidate_version_id,
+        governing_manifest_digest=pending.governing_manifest_digest,
+        sink_id=pending.sink_id,
+        outcome=AcknowledgementOutcome.ACKNOWLEDGED,
+        response_digest="sha256:" + "a" * 64,
+    )
+    rejected = Acknowledgement.create(
+        handoff_id=pending.handoff_id,
+        attempt_id=first.attempt_id,
+        candidate_version_id=pending.candidate_version_id,
+        governing_manifest_digest=pending.governing_manifest_digest,
+        sink_id=pending.sink_id,
+        outcome=AcknowledgementOutcome.REJECTED,
+        response_digest="sha256:" + "b" * 64,
+    )
+    pending = store.correlate_acknowledgement(pending.handoff_id, accepted)
+    pending = store.correlate_acknowledgement(pending.handoff_id, rejected)
+    assert pending.state is HandoffState.PENDING
+    connection.close()
+
+    connection = _open(database)
+    store = EvaluationHandoffStore(connection)
+    pending = store.load(pending.handoff_id)
+    assert pending.state is HandoffState.PENDING
+    sent = store.mark_attempt_sent(pending.handoff_id, pending.attempts[1].attempt_id)
+    timed_out = store.mark_attempt_ambiguous(sent.handoff_id, sent.attempts[1].attempt_id)
+    assert timed_out.state is HandoffState.AMBIGUOUS
+    assert timed_out.ambiguity_reason == "conflicting_acknowledgements"
     connection.close()
 
 def test_concurrent_pristine_ack_and_attempt_persistence_remain_retry_inert(
@@ -646,7 +820,7 @@ def test_concurrent_pristine_ack_and_attempt_persistence_remain_retry_inert(
         retained = EvaluationHandoffStore(connection).load(handoff.handoff_id)
         assert retained.state is HandoffState.PENDING
         assert len(retained.attempts) == 1
-        assert retained.acknowledgements == (wrong,)
+        assert retained.acknowledgements == ()
     finally:
         connection.close()
 
@@ -736,7 +910,7 @@ def test_wrong_handoff_observation_cannot_poison_rightful_ack_correlation(
     poisoned = store.correlate_acknowledgement(first.handoff_id, acknowledgement)
     rightful = store.correlate_acknowledgement(second.handoff_id, acknowledgement)
 
-    assert poisoned.state is HandoffState.AMBIGUOUS
+    assert poisoned == first
     assert rightful.state is HandoffState.ACKNOWLEDGED
     assert store.correlate_acknowledgement(
         second.handoff_id, acknowledgement
@@ -745,7 +919,7 @@ def test_wrong_handoff_observation_cannot_poison_rightful_ack_correlation(
         "SELECT recorded_handoff_id FROM evaluation_handoff_acknowledgements "
         "WHERE acknowledgement_id=? ORDER BY recorded_handoff_id",
         (acknowledgement.acknowledgement_id,),
-    ).fetchall() == sorted([(first.handoff_id,), (second.handoff_id,)])
+    ).fetchall() == [(second.handoff_id,)]
     connection.close()
 
 

--- a/newsroom/tests/test_increment6f1_handoff_migrations.py
+++ b/newsroom/tests/test_increment6f1_handoff_migrations.py
@@ -784,6 +784,60 @@ def test_store_conflicting_old_acks_preserve_active_retry_across_restart(
     assert timed_out.ambiguity_reason == "conflicting_acknowledgements"
     connection.close()
 
+
+def test_sql_and_restart_reject_current_attempt_conflict_as_non_ambiguous(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "current-conflict-tamper.sqlite3"
+    connection = _fresh(database)
+    store = EvaluationHandoffStore(connection)
+    handoff = store.persist_attempt(store.register(_handoff()).handoff_id)
+    first = handoff.attempts[0]
+    handoff = store.mark_attempt_sent(handoff.handoff_id, first.attempt_id)
+    handoff = store.mark_attempt_ambiguous(handoff.handoff_id, first.attempt_id)
+    handoff = store.persist_attempt(store.request_retry(handoff.handoff_id).handoff_id)
+    handoff = store.mark_attempt_sent(handoff.handoff_id, handoff.attempts[1].attempt_id)
+    accepted_current = Acknowledgement.create(
+        handoff_id=handoff.handoff_id,
+        attempt_id=handoff.attempts[1].attempt_id,
+        candidate_version_id=handoff.candidate_version_id,
+        governing_manifest_digest=handoff.governing_manifest_digest,
+        sink_id=handoff.sink_id,
+        outcome=AcknowledgementOutcome.ACKNOWLEDGED,
+        response_digest="sha256:" + "2" * 64,
+    )
+    rejected_old = Acknowledgement.create(
+        handoff_id=handoff.handoff_id,
+        attempt_id=first.attempt_id,
+        candidate_version_id=handoff.candidate_version_id,
+        governing_manifest_digest=handoff.governing_manifest_digest,
+        sink_id=handoff.sink_id,
+        outcome=AcknowledgementOutcome.REJECTED,
+        response_digest="sha256:" + "3" * 64,
+    )
+    handoff = store.correlate_acknowledgement(handoff.handoff_id, accepted_current)
+    handoff = store.correlate_acknowledgement(handoff.handoff_id, rejected_old)
+    assert handoff.state is HandoffState.AMBIGUOUS
+
+    with pytest.raises(sqlite3.IntegrityError, match="state transition"):
+        connection.execute(
+            "UPDATE evaluation_handoffs SET transport_state='acknowledged',"
+            "ambiguity_reason=NULL WHERE handoff_id=?",
+            (handoff.handoff_id,),
+        )
+
+    connection.execute("DROP TRIGGER evaluation_handoff_state_guard")
+    connection.execute(
+        "UPDATE evaluation_handoffs SET transport_state='pending',"
+        "ambiguity_reason=NULL WHERE handoff_id=?",
+        (handoff.handoff_id,),
+    )
+    connection.close()
+    connection = _open(database)
+    with pytest.raises(HandoffContractError, match="Handoff state"):
+        EvaluationHandoffStore(connection).load(handoff.handoff_id)
+    connection.close()
+
 def test_concurrent_pristine_ack_and_attempt_persistence_remain_retry_inert(
     tmp_path: Path,
 ) -> None:

--- a/newsroom/tests/test_increment6f1_handoff_migrations.py
+++ b/newsroom/tests/test_increment6f1_handoff_migrations.py
@@ -30,6 +30,10 @@ from newsroom.increment6.handoffs import (
     create_handoff,
 )
 
+from .graphiti_adapter_4d_migration_helpers import (
+    downgrade_empty_graphiti_adapter_schema_to_v15,
+)
+
 
 CANDIDATE_VERSION_ID = "candidate-version:01JZX7V7G8Q6XKNR4M8J5TH9WD"
 MANIFEST_DIGEST = "sha256:" + "a" * 64
@@ -158,6 +162,34 @@ def test_exact_v16_upgrade_requires_and_retains_exact_backup_digest(
             "WHERE version<=16 ORDER BY version"
         ).fetchall() == retained_v16_history
 
+    finally:
+        connection.close()
+
+
+def test_multihop_existing_upgrade_checkpoints_v16_backup_before_v17(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "multihop.sqlite3"
+    _fresh(database).close()
+    downgrade_empty_graphiti_adapter_schema_to_v15(database)
+
+    connection = _open(database)
+    try:
+        apply_pending_migrations(
+            connection, applied_at="2042-03-12T10:00:01.000000Z"
+        )
+        backup, digest_path = evaluation_handoff_backup_paths(database)
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 17
+        assert backup.is_file()
+        assert digest_path.is_file()
+        backup_connection = _open(backup)
+        try:
+            assert backup_connection.execute("PRAGMA user_version").fetchone()[0] == 16
+            assert backup_connection.execute(
+                "SELECT MAX(version) FROM authority_migrations"
+            ).fetchone()[0] == 16
+        finally:
+            backup_connection.close()
     finally:
         connection.close()
 

--- a/newsroom/tests/test_increment6f1_handoffs.py
+++ b/newsroom/tests/test_increment6f1_handoffs.py
@@ -216,6 +216,77 @@ def test_replayed_timeout_for_earlier_attempt_does_not_undo_active_retry() -> No
     assert handoff.state is HandoffState.PENDING
 
 
+def test_delayed_timeout_for_earlier_attempt_preserves_sent_active_retry() -> None:
+    initial = persist_attempt(_handoff())
+    first = initial.attempts[0]
+    initial = mark_attempt_sent(initial, first.attempt_id)
+    wrong = _ack(
+        initial,
+        first,
+        handoff_id="handoff:sha256:" + "0" * 64,
+    )
+
+    timeout_first = correlate_acknowledgement(initial, wrong)
+    timeout_first = mark_attempt_ambiguous(timeout_first, first.attempt_id)
+    timeout_first = persist_attempt(request_retry(timeout_first))
+    timeout_first = mark_attempt_sent(
+        timeout_first, timeout_first.attempts[1].attempt_id
+    )
+
+    retry_first = correlate_acknowledgement(initial, wrong)
+    retry_first = persist_attempt(request_retry(retry_first))
+    retry_first = mark_attempt_sent(retry_first, retry_first.attempts[1].attempt_id)
+    retry_first = mark_attempt_ambiguous(retry_first, first.attempt_id)
+
+    assert retry_first == timeout_first
+    assert retry_first.state is HandoffState.PENDING
+    assert retry_first.attempts[0].ambiguous is True
+    assert retry_first.attempts[1].sent is True
+    assert persist_attempt(retry_first) == retry_first
+    with pytest.raises(HandoffContractError, match="retry requires ambiguous"):
+        request_retry(retry_first)
+
+
+def test_public_handoff_rejects_premature_retry_attempt_history() -> None:
+    first = persist_attempt(_handoff())
+    first = mark_attempt_sent(first, first.attempts[0].attempt_id)
+    valid = mark_attempt_ambiguous(first, first.attempts[0].attempt_id)
+    valid = persist_attempt(request_retry(valid))
+
+    with pytest.raises(HandoffContractError, match="attempt history"):
+        replace(first, attempts=(first.attempts[0], valid.attempts[1]))
+
+
+def test_pristine_wrong_ack_is_audited_without_granting_retry_authority() -> None:
+    handoff = _handoff()
+    future_attempt = persist_attempt(handoff).attempts[0]
+    wrong = _ack(
+        handoff,
+        future_attempt,
+        handoff_id="handoff:sha256:" + "0" * 64,
+    )
+
+    retained = correlate_acknowledgement(handoff, wrong)
+
+    assert retained.state is HandoffState.PENDING
+    assert retained.acknowledgements == (wrong,)
+    assert correlate_acknowledgement(retained, wrong) == retained
+    first = persist_attempt(retained)
+    assert first.state is HandoffState.PENDING
+    assert len(first.attempts) == 1
+    with pytest.raises(HandoffContractError, match="retry requires ambiguous"):
+        request_retry(first)
+
+    with pytest.raises(HandoffContractError, match="causal acknowledgement"):
+        replace(
+            handoff,
+            state=HandoffState.AMBIGUOUS,
+            acknowledgements=(wrong,),
+            causal_acknowledgement_ids=(wrong.acknowledgement_id,),
+            ambiguity_reason="acknowledgement_handoff_id_mismatch",
+        )
+
+
 @pytest.mark.parametrize(
     ("field", "value", "reason"),
     [

--- a/newsroom/tests/test_increment6f1_handoffs.py
+++ b/newsroom/tests/test_increment6f1_handoffs.py
@@ -233,7 +233,8 @@ def test_delayed_timeout_for_earlier_attempt_preserves_sent_active_retry() -> No
         timeout_first, timeout_first.attempts[1].attempt_id
     )
 
-    retry_first = correlate_acknowledgement(initial, wrong)
+    retry_first = mark_attempt_ambiguous(initial, first.attempt_id)
+    retry_first = correlate_acknowledgement(retry_first, wrong)
     retry_first = persist_attempt(request_retry(retry_first))
     retry_first = mark_attempt_sent(retry_first, retry_first.attempts[1].attempt_id)
     retry_first = mark_attempt_ambiguous(retry_first, first.attempt_id)
@@ -257,7 +258,26 @@ def test_public_handoff_rejects_premature_retry_attempt_history() -> None:
         replace(first, attempts=(first.attempts[0], valid.attempts[1]))
 
 
-def test_pristine_wrong_ack_is_audited_without_granting_retry_authority() -> None:
+def test_public_handoff_rejects_pre_send_acknowledgement_authority() -> None:
+    persisted = persist_attempt(_handoff())
+    acknowledgement = _ack(persisted, persisted.attempts[0])
+
+    with pytest.raises(TypeError, match="causal_acknowledgement_ids"):
+        replace(
+            persisted,
+            state=HandoffState.ACKNOWLEDGED,
+            acknowledgements=(acknowledgement,),
+            causal_acknowledgement_ids=(acknowledgement.acknowledgement_id,),
+        )
+    with pytest.raises(HandoffContractError, match="acknowledgement"):
+        replace(
+            persisted,
+            state=HandoffState.ACKNOWLEDGED,
+            acknowledgements=(acknowledgement,),
+        )
+
+
+def test_pristine_wrong_ack_is_not_an_authority_acknowledgement() -> None:
     handoff = _handoff()
     future_attempt = persist_attempt(handoff).attempts[0]
     wrong = _ack(
@@ -266,24 +286,18 @@ def test_pristine_wrong_ack_is_audited_without_granting_retry_authority() -> Non
         handoff_id="handoff:sha256:" + "0" * 64,
     )
 
-    retained = correlate_acknowledgement(handoff, wrong)
-
-    assert retained.state is HandoffState.PENDING
-    assert retained.acknowledgements == (wrong,)
-    assert correlate_acknowledgement(retained, wrong) == retained
-    first = persist_attempt(retained)
+    assert correlate_acknowledgement(handoff, wrong) == handoff
+    first = persist_attempt(handoff)
     assert first.state is HandoffState.PENDING
     assert len(first.attempts) == 1
     with pytest.raises(HandoffContractError, match="retry requires ambiguous"):
         request_retry(first)
 
-    with pytest.raises(HandoffContractError, match="causal acknowledgement"):
+    with pytest.raises(HandoffContractError, match="acknowledgement"):
         replace(
             handoff,
-            state=HandoffState.AMBIGUOUS,
+            state=HandoffState.ACKNOWLEDGED,
             acknowledgements=(wrong,),
-            causal_acknowledgement_ids=(wrong.acknowledgement_id,),
-            ambiguity_reason="acknowledgement_handoff_id_mismatch",
         )
 
 
@@ -297,17 +311,81 @@ def test_pristine_wrong_ack_is_audited_without_granting_retry_authority() -> Non
         ("sink_id", "evaluation-sink:other", "sink_id"),
     ],
 )
-def test_uncorrelated_acknowledgements_are_retained_as_ambiguous(
+def test_uncorrelated_responses_are_deterministic_inert_no_ops(
     field: str, value: str, reason: str
 ) -> None:
     handoff = persist_attempt(_handoff())
     handoff = mark_attempt_sent(handoff, handoff.attempts[0].attempt_id)
     acknowledgement = _ack(handoff, handoff.attempts[0], **{field: value})
 
-    ambiguous = correlate_acknowledgement(handoff, acknowledgement)
-    assert ambiguous.state is HandoffState.AMBIGUOUS
-    assert ambiguous.ambiguity_reason == f"acknowledgement_{reason}_mismatch"
-    assert ambiguous.acknowledgements == (acknowledgement,)
+    assert correlate_acknowledgement(handoff, acknowledgement) == handoff
+
+
+def test_future_attempt_response_only_correlates_after_that_attempt_is_sent() -> None:
+    handoff = persist_attempt(_handoff())
+    first = handoff.attempts[0]
+    handoff = mark_attempt_sent(handoff, first.attempt_id)
+    handoff = mark_attempt_ambiguous(handoff, first.attempt_id)
+    future = persist_attempt(request_retry(handoff))
+    second = future.attempts[1]
+    response = _ack(future, second)
+
+    assert correlate_acknowledgement(handoff, response) == handoff
+    assert correlate_acknowledgement(future, response) == future
+
+    sent = mark_attempt_sent(future, second.attempt_id)
+    assert correlate_acknowledgement(sent, response).state is HandoffState.ACKNOWLEDGED
+
+
+def test_wrong_response_cannot_cancel_persisted_unsent_active_retry() -> None:
+    handoff = persist_attempt(_handoff())
+    first = handoff.attempts[0]
+    handoff = mark_attempt_sent(handoff, first.attempt_id)
+    handoff = mark_attempt_ambiguous(handoff, first.attempt_id)
+    pending = persist_attempt(request_retry(handoff))
+    wrong = _ack(
+        pending,
+        first,
+        handoff_id="handoff:sha256:" + "0" * 64,
+    )
+
+    assert correlate_acknowledgement(pending, wrong) == pending
+    sent = mark_attempt_sent(pending, pending.attempts[1].attempt_id)
+    rightful = _ack(sent, sent.attempts[1])
+    assert correlate_acknowledgement(sent, rightful).state is HandoffState.ACKNOWLEDGED
+
+
+def test_wrong_future_and_rightful_response_arrival_orders_are_deterministic() -> None:
+    handoff = persist_attempt(_handoff())
+    handoff = mark_attempt_sent(handoff, handoff.attempts[0].attempt_id)
+    first = handoff.attempts[0]
+    future = persist_attempt(
+        request_retry(mark_attempt_ambiguous(handoff, first.attempt_id))
+    )
+    responses = (
+        _ack(handoff, first),
+        _ack(
+            handoff,
+            first,
+            handoff_id="handoff:sha256:" + "0" * 64,
+            response_digest="sha256:" + "c" * 64,
+        ),
+        _ack(
+            future,
+            future.attempts[1],
+            response_digest="sha256:" + "d" * 64,
+        ),
+    )
+
+    results = []
+    for arrivals in permutations(responses):
+        result = handoff
+        for response in arrivals:
+            result = correlate_acknowledgement(result, response)
+        results.append(result)
+
+    assert {item.state for item in results} == {HandoffState.ACKNOWLEDGED}
+    assert len({item.acknowledgements for item in results}) == 1
 
 
 def test_conflicting_delayed_acknowledgement_is_ambiguous_not_overwritten() -> None:
@@ -355,6 +433,36 @@ def test_conflicting_acknowledgement_arrival_orders_remain_ambiguous() -> None:
         "conflicting_acknowledgements"
     }
     assert len({item.acknowledgements for item in results}) == 1
+
+
+def test_conflicting_old_acknowledgements_preserve_active_unsent_retry() -> None:
+    handoff = persist_attempt(_handoff())
+    first = handoff.attempts[0]
+    handoff = mark_attempt_sent(handoff, first.attempt_id)
+    handoff = mark_attempt_ambiguous(handoff, first.attempt_id)
+    pending = persist_attempt(request_retry(handoff))
+    accepted = _ack(pending, first)
+    rejected = _ack(
+        pending,
+        first,
+        outcome=AcknowledgementOutcome.REJECTED,
+        response_digest="sha256:" + "f" * 64,
+    )
+
+    results = []
+    for arrivals in permutations((accepted, rejected)):
+        result = pending
+        for acknowledgement in arrivals:
+            result = correlate_acknowledgement(result, acknowledgement)
+        results.append(result)
+
+    assert {item.state for item in results} == {HandoffState.PENDING}
+    assert {item.ambiguity_reason for item in results} == {None}
+    assert len({item.acknowledgements for item in results}) == 1
+    sent = mark_attempt_sent(results[0], pending.attempts[1].attempt_id)
+    timed_out = mark_attempt_ambiguous(sent, sent.attempts[1].attempt_id)
+    assert timed_out.state is HandoffState.AMBIGUOUS
+    assert timed_out.ambiguity_reason == "conflicting_acknowledgements"
 
 
 def test_acknowledgement_identity_is_immutable_content_identity() -> None:

--- a/newsroom/tests/test_increment6f1_handoffs.py
+++ b/newsroom/tests/test_increment6f1_handoffs.py
@@ -465,6 +465,41 @@ def test_conflicting_old_acknowledgements_preserve_active_unsent_retry() -> None
     assert timed_out.ambiguity_reason == "conflicting_acknowledgements"
 
 
+def test_current_attempt_conflict_cannot_be_forged_as_pending() -> None:
+    handoff = persist_attempt(_handoff())
+    first = handoff.attempts[0]
+    handoff = mark_attempt_sent(handoff, first.attempt_id)
+    handoff = mark_attempt_ambiguous(handoff, first.attempt_id)
+    handoff = persist_attempt(request_retry(handoff))
+    handoff = mark_attempt_sent(handoff, handoff.attempts[1].attempt_id)
+    accepted_current = _ack(handoff, handoff.attempts[1])
+    rejected_old = _ack(
+        handoff,
+        first,
+        outcome=AcknowledgementOutcome.REJECTED,
+        response_digest="sha256:" + "1" * 64,
+    )
+
+    results = []
+    for arrivals in permutations((accepted_current, rejected_old)):
+        result = handoff
+        for acknowledgement in arrivals:
+            result = correlate_acknowledgement(result, acknowledgement)
+        results.append(result)
+
+    assert {item.state for item in results} == {HandoffState.AMBIGUOUS}
+    assert {item.ambiguity_reason for item in results} == {
+        "conflicting_acknowledgements"
+    }
+    with pytest.raises(HandoffContractError, match="Handoff state"):
+        replace(
+            results[0],
+            state=HandoffState.PENDING,
+            retry_exhausted=False,
+            ambiguity_reason=None,
+        )
+
+
 def test_acknowledgement_identity_is_immutable_content_identity() -> None:
     handoff = persist_attempt(_handoff())
     handoff = mark_attempt_sent(handoff, handoff.attempts[0].attempt_id)

--- a/newsroom/tests/test_increment6f1_handoffs.py
+++ b/newsroom/tests/test_increment6f1_handoffs.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError, replace
+
+import pytest
+
+from newsroom.increment6.handoffs import (
+    Acknowledgement,
+    AcknowledgementOutcome,
+    HandoffContractError,
+    HandoffState,
+    correlate_acknowledgement,
+    create_handoff,
+    mark_attempt_ambiguous,
+    mark_attempt_sent,
+    persist_attempt,
+    request_retry,
+)
+
+
+CANDIDATE_VERSION_ID = "candidate-version:01JZX7V7G8Q6XKNR4M8J5TH9WD"
+MANIFEST_DIGEST = "sha256:" + "a" * 64
+SINK_ID = "evaluation-sink:fixture-v1"
+
+
+def _handoff(*, max_attempts: int = 3):
+    return create_handoff(
+        candidate_version_id=CANDIDATE_VERSION_ID,
+        governing_manifest_digest=MANIFEST_DIGEST,
+        sink_id=SINK_ID,
+        max_attempts=max_attempts,
+    )
+
+
+def _ack(handoff, attempt, *, outcome=AcknowledgementOutcome.ACKNOWLEDGED):
+    return Acknowledgement.create(
+        acknowledgement_id=f"sink-ack:{attempt.attempt_number}:{outcome.value}",
+        handoff_id=handoff.handoff_id,
+        attempt_id=attempt.attempt_id,
+        candidate_version_id=handoff.candidate_version_id,
+        governing_manifest_digest=handoff.governing_manifest_digest,
+        sink_id=handoff.sink_id,
+        outcome=outcome,
+        response_digest="sha256:" + "b" * 64,
+    )
+
+
+def test_logical_identity_is_immutable_semantic_and_exactly_bound() -> None:
+    first = _handoff()
+    replay = _handoff()
+
+    assert first == replay
+    assert first.handoff_id.startswith("handoff:sha256:")
+    assert first.candidate_version_id == CANDIDATE_VERSION_ID
+    assert first.governing_manifest_digest == MANIFEST_DIGEST
+    assert first.evaluation_only is True
+    assert first.publication_authority is False
+    assert first.evidence_authority is False
+    with pytest.raises(FrozenInstanceError):
+        first.sink_id = "evaluation-sink:other"  # type: ignore[misc]
+
+    changed_version = create_handoff(
+        candidate_version_id=CANDIDATE_VERSION_ID + ":2",
+        governing_manifest_digest=MANIFEST_DIGEST,
+        sink_id=SINK_ID,
+    )
+    changed_manifest = create_handoff(
+        candidate_version_id=CANDIDATE_VERSION_ID,
+        governing_manifest_digest="sha256:" + "c" * 64,
+        sink_id=SINK_ID,
+    )
+    assert len({first.handoff_id, changed_version.handoff_id, changed_manifest.handoff_id}) == 3
+
+
+def test_binding_and_evaluation_only_semantics_are_fail_closed() -> None:
+    with pytest.raises(HandoffContractError, match="candidate_version_id"):
+        create_handoff("", MANIFEST_DIGEST, SINK_ID)
+    with pytest.raises(HandoffContractError, match="governing_manifest_digest"):
+        create_handoff(CANDIDATE_VERSION_ID, "a" * 64, SINK_ID)
+    with pytest.raises(HandoffContractError, match="sink_id"):
+        create_handoff(CANDIDATE_VERSION_ID, MANIFEST_DIGEST, "publication:discord")
+    with pytest.raises(HandoffContractError, match="evaluation_only"):
+        replace(_handoff(), evaluation_only=False)
+    with pytest.raises(HandoffContractError, match="publication_authority"):
+        replace(_handoff(), publication_authority=True)
+
+
+def test_attempt_is_persisted_before_it_can_be_sent_and_replay_is_idempotent() -> None:
+    handoff = _handoff()
+    assert handoff.state is HandoffState.PENDING
+    assert handoff.attempts == ()
+
+    persisted = persist_attempt(handoff)
+    attempt = persisted.attempts[0]
+    assert attempt.persisted_before_send is True
+    assert attempt.attempt_number == 1
+    assert attempt.semantic_idempotency_key == handoff.handoff_id
+    assert persist_attempt(persisted) == persisted
+
+    sent = mark_attempt_sent(persisted, attempt.attempt_id)
+    assert sent.attempts[0].sent is True
+    assert mark_attempt_sent(sent, attempt.attempt_id) == sent
+    with pytest.raises(HandoffContractError, match="unknown attempt"):
+        mark_attempt_sent(handoff, "attempt:sha256:" + "0" * 64)
+
+
+def test_lost_ack_becomes_ambiguous_then_retry_reuses_logical_identity() -> None:
+    first = persist_attempt(_handoff())
+    first = mark_attempt_sent(first, first.attempts[0].attempt_id)
+    ambiguous = mark_attempt_ambiguous(first, first.attempts[0].attempt_id)
+    assert ambiguous.state is HandoffState.AMBIGUOUS
+
+    retry = request_retry(ambiguous)
+    assert retry.state is HandoffState.RETRY
+    second = persist_attempt(retry)
+    assert second.state is HandoffState.PENDING
+    assert second.handoff_id == first.handoff_id
+    assert second.attempts[1].attempt_number == 2
+    assert second.attempts[1].attempt_id != second.attempts[0].attempt_id
+    assert second.attempts[1].semantic_idempotency_key == first.handoff_id
+
+
+def test_retry_is_bounded_and_exhaustion_remains_truthfully_ambiguous() -> None:
+    handoff = persist_attempt(_handoff(max_attempts=1))
+    handoff = mark_attempt_sent(handoff, handoff.attempts[0].attempt_id)
+    handoff = mark_attempt_ambiguous(handoff, handoff.attempts[0].attempt_id)
+
+    exhausted = request_retry(handoff)
+    assert exhausted.state is HandoffState.AMBIGUOUS
+    assert exhausted.retry_exhausted is True
+    assert persist_attempt(exhausted) == exhausted
+
+
+def test_exact_acknowledgement_and_duplicate_replay_are_idempotent() -> None:
+    handoff = persist_attempt(_handoff())
+    handoff = mark_attempt_sent(handoff, handoff.attempts[0].attempt_id)
+    acknowledgement = _ack(handoff, handoff.attempts[0])
+
+    acknowledged = correlate_acknowledgement(handoff, acknowledgement)
+    assert acknowledged.state is HandoffState.ACKNOWLEDGED
+    assert acknowledged.acknowledgements == (acknowledgement,)
+    assert correlate_acknowledgement(acknowledged, acknowledgement) == acknowledged
+
+
+def test_rejected_acknowledgement_is_a_distinct_terminal_outcome() -> None:
+    handoff = persist_attempt(_handoff())
+    handoff = mark_attempt_sent(handoff, handoff.attempts[0].attempt_id)
+
+    rejected = correlate_acknowledgement(
+        handoff,
+        _ack(handoff, handoff.attempts[0], outcome=AcknowledgementOutcome.REJECTED),
+    )
+    assert rejected.state is HandoffState.REJECTED
+    with pytest.raises(HandoffContractError, match="terminal"):
+        request_retry(rejected)
+
+
+def test_delayed_ack_for_an_earlier_attempt_correlates_to_same_handoff() -> None:
+    handoff = persist_attempt(_handoff())
+    first_attempt = handoff.attempts[0]
+    handoff = mark_attempt_sent(handoff, first_attempt.attempt_id)
+    handoff = mark_attempt_ambiguous(handoff, first_attempt.attempt_id)
+    handoff = persist_attempt(request_retry(handoff))
+    handoff = mark_attempt_sent(handoff, handoff.attempts[1].attempt_id)
+
+    acknowledged = correlate_acknowledgement(handoff, _ack(handoff, first_attempt))
+    assert acknowledged.state is HandoffState.ACKNOWLEDGED
+    assert acknowledged.handoff_id == handoff.handoff_id
+
+
+def test_replayed_timeout_for_earlier_attempt_does_not_undo_active_retry() -> None:
+    handoff = persist_attempt(_handoff())
+    first_attempt = handoff.attempts[0]
+    handoff = mark_attempt_sent(handoff, first_attempt.attempt_id)
+    handoff = mark_attempt_ambiguous(handoff, first_attempt.attempt_id)
+    handoff = persist_attempt(request_retry(handoff))
+
+    assert mark_attempt_ambiguous(handoff, first_attempt.attempt_id) == handoff
+    assert handoff.state is HandoffState.PENDING
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "reason"),
+    [
+        ("handoff_id", "handoff:sha256:" + "0" * 64, "handoff_id"),
+        ("attempt_id", "attempt:sha256:" + "0" * 64, "attempt_id"),
+        ("candidate_version_id", CANDIDATE_VERSION_ID + ":other", "candidate_version_id"),
+        ("governing_manifest_digest", "sha256:" + "c" * 64, "governing_manifest_digest"),
+        ("sink_id", "evaluation-sink:other", "sink_id"),
+    ],
+)
+def test_uncorrelated_acknowledgements_are_retained_as_ambiguous(
+    field: str, value: str, reason: str
+) -> None:
+    handoff = persist_attempt(_handoff())
+    handoff = mark_attempt_sent(handoff, handoff.attempts[0].attempt_id)
+    acknowledgement = replace(_ack(handoff, handoff.attempts[0]), **{field: value})
+
+    ambiguous = correlate_acknowledgement(handoff, acknowledgement)
+    assert ambiguous.state is HandoffState.AMBIGUOUS
+    assert ambiguous.ambiguity_reason == f"acknowledgement_{reason}_mismatch"
+    assert ambiguous.acknowledgements == (acknowledgement,)
+
+
+def test_conflicting_delayed_acknowledgement_is_ambiguous_not_overwritten() -> None:
+    handoff = persist_attempt(_handoff())
+    handoff = mark_attempt_sent(handoff, handoff.attempts[0].attempt_id)
+    accepted = _ack(handoff, handoff.attempts[0])
+    handoff = correlate_acknowledgement(handoff, accepted)
+    rejected = replace(
+        accepted,
+        acknowledgement_id="sink-ack:conflict",
+        outcome=AcknowledgementOutcome.REJECTED,
+        response_digest="sha256:" + "d" * 64,
+    )
+
+    result = correlate_acknowledgement(handoff, rejected)
+    assert result.state is HandoffState.AMBIGUOUS
+    assert result.ambiguity_reason == "conflicting_acknowledgements"
+
+
+def test_same_acknowledgement_identity_cannot_replay_different_content() -> None:
+    handoff = persist_attempt(_handoff())
+    handoff = mark_attempt_sent(handoff, handoff.attempts[0].attempt_id)
+    accepted = _ack(handoff, handoff.attempts[0])
+    handoff = correlate_acknowledgement(handoff, accepted)
+
+    with pytest.raises(HandoffContractError, match="acknowledgement identity conflict"):
+        correlate_acknowledgement(
+            handoff,
+            replace(accepted, response_digest="sha256:" + "e" * 64),
+        )

--- a/newsroom/tests/test_increment6f1_handoffs.py
+++ b/newsroom/tests/test_increment6f1_handoffs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import FrozenInstanceError, replace
+from itertools import permutations
 
 import pytest
 
@@ -236,6 +237,36 @@ def test_conflicting_delayed_acknowledgement_is_ambiguous_not_overwritten() -> N
     result = correlate_acknowledgement(handoff, rejected)
     assert result.state is HandoffState.AMBIGUOUS
     assert result.ambiguity_reason == "conflicting_acknowledgements"
+
+
+def test_conflicting_acknowledgement_arrival_orders_remain_ambiguous() -> None:
+    handoff = persist_attempt(_handoff())
+    handoff = mark_attempt_sent(handoff, handoff.attempts[0].attempt_id)
+    accepted = _ack(handoff, handoff.attempts[0])
+    rejected = _ack(
+        handoff,
+        handoff.attempts[0],
+        outcome=AcknowledgementOutcome.REJECTED,
+        response_digest="sha256:" + "d" * 64,
+    )
+    later_accepted = _ack(
+        handoff,
+        handoff.attempts[0],
+        response_digest="sha256:" + "e" * 64,
+    )
+
+    results = []
+    for arrivals in permutations((accepted, rejected, later_accepted)):
+        result = handoff
+        for acknowledgement in arrivals:
+            result = correlate_acknowledgement(result, acknowledgement)
+        results.append(result)
+
+    assert {item.state for item in results} == {HandoffState.AMBIGUOUS}
+    assert {item.ambiguity_reason for item in results} == {
+        "conflicting_acknowledgements"
+    }
+    assert len({item.acknowledgements for item in results}) == 1
 
 
 def test_acknowledgement_identity_is_immutable_content_identity() -> None:

--- a/newsroom/tests/test_increment6f1_handoffs.py
+++ b/newsroom/tests/test_increment6f1_handoffs.py
@@ -8,7 +8,12 @@ from newsroom.increment6.handoffs import (
     Acknowledgement,
     AcknowledgementOutcome,
     HandoffContractError,
+    HandoffAttempt,
     HandoffState,
+    EVALUATION_HANDOFF,
+    HANDOFF_ACKNOWLEDGEMENT,
+    HANDOFF_ATTEMPT,
+    HANDOFF_TRANSPORT_STATE,
     correlate_acknowledgement,
     create_handoff,
     mark_attempt_ambiguous,
@@ -32,16 +37,26 @@ def _handoff(*, max_attempts: int = 3):
     )
 
 
-def _ack(handoff, attempt, *, outcome=AcknowledgementOutcome.ACKNOWLEDGED):
+def _ack(
+    handoff,
+    attempt,
+    *,
+    outcome=AcknowledgementOutcome.ACKNOWLEDGED,
+    response_digest="sha256:" + "b" * 64,
+    **overrides,
+):
+    values = {
+        "handoff_id": handoff.handoff_id,
+        "attempt_id": attempt.attempt_id,
+        "candidate_version_id": handoff.candidate_version_id,
+        "governing_manifest_digest": handoff.governing_manifest_digest,
+        "sink_id": handoff.sink_id,
+    }
+    values.update(overrides)
     return Acknowledgement.create(
-        acknowledgement_id=f"sink-ack:{attempt.attempt_number}:{outcome.value}",
-        handoff_id=handoff.handoff_id,
-        attempt_id=attempt.attempt_id,
-        candidate_version_id=handoff.candidate_version_id,
-        governing_manifest_digest=handoff.governing_manifest_digest,
-        sink_id=handoff.sink_id,
         outcome=outcome,
-        response_digest="sha256:" + "b" * 64,
+        response_digest=response_digest,
+        **values,
     )
 
 
@@ -50,6 +65,10 @@ def test_logical_identity_is_immutable_semantic_and_exactly_bound() -> None:
     replay = _handoff()
 
     assert first == replay
+    assert first.schema_identity == EVALUATION_HANDOFF
+    assert HandoffAttempt.schema_identity == HANDOFF_ATTEMPT
+    assert Acknowledgement.schema_identity == HANDOFF_ACKNOWLEDGEMENT
+    assert HANDOFF_TRANSPORT_STATE == tuple(item.value for item in HandoffState)
     assert first.handoff_id.startswith("handoff:sha256:")
     assert first.candidate_version_id == CANDIDATE_VERSION_ID
     assert first.governing_manifest_digest == MANIFEST_DIGEST
@@ -194,7 +213,7 @@ def test_uncorrelated_acknowledgements_are_retained_as_ambiguous(
 ) -> None:
     handoff = persist_attempt(_handoff())
     handoff = mark_attempt_sent(handoff, handoff.attempts[0].attempt_id)
-    acknowledgement = replace(_ack(handoff, handoff.attempts[0]), **{field: value})
+    acknowledgement = _ack(handoff, handoff.attempts[0], **{field: value})
 
     ambiguous = correlate_acknowledgement(handoff, acknowledgement)
     assert ambiguous.state is HandoffState.AMBIGUOUS
@@ -207,9 +226,9 @@ def test_conflicting_delayed_acknowledgement_is_ambiguous_not_overwritten() -> N
     handoff = mark_attempt_sent(handoff, handoff.attempts[0].attempt_id)
     accepted = _ack(handoff, handoff.attempts[0])
     handoff = correlate_acknowledgement(handoff, accepted)
-    rejected = replace(
-        accepted,
-        acknowledgement_id="sink-ack:conflict",
+    rejected = _ack(
+        handoff,
+        handoff.attempts[0],
         outcome=AcknowledgementOutcome.REJECTED,
         response_digest="sha256:" + "d" * 64,
     )
@@ -219,14 +238,10 @@ def test_conflicting_delayed_acknowledgement_is_ambiguous_not_overwritten() -> N
     assert result.ambiguity_reason == "conflicting_acknowledgements"
 
 
-def test_same_acknowledgement_identity_cannot_replay_different_content() -> None:
+def test_acknowledgement_identity_is_immutable_content_identity() -> None:
     handoff = persist_attempt(_handoff())
     handoff = mark_attempt_sent(handoff, handoff.attempts[0].attempt_id)
     accepted = _ack(handoff, handoff.attempts[0])
-    handoff = correlate_acknowledgement(handoff, accepted)
 
-    with pytest.raises(HandoffContractError, match="acknowledgement identity conflict"):
-        correlate_acknowledgement(
-            handoff,
-            replace(accepted, response_digest="sha256:" + "e" * 64),
-        )
+    with pytest.raises(HandoffContractError, match="acknowledgement_id"):
+        replace(accepted, response_digest="sha256:" + "e" * 64)

--- a/newsroom/tests/test_increment6f1_handoffs.py
+++ b/newsroom/tests/test_increment6f1_handoffs.py
@@ -105,6 +105,23 @@ def test_binding_and_evaluation_only_semantics_are_fail_closed() -> None:
         replace(_handoff(), publication_authority=True)
 
 
+@pytest.mark.parametrize(
+    ("state", "reason"),
+    [
+        (HandoffState.ACKNOWLEDGED, None),
+        (HandoffState.REJECTED, None),
+        (HandoffState.AMBIGUOUS, "target_outcome_unknown"),
+        (HandoffState.RETRY, None),
+    ],
+)
+def test_public_handoff_rejects_state_not_derived_from_records(
+    state: HandoffState,
+    reason: str | None,
+) -> None:
+    with pytest.raises(HandoffContractError, match="Handoff state"):
+        replace(_handoff(), state=state, ambiguity_reason=reason)
+
+
 def test_attempt_is_persisted_before_it_can_be_sent_and_replay_is_idempotent() -> None:
     handoff = _handoff()
     assert handoff.state is HandoffState.PENDING


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-6f1
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

## Accepted allocation

- Contract digest: `sha256:13b43c927e4222c143b8691eaf179eb956096c19a72f4cc29cae13008d6e0590`
- Accepted 6R merge: `main@a44a073e3d798521a373115aa2c54f104b58a4cd`
- Rebased central policy boundary: `main@8645ea0db0a8c99cf76d9acc294dcf52b9efd520`
- Effective wave: 1
- Dependency: #354
- Gate tier: **Tier S**
- Sole public module: `newsroom.increment6.handoffs`
- Exact schema identities:
  - `newsroom.increment6.evaluation-handoff.v1`
  - `newsroom.increment6.evaluation-handoff-attempt.v1`
  - `newsroom.increment6.evaluation-handoff-acknowledgement.v1`
- Sole interface ownership: `EVALUATION_HANDOFF`, `HANDOFF_ATTEMPT`, `HANDOFF_ACKNOWLEDGEMENT`, `HANDOFF_TRANSPORT_STATE`
- Migration allocation: v17 / `newsroom.authority.evaluation_handoff_migrations` / `evaluation_handoff_authority_v17`
- Reserved persistent tables only: `evaluation_handoffs`, `evaluation_handoff_attempts`, `evaluation_handoff_acknowledgements`

## Summary

- Adds stable, immutable Handoff, attempt and acknowledgement identities with exact Candidate Version and governing-manifest binding.
- Implements deterministic pending, acknowledged, rejected, ambiguous and bounded-retry state transitions, including persist-before-send, acknowledgement correlation and idempotent replay.
- Persists and re-derives Handoff state through a SQLite-backed store across restart and concurrency boundaries.
- Keeps the sink explicitly evaluation-only: it grants no publication, evidence or production authority.
- Appends checked migration v17 `evaluation_handoff_authority_v17` to the central sequential history and fingerprint registry.

## Independent-review corrections

At rebased `4d7fe00` and `f38b7b7`:

1. Conflicting acknowledgement outcomes remain deterministically ambiguous for every later acknowledgement, independent of arrival order.
2. Acknowledgement association uses `(recorded_handoff_id, acknowledgement_id)`, so a wrong-Handoff record cannot poison or consume rightful delayed/idempotent correlation to another Handoff.
3. Exact-v16 upgrade requires a verified pre-migration backup receipt and SHA-256 digest; multihop upgrade checkpoints v16 before the same boundary.
4. Restart re-derives state from retained records and rejects terminal-to-ambiguous SQL tampering.
5. Retry timeout after wrong/conflicting acknowledgement retains the canonical reason and exact exhaustion state; premature exhaustion is rejected.
6. Public `Handoff` construction enforces the same record-derived invariants as persisted reloads.
7. Actual event-store and object-store open paths run migration backup preflight without adopting a caller transaction.

At exact head `d295bb037093d9063049d9a6de4f4c9de0f41374`:

1. Evidence Intake Acknowledgements are admitted only when every binding field matches one exact retained Handoff and an exact sent attempt. Wrong, future, pre-send and otherwise unmatched responses are deterministic inert no-ops and are not persisted as authority acknowledgements.
2. Removes caller-supplied `causal_acknowledgement_ids` and persisted `state_authority`; all retained acknowledgement records are exact causal records and Handoff state is derived from that closed set.
3. The SQLite insert guard independently enforces recorded Handoff, Candidate Version, governing manifest, sink, attempt identity and sent state. Direct SQL cannot suppress an exact acknowledgement or admit an unmatched response.
4. A future response can correlate only after its exact attempt is sent; a wrong response cannot cancel a persisted unsent retry; rightful later acknowledgement and timeout paths remain deterministic across replay, restart and concurrency.
5. Conflicting exact acknowledgements for an older attempt remain visible but preserve a newer pending active retry. The retry stays sendable across restart and becomes deterministically ambiguous only if its current attempt times out.
6. The public validator now permits that pending exception only when every conflicting acknowledgement targets an older attempt. Any conflict involving the current attempt remains ambiguous; SQL rejects ambiguous-to-terminal conflict narrowing before commit, and restart rejects forced pending tampering.

## Migration and rollback evidence

- Fresh creation reaches exact checked v17.
- Exact-v16 upgrade requires and retains the verified backup plus digest boundary.
- Multihop upgrade checkpoints exact v16, commits it, prepares/verifies the backup, then applies v17 exclusively.
- Missing or changed backup evidence fails closed.
- Injected v17 failure rolls back exclusively without partial schema/history state.
- Migration checksum: `sha256:c15b3a3fc90833048938b591291d16f59ee1f36b54a6d72dbd04b63877682e7f`
- Expected schema fingerprint: `sha256:aaa9544bc6f90dce5831452cffb227967175901e4f7b085e17056ac4194109f5`
- History, foreign-key and quick-check gates cover fresh, upgrade, restart, replay and concurrency cases.

## Verification

- Focused Increment 6F1 tests: `57 passed`.
- Affected authority/readiness/Graphiti selection: `101 passed`.
- Migration/fingerprint selection: `86 passed, 2611 deselected`.
- `python -m compileall` and `git diff --check`: passed.
- Full suite: `2636 passed, 41 skipped, 20 environment-specific failures`.
  - 16 Increment 5 profile-validator cases require a trusted interpreter rather than `/usr/bin/python3`.
  - 3 no-replace SDLC transport cases are Linux-only and fail closed on macOS.
  - 1 watchdog case reports `ENVIRONMENT_ERROR`.

Issue: #357


