### PR TITLE
Increment 6C1: add strict triage proposal contract

### DIFF
--- a/newsroom/increment6/proposals.py
+++ b/newsroom/increment6/proposals.py
@@ -134,6 +134,14 @@ def _optional_uuid(value: object, field: str) -> str | None:
     return None if value is None else _uuid(value, field)
 
 
+def _optional_text(value: object, field: str) -> str | None:
+    return None if value is None else _text(value, field)
+
+
+def _optional_token(value: object, field: str) -> str | None:
+    return None if value is None else _token(value, field)
+
+
 def _uint(value: object, field: str, *, minimum: int = 0, maximum: int | None = None) -> int:
     if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
         raise ProposalContractError(f"{field} must be a bounded non-negative integer")
@@ -377,6 +385,7 @@ class InputCitation:
     byte_start: int
     byte_end: int
     quote_digest: str
+    target_hypothesis_id: str | None
 
     @classmethod
     def from_value(cls, value: object) -> "InputCitation":
@@ -391,6 +400,7 @@ class InputCitation:
                 "byte_start",
                 "byte_end",
                 "quote_digest",
+                "target_hypothesis_id",
             },
             "input citation",
         )
@@ -406,6 +416,17 @@ class InputCitation:
             in {CitationSourceKind.DECISION_LEAD, CitationSourceKind.CONTEXT_LEAD}
             else _token(item["source_id"], "citation source_id")
         )
+        target_hypothesis_id = _optional_uuid(
+            item["target_hypothesis_id"], "citation target_hypothesis_id"
+        )
+        if (
+            source_kind
+            in {CitationSourceKind.DECISION_LEAD, CitationSourceKind.CONTEXT_LEAD}
+            and target_hypothesis_id is not None
+        ):
+            raise ProposalContractError(
+                "a Lead citation cannot bind a retrieved Hypothesis target"
+            )
         return cls(
             citation_id=_token(item["citation_id"], "citation_id"),
             source_kind=source_kind,
@@ -415,6 +436,7 @@ class InputCitation:
             byte_start=byte_start,
             byte_end=byte_end,
             quote_digest=_digest(item["quote_digest"], "citation quote_digest"),
+            target_hypothesis_id=target_hypothesis_id,
         )
 
     def canonical_value(self) -> dict[str, object]:
@@ -427,6 +449,7 @@ class InputCitation:
             "byte_start": self.byte_start,
             "byte_end": self.byte_end,
             "quote_digest": self.quote_digest,
+            "target_hypothesis_id": self.target_hypothesis_id,
         }
 
 
@@ -551,6 +574,75 @@ class SupplementalAction:
 
 
 @dataclass(frozen=True, slots=True)
+class OperationalAction:
+    action_kind: str
+    owner_id: str | None
+    dependency: str | None
+    retry_condition: str | None
+    review_condition: str | None
+    expiry_condition: str | None
+
+    @classmethod
+    def from_value(cls, value: object) -> "OperationalAction":
+        item = _exact_keys(
+            value,
+            {
+                "action_kind",
+                "owner_id",
+                "dependency",
+                "retry_condition",
+                "review_condition",
+                "expiry_condition",
+            },
+            "operational action",
+        )
+        action_kind = _optional_token(item["action_kind"], "operational action_kind")
+        owner_id = _optional_token(item["owner_id"], "operational owner_id")
+        dependency = _optional_token(
+            item["dependency"], "operational dependency"
+        )
+        retry_condition = _optional_text(
+            item["retry_condition"], "operational retry_condition"
+        )
+        review_condition = _optional_text(
+            item["review_condition"], "operational review_condition"
+        )
+        expiry_condition = _optional_text(
+            item["expiry_condition"], "operational expiry_condition"
+        )
+        if action_kind is None or not any(
+            (
+                owner_id,
+                dependency,
+                retry_condition,
+                review_condition,
+                expiry_condition,
+            )
+        ):
+            raise ProposalContractError(
+                "operational hold requires an inspectable action and condition"
+            )
+        return cls(
+            action_kind=action_kind,
+            owner_id=owner_id,
+            dependency=dependency,
+            retry_condition=retry_condition,
+            review_condition=review_condition,
+            expiry_condition=expiry_condition,
+        )
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "action_kind": self.action_kind,
+            "owner_id": self.owner_id,
+            "dependency": self.dependency,
+            "retry_condition": self.retry_condition,
+            "review_condition": self.review_condition,
+            "expiry_condition": self.expiry_condition,
+        }
+
+
+@dataclass(frozen=True, slots=True)
 class CandidateManifest:
     manifest_kind: CandidateManifestKind
     contributing_lead_ids: tuple[str, ...]
@@ -645,6 +737,7 @@ class LeadRecommendation:
     hypothesis: ProposedHypothesis | None
     watch_action: WatchAction | None
     supplemental_action: SupplementalAction | None
+    operational_action: OperationalAction | None
     candidate_manifest: CandidateManifest | None
 
     @classmethod
@@ -664,6 +757,7 @@ class LeadRecommendation:
                 "hypothesis",
                 "watch_action",
                 "supplemental_action",
+                "operational_action",
                 "candidate_manifest",
             },
             "recommendation",
@@ -696,6 +790,11 @@ class LeadRecommendation:
             if item["supplemental_action"] is None
             else SupplementalAction.from_value(item["supplemental_action"])
         )
+        operational = (
+            None
+            if item["operational_action"] is None
+            else OperationalAction.from_value(item["operational_action"])
+        )
         candidate = (
             None
             if item["candidate_manifest"] is None
@@ -707,6 +806,10 @@ class LeadRecommendation:
         if (route is ProposalRoute.SUPPLEMENTAL_DISCOVERY) != (supplemental is not None):
             raise ProposalContractError(
                 "supplemental action must exist only for SUPPLEMENTAL_DISCOVERY"
+            )
+        if (route is ProposalRoute.OPERATIONAL_HOLD) != (operational is not None):
+            raise ProposalContractError(
+                "operational action must exist only for OPERATIONAL_HOLD"
             )
         candidate_kinds = {
             ProposalRoute.NEW_EVENT_CANDIDATE: CandidateManifestKind.NEW_EVENT,
@@ -772,6 +875,7 @@ class LeadRecommendation:
             hypothesis=hypothesis,
             watch_action=watch,
             supplemental_action=supplemental,
+            operational_action=operational,
             candidate_manifest=candidate,
         )
 
@@ -796,6 +900,11 @@ class LeadRecommendation:
                 None
                 if self.supplemental_action is None
                 else self.supplemental_action.canonical_value()
+            ),
+            "operational_action": (
+                None
+                if self.operational_action is None
+                else self.operational_action.canonical_value()
             ),
             "candidate_manifest": (
                 None
@@ -932,6 +1041,37 @@ class TriageProposal:
             )
 
         admitted_leads = set(decision_leads) | set(context_leads)
+        recommendations_by_lead = {
+            recommendation.decision_lead_id: recommendation
+            for recommendation in recommendations
+        }
+        hypotheses_by_local_id: dict[str, dict[str, object]] = {}
+        for recommendation in recommendations:
+            hypothesis = recommendation.hypothesis
+            if hypothesis is None:
+                continue
+            hypothesis_value = hypothesis.canonical_value()
+            prior = hypotheses_by_local_id.setdefault(
+                hypothesis.proposal_local_id, hypothesis_value
+            )
+            if prior != hypothesis_value:
+                raise ProposalContractError(
+                    "proposal_local_id conflicts across Hypothesis recommendations"
+                )
+            if hypothesis.target_hypothesis_id is not None and not any(
+                citation.source_kind
+                in {
+                    CitationSourceKind.RETRIEVAL_MATCH,
+                    CitationSourceKind.RETRIEVAL_CONTRADICTION,
+                }
+                and citation.target_hypothesis_id
+                == hypothesis.target_hypothesis_id
+                for citation in recommendation.input_citations
+            ):
+                raise ProposalContractError(
+                    "relationship target lacks an exact Retrieval Context citation"
+                )
+
         for recommendation in recommendations:
             for citation in recommendation.input_citations:
                 if (
@@ -973,6 +1113,24 @@ class TriageProposal:
                     raise ProposalContractError(
                         "Candidate manifest contains an unbound Lead"
                     )
+                if not set(manifest.contributing_lead_ids) <= set(decision_leads):
+                    raise ProposalContractError(
+                        "Candidate contributor cannot be a context-only Lead"
+                    )
+                assert recommendation.hypothesis is not None
+                for contributor_id in manifest.contributing_lead_ids:
+                    contributor = recommendations_by_lead[contributor_id]
+                    if (
+                        contributor.candidate_manifest is None
+                        or contributor.hypothesis is None
+                        or contributor.hypothesis.proposal_local_id
+                        != recommendation.hypothesis.proposal_local_id
+                        or contributor.candidate_manifest.canonical_value()
+                        != manifest.canonical_value()
+                    ):
+                        raise ProposalContractError(
+                            "Candidate contributor is unrelated or has a non-Candidate route"
+                        )
 
         result = cls(
             proposal_id=_uuid(proposal["proposal_id"], "proposal_id"),
@@ -1040,6 +1198,7 @@ __all__ = [
     "HypothesisRelationship",
     "InputCitation",
     "LeadRecommendation",
+    "OperationalAction",
     "ProposalAuthority",
     "ProposalContractError",
     "ProposalRoute",

--- a/newsroom/increment6/proposals.py
+++ b/newsroom/increment6/proposals.py
@@ -1,0 +1,530 @@
+"""Strict, provider-independent Triage Proposal contract for Increment 6C1.
+
+A proposal is retained untrusted worker output.  Its digest is content identity,
+not approval: parsing or retaining one creates no Hypothesis or Candidate and
+grants no evidence, publication, operational, or other editorial authority.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Mapping
+
+from newsroom.authority.canonical import (
+    CanonicalizationError,
+    canonical_json_bytes,
+    digest_bytes,
+    validate_sha256_digest,
+)
+
+
+PROPOSAL_SCHEMA_VERSION = "newsroom.increment6.triage-proposal.v1"
+PROBABILITY_SCALE = 1_000_000
+MAX_EVIDENCE_REFERENCES = 32
+MAX_RATIONALE_BYTES = 4_096
+MAX_CITATION_SPAN_BYTES = 262_144
+
+_TOKEN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:\-]{0,255}\Z")
+_DECIMAL = re.compile(r"(?:0\.[0-9]{6}|1\.000000)\Z")
+
+
+class ProposalContractError(ValueError):
+    """Untrusted proposal bytes do not satisfy the exact v1 contract."""
+
+
+class ProposalRoute(StrEnum):
+    CREATE_HYPOTHESIS = "CREATE_HYPOTHESIS"
+    ASSOCIATE_HYPOTHESIS = "ASSOCIATE_HYPOTHESIS"
+    HOLD = "HOLD"
+    WATCH = "WATCH"
+    DISMISS = "DISMISS"
+
+
+class FixtureWorkerKind(StrEnum):
+    FAKE = "FAKE"
+    REPLAY = "REPLAY"
+
+
+def _exact_keys(
+    value: object, expected: set[str], field: str
+) -> Mapping[str, object]:
+    if not isinstance(value, dict) or set(value) != expected:
+        raise ProposalContractError(f"{field} keys are not exact")
+    return value
+
+
+def _digest(value: object, field: str) -> str:
+    if not isinstance(value, str):
+        raise ProposalContractError(f"{field} must be a canonical SHA-256 digest")
+    try:
+        return validate_sha256_digest(value, field=field)
+    except CanonicalizationError as exc:
+        raise ProposalContractError(str(exc)) from exc
+
+
+def _text(value: object, field: str, maximum_bytes: int = 256) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or value != value.strip()
+        or len(value.encode("utf-8")) > maximum_bytes
+    ):
+        raise ProposalContractError(f"{field} must be bounded canonical text")
+    return value
+
+
+def _token(value: object, field: str) -> str:
+    if not isinstance(value, str) or _TOKEN.fullmatch(value) is None:
+        raise ProposalContractError(f"{field} must be a bounded canonical token")
+    return value
+
+
+def _uuid(value: object, field: str) -> str:
+    if not isinstance(value, str):
+        raise ProposalContractError(f"{field} must be a canonical UUID")
+    try:
+        parsed = uuid.UUID(value)
+    except (ValueError, AttributeError) as exc:
+        raise ProposalContractError(f"{field} must be a canonical UUID") from exc
+    if str(parsed) != value:
+        raise ProposalContractError(f"{field} must be a canonical UUID")
+    return value
+
+
+def _uint(value: object, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ProposalContractError(f"{field} must be a non-negative integer")
+    return value
+
+
+def _unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    value: dict[str, object] = {}
+    for name, item in pairs:
+        if name in value:
+            raise ProposalContractError(f"duplicate object name: {name}")
+        value[name] = item
+    return value
+
+
+def _decode_canonical(raw: bytes) -> dict[str, object]:
+    if not isinstance(raw, bytes):
+        raise ProposalContractError("proposal input must be immutable bytes")
+    try:
+        value = json.loads(
+            raw.decode("utf-8"),
+            object_pairs_hook=_unique_object,
+            parse_constant=lambda value: (_ for _ in ()).throw(
+                ProposalContractError(f"unsupported JSON constant: {value}")
+            ),
+        )
+    except ProposalContractError:
+        raise
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ProposalContractError("proposal is not valid UTF-8 JSON") from exc
+    if not isinstance(value, dict):
+        raise ProposalContractError("proposal document must be an object")
+    try:
+        expected = canonical_json_bytes(value)
+    except CanonicalizationError as exc:
+        raise ProposalContractError("proposal is outside canonical JSON") from exc
+    if raw != expected:
+        raise ProposalContractError("proposal is not exact canonical JSON")
+    return value
+
+
+def _content_identity(proposal: Mapping[str, object]) -> str:
+    """Scope content identity to this exact contract version."""
+
+    return digest_bytes(
+        canonical_json_bytes(
+            {
+                "schema_version": PROPOSAL_SCHEMA_VERSION,
+                "proposal": proposal,
+            }
+        )
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class FixedProbability:
+    """A [0, 1] value represented by both exact integer and decimal forms."""
+
+    decimal: str
+    millionths: int
+
+    @classmethod
+    def from_value(cls, value: object, field: str) -> "FixedProbability":
+        item = _exact_keys(value, {"decimal", "millionths"}, field)
+        millionths = item["millionths"]
+        if (
+            isinstance(millionths, bool)
+            or not isinstance(millionths, int)
+            or not 0 <= millionths <= PROBABILITY_SCALE
+        ):
+            raise ProposalContractError(
+                f"{field}.millionths must be an integer from 0 to 1000000"
+            )
+        decimal = item["decimal"]
+        if not isinstance(decimal, str) or _DECIMAL.fullmatch(decimal) is None:
+            raise ProposalContractError(
+                f"{field}.decimal must use exact six-place [0,1] text"
+            )
+        whole = millionths // PROBABILITY_SCALE
+        fraction = millionths % PROBABILITY_SCALE
+        expected = f"{whole}.{fraction:06d}"
+        if decimal != expected:
+            raise ProposalContractError(
+                f"{field} decimal and integer representations differ"
+            )
+        return cls(decimal=decimal, millionths=millionths)
+
+    def canonical_value(self) -> dict[str, object]:
+        return {"decimal": self.decimal, "millionths": self.millionths}
+
+
+@dataclass(frozen=True, slots=True)
+class RetrievalContextBinding:
+    context_id: str
+    context_digest: str
+    contract_digest: str
+
+    @classmethod
+    def from_value(cls, value: object) -> "RetrievalContextBinding":
+        item = _exact_keys(
+            value,
+            {"context_id", "context_digest", "contract_digest"},
+            "retrieval_context_binding",
+        )
+        return cls(
+            context_id=_uuid(item["context_id"], "context_id"),
+            context_digest=_digest(item["context_digest"], "context_digest"),
+            contract_digest=_digest(item["contract_digest"], "contract_digest"),
+        )
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "context_id": self.context_id,
+            "context_digest": self.context_digest,
+            "contract_digest": self.contract_digest,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class WorkerAttemptBinding:
+    attempt_id: str
+    attempt_digest: str
+    worker_kind: FixtureWorkerKind
+    worker_version: str
+    input_digest: str
+    retrieval_context_digest: str
+
+    @classmethod
+    def from_value(cls, value: object) -> "WorkerAttemptBinding":
+        item = _exact_keys(
+            value,
+            {
+                "attempt_id",
+                "attempt_digest",
+                "worker_kind",
+                "worker_version",
+                "input_digest",
+                "retrieval_context_digest",
+            },
+            "worker_attempt_binding",
+        )
+        try:
+            worker_kind = FixtureWorkerKind(item["worker_kind"])
+        except (TypeError, ValueError) as exc:
+            raise ProposalContractError(
+                "worker_kind must be FAKE or REPLAY"
+            ) from exc
+        return cls(
+            attempt_id=_token(item["attempt_id"], "attempt_id"),
+            attempt_digest=_digest(item["attempt_digest"], "attempt_digest"),
+            worker_kind=worker_kind,
+            worker_version=_token(item["worker_version"], "worker_version"),
+            input_digest=_digest(item["input_digest"], "input_digest"),
+            retrieval_context_digest=_digest(
+                item["retrieval_context_digest"],
+                "worker_retrieval_context_digest",
+            ),
+        )
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "attempt_id": self.attempt_id,
+            "attempt_digest": self.attempt_digest,
+            "worker_kind": self.worker_kind.value,
+            "worker_version": self.worker_version,
+            "input_digest": self.input_digest,
+            "retrieval_context_digest": self.retrieval_context_digest,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceReference:
+    citation_id: str
+    context_item_digest: str
+    passage_id: str
+    passage_text_digest: str
+    byte_start: int
+    byte_end: int
+    quote_digest: str
+
+    @classmethod
+    def from_value(cls, value: object) -> "EvidenceReference":
+        item = _exact_keys(
+            value,
+            {
+                "citation_id",
+                "context_item_digest",
+                "passage_id",
+                "passage_text_digest",
+                "byte_start",
+                "byte_end",
+                "quote_digest",
+            },
+            "evidence reference",
+        )
+        byte_start = _uint(item["byte_start"], "citation byte_start")
+        byte_end = _uint(item["byte_end"], "citation byte_end")
+        if (
+            byte_end <= byte_start
+            or byte_end - byte_start > MAX_CITATION_SPAN_BYTES
+        ):
+            raise ProposalContractError("citation byte range is invalid or unbounded")
+        return cls(
+            citation_id=_token(item["citation_id"], "citation_id"),
+            context_item_digest=_digest(
+                item["context_item_digest"], "context_item_digest"
+            ),
+            passage_id=_text(item["passage_id"], "passage_id"),
+            passage_text_digest=_digest(
+                item["passage_text_digest"], "passage_text_digest"
+            ),
+            byte_start=byte_start,
+            byte_end=byte_end,
+            quote_digest=_digest(item["quote_digest"], "quote_digest"),
+        )
+
+    @property
+    def byte_range(self) -> tuple[int, int]:
+        return self.byte_start, self.byte_end
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "citation_id": self.citation_id,
+            "context_item_digest": self.context_item_digest,
+            "passage_id": self.passage_id,
+            "passage_text_digest": self.passage_text_digest,
+            "byte_start": self.byte_start,
+            "byte_end": self.byte_end,
+            "quote_digest": self.quote_digest,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ProposalAuthority:
+    effect: str
+    creates_hypothesis: bool
+    creates_candidate: bool
+    mutates_editorial_state: bool
+    publication_authority: bool
+    evidence_authority: bool
+    operational_authority: bool
+
+    @classmethod
+    def from_value(cls, value: object) -> "ProposalAuthority":
+        fields = {
+            "effect",
+            "creates_hypothesis",
+            "creates_candidate",
+            "mutates_editorial_state",
+            "publication_authority",
+            "evidence_authority",
+            "operational_authority",
+        }
+        item = _exact_keys(value, fields, "authority")
+        if item["effect"] != "NONE" or any(
+            item[name] is not False for name in fields - {"effect"}
+        ):
+            raise ProposalContractError(
+                "a Triage Proposal grants no authority and has no editorial effect"
+            )
+        return cls(
+            effect="NONE",
+            creates_hypothesis=False,
+            creates_candidate=False,
+            mutates_editorial_state=False,
+            publication_authority=False,
+            evidence_authority=False,
+            operational_authority=False,
+        )
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "effect": self.effect,
+            "creates_hypothesis": self.creates_hypothesis,
+            "creates_candidate": self.creates_candidate,
+            "mutates_editorial_state": self.mutates_editorial_state,
+            "publication_authority": self.publication_authority,
+            "evidence_authority": self.evidence_authority,
+            "operational_authority": self.operational_authority,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class TriageProposal:
+    proposal_id: str
+    retrieval_context: RetrievalContextBinding
+    worker_attempt: WorkerAttemptBinding
+    route: ProposalRoute
+    confidence: FixedProbability
+    uncertainty: FixedProbability
+    evidence_references: tuple[EvidenceReference, ...]
+    rationale: str
+    authority: ProposalAuthority
+    content_identity: str
+
+    @classmethod
+    def from_canonical_bytes(cls, raw: bytes) -> "TriageProposal":
+        document = _decode_canonical(raw)
+        root = _exact_keys(
+            document,
+            {"schema_version", "content_identity", "proposal"},
+            "proposal document",
+        )
+        if root["schema_version"] != PROPOSAL_SCHEMA_VERSION:
+            raise ProposalContractError("proposal schema version is unsupported")
+        content_identity = _digest(root["content_identity"], "content_identity")
+        proposal = _exact_keys(
+            root["proposal"],
+            {
+                "proposal_id",
+                "retrieval_context_binding",
+                "worker_attempt_binding",
+                "route",
+                "confidence",
+                "uncertainty",
+                "evidence_references",
+                "rationale",
+                "authority",
+            },
+            "proposal",
+        )
+        if _content_identity(proposal) != content_identity:
+            raise ProposalContractError("proposal content identity differs")
+
+        retrieval_context = RetrievalContextBinding.from_value(
+            proposal["retrieval_context_binding"]
+        )
+        worker_attempt = WorkerAttemptBinding.from_value(
+            proposal["worker_attempt_binding"]
+        )
+        if (
+            worker_attempt.retrieval_context_digest
+            != retrieval_context.context_digest
+        ):
+            raise ProposalContractError(
+                "worker attempt retrieval context digest differs"
+            )
+        try:
+            route = ProposalRoute(proposal["route"])
+        except (TypeError, ValueError) as exc:
+            raise ProposalContractError("proposal route is unsupported") from exc
+
+        raw_references = proposal["evidence_references"]
+        if not isinstance(raw_references, list):
+            raise ProposalContractError("evidence references must be an array")
+        if not 1 <= len(raw_references) <= MAX_EVIDENCE_REFERENCES:
+            raise ProposalContractError("evidence references are empty or unbounded")
+        evidence_references = tuple(
+            EvidenceReference.from_value(item) for item in raw_references
+        )
+        citation_ids = tuple(item.citation_id for item in evidence_references)
+        if citation_ids != tuple(sorted(set(citation_ids))):
+            raise ProposalContractError(
+                "evidence references must be sorted and unique by citation_id"
+            )
+
+        result = cls(
+            proposal_id=_uuid(proposal["proposal_id"], "proposal_id"),
+            retrieval_context=retrieval_context,
+            worker_attempt=worker_attempt,
+            route=route,
+            confidence=FixedProbability.from_value(
+                proposal["confidence"], "confidence"
+            ),
+            uncertainty=FixedProbability.from_value(
+                proposal["uncertainty"], "uncertainty"
+            ),
+            evidence_references=evidence_references,
+            rationale=_text(
+                proposal["rationale"], "rationale", MAX_RATIONALE_BYTES
+            ),
+            authority=ProposalAuthority.from_value(proposal["authority"]),
+            content_identity=content_identity,
+        )
+        if result.canonical_bytes != raw:
+            raise ProposalContractError("proposal typed replay differs")
+        return result
+
+    @property
+    def grants_authority(self) -> bool:
+        return False
+
+    @property
+    def creates_hypothesis(self) -> bool:
+        return False
+
+    @property
+    def creates_candidate(self) -> bool:
+        return False
+
+    def proposal_value(self) -> dict[str, object]:
+        return {
+            "proposal_id": self.proposal_id,
+            "retrieval_context_binding": self.retrieval_context.canonical_value(),
+            "worker_attempt_binding": self.worker_attempt.canonical_value(),
+            "route": self.route.value,
+            "confidence": self.confidence.canonical_value(),
+            "uncertainty": self.uncertainty.canonical_value(),
+            "evidence_references": [
+                item.canonical_value() for item in self.evidence_references
+            ],
+            "rationale": self.rationale,
+            "authority": self.authority.canonical_value(),
+        }
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "schema_version": PROPOSAL_SCHEMA_VERSION,
+            "content_identity": self.content_identity,
+            "proposal": self.proposal_value(),
+        }
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return canonical_json_bytes(self.canonical_value())
+
+
+__all__ = [
+    "MAX_CITATION_SPAN_BYTES",
+    "MAX_EVIDENCE_REFERENCES",
+    "MAX_RATIONALE_BYTES",
+    "PROBABILITY_SCALE",
+    "PROPOSAL_SCHEMA_VERSION",
+    "EvidenceReference",
+    "FixedProbability",
+    "FixtureWorkerKind",
+    "ProposalAuthority",
+    "ProposalContractError",
+    "ProposalRoute",
+    "RetrievalContextBinding",
+    "TriageProposal",
+    "WorkerAttemptBinding",
+]

--- a/newsroom/increment6/proposals.py
+++ b/newsroom/increment6/proposals.py
@@ -1,8 +1,8 @@
 """Strict, provider-independent Triage Proposal contract for Increment 6C1.
 
-A proposal is retained untrusted worker output.  Its digest is content identity,
-not approval: parsing or retaining one creates no Hypothesis or Candidate and
-grants no evidence, publication, operational, or other editorial authority.
+A proposal is immutable untrusted fixture output.  Its content digest is not a
+decision: parsing or retaining it creates no Hypothesis or Candidate and grants
+no evidence, publication, operational, or other editorial authority.
 """
 
 from __future__ import annotations
@@ -20,12 +20,24 @@ from newsroom.authority.canonical import (
     digest_bytes,
     validate_sha256_digest,
 )
+from newsroom.increment5.retrieval_context import RETRIEVAL_CONTEXT_CONTRACT_DIGEST
 
 
 PROPOSAL_SCHEMA_VERSION = "newsroom.increment6.triage-proposal.v1"
+TRIAGE_PROPOSAL = PROPOSAL_SCHEMA_VERSION
+PROPOSAL_CONTENT_IDENTITY = "SHA256_CANONICAL_SCHEMA_AND_PROPOSAL"
+PROPOSAL_NO_AUTHORITY_BOUNDARY = (
+    "NO_HYPOTHESIS_OR_CANDIDATE_MUTATION;"
+    "NO_PUBLICATION_EVIDENCE_OR_OPERATIONAL_AUTHORITY"
+)
+
 PROBABILITY_SCALE = 1_000_000
-MAX_EVIDENCE_REFERENCES = 32
+MAX_DECISION_LEADS = 32
+MAX_CONTEXT_LEADS = 64
+MAX_INPUT_CITATIONS = 64
+MAX_LIST_ITEMS = 32
 MAX_RATIONALE_BYTES = 4_096
+MAX_TEXT_BYTES = 1_024
 MAX_CITATION_SPAN_BYTES = 262_144
 
 _TOKEN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:\-]{0,255}\Z")
@@ -37,11 +49,14 @@ class ProposalContractError(ValueError):
 
 
 class ProposalRoute(StrEnum):
-    CREATE_HYPOTHESIS = "CREATE_HYPOTHESIS"
-    ASSOCIATE_HYPOTHESIS = "ASSOCIATE_HYPOTHESIS"
-    HOLD = "HOLD"
-    WATCH = "WATCH"
-    DISMISS = "DISMISS"
+    EDITORIAL_REJECT = "EDITORIAL_REJECT"
+    WATCH_DEFER = "WATCH_DEFER"
+    ASSOCIATE_WITHOUT_CANDIDATE = "ASSOCIATE_WITHOUT_CANDIDATE"
+    SUPPLEMENTAL_DISCOVERY = "SUPPLEMENTAL_DISCOVERY"
+    OPERATIONAL_HOLD = "OPERATIONAL_HOLD"
+    NEW_EVENT_CANDIDATE = "NEW_EVENT_CANDIDATE"
+    DEVELOPMENT_CANDIDATE = "DEVELOPMENT_CANDIDATE"
+    CORRECTION_CANDIDATE = "CORRECTION_CANDIDATE"
 
 
 class FixtureWorkerKind(StrEnum):
@@ -49,9 +64,29 @@ class FixtureWorkerKind(StrEnum):
     REPLAY = "REPLAY"
 
 
-def _exact_keys(
-    value: object, expected: set[str], field: str
-) -> Mapping[str, object]:
+class CitationSourceKind(StrEnum):
+    DECISION_LEAD = "DECISION_LEAD"
+    CONTEXT_LEAD = "CONTEXT_LEAD"
+    RETRIEVAL_MATCH = "RETRIEVAL_MATCH"
+    RETRIEVAL_CONTRADICTION = "RETRIEVAL_CONTRADICTION"
+
+
+class HypothesisRelationship(StrEnum):
+    SAME_STATE = "SAME_STATE"
+    DEVELOPMENT_OF = "DEVELOPMENT_OF"
+    CORRECTION_REVERSAL_OF = "CORRECTION_REVERSAL_OF"
+    RELATED_DISTINCT = "RELATED_DISTINCT"
+    NO_ADEQUATE_PRIOR_MATCH = "NO_ADEQUATE_PRIOR_MATCH"
+    UNCERTAIN = "UNCERTAIN"
+
+
+class CandidateManifestKind(StrEnum):
+    NEW_EVENT = "NEW_EVENT"
+    DEVELOPMENT = "DEVELOPMENT"
+    CORRECTION = "CORRECTION"
+
+
+def _exact_keys(value: object, expected: set[str], field: str) -> Mapping[str, object]:
     if not isinstance(value, dict) or set(value) != expected:
         raise ProposalContractError(f"{field} keys are not exact")
     return value
@@ -66,7 +101,7 @@ def _digest(value: object, field: str) -> str:
         raise ProposalContractError(str(exc)) from exc
 
 
-def _text(value: object, field: str, maximum_bytes: int = 256) -> str:
+def _text(value: object, field: str, maximum_bytes: int = MAX_TEXT_BYTES) -> str:
     if (
         not isinstance(value, str)
         or not value
@@ -95,10 +130,59 @@ def _uuid(value: object, field: str) -> str:
     return value
 
 
-def _uint(value: object, field: str) -> int:
-    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
-        raise ProposalContractError(f"{field} must be a non-negative integer")
+def _optional_uuid(value: object, field: str) -> str | None:
+    return None if value is None else _uuid(value, field)
+
+
+def _uint(value: object, field: str, *, minimum: int = 0, maximum: int | None = None) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        raise ProposalContractError(f"{field} must be a bounded non-negative integer")
+    if maximum is not None and value > maximum:
+        raise ProposalContractError(f"{field} must be a bounded non-negative integer")
     return value
+
+
+def _enum(enum_type: type[StrEnum], value: object, field: str) -> StrEnum:
+    try:
+        return enum_type(value)
+    except (TypeError, ValueError) as exc:
+        raise ProposalContractError(f"{field} is unsupported") from exc
+
+
+def _string_list(
+    value: object,
+    field: str,
+    *,
+    maximum_items: int = MAX_LIST_ITEMS,
+    allow_empty: bool = True,
+    tokens: bool = False,
+) -> tuple[str, ...]:
+    if not isinstance(value, list) or len(value) > maximum_items:
+        raise ProposalContractError(f"{field} must be a bounded array")
+    if not allow_empty and not value:
+        raise ProposalContractError(f"{field} must not be empty")
+    converter = _token if tokens else _text
+    result = tuple(converter(item, field) for item in value)
+    if result != tuple(sorted(set(result))):
+        raise ProposalContractError(f"{field} must be sorted and unique")
+    return result
+
+
+def _uuid_list(
+    value: object,
+    field: str,
+    *,
+    maximum_items: int,
+    allow_empty: bool,
+) -> tuple[str, ...]:
+    if not isinstance(value, list) or len(value) > maximum_items:
+        raise ProposalContractError(f"{field} must be a bounded array")
+    if not allow_empty and not value:
+        raise ProposalContractError(f"{field} must not be empty")
+    result = tuple(_uuid(item, field) for item in value)
+    if result != tuple(sorted(set(result))):
+        raise ProposalContractError(f"{field} must be sorted and unique")
+    return result
 
 
 def _unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
@@ -117,8 +201,8 @@ def _decode_canonical(raw: bytes) -> dict[str, object]:
         value = json.loads(
             raw.decode("utf-8"),
             object_pairs_hook=_unique_object,
-            parse_constant=lambda value: (_ for _ in ()).throw(
-                ProposalContractError(f"unsupported JSON constant: {value}")
+            parse_constant=lambda constant: (_ for _ in ()).throw(
+                ProposalContractError(f"unsupported JSON constant: {constant}")
             ),
         )
     except ProposalContractError:
@@ -137,53 +221,67 @@ def _decode_canonical(raw: bytes) -> dict[str, object]:
 
 
 def _content_identity(proposal: Mapping[str, object]) -> str:
-    """Scope content identity to this exact contract version."""
-
     return digest_bytes(
         canonical_json_bytes(
-            {
-                "schema_version": PROPOSAL_SCHEMA_VERSION,
-                "proposal": proposal,
-            }
+            {"schema_version": PROPOSAL_SCHEMA_VERSION, "proposal": proposal}
         )
     )
 
 
 @dataclass(frozen=True, slots=True)
 class FixedProbability:
-    """A [0, 1] value represented by both exact integer and decimal forms."""
-
     decimal: str
     millionths: int
 
     @classmethod
     def from_value(cls, value: object, field: str) -> "FixedProbability":
         item = _exact_keys(value, {"decimal", "millionths"}, field)
-        millionths = item["millionths"]
-        if (
-            isinstance(millionths, bool)
-            or not isinstance(millionths, int)
-            or not 0 <= millionths <= PROBABILITY_SCALE
-        ):
-            raise ProposalContractError(
-                f"{field}.millionths must be an integer from 0 to 1000000"
-            )
+        millionths = _uint(
+            item["millionths"], field + ".millionths", maximum=PROBABILITY_SCALE
+        )
         decimal = item["decimal"]
         if not isinstance(decimal, str) or _DECIMAL.fullmatch(decimal) is None:
             raise ProposalContractError(
                 f"{field}.decimal must use exact six-place [0,1] text"
             )
-        whole = millionths // PROBABILITY_SCALE
-        fraction = millionths % PROBABILITY_SCALE
-        expected = f"{whole}.{fraction:06d}"
+        expected = f"{millionths // PROBABILITY_SCALE}.{millionths % PROBABILITY_SCALE:06d}"
         if decimal != expected:
-            raise ProposalContractError(
-                f"{field} decimal and integer representations differ"
-            )
+            raise ProposalContractError(f"{field} decimal and integer representations differ")
         return cls(decimal=decimal, millionths=millionths)
 
     def canonical_value(self) -> dict[str, object]:
         return {"decimal": self.decimal, "millionths": self.millionths}
+
+
+@dataclass(frozen=True, slots=True)
+class WorkItemBinding:
+    work_item_id: str
+    work_item_version_id: str
+    work_item_version_digest: str
+
+    @classmethod
+    def from_value(cls, value: object) -> "WorkItemBinding":
+        item = _exact_keys(
+            value,
+            {"work_item_id", "work_item_version_id", "work_item_version_digest"},
+            "work_item_binding",
+        )
+        return cls(
+            work_item_id=_uuid(item["work_item_id"], "work_item_id"),
+            work_item_version_id=_uuid(
+                item["work_item_version_id"], "work_item_version_id"
+            ),
+            work_item_version_digest=_digest(
+                item["work_item_version_digest"], "work_item_version_digest"
+            ),
+        )
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "work_item_id": self.work_item_id,
+            "work_item_version_id": self.work_item_version_id,
+            "work_item_version_digest": self.work_item_version_digest,
+        }
 
 
 @dataclass(frozen=True, slots=True)
@@ -199,10 +297,13 @@ class RetrievalContextBinding:
             {"context_id", "context_digest", "contract_digest"},
             "retrieval_context_binding",
         )
+        contract_digest = _digest(item["contract_digest"], "contract_digest")
+        if contract_digest != RETRIEVAL_CONTEXT_CONTRACT_DIGEST:
+            raise ProposalContractError("retrieval context contract digest differs")
         return cls(
             context_id=_uuid(item["context_id"], "context_id"),
             context_digest=_digest(item["context_digest"], "context_digest"),
-            contract_digest=_digest(item["contract_digest"], "contract_digest"),
+            contract_digest=contract_digest,
         )
 
     def canonical_value(self) -> dict[str, object]:
@@ -220,6 +321,7 @@ class WorkerAttemptBinding:
     worker_kind: FixtureWorkerKind
     worker_version: str
     input_digest: str
+    work_item_version_digest: str
     retrieval_context_digest: str
 
     @classmethod
@@ -232,25 +334,24 @@ class WorkerAttemptBinding:
                 "worker_kind",
                 "worker_version",
                 "input_digest",
+                "work_item_version_digest",
                 "retrieval_context_digest",
             },
             "worker_attempt_binding",
         )
-        try:
-            worker_kind = FixtureWorkerKind(item["worker_kind"])
-        except (TypeError, ValueError) as exc:
-            raise ProposalContractError(
-                "worker_kind must be FAKE or REPLAY"
-            ) from exc
+        worker_kind = _enum(FixtureWorkerKind, item["worker_kind"], "worker_kind")
+        assert isinstance(worker_kind, FixtureWorkerKind)
         return cls(
             attempt_id=_token(item["attempt_id"], "attempt_id"),
             attempt_digest=_digest(item["attempt_digest"], "attempt_digest"),
             worker_kind=worker_kind,
             worker_version=_token(item["worker_version"], "worker_version"),
             input_digest=_digest(item["input_digest"], "input_digest"),
+            work_item_version_digest=_digest(
+                item["work_item_version_digest"], "worker_work_item_version_digest"
+            ),
             retrieval_context_digest=_digest(
-                item["retrieval_context_digest"],
-                "worker_retrieval_context_digest",
+                item["retrieval_context_digest"], "worker_retrieval_context_digest"
             ),
         )
 
@@ -261,66 +362,68 @@ class WorkerAttemptBinding:
             "worker_kind": self.worker_kind.value,
             "worker_version": self.worker_version,
             "input_digest": self.input_digest,
+            "work_item_version_digest": self.work_item_version_digest,
             "retrieval_context_digest": self.retrieval_context_digest,
         }
 
 
 @dataclass(frozen=True, slots=True)
-class EvidenceReference:
+class InputCitation:
     citation_id: str
-    context_item_digest: str
-    passage_id: str
-    passage_text_digest: str
+    source_kind: CitationSourceKind
+    source_id: str
+    source_digest: str
+    field_path: str
     byte_start: int
     byte_end: int
     quote_digest: str
 
     @classmethod
-    def from_value(cls, value: object) -> "EvidenceReference":
+    def from_value(cls, value: object) -> "InputCitation":
         item = _exact_keys(
             value,
             {
                 "citation_id",
-                "context_item_digest",
-                "passage_id",
-                "passage_text_digest",
+                "source_kind",
+                "source_id",
+                "source_digest",
+                "field_path",
                 "byte_start",
                 "byte_end",
                 "quote_digest",
             },
-            "evidence reference",
+            "input citation",
         )
+        source_kind = _enum(CitationSourceKind, item["source_kind"], "source_kind")
+        assert isinstance(source_kind, CitationSourceKind)
         byte_start = _uint(item["byte_start"], "citation byte_start")
         byte_end = _uint(item["byte_end"], "citation byte_end")
-        if (
-            byte_end <= byte_start
-            or byte_end - byte_start > MAX_CITATION_SPAN_BYTES
-        ):
+        if byte_end <= byte_start or byte_end - byte_start > MAX_CITATION_SPAN_BYTES:
             raise ProposalContractError("citation byte range is invalid or unbounded")
+        source_id = (
+            _uuid(item["source_id"], "citation source_id")
+            if source_kind
+            in {CitationSourceKind.DECISION_LEAD, CitationSourceKind.CONTEXT_LEAD}
+            else _token(item["source_id"], "citation source_id")
+        )
         return cls(
             citation_id=_token(item["citation_id"], "citation_id"),
-            context_item_digest=_digest(
-                item["context_item_digest"], "context_item_digest"
-            ),
-            passage_id=_text(item["passage_id"], "passage_id"),
-            passage_text_digest=_digest(
-                item["passage_text_digest"], "passage_text_digest"
-            ),
+            source_kind=source_kind,
+            source_id=source_id,
+            source_digest=_digest(item["source_digest"], "citation source_digest"),
+            field_path=_text(item["field_path"], "citation field_path", 256),
             byte_start=byte_start,
             byte_end=byte_end,
-            quote_digest=_digest(item["quote_digest"], "quote_digest"),
+            quote_digest=_digest(item["quote_digest"], "citation quote_digest"),
         )
-
-    @property
-    def byte_range(self) -> tuple[int, int]:
-        return self.byte_start, self.byte_end
 
     def canonical_value(self) -> dict[str, object]:
         return {
             "citation_id": self.citation_id,
-            "context_item_digest": self.context_item_digest,
-            "passage_id": self.passage_id,
-            "passage_text_digest": self.passage_text_digest,
+            "source_kind": self.source_kind.value,
+            "source_id": self.source_id,
+            "source_digest": self.source_digest,
+            "field_path": self.field_path,
             "byte_start": self.byte_start,
             "byte_end": self.byte_end,
             "quote_digest": self.quote_digest,
@@ -328,14 +431,389 @@ class EvidenceReference:
 
 
 @dataclass(frozen=True, slots=True)
+class ProposedHypothesis:
+    proposal_local_id: str
+    summary: str
+    relationship_kind: HypothesisRelationship
+    target_hypothesis_id: str | None
+
+    @classmethod
+    def from_value(cls, value: object) -> "ProposedHypothesis":
+        item = _exact_keys(
+            value,
+            {
+                "proposal_local_id",
+                "summary",
+                "relationship_kind",
+                "target_hypothesis_id",
+            },
+            "hypothesis",
+        )
+        relationship = _enum(
+            HypothesisRelationship, item["relationship_kind"], "relationship_kind"
+        )
+        assert isinstance(relationship, HypothesisRelationship)
+        target = _optional_uuid(item["target_hypothesis_id"], "target_hypothesis_id")
+        target_required = relationship is not HypothesisRelationship.NO_ADEQUATE_PRIOR_MATCH
+        if target_required != (target is not None):
+            raise ProposalContractError(
+                "hypothesis relationship target does not match relationship kind"
+            )
+        return cls(
+            proposal_local_id=_token(item["proposal_local_id"], "proposal_local_id"),
+            summary=_text(item["summary"], "hypothesis summary"),
+            relationship_kind=relationship,
+            target_hypothesis_id=target,
+        )
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "proposal_local_id": self.proposal_local_id,
+            "summary": self.summary,
+            "relationship_kind": self.relationship_kind.value,
+            "target_hypothesis_id": self.target_hypothesis_id,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class WatchAction:
+    condition_kind: str
+    condition: str
+    next_action: str
+
+    @classmethod
+    def from_value(cls, value: object) -> "WatchAction":
+        item = _exact_keys(
+            value, {"condition_kind", "condition", "next_action"}, "watch action"
+        )
+        allowed = {
+            "SOURCE_UPDATE",
+            "CORROBORATING_LEAD",
+            "OCCURRENCE",
+            "DEADLINE",
+            "EXPIRY",
+            "REVIEW",
+        }
+        condition_kind = _token(item["condition_kind"], "watch condition_kind")
+        if condition_kind not in allowed:
+            raise ProposalContractError("watch condition_kind is unsupported")
+        return cls(
+            condition_kind=condition_kind,
+            condition=_text(item["condition"], "watch condition"),
+            next_action=_token(item["next_action"], "watch next_action"),
+        )
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "condition_kind": self.condition_kind,
+            "condition": self.condition,
+            "next_action": self.next_action,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class SupplementalAction:
+    action_kind: str
+    scope: str
+    maximum_attempts: int
+    requires_approval: bool
+
+    @classmethod
+    def from_value(cls, value: object) -> "SupplementalAction":
+        item = _exact_keys(
+            value,
+            {"action_kind", "scope", "maximum_attempts", "requires_approval"},
+            "supplemental action",
+        )
+        if item["requires_approval"] is not True:
+            raise ProposalContractError(
+                "a supplemental proposal must retain the approval boundary"
+            )
+        return cls(
+            action_kind=_token(item["action_kind"], "supplemental action_kind"),
+            scope=_text(item["scope"], "supplemental scope"),
+            maximum_attempts=_uint(
+                item["maximum_attempts"],
+                "supplemental maximum_attempts",
+                minimum=1,
+                maximum=10,
+            ),
+            requires_approval=True,
+        )
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "action_kind": self.action_kind,
+            "scope": self.scope,
+            "maximum_attempts": self.maximum_attempts,
+            "requires_approval": self.requires_approval,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateManifest:
+    manifest_kind: CandidateManifestKind
+    contributing_lead_ids: tuple[str, ...]
+    proposed_geography: str
+    proposed_category: str
+    urgency: str
+    likely_new_information: str
+    reader_utility_basis: str
+    uncertainties: tuple[str, ...]
+    evidence_objectives: tuple[str, ...]
+    governing_versions: tuple[str, ...]
+
+    @classmethod
+    def from_value(cls, value: object) -> "CandidateManifest":
+        item = _exact_keys(
+            value,
+            {
+                "manifest_kind",
+                "contributing_lead_ids",
+                "proposed_geography",
+                "proposed_category",
+                "urgency",
+                "likely_new_information",
+                "reader_utility_basis",
+                "uncertainties",
+                "evidence_objectives",
+                "governing_versions",
+            },
+            "Candidate manifest",
+        )
+        kind = _enum(CandidateManifestKind, item["manifest_kind"], "manifest_kind")
+        assert isinstance(kind, CandidateManifestKind)
+        return cls(
+            manifest_kind=kind,
+            contributing_lead_ids=_uuid_list(
+                item["contributing_lead_ids"],
+                "contributing_lead_ids",
+                maximum_items=MAX_DECISION_LEADS + MAX_CONTEXT_LEADS,
+                allow_empty=False,
+            ),
+            proposed_geography=_token(item["proposed_geography"], "proposed_geography"),
+            proposed_category=_token(item["proposed_category"], "proposed_category"),
+            urgency=_token(item["urgency"], "urgency"),
+            likely_new_information=_text(
+                item["likely_new_information"], "Candidate likely_new_information"
+            ),
+            reader_utility_basis=_text(
+                item["reader_utility_basis"], "Candidate reader_utility_basis"
+            ),
+            uncertainties=_string_list(
+                item["uncertainties"], "Candidate uncertainties", allow_empty=False
+            ),
+            evidence_objectives=_string_list(
+                item["evidence_objectives"],
+                "Candidate evidence_objectives",
+                allow_empty=False,
+            ),
+            governing_versions=_string_list(
+                item["governing_versions"],
+                "Candidate governing_versions",
+                allow_empty=False,
+                tokens=True,
+            ),
+        )
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "manifest_kind": self.manifest_kind.value,
+            "contributing_lead_ids": list(self.contributing_lead_ids),
+            "proposed_geography": self.proposed_geography,
+            "proposed_category": self.proposed_category,
+            "urgency": self.urgency,
+            "likely_new_information": self.likely_new_information,
+            "reader_utility_basis": self.reader_utility_basis,
+            "uncertainties": list(self.uncertainties),
+            "evidence_objectives": list(self.evidence_objectives),
+            "governing_versions": list(self.governing_versions),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class LeadRecommendation:
+    decision_lead_id: str
+    route: ProposalRoute
+    confidence: FixedProbability
+    uncertainty: FixedProbability
+    input_citations: tuple[InputCitation, ...]
+    likely_new_information: str
+    materiality_basis: str
+    missing_context: tuple[str, ...]
+    retrieval_incompleteness: tuple[str, ...]
+    hypothesis: ProposedHypothesis | None
+    watch_action: WatchAction | None
+    supplemental_action: SupplementalAction | None
+    candidate_manifest: CandidateManifest | None
+
+    @classmethod
+    def from_value(cls, value: object) -> "LeadRecommendation":
+        item = _exact_keys(
+            value,
+            {
+                "decision_lead_id",
+                "route",
+                "confidence",
+                "uncertainty",
+                "input_citations",
+                "likely_new_information",
+                "materiality_basis",
+                "missing_context",
+                "retrieval_incompleteness",
+                "hypothesis",
+                "watch_action",
+                "supplemental_action",
+                "candidate_manifest",
+            },
+            "recommendation",
+        )
+        route = _enum(ProposalRoute, item["route"], "proposal route")
+        assert isinstance(route, ProposalRoute)
+        raw_citations = item["input_citations"]
+        if (
+            not isinstance(raw_citations, list)
+            or not 1 <= len(raw_citations) <= MAX_INPUT_CITATIONS
+        ):
+            raise ProposalContractError("input citations must be a non-empty bounded array")
+        citations = tuple(InputCitation.from_value(citation) for citation in raw_citations)
+        citation_ids = tuple(citation.citation_id for citation in citations)
+        if citation_ids != tuple(sorted(set(citation_ids))):
+            raise ProposalContractError("input citations must be sorted and unique")
+
+        hypothesis = (
+            None
+            if item["hypothesis"] is None
+            else ProposedHypothesis.from_value(item["hypothesis"])
+        )
+        watch = (
+            None
+            if item["watch_action"] is None
+            else WatchAction.from_value(item["watch_action"])
+        )
+        supplemental = (
+            None
+            if item["supplemental_action"] is None
+            else SupplementalAction.from_value(item["supplemental_action"])
+        )
+        candidate = (
+            None
+            if item["candidate_manifest"] is None
+            else CandidateManifest.from_value(item["candidate_manifest"])
+        )
+
+        if (route is ProposalRoute.WATCH_DEFER) != (watch is not None):
+            raise ProposalContractError("watch action must exist only for WATCH_DEFER")
+        if (route is ProposalRoute.SUPPLEMENTAL_DISCOVERY) != (supplemental is not None):
+            raise ProposalContractError(
+                "supplemental action must exist only for SUPPLEMENTAL_DISCOVERY"
+            )
+        candidate_kinds = {
+            ProposalRoute.NEW_EVENT_CANDIDATE: CandidateManifestKind.NEW_EVENT,
+            ProposalRoute.DEVELOPMENT_CANDIDATE: CandidateManifestKind.DEVELOPMENT,
+            ProposalRoute.CORRECTION_CANDIDATE: CandidateManifestKind.CORRECTION,
+        }
+        expected_kind = candidate_kinds.get(route)
+        if (expected_kind is None) != (candidate is None):
+            raise ProposalContractError(
+                "Candidate manifest must exist only for a Candidate route"
+            )
+        if candidate is not None and candidate.manifest_kind is not expected_kind:
+            raise ProposalContractError("Candidate manifest kind differs from route")
+
+        hypothesis_routes = {
+            ProposalRoute.ASSOCIATE_WITHOUT_CANDIDATE,
+            *candidate_kinds,
+        }
+        if (route in hypothesis_routes) != (hypothesis is not None):
+            raise ProposalContractError(
+                "hypothesis must exist exactly for association or Candidate routes"
+            )
+        required_relationships = {
+            ProposalRoute.NEW_EVENT_CANDIDATE: HypothesisRelationship.NO_ADEQUATE_PRIOR_MATCH,
+            ProposalRoute.DEVELOPMENT_CANDIDATE: HypothesisRelationship.DEVELOPMENT_OF,
+            ProposalRoute.CORRECTION_CANDIDATE: HypothesisRelationship.CORRECTION_REVERSAL_OF,
+        }
+        required_relationship = required_relationships.get(route)
+        if (
+            required_relationship is not None
+            and hypothesis is not None
+            and hypothesis.relationship_kind is not required_relationship
+        ):
+            raise ProposalContractError("hypothesis relationship differs from Candidate route")
+        if route is ProposalRoute.ASSOCIATE_WITHOUT_CANDIDATE and (
+            hypothesis is None
+            or hypothesis.target_hypothesis_id is None
+            or hypothesis.relationship_kind
+            not in {
+                HypothesisRelationship.SAME_STATE,
+                HypothesisRelationship.RELATED_DISTINCT,
+                HypothesisRelationship.UNCERTAIN,
+            }
+        ):
+            raise ProposalContractError(
+                "association must name an allowed prior Hypothesis relationship"
+            )
+
+        return cls(
+            decision_lead_id=_uuid(item["decision_lead_id"], "decision_lead_id"),
+            route=route,
+            confidence=FixedProbability.from_value(item["confidence"], "confidence"),
+            uncertainty=FixedProbability.from_value(item["uncertainty"], "uncertainty"),
+            input_citations=citations,
+            likely_new_information=_text(
+                item["likely_new_information"], "likely_new_information"
+            ),
+            materiality_basis=_text(item["materiality_basis"], "materiality_basis"),
+            missing_context=_string_list(item["missing_context"], "missing_context"),
+            retrieval_incompleteness=_string_list(
+                item["retrieval_incompleteness"], "retrieval_incompleteness"
+            ),
+            hypothesis=hypothesis,
+            watch_action=watch,
+            supplemental_action=supplemental,
+            candidate_manifest=candidate,
+        )
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "decision_lead_id": self.decision_lead_id,
+            "route": self.route.value,
+            "confidence": self.confidence.canonical_value(),
+            "uncertainty": self.uncertainty.canonical_value(),
+            "input_citations": [citation.canonical_value() for citation in self.input_citations],
+            "likely_new_information": self.likely_new_information,
+            "materiality_basis": self.materiality_basis,
+            "missing_context": list(self.missing_context),
+            "retrieval_incompleteness": list(self.retrieval_incompleteness),
+            "hypothesis": None if self.hypothesis is None else self.hypothesis.canonical_value(),
+            "watch_action": (
+                None
+                if self.watch_action is None
+                else self.watch_action.canonical_value()
+            ),
+            "supplemental_action": (
+                None
+                if self.supplemental_action is None
+                else self.supplemental_action.canonical_value()
+            ),
+            "candidate_manifest": (
+                None
+                if self.candidate_manifest is None
+                else self.candidate_manifest.canonical_value()
+            ),
+        }
+
+
+@dataclass(frozen=True, slots=True)
 class ProposalAuthority:
-    effect: str
-    creates_hypothesis: bool
-    creates_candidate: bool
-    mutates_editorial_state: bool
-    publication_authority: bool
-    evidence_authority: bool
-    operational_authority: bool
+    effect: str = "NONE"
+    creates_hypothesis: bool = False
+    creates_candidate: bool = False
+    mutates_editorial_state: bool = False
+    publication_authority: bool = False
+    evidence_authority: bool = False
+    operational_authority: bool = False
 
     @classmethod
     def from_value(cls, value: object) -> "ProposalAuthority":
@@ -355,15 +833,7 @@ class ProposalAuthority:
             raise ProposalContractError(
                 "a Triage Proposal grants no authority and has no editorial effect"
             )
-        return cls(
-            effect="NONE",
-            creates_hypothesis=False,
-            creates_candidate=False,
-            mutates_editorial_state=False,
-            publication_authority=False,
-            evidence_authority=False,
-            operational_authority=False,
-        )
+        return cls()
 
     def canonical_value(self) -> dict[str, object]:
         return {
@@ -380,12 +850,12 @@ class ProposalAuthority:
 @dataclass(frozen=True, slots=True)
 class TriageProposal:
     proposal_id: str
+    work_item: WorkItemBinding
     retrieval_context: RetrievalContextBinding
     worker_attempt: WorkerAttemptBinding
-    route: ProposalRoute
-    confidence: FixedProbability
-    uncertainty: FixedProbability
-    evidence_references: tuple[EvidenceReference, ...]
+    decision_lead_ids: tuple[str, ...]
+    context_lead_ids: tuple[str, ...]
+    recommendations: tuple[LeadRecommendation, ...]
     rationale: str
     authority: ProposalAuthority
     content_identity: str
@@ -405,12 +875,12 @@ class TriageProposal:
             root["proposal"],
             {
                 "proposal_id",
+                "work_item_binding",
                 "retrieval_context_binding",
                 "worker_attempt_binding",
-                "route",
-                "confidence",
-                "uncertainty",
-                "evidence_references",
+                "decision_lead_ids",
+                "context_lead_ids",
+                "recommendations",
                 "rationale",
                 "authority",
             },
@@ -419,53 +889,100 @@ class TriageProposal:
         if _content_identity(proposal) != content_identity:
             raise ProposalContractError("proposal content identity differs")
 
+        work_item = WorkItemBinding.from_value(proposal["work_item_binding"])
         retrieval_context = RetrievalContextBinding.from_value(
             proposal["retrieval_context_binding"]
         )
         worker_attempt = WorkerAttemptBinding.from_value(
             proposal["worker_attempt_binding"]
         )
-        if (
-            worker_attempt.retrieval_context_digest
-            != retrieval_context.context_digest
-        ):
-            raise ProposalContractError(
-                "worker attempt retrieval context digest differs"
-            )
-        try:
-            route = ProposalRoute(proposal["route"])
-        except (TypeError, ValueError) as exc:
-            raise ProposalContractError("proposal route is unsupported") from exc
+        if worker_attempt.work_item_version_digest != work_item.work_item_version_digest:
+            raise ProposalContractError("worker attempt work item digest differs")
+        if worker_attempt.retrieval_context_digest != retrieval_context.context_digest:
+            raise ProposalContractError("worker attempt retrieval context digest differs")
 
-        raw_references = proposal["evidence_references"]
-        if not isinstance(raw_references, list):
-            raise ProposalContractError("evidence references must be an array")
-        if not 1 <= len(raw_references) <= MAX_EVIDENCE_REFERENCES:
-            raise ProposalContractError("evidence references are empty or unbounded")
-        evidence_references = tuple(
-            EvidenceReference.from_value(item) for item in raw_references
+        decision_leads = _uuid_list(
+            proposal["decision_lead_ids"],
+            "decision_lead_ids",
+            maximum_items=MAX_DECISION_LEADS,
+            allow_empty=False,
         )
-        citation_ids = tuple(item.citation_id for item in evidence_references)
-        if citation_ids != tuple(sorted(set(citation_ids))):
+        context_leads = _uuid_list(
+            proposal["context_lead_ids"],
+            "context_lead_ids",
+            maximum_items=MAX_CONTEXT_LEADS,
+            allow_empty=True,
+        )
+        if set(decision_leads) & set(context_leads):
+            raise ProposalContractError("decision and context Lead manifests overlap")
+
+        raw_recommendations = proposal["recommendations"]
+        if (
+            not isinstance(raw_recommendations, list)
+            or not 1 <= len(raw_recommendations) <= MAX_DECISION_LEADS
+        ):
+            raise ProposalContractError("recommendations must be a non-empty bounded array")
+        recommendations = tuple(
+            LeadRecommendation.from_value(value) for value in raw_recommendations
+        )
+        recommendation_leads = tuple(item.decision_lead_id for item in recommendations)
+        if recommendation_leads != decision_leads:
             raise ProposalContractError(
-                "evidence references must be sorted and unique by citation_id"
+                "every decision Lead must be recommended exactly once in manifest order"
             )
+
+        admitted_leads = set(decision_leads) | set(context_leads)
+        for recommendation in recommendations:
+            for citation in recommendation.input_citations:
+                if (
+                    citation.source_kind is CitationSourceKind.DECISION_LEAD
+                    and citation.source_id not in decision_leads
+                ):
+                    raise ProposalContractError(
+                        "citation does not name the decision Lead manifest"
+                    )
+                if (
+                    citation.source_kind is CitationSourceKind.CONTEXT_LEAD
+                    and citation.source_id not in context_leads
+                ):
+                    raise ProposalContractError(
+                        "citation does not name the context Lead manifest"
+                    )
+            if not any(
+                citation.source_kind is CitationSourceKind.DECISION_LEAD
+                and citation.source_id == recommendation.decision_lead_id
+                for citation in recommendation.input_citations
+            ):
+                raise ProposalContractError(
+                    "recommendation must cite its exact decision Lead input"
+                )
+            manifest = recommendation.candidate_manifest
+            if manifest is not None:
+                if (
+                    manifest.likely_new_information
+                    != recommendation.likely_new_information
+                ):
+                    raise ProposalContractError(
+                        "Candidate manifest likely new information differs"
+                    )
+                if recommendation.decision_lead_id not in manifest.contributing_lead_ids:
+                    raise ProposalContractError(
+                        "Candidate manifest omits its decision Lead"
+                    )
+                if not set(manifest.contributing_lead_ids) <= admitted_leads:
+                    raise ProposalContractError(
+                        "Candidate manifest contains an unbound Lead"
+                    )
 
         result = cls(
             proposal_id=_uuid(proposal["proposal_id"], "proposal_id"),
+            work_item=work_item,
             retrieval_context=retrieval_context,
             worker_attempt=worker_attempt,
-            route=route,
-            confidence=FixedProbability.from_value(
-                proposal["confidence"], "confidence"
-            ),
-            uncertainty=FixedProbability.from_value(
-                proposal["uncertainty"], "uncertainty"
-            ),
-            evidence_references=evidence_references,
-            rationale=_text(
-                proposal["rationale"], "rationale", MAX_RATIONALE_BYTES
-            ),
+            decision_lead_ids=decision_leads,
+            context_lead_ids=context_leads,
+            recommendations=recommendations,
+            rationale=_text(proposal["rationale"], "rationale", MAX_RATIONALE_BYTES),
             authority=ProposalAuthority.from_value(proposal["authority"]),
             content_identity=content_identity,
         )
@@ -488,14 +1005,12 @@ class TriageProposal:
     def proposal_value(self) -> dict[str, object]:
         return {
             "proposal_id": self.proposal_id,
+            "work_item_binding": self.work_item.canonical_value(),
             "retrieval_context_binding": self.retrieval_context.canonical_value(),
             "worker_attempt_binding": self.worker_attempt.canonical_value(),
-            "route": self.route.value,
-            "confidence": self.confidence.canonical_value(),
-            "uncertainty": self.uncertainty.canonical_value(),
-            "evidence_references": [
-                item.canonical_value() for item in self.evidence_references
-            ],
+            "decision_lead_ids": list(self.decision_lead_ids),
+            "context_lead_ids": list(self.context_lead_ids),
+            "recommendations": [item.canonical_value() for item in self.recommendations],
             "rationale": self.rationale,
             "authority": self.authority.canonical_value(),
         }
@@ -513,18 +1028,26 @@ class TriageProposal:
 
 
 __all__ = [
-    "MAX_CITATION_SPAN_BYTES",
-    "MAX_EVIDENCE_REFERENCES",
-    "MAX_RATIONALE_BYTES",
-    "PROBABILITY_SCALE",
+    "PROPOSAL_CONTENT_IDENTITY",
+    "PROPOSAL_NO_AUTHORITY_BOUNDARY",
     "PROPOSAL_SCHEMA_VERSION",
-    "EvidenceReference",
+    "TRIAGE_PROPOSAL",
+    "CandidateManifest",
+    "CandidateManifestKind",
+    "CitationSourceKind",
     "FixedProbability",
     "FixtureWorkerKind",
+    "HypothesisRelationship",
+    "InputCitation",
+    "LeadRecommendation",
     "ProposalAuthority",
     "ProposalContractError",
     "ProposalRoute",
+    "ProposedHypothesis",
     "RetrievalContextBinding",
+    "SupplementalAction",
     "TriageProposal",
+    "WatchAction",
     "WorkerAttemptBinding",
+    "WorkItemBinding",
 ]

--- a/newsroom/tests/test_increment6c1_proposals.py
+++ b/newsroom/tests/test_increment6c1_proposals.py
@@ -37,6 +37,7 @@ def _citation(citation_id: str, source_kind: str, source_id: str) -> dict[str, o
         "byte_start": 0,
         "byte_end": 18,
         "quote_digest": DIGEST_D,
+        "target_hypothesis_id": None,
     }
 
 
@@ -62,6 +63,7 @@ def _recommendation(lead_id: str = LEAD_A) -> dict[str, object]:
         },
         "watch_action": None,
         "supplemental_action": None,
+        "operational_action": None,
         "candidate_manifest": {
             "manifest_kind": "NEW_EVENT",
             "contributing_lead_ids": [lead_id],
@@ -279,6 +281,15 @@ def test_only_normative_routes_are_admitted(route: str) -> None:
             "maximum_attempts": 1,
             "requires_approval": True,
         }
+    elif route == "OPERATIONAL_HOLD":
+        recommendation["operational_action"] = {
+            "action_kind": "RETRY_RETRIEVAL",
+            "owner_id": "owner:newsroom",
+            "dependency": "retrieval-service",
+            "retry_condition": "Retry after the retrieval service is healthy.",
+            "review_condition": None,
+            "expiry_condition": None,
+        }
     elif route == "ASSOCIATE_WITHOUT_CANDIDATE":
         recommendation["hypothesis"] = {
             "proposal_local_id": "hypothesis:001",
@@ -286,6 +297,13 @@ def test_only_normative_routes_are_admitted(route: str) -> None:
             "relationship_kind": "SAME_STATE",
             "target_hypothesis_id": "44444444-4444-4444-8444-444444444444",
         }
+        citations = recommendation["input_citations"]
+        assert isinstance(citations, list)
+        retrieval_citation = citations[1]
+        assert isinstance(retrieval_citation, dict)
+        retrieval_citation["target_hypothesis_id"] = (
+            "44444444-4444-4444-8444-444444444444"
+        )
     elif route.endswith("_CANDIDATE"):
         kind, relationship, target = {
             "NEW_EVENT_CANDIDATE": ("NEW_EVENT", "NO_ADEQUATE_PRIOR_MATCH", None),
@@ -306,6 +324,12 @@ def test_only_normative_routes_are_admitted(route: str) -> None:
             "relationship_kind": relationship,
             "target_hypothesis_id": target,
         }
+        if target is not None:
+            citations = recommendation["input_citations"]
+            assert isinstance(citations, list)
+            retrieval_citation = citations[1]
+            assert isinstance(retrieval_citation, dict)
+            retrieval_citation["target_hypothesis_id"] = target
         manifest = deepcopy(_recommendation()["candidate_manifest"])
         assert isinstance(manifest, dict)
         manifest["manifest_kind"] = kind
@@ -313,6 +337,132 @@ def test_only_normative_routes_are_admitted(route: str) -> None:
 
     parsed = TriageProposal.from_canonical_bytes(_resign(document))
     assert parsed.recommendations[0].route.value == route
+
+
+def test_operational_hold_requires_an_inspectable_action_boundary() -> None:
+    missing = _proposal_value()
+    recommendation = _recommendation_value(missing)
+    recommendation["route"] = "OPERATIONAL_HOLD"
+    recommendation["hypothesis"] = None
+    recommendation["candidate_manifest"] = None
+    with pytest.raises(ProposalContractError, match="operational action"):
+        TriageProposal.from_canonical_bytes(_resign(missing))
+
+    uninspectable = deepcopy(missing)
+    recommendation = _recommendation_value(uninspectable)
+    recommendation["operational_action"] = {
+        "action_kind": None,
+        "owner_id": None,
+        "dependency": None,
+        "retry_condition": None,
+        "review_condition": None,
+        "expiry_condition": None,
+    }
+    with pytest.raises(ProposalContractError, match="inspectable"):
+        TriageProposal.from_canonical_bytes(_resign(uninspectable))
+
+
+@pytest.mark.parametrize(
+    "route",
+    [
+        "ASSOCIATE_WITHOUT_CANDIDATE",
+        "DEVELOPMENT_CANDIDATE",
+        "CORRECTION_CANDIDATE",
+    ],
+)
+def test_relationship_target_requires_exact_retrieval_context_citation(
+    route: str,
+) -> None:
+    target = "44444444-4444-4444-8444-444444444444"
+    document = _proposal_value()
+    recommendation = _recommendation_value(document)
+    recommendation["route"] = route
+    recommendation["hypothesis"] = {
+        "proposal_local_id": "hypothesis:targeted",
+        "summary": "The Lead may relate to one exact retrieved Hypothesis.",
+        "relationship_kind": {
+            "ASSOCIATE_WITHOUT_CANDIDATE": "SAME_STATE",
+            "DEVELOPMENT_CANDIDATE": "DEVELOPMENT_OF",
+            "CORRECTION_CANDIDATE": "CORRECTION_REVERSAL_OF",
+        }[route],
+        "target_hypothesis_id": target,
+    }
+    if route == "ASSOCIATE_WITHOUT_CANDIDATE":
+        recommendation["candidate_manifest"] = None
+    else:
+        manifest = recommendation["candidate_manifest"]
+        assert isinstance(manifest, dict)
+        manifest["manifest_kind"] = {
+            "DEVELOPMENT_CANDIDATE": "DEVELOPMENT",
+            "CORRECTION_CANDIDATE": "CORRECTION",
+        }[route]
+
+    citations = recommendation["input_citations"]
+    assert isinstance(citations, list)
+    citations.pop(1)
+    with pytest.raises(ProposalContractError, match="Retrieval Context citation"):
+        TriageProposal.from_canonical_bytes(_resign(document))
+
+    mismatched = deepcopy(document)
+    citations = _recommendation_value(mismatched)["input_citations"]
+    assert isinstance(citations, list)
+    citations.append(_citation("citation:002", "RETRIEVAL_MATCH", "passage:001"))
+    citation = citations[1]
+    assert isinstance(citation, dict)
+    citation["target_hypothesis_id"] = (
+        "55555555-5555-4555-8555-555555555555"
+    )
+    with pytest.raises(ProposalContractError, match="Retrieval Context citation"):
+        TriageProposal.from_canonical_bytes(_resign(mismatched))
+
+
+def test_cross_lead_candidate_and_hypothesis_content_must_be_coherent() -> None:
+    rejected_contributor = _proposal_value()
+    proposal = _proposal(rejected_contributor)
+    proposal["decision_lead_ids"] = [LEAD_A, LEAD_C]
+    candidate = _recommendation(LEAD_A)
+    manifest = candidate["candidate_manifest"]
+    assert isinstance(manifest, dict)
+    manifest["contributing_lead_ids"] = [LEAD_A, LEAD_C]
+    rejected = _recommendation(LEAD_C)
+    rejected["route"] = "EDITORIAL_REJECT"
+    rejected["hypothesis"] = None
+    rejected["candidate_manifest"] = None
+    proposal["recommendations"] = [candidate, rejected]
+    with pytest.raises(ProposalContractError, match="Candidate contributor"):
+        TriageProposal.from_canonical_bytes(_resign(rejected_contributor))
+
+    conflicting_hypothesis = _proposal_value()
+    proposal = _proposal(conflicting_hypothesis)
+    proposal["decision_lead_ids"] = [LEAD_A, LEAD_C]
+    first = _recommendation(LEAD_A)
+    second = _recommendation(LEAD_C)
+    first_manifest = first["candidate_manifest"]
+    second_manifest = second["candidate_manifest"]
+    assert isinstance(first_manifest, dict)
+    assert isinstance(second_manifest, dict)
+    first_manifest["contributing_lead_ids"] = [LEAD_A, LEAD_C]
+    second_manifest["contributing_lead_ids"] = [LEAD_A, LEAD_C]
+    second_hypothesis = second["hypothesis"]
+    assert isinstance(second_hypothesis, dict)
+    second_hypothesis["summary"] = "A conflicting summary for the same local identity."
+    proposal["recommendations"] = [first, second]
+    with pytest.raises(ProposalContractError, match="proposal_local_id conflicts"):
+        TriageProposal.from_canonical_bytes(_resign(conflicting_hypothesis))
+
+    coherent = _proposal_value()
+    proposal = _proposal(coherent)
+    proposal["decision_lead_ids"] = [LEAD_A, LEAD_C]
+    first = _recommendation(LEAD_A)
+    second = _recommendation(LEAD_C)
+    for recommendation in (first, second):
+        manifest = recommendation["candidate_manifest"]
+        assert isinstance(manifest, dict)
+        manifest["contributing_lead_ids"] = [LEAD_A, LEAD_C]
+    proposal["recommendations"] = [first, second]
+
+    parsed = TriageProposal.from_canonical_bytes(_resign(coherent))
+    assert len(parsed.recommendations) == 2
 
 
 @pytest.mark.parametrize(

--- a/newsroom/tests/test_increment6c1_proposals.py
+++ b/newsroom/tests/test_increment6c1_proposals.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+
+import pytest
+
+from newsroom.authority.canonical import canonical_json_bytes, digest_bytes
+from newsroom.increment6.proposals import (
+    PROPOSAL_SCHEMA_VERSION,
+    ProposalContractError,
+    ProposalRoute,
+    TriageProposal,
+)
+
+
+DIGEST_A = "sha256:" + "a" * 64
+DIGEST_B = "sha256:" + "b" * 64
+DIGEST_C = "sha256:" + "c" * 64
+DIGEST_D = "sha256:" + "d" * 64
+
+
+def _proposal_value(*, worker_kind: str = "FAKE") -> dict[str, object]:
+    proposal: dict[str, object] = {
+        "proposal_id": "84d0ae8c-1378-4b76-8792-1bb805ab6a91",
+        "retrieval_context_binding": {
+            "context_id": "3d2f3791-c365-47f6-b543-65ecfd6b0eba",
+            "context_digest": DIGEST_A,
+            "contract_digest": DIGEST_B,
+        },
+        "worker_attempt_binding": {
+            "attempt_id": "attempt:fixture:0001",
+            "attempt_digest": DIGEST_C,
+            "worker_kind": worker_kind,
+            "worker_version": "fixture-worker-v1",
+            "input_digest": DIGEST_D,
+            "retrieval_context_digest": DIGEST_A,
+        },
+        "route": "CREATE_HYPOTHESIS",
+        "confidence": {"decimal": "0.750000", "millionths": 750_000},
+        "uncertainty": {"decimal": "0.125000", "millionths": 125_000},
+        "evidence_references": [
+            {
+                "citation_id": "citation:001",
+                "context_item_digest": DIGEST_B,
+                "passage_id": "passage:001",
+                "passage_text_digest": DIGEST_C,
+                "byte_start": 0,
+                "byte_end": 18,
+                "quote_digest": DIGEST_D,
+            }
+        ],
+        "rationale": "The replay evidence supports a bounded triage route.",
+        "authority": {
+            "effect": "NONE",
+            "creates_hypothesis": False,
+            "creates_candidate": False,
+            "mutates_editorial_state": False,
+            "publication_authority": False,
+            "evidence_authority": False,
+            "operational_authority": False,
+        },
+    }
+    identity_value = {
+        "schema_version": PROPOSAL_SCHEMA_VERSION,
+        "proposal": proposal,
+    }
+    return {
+        **identity_value,
+        "content_identity": digest_bytes(canonical_json_bytes(identity_value)),
+    }
+
+
+def _bytes(*, worker_kind: str = "FAKE") -> bytes:
+    return canonical_json_bytes(_proposal_value(worker_kind=worker_kind))
+
+
+def _resign(value: dict[str, object]) -> bytes:
+    proposal = value["proposal"]
+    identity_value = {
+        "schema_version": PROPOSAL_SCHEMA_VERSION,
+        "proposal": proposal,
+    }
+    value["content_identity"] = digest_bytes(canonical_json_bytes(identity_value))
+    return canonical_json_bytes(value)
+
+
+def test_fake_and_replay_proposals_round_trip_byte_identically() -> None:
+    fake_raw = _bytes()
+    fake = TriageProposal.from_canonical_bytes(fake_raw)
+
+    assert fake.canonical_bytes == fake_raw
+    assert fake.content_identity == _proposal_value()["content_identity"]
+    assert fake.route is ProposalRoute.CREATE_HYPOTHESIS
+    assert fake.confidence.millionths == 750_000
+    assert fake.confidence.decimal == "0.750000"
+    assert fake.uncertainty.millionths == 125_000
+    assert fake.grants_authority is False
+    assert fake.creates_hypothesis is False
+    assert fake.creates_candidate is False
+
+    replay_raw = _bytes(worker_kind="REPLAY")
+    replay = TriageProposal.from_canonical_bytes(replay_raw)
+    assert replay.canonical_bytes == replay_raw
+    assert replay.worker_attempt.worker_kind.value == "REPLAY"
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("confidence", {"decimal": "1.000001", "millionths": 1_000_001}),
+        ("confidence", {"decimal": "0.100000", "millionths": 100_001}),
+        ("confidence", {"decimal": "0.1", "millionths": 100_000}),
+        ("uncertainty", {"decimal": "-0.000001", "millionths": -1}),
+        ("uncertainty", {"decimal": "0.500000", "millionths": True}),
+    ],
+)
+def test_confidence_and_uncertainty_are_bounded_exact_fixed_point(
+    field: str, value: object
+) -> None:
+    document = _proposal_value()
+    proposal = document["proposal"]
+    assert isinstance(proposal, dict)
+    proposal[field] = value
+
+    with pytest.raises(ProposalContractError, match=field):
+        TriageProposal.from_canonical_bytes(_resign(document))
+
+
+def test_context_worker_attempt_and_citations_are_exactly_bound() -> None:
+    parsed = TriageProposal.from_canonical_bytes(_bytes())
+
+    assert parsed.worker_attempt.retrieval_context_digest == (
+        parsed.retrieval_context.context_digest
+    )
+    assert parsed.evidence_references[0].passage_id == "passage:001"
+    assert parsed.evidence_references[0].byte_range == (0, 18)
+
+    mismatched = _proposal_value()
+    proposal = mismatched["proposal"]
+    assert isinstance(proposal, dict)
+    worker = proposal["worker_attempt_binding"]
+    assert isinstance(worker, dict)
+    worker["retrieval_context_digest"] = DIGEST_D
+    with pytest.raises(ProposalContractError, match="retrieval context digest"):
+        TriageProposal.from_canonical_bytes(_resign(mismatched))
+
+
+def test_evidence_references_are_non_empty_sorted_unique_and_bounded() -> None:
+    duplicate = _proposal_value()
+    proposal = duplicate["proposal"]
+    assert isinstance(proposal, dict)
+    references = proposal["evidence_references"]
+    assert isinstance(references, list)
+    references.append(deepcopy(references[0]))
+    with pytest.raises(ProposalContractError, match="sorted and unique"):
+        TriageProposal.from_canonical_bytes(_resign(duplicate))
+
+    malformed_range = _proposal_value()
+    proposal = malformed_range["proposal"]
+    assert isinstance(proposal, dict)
+    reference = proposal["evidence_references"][0]  # type: ignore[index]
+    assert isinstance(reference, dict)
+    reference["byte_end"] = 0
+    with pytest.raises(ProposalContractError, match="byte range"):
+        TriageProposal.from_canonical_bytes(_resign(malformed_range))
+
+
+def test_unknown_duplicate_malformed_and_cross_version_output_fail_closed() -> None:
+    unknown = _proposal_value()
+    proposal = unknown["proposal"]
+    assert isinstance(proposal, dict)
+    proposal["surprise"] = True
+    with pytest.raises(ProposalContractError, match="proposal keys are not exact"):
+        TriageProposal.from_canonical_bytes(_resign(unknown))
+
+    malformed_digest = _proposal_value()
+    proposal = malformed_digest["proposal"]
+    assert isinstance(proposal, dict)
+    context = proposal["retrieval_context_binding"]
+    assert isinstance(context, dict)
+    context["context_digest"] = 7
+    with pytest.raises(ProposalContractError, match="context_digest"):
+        TriageProposal.from_canonical_bytes(_resign(malformed_digest))
+
+    raw = _bytes()
+    duplicate = raw.decode("utf-8").replace(
+        f'"schema_version":"{PROPOSAL_SCHEMA_VERSION}"',
+        f'"schema_version":"{PROPOSAL_SCHEMA_VERSION}",'
+        f'"schema_version":"{PROPOSAL_SCHEMA_VERSION}"',
+        1,
+    )
+    with pytest.raises(ProposalContractError, match="duplicate object name"):
+        TriageProposal.from_canonical_bytes(duplicate.encode("utf-8"))
+
+    pretty = json.dumps(_proposal_value(), indent=2).encode("utf-8")
+    with pytest.raises(ProposalContractError, match="canonical JSON"):
+        TriageProposal.from_canonical_bytes(pretty)
+
+    wrong_version = _proposal_value()
+    wrong_version["schema_version"] = "newsroom.increment6.triage-proposal.v2"
+    with pytest.raises(ProposalContractError, match="schema version"):
+        TriageProposal.from_canonical_bytes(canonical_json_bytes(wrong_version))
+
+
+def test_content_identity_detects_mutation_and_is_not_authority() -> None:
+    mutated = _proposal_value()
+    proposal = mutated["proposal"]
+    assert isinstance(proposal, dict)
+    proposal["rationale"] = "Changed after identity was assigned."
+    with pytest.raises(ProposalContractError, match="content identity differs"):
+        TriageProposal.from_canonical_bytes(canonical_json_bytes(mutated))
+
+    authority = _proposal_value()
+    proposal = authority["proposal"]
+    assert isinstance(proposal, dict)
+    effects = proposal["authority"]
+    assert isinstance(effects, dict)
+    effects["publication_authority"] = True
+    with pytest.raises(ProposalContractError, match="grants no authority"):
+        TriageProposal.from_canonical_bytes(_resign(authority))
+
+
+def test_real_or_provider_backed_worker_output_is_outside_the_contract() -> None:
+    for worker_kind in ("MODEL", "PROVIDER", "LIVE"):
+        with pytest.raises(ProposalContractError, match="worker_kind"):
+            TriageProposal.from_canonical_bytes(_bytes(worker_kind=worker_kind))

--- a/newsroom/tests/test_increment6c1_proposals.py
+++ b/newsroom/tests/test_increment6c1_proposals.py
@@ -6,8 +6,12 @@ from copy import deepcopy
 import pytest
 
 from newsroom.authority.canonical import canonical_json_bytes, digest_bytes
+from newsroom.increment5.retrieval_context import RETRIEVAL_CONTEXT_CONTRACT_DIGEST
 from newsroom.increment6.proposals import (
+    PROPOSAL_CONTENT_IDENTITY,
+    PROPOSAL_NO_AUTHORITY_BOUNDARY,
     PROPOSAL_SCHEMA_VERSION,
+    TRIAGE_PROPOSAL,
     ProposalContractError,
     ProposalRoute,
     TriageProposal,
@@ -18,39 +22,87 @@ DIGEST_A = "sha256:" + "a" * 64
 DIGEST_B = "sha256:" + "b" * 64
 DIGEST_C = "sha256:" + "c" * 64
 DIGEST_D = "sha256:" + "d" * 64
+LEAD_A = "11111111-1111-4111-8111-111111111111"
+LEAD_B = "22222222-2222-4222-8222-222222222222"
+LEAD_C = "33333333-3333-4333-8333-333333333333"
+
+
+def _citation(citation_id: str, source_kind: str, source_id: str) -> dict[str, object]:
+    return {
+        "citation_id": citation_id,
+        "source_kind": source_kind,
+        "source_id": source_id,
+        "source_digest": DIGEST_B,
+        "field_path": "lead.summary",
+        "byte_start": 0,
+        "byte_end": 18,
+        "quote_digest": DIGEST_D,
+    }
+
+
+def _recommendation(lead_id: str = LEAD_A) -> dict[str, object]:
+    return {
+        "decision_lead_id": lead_id,
+        "route": "NEW_EVENT_CANDIDATE",
+        "confidence": {"decimal": "0.750000", "millionths": 750_000},
+        "uncertainty": {"decimal": "0.125000", "millionths": 125_000},
+        "input_citations": [
+            _citation("citation:001", "DECISION_LEAD", lead_id),
+            _citation("citation:002", "RETRIEVAL_MATCH", "passage:001"),
+        ],
+        "likely_new_information": "A material new state may have occurred.",
+        "materiality_basis": "The possible change may affect readers.",
+        "missing_context": ["Confirmation from the primary organisation"],
+        "retrieval_incompleteness": ["One prior event was unavailable"],
+        "hypothesis": {
+            "proposal_local_id": "hypothesis:001",
+            "summary": "The lead may describe a distinct new event.",
+            "relationship_kind": "NO_ADEQUATE_PRIOR_MATCH",
+            "target_hypothesis_id": None,
+        },
+        "watch_action": None,
+        "supplemental_action": None,
+        "candidate_manifest": {
+            "manifest_kind": "NEW_EVENT",
+            "contributing_lead_ids": [lead_id],
+            "proposed_geography": "GB",
+            "proposed_category": "UK_NEWS",
+            "urgency": "ROUTINE",
+            "likely_new_information": "A material new state may have occurred.",
+            "reader_utility_basis": "Readers may need the changed state explained.",
+            "uncertainties": ["The event remains unverified"],
+            "evidence_objectives": ["Confirm the changed state independently"],
+            "governing_versions": ["candidate-policy-v1", "rights-policy-v1"],
+        },
+    }
 
 
 def _proposal_value(*, worker_kind: str = "FAKE") -> dict[str, object]:
     proposal: dict[str, object] = {
         "proposal_id": "84d0ae8c-1378-4b76-8792-1bb805ab6a91",
+        "work_item_binding": {
+            "work_item_id": "4d3b1b83-205e-4f77-a46b-ffbf5509d254",
+            "work_item_version_id": "c37c30fd-cfab-4a57-ab69-a72515ebaa31",
+            "work_item_version_digest": DIGEST_D,
+        },
         "retrieval_context_binding": {
             "context_id": "3d2f3791-c365-47f6-b543-65ecfd6b0eba",
             "context_digest": DIGEST_A,
-            "contract_digest": DIGEST_B,
+            "contract_digest": RETRIEVAL_CONTEXT_CONTRACT_DIGEST,
         },
         "worker_attempt_binding": {
             "attempt_id": "attempt:fixture:0001",
             "attempt_digest": DIGEST_C,
             "worker_kind": worker_kind,
             "worker_version": "fixture-worker-v1",
-            "input_digest": DIGEST_D,
+            "input_digest": DIGEST_B,
+            "work_item_version_digest": DIGEST_D,
             "retrieval_context_digest": DIGEST_A,
         },
-        "route": "CREATE_HYPOTHESIS",
-        "confidence": {"decimal": "0.750000", "millionths": 750_000},
-        "uncertainty": {"decimal": "0.125000", "millionths": 125_000},
-        "evidence_references": [
-            {
-                "citation_id": "citation:001",
-                "context_item_digest": DIGEST_B,
-                "passage_id": "passage:001",
-                "passage_text_digest": DIGEST_C,
-                "byte_start": 0,
-                "byte_end": 18,
-                "quote_digest": DIGEST_D,
-            }
-        ],
-        "rationale": "The replay evidence supports a bounded triage route.",
+        "decision_lead_ids": [LEAD_A],
+        "context_lead_ids": [LEAD_B],
+        "recommendations": [_recommendation()],
+        "rationale": "The replay inputs support a bounded triage recommendation.",
         "authority": {
             "effect": "NONE",
             "creates_hypothesis": False,
@@ -76,33 +128,237 @@ def _bytes(*, worker_kind: str = "FAKE") -> bytes:
 
 
 def _resign(value: dict[str, object]) -> bytes:
-    proposal = value["proposal"]
     identity_value = {
         "schema_version": PROPOSAL_SCHEMA_VERSION,
-        "proposal": proposal,
+        "proposal": value["proposal"],
     }
     value["content_identity"] = digest_bytes(canonical_json_bytes(identity_value))
     return canonical_json_bytes(value)
 
 
+def _proposal(document: dict[str, object]) -> dict[str, object]:
+    proposal = document["proposal"]
+    assert isinstance(proposal, dict)
+    return proposal
+
+
+def _recommendation_value(document: dict[str, object]) -> dict[str, object]:
+    recommendations = _proposal(document)["recommendations"]
+    assert isinstance(recommendations, list)
+    recommendation = recommendations[0]
+    assert isinstance(recommendation, dict)
+    return recommendation
+
+
+def test_public_contract_names_match_the_accepted_6r_allocation() -> None:
+    assert TRIAGE_PROPOSAL == PROPOSAL_SCHEMA_VERSION
+    assert PROPOSAL_CONTENT_IDENTITY == "SHA256_CANONICAL_SCHEMA_AND_PROPOSAL"
+    assert PROPOSAL_NO_AUTHORITY_BOUNDARY == (
+        "NO_HYPOTHESIS_OR_CANDIDATE_MUTATION;"
+        "NO_PUBLICATION_EVIDENCE_OR_OPERATIONAL_AUTHORITY"
+    )
+
+
 def test_fake_and_replay_proposals_round_trip_byte_identically() -> None:
-    fake_raw = _bytes()
-    fake = TriageProposal.from_canonical_bytes(fake_raw)
+    for worker_kind in ("FAKE", "REPLAY"):
+        raw = _bytes(worker_kind=worker_kind)
+        parsed = TriageProposal.from_canonical_bytes(raw)
 
-    assert fake.canonical_bytes == fake_raw
-    assert fake.content_identity == _proposal_value()["content_identity"]
-    assert fake.route is ProposalRoute.CREATE_HYPOTHESIS
-    assert fake.confidence.millionths == 750_000
-    assert fake.confidence.decimal == "0.750000"
-    assert fake.uncertainty.millionths == 125_000
-    assert fake.grants_authority is False
-    assert fake.creates_hypothesis is False
-    assert fake.creates_candidate is False
+        assert parsed.canonical_bytes == raw
+        assert parsed.content_identity == _proposal_value(
+            worker_kind=worker_kind
+        )["content_identity"]
+        assert parsed.worker_attempt.worker_kind.value == worker_kind
+        assert parsed.recommendations[0].route is ProposalRoute.NEW_EVENT_CANDIDATE
+        assert parsed.recommendations[0].confidence.millionths == 750_000
+        assert parsed.grants_authority is False
+        assert parsed.creates_hypothesis is False
+        assert parsed.creates_candidate is False
 
-    replay_raw = _bytes(worker_kind="REPLAY")
-    replay = TriageProposal.from_canonical_bytes(replay_raw)
-    assert replay.canonical_bytes == replay_raw
-    assert replay.worker_attempt.worker_kind.value == "REPLAY"
+
+def test_exact_work_item_context_attempt_and_input_citation_binding() -> None:
+    parsed = TriageProposal.from_canonical_bytes(_bytes())
+
+    assert parsed.worker_attempt.work_item_version_digest == (
+        parsed.work_item.work_item_version_digest
+    )
+    assert parsed.worker_attempt.retrieval_context_digest == (
+        parsed.retrieval_context.context_digest
+    )
+    assert parsed.recommendations[0].input_citations[0].source_id == LEAD_A
+
+    for worker_field, binding_field, message in (
+        ("work_item_version_digest", "work_item_version_digest", "work item"),
+        ("retrieval_context_digest", "context_digest", "retrieval context"),
+    ):
+        mismatched = _proposal_value()
+        proposal = _proposal(mismatched)
+        worker = proposal["worker_attempt_binding"]
+        assert isinstance(worker, dict)
+        worker[worker_field] = DIGEST_C
+        binding_name = (
+            "work_item_binding"
+            if binding_field == "work_item_version_digest"
+            else "retrieval_context_binding"
+        )
+        binding = proposal[binding_name]
+        assert isinstance(binding, dict)
+        binding[binding_field] = DIGEST_D
+        with pytest.raises(ProposalContractError, match=message):
+            TriageProposal.from_canonical_bytes(_resign(mismatched))
+
+
+def test_every_decision_lead_is_recommended_once_and_context_leads_are_isolated() -> None:
+    duplicate = _proposal_value()
+    proposal = _proposal(duplicate)
+    proposal["recommendations"] = [
+        _recommendation(LEAD_A),
+        _recommendation(LEAD_A),
+    ]
+    with pytest.raises(ProposalContractError, match="exactly once"):
+        TriageProposal.from_canonical_bytes(_resign(duplicate))
+
+    omitted = _proposal_value()
+    proposal = _proposal(omitted)
+    proposal["decision_lead_ids"] = [LEAD_A, LEAD_C]
+    with pytest.raises(ProposalContractError, match="exactly once"):
+        TriageProposal.from_canonical_bytes(_resign(omitted))
+
+    context_routed = _proposal_value()
+    _recommendation_value(context_routed)["decision_lead_id"] = LEAD_B
+    with pytest.raises(ProposalContractError, match="exactly once"):
+        TriageProposal.from_canonical_bytes(_resign(context_routed))
+
+    bad_citation = _proposal_value()
+    citations = _recommendation_value(bad_citation)["input_citations"]
+    assert isinstance(citations, list)
+    citation = citations[0]
+    assert isinstance(citation, dict)
+    citation["source_kind"] = "CONTEXT_LEAD"
+    with pytest.raises(ProposalContractError, match="context Lead manifest"):
+        TriageProposal.from_canonical_bytes(_resign(bad_citation))
+
+    missing_own_citation = _proposal_value()
+    citations = _recommendation_value(missing_own_citation)["input_citations"]
+    assert isinstance(citations, list)
+    citations.pop(0)
+    with pytest.raises(ProposalContractError, match="exact decision Lead input"):
+        TriageProposal.from_canonical_bytes(_resign(missing_own_citation))
+
+
+@pytest.mark.parametrize(
+    "route",
+    [
+        "EDITORIAL_REJECT",
+        "WATCH_DEFER",
+        "ASSOCIATE_WITHOUT_CANDIDATE",
+        "SUPPLEMENTAL_DISCOVERY",
+        "OPERATIONAL_HOLD",
+        "NEW_EVENT_CANDIDATE",
+        "DEVELOPMENT_CANDIDATE",
+        "CORRECTION_CANDIDATE",
+    ],
+)
+def test_only_normative_routes_are_admitted(route: str) -> None:
+    document = _proposal_value()
+    recommendation = _recommendation_value(document)
+    recommendation["route"] = route
+    recommendation["hypothesis"] = None
+    recommendation["candidate_manifest"] = None
+
+    if route == "WATCH_DEFER":
+        recommendation["watch_action"] = {
+            "condition_kind": "SOURCE_UPDATE",
+            "condition": "Resume when the named source publishes an update.",
+            "next_action": "REENTER_DISCOVERY",
+        }
+    elif route == "SUPPLEMENTAL_DISCOVERY":
+        recommendation["supplemental_action"] = {
+            "action_kind": "CHECK_NAMED_SOURCE",
+            "scope": "The primary organisation newsroom",
+            "maximum_attempts": 1,
+            "requires_approval": True,
+        }
+    elif route == "ASSOCIATE_WITHOUT_CANDIDATE":
+        recommendation["hypothesis"] = {
+            "proposal_local_id": "hypothesis:001",
+            "summary": "The lead may concern the prior state.",
+            "relationship_kind": "SAME_STATE",
+            "target_hypothesis_id": "44444444-4444-4444-8444-444444444444",
+        }
+    elif route.endswith("_CANDIDATE"):
+        kind, relationship, target = {
+            "NEW_EVENT_CANDIDATE": ("NEW_EVENT", "NO_ADEQUATE_PRIOR_MATCH", None),
+            "DEVELOPMENT_CANDIDATE": (
+                "DEVELOPMENT",
+                "DEVELOPMENT_OF",
+                "44444444-4444-4444-8444-444444444444",
+            ),
+            "CORRECTION_CANDIDATE": (
+                "CORRECTION",
+                "CORRECTION_REVERSAL_OF",
+                "44444444-4444-4444-8444-444444444444",
+            ),
+        }[route]
+        recommendation["hypothesis"] = {
+            "proposal_local_id": "hypothesis:001",
+            "summary": "The lead may represent the proposed relationship.",
+            "relationship_kind": relationship,
+            "target_hypothesis_id": target,
+        }
+        manifest = deepcopy(_recommendation()["candidate_manifest"])
+        assert isinstance(manifest, dict)
+        manifest["manifest_kind"] = kind
+        recommendation["candidate_manifest"] = manifest
+
+    parsed = TriageProposal.from_canonical_bytes(_resign(document))
+    assert parsed.recommendations[0].route.value == route
+
+
+@pytest.mark.parametrize(
+    ("route", "field", "value", "message"),
+    [
+        ("WATCH_DEFER", "watch_action", None, "watch action"),
+        (
+            "EDITORIAL_REJECT",
+            "watch_action",
+            {
+                "condition_kind": "REVIEW",
+                "condition": "Review later.",
+                "next_action": "REVIEW",
+            },
+            "watch action",
+        ),
+        ("SUPPLEMENTAL_DISCOVERY", "supplemental_action", None, "supplemental"),
+        (
+            "EDITORIAL_REJECT",
+            "supplemental_action",
+            {
+                "action_kind": "CHECK_SOURCE",
+                "scope": "source",
+                "maximum_attempts": 1,
+                "requires_approval": True,
+            },
+            "supplemental",
+        ),
+        ("NEW_EVENT_CANDIDATE", "candidate_manifest", None, "Candidate manifest"),
+    ],
+)
+def test_route_specific_seams_fail_closed(
+    route: str, field: str, value: object, message: str
+) -> None:
+    document = _proposal_value()
+    recommendation = _recommendation_value(document)
+    recommendation["route"] = route
+    recommendation[field] = value
+    if route == "WATCH_DEFER":
+        recommendation["candidate_manifest"] = None
+        recommendation["hypothesis"] = None
+    if route == "SUPPLEMENTAL_DISCOVERY":
+        recommendation["candidate_manifest"] = None
+        recommendation["hypothesis"] = None
+    with pytest.raises(ProposalContractError, match=message):
+        TriageProposal.from_canonical_bytes(_resign(document))
 
 
 @pytest.mark.parametrize(
@@ -119,69 +375,23 @@ def test_confidence_and_uncertainty_are_bounded_exact_fixed_point(
     field: str, value: object
 ) -> None:
     document = _proposal_value()
-    proposal = document["proposal"]
-    assert isinstance(proposal, dict)
-    proposal[field] = value
-
+    _recommendation_value(document)[field] = value
     with pytest.raises(ProposalContractError, match=field):
         TriageProposal.from_canonical_bytes(_resign(document))
 
 
-def test_context_worker_attempt_and_citations_are_exactly_bound() -> None:
-    parsed = TriageProposal.from_canonical_bytes(_bytes())
-
-    assert parsed.worker_attempt.retrieval_context_digest == (
-        parsed.retrieval_context.context_digest
-    )
-    assert parsed.evidence_references[0].passage_id == "passage:001"
-    assert parsed.evidence_references[0].byte_range == (0, 18)
-
-    mismatched = _proposal_value()
-    proposal = mismatched["proposal"]
-    assert isinstance(proposal, dict)
-    worker = proposal["worker_attempt_binding"]
-    assert isinstance(worker, dict)
-    worker["retrieval_context_digest"] = DIGEST_D
-    with pytest.raises(ProposalContractError, match="retrieval context digest"):
-        TriageProposal.from_canonical_bytes(_resign(mismatched))
-
-
-def test_evidence_references_are_non_empty_sorted_unique_and_bounded() -> None:
-    duplicate = _proposal_value()
-    proposal = duplicate["proposal"]
-    assert isinstance(proposal, dict)
-    references = proposal["evidence_references"]
-    assert isinstance(references, list)
-    references.append(deepcopy(references[0]))
-    with pytest.raises(ProposalContractError, match="sorted and unique"):
-        TriageProposal.from_canonical_bytes(_resign(duplicate))
-
-    malformed_range = _proposal_value()
-    proposal = malformed_range["proposal"]
-    assert isinstance(proposal, dict)
-    reference = proposal["evidence_references"][0]  # type: ignore[index]
-    assert isinstance(reference, dict)
-    reference["byte_end"] = 0
-    with pytest.raises(ProposalContractError, match="byte range"):
-        TriageProposal.from_canonical_bytes(_resign(malformed_range))
-
-
 def test_unknown_duplicate_malformed_and_cross_version_output_fail_closed() -> None:
     unknown = _proposal_value()
-    proposal = unknown["proposal"]
-    assert isinstance(proposal, dict)
-    proposal["surprise"] = True
-    with pytest.raises(ProposalContractError, match="proposal keys are not exact"):
+    _recommendation_value(unknown)["surprise"] = True
+    with pytest.raises(ProposalContractError, match="recommendation keys are not exact"):
         TriageProposal.from_canonical_bytes(_resign(unknown))
 
-    malformed_digest = _proposal_value()
-    proposal = malformed_digest["proposal"]
-    assert isinstance(proposal, dict)
-    context = proposal["retrieval_context_binding"]
+    malformed = _proposal_value()
+    context = _proposal(malformed)["retrieval_context_binding"]
     assert isinstance(context, dict)
     context["context_digest"] = 7
     with pytest.raises(ProposalContractError, match="context_digest"):
-        TriageProposal.from_canonical_bytes(_resign(malformed_digest))
+        TriageProposal.from_canonical_bytes(_resign(malformed))
 
     raw = _bytes()
     duplicate = raw.decode("utf-8").replace(
@@ -193,9 +403,8 @@ def test_unknown_duplicate_malformed_and_cross_version_output_fail_closed() -> N
     with pytest.raises(ProposalContractError, match="duplicate object name"):
         TriageProposal.from_canonical_bytes(duplicate.encode("utf-8"))
 
-    pretty = json.dumps(_proposal_value(), indent=2).encode("utf-8")
     with pytest.raises(ProposalContractError, match="canonical JSON"):
-        TriageProposal.from_canonical_bytes(pretty)
+        TriageProposal.from_canonical_bytes(json.dumps(_proposal_value(), indent=2).encode())
 
     wrong_version = _proposal_value()
     wrong_version["schema_version"] = "newsroom.increment6.triage-proposal.v2"
@@ -203,22 +412,25 @@ def test_unknown_duplicate_malformed_and_cross_version_output_fail_closed() -> N
         TriageProposal.from_canonical_bytes(canonical_json_bytes(wrong_version))
 
 
-def test_content_identity_detects_mutation_and_is_not_authority() -> None:
+def test_content_identity_and_no_authority_boundary_fail_closed() -> None:
     mutated = _proposal_value()
-    proposal = mutated["proposal"]
-    assert isinstance(proposal, dict)
-    proposal["rationale"] = "Changed after identity was assigned."
+    _proposal(mutated)["rationale"] = "Changed after identity was assigned."
     with pytest.raises(ProposalContractError, match="content identity differs"):
         TriageProposal.from_canonical_bytes(canonical_json_bytes(mutated))
 
-    authority = _proposal_value()
-    proposal = authority["proposal"]
-    assert isinstance(proposal, dict)
-    effects = proposal["authority"]
-    assert isinstance(effects, dict)
-    effects["publication_authority"] = True
-    with pytest.raises(ProposalContractError, match="grants no authority"):
-        TriageProposal.from_canonical_bytes(_resign(authority))
+    for field in (
+        "creates_hypothesis",
+        "creates_candidate",
+        "publication_authority",
+        "evidence_authority",
+        "operational_authority",
+    ):
+        authority = _proposal_value()
+        effects = _proposal(authority)["authority"]
+        assert isinstance(effects, dict)
+        effects[field] = True
+        with pytest.raises(ProposalContractError, match="grants no authority"):
+            TriageProposal.from_canonical_bytes(_resign(authority))
 
 
 def test_real_or_provider_backed_worker_output_is_outside_the_contract() -> None:


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-6c1
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

## Accepted allocation

- Issue: #356 / Increment 6C1
- Accepted 6R contract digest: `sha256:13b43c927e4222c143b8691eaf179eb956096c19a72f4cc29cae13008d6e0590`
- Accepted 6R merge: `main@a44a073e3d798521a373115aa2c54f104b58a4cd`
- Implementation head: `6c77e1c26929cf96624668831e37a90b9fdcd945`
- Effective wave: 1
- Dependency: #354
- Gate: Tier L
- Sole public module: `newsroom.increment6.proposals`
- Schema identity: `newsroom.increment6.triage-proposal.v1`
- Sole interface ownership: `TRIAGE_PROPOSAL`, `PROPOSAL_CONTENT_IDENTITY`, `PROPOSAL_NO_AUTHORITY_BOUNDARY`
- Migration allocation: none

## Summary

- completes the strict, canonical `newsroom.increment6.triage-proposal.v1` contract for fake/replay fixture workers only
- binds each Proposal to one exact Work Item version, accepted Retrieval Context contract/digest and worker attempt
- represents per-decision-Lead confidence and uncertainty as exact bounded fixed-point decimal/integer pairs
- isolates context-only Leads, requires every decision Lead exactly once and retains bounded exact input-field/match/contradiction citations
- admits only the normative editorial, Watch/defer, association, supplemental-discovery, operational-hold and Candidate routes
- requires route-specific Watch, bounded approval-retaining supplemental-action and minimum Candidate-manifest seams
- retains proposed Hypothesis relationships as untrusted proposal data only
- computes version-scoped canonical content identity and replays accepted canonical bytes byte-for-byte
- rejects duplicate names, unknown fields, malformed/cross-version values, mismatched bindings, unsupported workers and authority-bearing output
- closes the independent P2 review findings: operational holds now require an inspectable action/owner/dependency/retry/review/expiry boundary; association/development/correction targets require matching Retrieval Context citations; and multi-Lead Candidate/Hypothesis content must remain coherent

## Scope and no-authority boundary

This PR changes only:

- `newsroom/increment6/proposals.py`
- `newsroom/tests/test_increment6c1_proposals.py`

It adds no migration, provider/model integration, persistence or external effect. Parsing or retaining a Proposal creates or mutates no Hypothesis or Candidate and grants no publication, evidence or operational authority.

## Verification

- `uv run pytest -q newsroom/tests/test_increment6r_readiness.py newsroom/tests/test_increment6c1_proposals.py newsroom/tests/test_increment5d2_retrieval_context.py` — **59 passed**
- `uv run pytest -q` — **2528 passed, 41 skipped, 20 environment-specific failures**
  - 16 existing macOS trusted-system-Python qualification failures (`/usr/bin/python3` is rejected by that lane)
  - 3 existing Linux-only no-replace transport failures on macOS
  - 1 existing watchdog timing/environment failure (`ENVIRONMENT_ERROR`)
- `python3 -m compileall -q newsroom/increment6/proposals.py newsroom/tests/test_increment6c1_proposals.py` — passed
- source-integrity boundary: exact two allocated files changed; no migration path changed — passed
- `git diff --check` — passed
- GitHub CI on implementation head `6c77e1c26929cf96624668831e37a90b9fdcd945` — all applicable checks passed (two deterministic `test` runs, `core`, `decision`, two authenticated Neo4j service runs, focused authority, governed-object, projection, route, validation and GitGuardian); inapplicable inventory/service/signed-closeout lanes skipped by design

## Review state

Draft remains open for feature-complete Tier-L review and CI. Do not merge or close #356 from this update.

