### PR TITLE
Increment 6E1: enforce current collision eligibility

### DIFF
--- a/newsroom/increment6/collision.py
+++ b/newsroom/increment6/collision.py
@@ -1,0 +1,971 @@
+"""Current authoritative collision eligibility and pre-effect enforcement.
+
+The seam consumes the exact retained Increment 5 authority evidence.  It owns
+no Candidate, migration, authority read or side effect: a downstream Candidate
+operation receives a permit only after the evidence has been revalidated and
+bound to one exact subject, request, generation, time and watermark.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import TypeVar
+
+from newsroom.authority.canonical import (
+    CanonicalizationError,
+    canonical_json_bytes,
+    digest_bytes,
+)
+from newsroom.increment5.named_tool_authority_execution import (
+    NamedAuthorityExecutionOutcome,
+    NamedAuthorityExecutionReceipt,
+    NamedToolAuthorityExecutionError,
+)
+from newsroom.increment5.named_tool_authority_receipt_validation import (
+    NamedAuthorityReceiptValidationError,
+    validate_named_authority_receipt,
+)
+from newsroom.increment5.named_tool_contracts import (
+    CollisionHydrationLookupToolRequest,
+    NamedToolId,
+)
+
+
+COLLISION_ELIGIBILITY_SCHEMA_VERSION = (
+    "newsroom.increment6.candidate-collision-eligibility.v1"
+)
+
+_TOKEN_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:\-]{0,255}\Z")
+_DIGEST_RE = re.compile(r"sha256:[0-9a-f]{64}\Z")
+_IDEMPOTENCY_PREFIX = "candidate-use:"
+
+
+class CollisionEligibilityContractError(ValueError):
+    """A collision binding, evidence record or decision is malformed."""
+
+
+class CandidateUseOperation(StrEnum):
+    ADMIT_NEW_CANDIDATE = "ADMIT_NEW_CANDIDATE"
+    USE_CURRENT_CANDIDATE = "USE_CURRENT_CANDIDATE"
+
+
+class CollisionState(StrEnum):
+    UNKNOWN = "UNKNOWN"
+    OCCUPIED = "OCCUPIED"
+    UNOCCUPIED = "UNOCCUPIED"
+
+
+class CollisionEligibilityOutcome(StrEnum):
+    ELIGIBLE = "ELIGIBLE"
+    COLLISION_CONFLICT = "COLLISION_CONFLICT"
+    STALE = "STALE"
+    INCOMPLETE = "INCOMPLETE"
+    UNAVAILABLE = "UNAVAILABLE"
+    POLICY_BLOCKED = "POLICY_BLOCKED"
+    INTEGRITY_BLOCKED = "INTEGRITY_BLOCKED"
+    BINDING_MISMATCH = "BINDING_MISMATCH"
+
+
+class CollisionEligibilityReason(StrEnum):
+    CURRENT_CANDIDATE_MATCH = "CURRENT_CANDIDATE_MATCH"
+    CURRENT_SLOT_UNOCCUPIED = "CURRENT_SLOT_UNOCCUPIED"
+    SLOT_ALREADY_OCCUPIED = "SLOT_ALREADY_OCCUPIED"
+    EXPECTED_CANDIDATE_ABSENT = "EXPECTED_CANDIDATE_ABSENT"
+    CURRENT_CANDIDATE_DIFFERS = "CURRENT_CANDIDATE_DIFFERS"
+    AUTHORITY_STALE = "AUTHORITY_STALE"
+    AUTHORITY_INCOMPLETE = "AUTHORITY_INCOMPLETE"
+    AUTHORITY_UNAVAILABLE = "AUTHORITY_UNAVAILABLE"
+    AUTHORITY_POLICY_BLOCKED = "AUTHORITY_POLICY_BLOCKED"
+    EXECUTION_RECEIPT_INVALID = "EXECUTION_RECEIPT_INVALID"
+    AUTHORITY_RECEIPT_INVALID = "AUTHORITY_RECEIPT_INVALID"
+    AUTHORITY_RECEIPT_MISSING = "AUTHORITY_RECEIPT_MISSING"
+    NAMED_REQUEST_BINDING_DIFFERS = "NAMED_REQUEST_BINDING_DIFFERS"
+    GENERATION_BINDING_DIFFERS = "GENERATION_BINDING_DIFFERS"
+    TIME_BINDING_DIFFERS = "TIME_BINDING_DIFFERS"
+    WATERMARK_BINDING_DIFFERS = "WATERMARK_BINDING_DIFFERS"
+
+
+def _require_token(value: object, *, field: str) -> str:
+    if not isinstance(value, str) or _TOKEN_RE.fullmatch(value) is None:
+        raise CollisionEligibilityContractError(
+            f"{field} must be a bounded canonical token"
+        )
+    return value
+
+
+def _require_digest(value: object, *, field: str) -> str:
+    if not isinstance(value, str) or _DIGEST_RE.fullmatch(value) is None:
+        raise CollisionEligibilityContractError(
+            f"{field} must be a canonical SHA-256 digest"
+        )
+    return value
+
+
+def _parse_utc(value: object, *, field: str) -> datetime:
+    if not isinstance(value, str):
+        raise CollisionEligibilityContractError(f"{field} must be a UTC timestamp")
+    try:
+        parsed = datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
+    except ValueError as exc:
+        raise CollisionEligibilityContractError(
+            f"{field} must be canonical second-resolution UTC"
+        ) from exc
+    if parsed.strftime("%Y-%m-%dT%H:%M:%SZ") != value:
+        raise CollisionEligibilityContractError(
+            f"{field} must be canonical second-resolution UTC"
+        )
+    return parsed
+
+
+def _strict_keys(
+    value: Mapping[str, object], *, required: set[str], field: str
+) -> None:
+    if set(value) != required:
+        raise CollisionEligibilityContractError(f"{field} keys are not exact")
+
+
+def _unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for name, value in pairs:
+        if name in result:
+            raise CollisionEligibilityContractError(f"duplicate JSON key: {name}")
+        result[name] = value
+    return result
+
+
+def _decode_canonical_object(raw: bytes, *, field: str) -> dict[str, object]:
+    if not isinstance(raw, bytes) or not raw:
+        raise CollisionEligibilityContractError(f"{field} bytes are required")
+    try:
+        value = json.loads(raw.decode("utf-8"), object_pairs_hook=_unique_object)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CollisionEligibilityContractError(f"{field} is not JSON") from exc
+    if not isinstance(value, dict):
+        raise CollisionEligibilityContractError(f"{field} must be an object")
+    try:
+        canonical = canonical_json_bytes(value)
+    except CanonicalizationError as exc:
+        raise CollisionEligibilityContractError(
+            f"{field} contains a non-canonical value"
+        ) from exc
+    if canonical != raw:
+        raise CollisionEligibilityContractError(f"{field} is not canonical")
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateUseCollisionBinding:
+    """One exact Candidate-use subject and its required authority position."""
+
+    subject_id: str
+    subject_version_id: str
+    subject_version_digest: str
+    operation: CandidateUseOperation
+    expected_candidate_id: str | None
+    collision_namespace: str
+    collision_key_digest: str
+    generation_id: str
+    query_valid_time: str
+    serving_time: str
+    authority_watermark: int
+
+    def __post_init__(self) -> None:
+        _require_token(self.subject_id, field="candidate_use_subject_id")
+        _require_token(
+            self.subject_version_id,
+            field="candidate_use_subject_version_id",
+        )
+        _require_digest(
+            self.subject_version_digest,
+            field="candidate_use_subject_version_digest",
+        )
+        if not isinstance(self.operation, CandidateUseOperation):
+            raise CollisionEligibilityContractError(
+                "candidate-use operation must be typed"
+            )
+        if self.operation is CandidateUseOperation.ADMIT_NEW_CANDIDATE:
+            if self.expected_candidate_id is not None:
+                raise CollisionEligibilityContractError(
+                    "new-Candidate admission cannot name an existing Candidate"
+                )
+        elif self.expected_candidate_id is None:
+            raise CollisionEligibilityContractError(
+                "current-Candidate use must name the expected Candidate"
+            )
+        else:
+            _require_token(
+                self.expected_candidate_id,
+                field="expected_candidate_id",
+            )
+        _require_token(self.collision_namespace, field="collision_namespace")
+        _require_digest(self.collision_key_digest, field="collision_key_digest")
+        _require_token(self.generation_id, field="candidate_use_generation_id")
+        query_valid = _parse_utc(
+            self.query_valid_time,
+            field="candidate_use_query_valid_time",
+        )
+        serving = _parse_utc(
+            self.serving_time,
+            field="candidate_use_serving_time",
+        )
+        if query_valid > serving:
+            raise CollisionEligibilityContractError(
+                "candidate-use query-valid time cannot follow serving time"
+            )
+        if (
+            isinstance(self.authority_watermark, bool)
+            or not isinstance(self.authority_watermark, int)
+            or self.authority_watermark < 0
+        ):
+            raise CollisionEligibilityContractError(
+                "candidate-use authority watermark must be non-negative"
+            )
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "subject_id": self.subject_id,
+            "subject_version_id": self.subject_version_id,
+            "subject_version_digest": self.subject_version_digest,
+            "operation": self.operation.value,
+            "expected_candidate_id": self.expected_candidate_id,
+            "collision_namespace": self.collision_namespace,
+            "collision_key_digest": self.collision_key_digest,
+            "generation_id": self.generation_id,
+            "query_valid_time": self.query_valid_time,
+            "serving_time": self.serving_time,
+            "authority_watermark": self.authority_watermark,
+        }
+
+    @property
+    def binding_digest(self) -> str:
+        return digest_bytes(
+            canonical_json_bytes(
+                {
+                    "schema_version": COLLISION_ELIGIBILITY_SCHEMA_VERSION,
+                    "record_type": "candidate_use_collision_binding",
+                    "binding": self.canonical_value(),
+                }
+            )
+        )
+
+    @property
+    def idempotency_key(self) -> str:
+        return _IDEMPOTENCY_PREFIX + self.binding_digest
+
+    @classmethod
+    def from_mapping(
+        cls,
+        value: Mapping[str, object],
+    ) -> "CandidateUseCollisionBinding":
+        _strict_keys(
+            value,
+            required={
+                "subject_id",
+                "subject_version_id",
+                "subject_version_digest",
+                "operation",
+                "expected_candidate_id",
+                "collision_namespace",
+                "collision_key_digest",
+                "generation_id",
+                "query_valid_time",
+                "serving_time",
+                "authority_watermark",
+            },
+            field="candidate_use_collision_binding",
+        )
+        try:
+            return cls(
+                subject_id=value["subject_id"],  # type: ignore[arg-type]
+                subject_version_id=value["subject_version_id"],  # type: ignore[arg-type]
+                subject_version_digest=value["subject_version_digest"],  # type: ignore[arg-type]
+                operation=CandidateUseOperation(value["operation"]),
+                expected_candidate_id=value["expected_candidate_id"],  # type: ignore[arg-type]
+                collision_namespace=value["collision_namespace"],  # type: ignore[arg-type]
+                collision_key_digest=value["collision_key_digest"],  # type: ignore[arg-type]
+                generation_id=value["generation_id"],  # type: ignore[arg-type]
+                query_valid_time=value["query_valid_time"],  # type: ignore[arg-type]
+                serving_time=value["serving_time"],  # type: ignore[arg-type]
+                authority_watermark=value["authority_watermark"],  # type: ignore[arg-type]
+            )
+        except (TypeError, ValueError) as exc:
+            raise CollisionEligibilityContractError(
+                "candidate-use collision binding is malformed"
+            ) from exc
+
+
+@dataclass(frozen=True, slots=True)
+class CurrentCollisionEligibilityRequest:
+    binding: CandidateUseCollisionBinding
+    named_request_digest: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.binding, CandidateUseCollisionBinding):
+            raise CollisionEligibilityContractError(
+                "eligibility request binding must be typed"
+            )
+        _require_digest(
+            self.named_request_digest,
+            field="eligibility_named_request_digest",
+        )
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "binding": self.binding.canonical_value(),
+            "named_request_digest": self.named_request_digest,
+        }
+
+    @property
+    def request_digest(self) -> str:
+        return digest_bytes(
+            canonical_json_bytes(
+                {
+                    "schema_version": COLLISION_ELIGIBILITY_SCHEMA_VERSION,
+                    "record_type": "current_collision_eligibility_request",
+                    "request": self.canonical_value(),
+                }
+            )
+        )
+
+    @classmethod
+    def from_mapping(
+        cls,
+        value: Mapping[str, object],
+    ) -> "CurrentCollisionEligibilityRequest":
+        _strict_keys(
+            value,
+            required={"binding", "named_request_digest"},
+            field="current_collision_eligibility_request",
+        )
+        raw_binding = value["binding"]
+        if not isinstance(raw_binding, dict):
+            raise CollisionEligibilityContractError(
+                "eligibility request binding must be an object"
+            )
+        return cls(
+            binding=CandidateUseCollisionBinding.from_mapping(raw_binding),
+            named_request_digest=value["named_request_digest"],  # type: ignore[arg-type]
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CurrentCollisionReceiptEvidence:
+    named_request: CollisionHydrationLookupToolRequest
+    execution_receipt_bytes: bytes
+    authority_receipt_bytes: bytes | None
+
+    def __post_init__(self) -> None:
+        if not isinstance(
+            self.named_request,
+            CollisionHydrationLookupToolRequest,
+        ):
+            raise CollisionEligibilityContractError(
+                "current collision evidence requires the typed collision request"
+            )
+        if not isinstance(self.execution_receipt_bytes, bytes) or not (
+            self.execution_receipt_bytes
+        ):
+            raise CollisionEligibilityContractError(
+                "current collision execution receipt bytes are required"
+            )
+        if self.authority_receipt_bytes is not None and (
+            not isinstance(self.authority_receipt_bytes, bytes)
+            or not self.authority_receipt_bytes
+        ):
+            raise CollisionEligibilityContractError(
+                "current collision authority receipt must be bytes or null"
+            )
+
+    @property
+    def execution_receipt_digest(self) -> str:
+        return digest_bytes(self.execution_receipt_bytes)
+
+    @property
+    def authority_receipt_digest(self) -> str | None:
+        if self.authority_receipt_bytes is None:
+            return None
+        return digest_bytes(self.authority_receipt_bytes)
+
+
+_ELIGIBLE_REASONS = frozenset(
+    {
+        CollisionEligibilityReason.CURRENT_CANDIDATE_MATCH,
+        CollisionEligibilityReason.CURRENT_SLOT_UNOCCUPIED,
+    }
+)
+_REASONS_BY_OUTCOME = {
+    CollisionEligibilityOutcome.ELIGIBLE: _ELIGIBLE_REASONS,
+    CollisionEligibilityOutcome.COLLISION_CONFLICT: frozenset(
+        {
+            CollisionEligibilityReason.SLOT_ALREADY_OCCUPIED,
+            CollisionEligibilityReason.EXPECTED_CANDIDATE_ABSENT,
+            CollisionEligibilityReason.CURRENT_CANDIDATE_DIFFERS,
+        }
+    ),
+    CollisionEligibilityOutcome.STALE: frozenset(
+        {CollisionEligibilityReason.AUTHORITY_STALE}
+    ),
+    CollisionEligibilityOutcome.INCOMPLETE: frozenset(
+        {CollisionEligibilityReason.AUTHORITY_INCOMPLETE}
+    ),
+    CollisionEligibilityOutcome.UNAVAILABLE: frozenset(
+        {
+            CollisionEligibilityReason.AUTHORITY_UNAVAILABLE,
+            CollisionEligibilityReason.AUTHORITY_RECEIPT_MISSING,
+        }
+    ),
+    CollisionEligibilityOutcome.POLICY_BLOCKED: frozenset(
+        {CollisionEligibilityReason.AUTHORITY_POLICY_BLOCKED}
+    ),
+    CollisionEligibilityOutcome.INTEGRITY_BLOCKED: frozenset(
+        {
+            CollisionEligibilityReason.EXECUTION_RECEIPT_INVALID,
+            CollisionEligibilityReason.AUTHORITY_RECEIPT_INVALID,
+        }
+    ),
+    CollisionEligibilityOutcome.BINDING_MISMATCH: frozenset(
+        {
+            CollisionEligibilityReason.NAMED_REQUEST_BINDING_DIFFERS,
+            CollisionEligibilityReason.GENERATION_BINDING_DIFFERS,
+            CollisionEligibilityReason.TIME_BINDING_DIFFERS,
+            CollisionEligibilityReason.WATERMARK_BINDING_DIFFERS,
+        }
+    ),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class CurrentCollisionEligibilityDecision:
+    request: CurrentCollisionEligibilityRequest
+    outcome: CollisionEligibilityOutcome
+    reason: CollisionEligibilityReason
+    execution_receipt_digest: str
+    authority_receipt_digest: str | None
+    authority_execution_outcome: NamedAuthorityExecutionOutcome | None
+    observed_authority_watermark: int | None
+    collision_state: CollisionState | None
+    observed_candidate_id: str | None
+    authority_effect: str = "NONE"
+    candidate_effect_performed: bool = False
+    production_activation_authorised: bool = False
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.request, CurrentCollisionEligibilityRequest):
+            raise CollisionEligibilityContractError(
+                "eligibility decision request must be typed"
+            )
+        if not isinstance(self.outcome, CollisionEligibilityOutcome):
+            raise CollisionEligibilityContractError(
+                "eligibility outcome must be typed"
+            )
+        if not isinstance(self.reason, CollisionEligibilityReason):
+            raise CollisionEligibilityContractError("eligibility reason must be typed")
+        _require_digest(
+            self.execution_receipt_digest,
+            field="eligibility_execution_receipt_digest",
+        )
+        if self.authority_receipt_digest is not None:
+            _require_digest(
+                self.authority_receipt_digest,
+                field="eligibility_authority_receipt_digest",
+            )
+        if self.authority_execution_outcome is not None and not isinstance(
+            self.authority_execution_outcome,
+            NamedAuthorityExecutionOutcome,
+        ):
+            raise CollisionEligibilityContractError(
+                "authority execution outcome must be typed"
+            )
+        if self.observed_authority_watermark is not None and (
+            isinstance(self.observed_authority_watermark, bool)
+            or not isinstance(self.observed_authority_watermark, int)
+            or self.observed_authority_watermark < 0
+        ):
+            raise CollisionEligibilityContractError(
+                "observed authority watermark must be non-negative or null"
+            )
+        if self.collision_state is not None and not isinstance(
+            self.collision_state,
+            CollisionState,
+        ):
+            raise CollisionEligibilityContractError("collision state must be typed")
+        if self.observed_candidate_id is not None:
+            _require_token(
+                self.observed_candidate_id,
+                field="observed_candidate_id",
+            )
+            if self.collision_state is not CollisionState.OCCUPIED:
+                raise CollisionEligibilityContractError(
+                    "only occupied state can name an observed Candidate"
+                )
+        if self.reason not in _REASONS_BY_OUTCOME[self.outcome]:
+            raise CollisionEligibilityContractError(
+                "collision eligibility outcome and reason differ"
+            )
+        if self.outcome is CollisionEligibilityOutcome.ELIGIBLE:
+            if (
+                self.authority_execution_outcome
+                is not NamedAuthorityExecutionOutcome.COMPLETE
+                or self.authority_receipt_digest is None
+                or self.observed_authority_watermark
+                != self.request.binding.authority_watermark
+            ):
+                raise CollisionEligibilityContractError(
+                    "eligible decision lacks exact complete authority evidence"
+                )
+            binding = self.request.binding
+            if binding.operation is CandidateUseOperation.ADMIT_NEW_CANDIDATE:
+                exact_operation_match = (
+                    self.reason
+                    is CollisionEligibilityReason.CURRENT_SLOT_UNOCCUPIED
+                    and self.collision_state is CollisionState.UNOCCUPIED
+                    and self.observed_candidate_id is None
+                )
+            else:
+                exact_operation_match = (
+                    self.reason
+                    is CollisionEligibilityReason.CURRENT_CANDIDATE_MATCH
+                    and self.collision_state is CollisionState.OCCUPIED
+                    and self.observed_candidate_id == binding.expected_candidate_id
+                )
+            if not exact_operation_match:
+                raise CollisionEligibilityContractError(
+                    "eligible decision differs from its exact Candidate operation"
+                )
+        if (
+            self.authority_effect != "NONE"
+            or self.candidate_effect_performed is not False
+            or self.production_activation_authorised is not False
+        ):
+            raise CollisionEligibilityContractError(
+                "eligibility decision cannot claim authority or a Candidate effect"
+            )
+
+    @property
+    def eligible(self) -> bool:
+        return self.outcome is CollisionEligibilityOutcome.ELIGIBLE
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "schema_version": COLLISION_ELIGIBILITY_SCHEMA_VERSION,
+            "eligibility_request": self.request.canonical_value(),
+            "eligibility_request_digest": self.request.request_digest,
+            "outcome": self.outcome.value,
+            "reason": self.reason.value,
+            "eligible": self.eligible,
+            "execution_receipt_digest": self.execution_receipt_digest,
+            "authority_receipt_digest": self.authority_receipt_digest,
+            "authority_execution_outcome": (
+                None
+                if self.authority_execution_outcome is None
+                else self.authority_execution_outcome.value
+            ),
+            "observed_authority_watermark": self.observed_authority_watermark,
+            "collision_state": (
+                None if self.collision_state is None else self.collision_state.value
+            ),
+            "observed_candidate_id": self.observed_candidate_id,
+            "authority_effect": self.authority_effect,
+            "candidate_effect_performed": self.candidate_effect_performed,
+            "production_activation_authorised": (
+                self.production_activation_authorised
+            ),
+        }
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return canonical_json_bytes(self.canonical_value())
+
+    @property
+    def decision_digest(self) -> str:
+        return digest_bytes(self.canonical_bytes)
+
+    @classmethod
+    def from_canonical_bytes(
+        cls,
+        raw: bytes,
+    ) -> "CurrentCollisionEligibilityDecision":
+        value = _decode_canonical_object(raw, field="collision_eligibility_decision")
+        _strict_keys(
+            value,
+            required={
+                "schema_version",
+                "eligibility_request",
+                "eligibility_request_digest",
+                "outcome",
+                "reason",
+                "eligible",
+                "execution_receipt_digest",
+                "authority_receipt_digest",
+                "authority_execution_outcome",
+                "observed_authority_watermark",
+                "collision_state",
+                "observed_candidate_id",
+                "authority_effect",
+                "candidate_effect_performed",
+                "production_activation_authorised",
+            },
+            field="collision_eligibility_decision",
+        )
+        if value["schema_version"] != COLLISION_ELIGIBILITY_SCHEMA_VERSION:
+            raise CollisionEligibilityContractError(
+                "collision eligibility decision schema is not accepted"
+            )
+        raw_request = value["eligibility_request"]
+        if not isinstance(raw_request, dict):
+            raise CollisionEligibilityContractError(
+                "collision eligibility request must be an object"
+            )
+        request = CurrentCollisionEligibilityRequest.from_mapping(raw_request)
+        if value["eligibility_request_digest"] != request.request_digest:
+            raise CollisionEligibilityContractError(
+                "collision eligibility request digest differs"
+            )
+        raw_authority_outcome = value["authority_execution_outcome"]
+        raw_state = value["collision_state"]
+        try:
+            decision = cls(
+                request=request,
+                outcome=CollisionEligibilityOutcome(value["outcome"]),
+                reason=CollisionEligibilityReason(value["reason"]),
+                execution_receipt_digest=value["execution_receipt_digest"],  # type: ignore[arg-type]
+                authority_receipt_digest=value["authority_receipt_digest"],  # type: ignore[arg-type]
+                authority_execution_outcome=(
+                    None
+                    if raw_authority_outcome is None
+                    else NamedAuthorityExecutionOutcome(raw_authority_outcome)
+                ),
+                observed_authority_watermark=value["observed_authority_watermark"],  # type: ignore[arg-type]
+                collision_state=(
+                    None if raw_state is None else CollisionState(raw_state)
+                ),
+                observed_candidate_id=value["observed_candidate_id"],  # type: ignore[arg-type]
+                authority_effect=value["authority_effect"],  # type: ignore[arg-type]
+                candidate_effect_performed=value["candidate_effect_performed"],  # type: ignore[arg-type]
+                production_activation_authorised=value[
+                    "production_activation_authorised"
+                ],  # type: ignore[arg-type]
+            )
+        except (TypeError, ValueError) as exc:
+            raise CollisionEligibilityContractError(
+                "collision eligibility decision is malformed"
+            ) from exc
+        if type(value["eligible"]) is not bool or value["eligible"] != (
+            decision.eligible
+        ):
+            raise CollisionEligibilityContractError(
+                "collision eligibility boolean differs from its outcome"
+            )
+        if decision.canonical_bytes != raw:
+            raise CollisionEligibilityContractError(
+                "collision eligibility decision is not canonical"
+            )
+        return decision
+
+
+def _decision(
+    *,
+    request: CurrentCollisionEligibilityRequest,
+    evidence: CurrentCollisionReceiptEvidence,
+    outcome: CollisionEligibilityOutcome,
+    reason: CollisionEligibilityReason,
+    execution: NamedAuthorityExecutionReceipt | None = None,
+    authority: Mapping[str, object] | None = None,
+) -> CurrentCollisionEligibilityDecision:
+    raw_state = None if authority is None else authority.get("collision_state")
+    try:
+        state = None if raw_state is None else CollisionState(raw_state)
+    except (TypeError, ValueError):
+        state = None
+    raw_candidate = None if authority is None else authority.get("candidate_id")
+    candidate_id = raw_candidate if isinstance(raw_candidate, str) else None
+    attribution = None if execution is None else execution.authority_attribution
+    return CurrentCollisionEligibilityDecision(
+        request=request,
+        outcome=outcome,
+        reason=reason,
+        execution_receipt_digest=evidence.execution_receipt_digest,
+        authority_receipt_digest=evidence.authority_receipt_digest,
+        authority_execution_outcome=(
+            None if execution is None else execution.outcome
+        ),
+        observed_authority_watermark=(
+            None if attribution is None else attribution.authority_watermark
+        ),
+        collision_state=state,
+        observed_candidate_id=candidate_id,
+    )
+
+
+def _request_binding_reason(
+    request: CurrentCollisionEligibilityRequest,
+    evidence: CurrentCollisionReceiptEvidence,
+) -> CollisionEligibilityReason | None:
+    binding = request.binding
+    named = evidence.named_request
+    envelope = named.envelope
+    if envelope.generation_id != binding.generation_id:
+        return CollisionEligibilityReason.GENERATION_BINDING_DIFFERS
+    if (
+        envelope.query_valid_time != binding.query_valid_time
+        or envelope.serving_time != binding.serving_time
+    ):
+        return CollisionEligibilityReason.TIME_BINDING_DIFFERS
+    if (
+        request.named_request_digest != named.request_digest
+        or envelope.idempotency_key != binding.idempotency_key
+        or named.collision_namespace != binding.collision_namespace
+        or named.collision_key_digest != binding.collision_key_digest
+        or envelope.tool_id
+        is not NamedToolId.CURRENT_COLLISION_AND_AUTHORITY_HYDRATION_LOOKUP
+    ):
+        return CollisionEligibilityReason.NAMED_REQUEST_BINDING_DIFFERS
+    return None
+
+
+def decide_current_collision_eligibility(
+    *,
+    request: CurrentCollisionEligibilityRequest,
+    evidence: CurrentCollisionReceiptEvidence,
+) -> CurrentCollisionEligibilityDecision:
+    """Revalidate exact retained authority evidence and decide fail-closed."""
+
+    if not isinstance(request, CurrentCollisionEligibilityRequest):
+        raise TypeError("collision eligibility request must be typed")
+    if not isinstance(evidence, CurrentCollisionReceiptEvidence):
+        raise TypeError("current collision evidence must be typed")
+
+    try:
+        execution = NamedAuthorityExecutionReceipt.from_canonical_bytes(
+            evidence.execution_receipt_bytes
+        )
+        if execution.canonical_bytes != evidence.execution_receipt_bytes:
+            raise CollisionEligibilityContractError(
+                "execution receipt bytes are not canonical"
+            )
+    except (
+        CollisionEligibilityContractError,
+        NamedToolAuthorityExecutionError,
+        TypeError,
+        ValueError,
+    ):
+        return _decision(
+            request=request,
+            evidence=evidence,
+            outcome=CollisionEligibilityOutcome.INTEGRITY_BLOCKED,
+            reason=CollisionEligibilityReason.EXECUTION_RECEIPT_INVALID,
+        )
+
+    named = evidence.named_request
+    if (
+        execution.tool_id
+        is not NamedToolId.CURRENT_COLLISION_AND_AUTHORITY_HYDRATION_LOOKUP
+        or execution.tool_request_digest != named.request_digest
+        or execution.tool_envelope_digest != named.envelope.envelope_digest
+    ):
+        return _decision(
+            request=request,
+            evidence=evidence,
+            outcome=CollisionEligibilityOutcome.INTEGRITY_BLOCKED,
+            reason=CollisionEligibilityReason.EXECUTION_RECEIPT_INVALID,
+            execution=execution,
+        )
+
+    raw = evidence.authority_receipt_bytes
+    if raw is None or execution.authority_attribution is None:
+        return _decision(
+            request=request,
+            evidence=evidence,
+            outcome=CollisionEligibilityOutcome.UNAVAILABLE,
+            reason=CollisionEligibilityReason.AUTHORITY_RECEIPT_MISSING,
+            execution=execution,
+        )
+
+    try:
+        validate_named_authority_receipt(
+            request=named,
+            execution_receipt=execution,
+            raw_receipt_bytes=raw,
+        )
+        authority = _decode_canonical_object(raw, field="authority_receipt")
+    except (
+        CollisionEligibilityContractError,
+        NamedAuthorityReceiptValidationError,
+        TypeError,
+        ValueError,
+    ):
+        return _decision(
+            request=request,
+            evidence=evidence,
+            outcome=CollisionEligibilityOutcome.INTEGRITY_BLOCKED,
+            reason=CollisionEligibilityReason.AUTHORITY_RECEIPT_INVALID,
+            execution=execution,
+        )
+
+    attribution = execution.authority_attribution
+    assert attribution is not None
+    if (
+        execution.outcome.value != attribution.outcome.value
+        or execution.result_count != attribution.result_count
+        or execution.no_match != attribution.no_match
+    ):
+        return _decision(
+            request=request,
+            evidence=evidence,
+            outcome=CollisionEligibilityOutcome.INTEGRITY_BLOCKED,
+            reason=CollisionEligibilityReason.EXECUTION_RECEIPT_INVALID,
+            execution=execution,
+            authority=authority,
+        )
+
+    if attribution.authority_watermark != request.binding.authority_watermark:
+        return _decision(
+            request=request,
+            evidence=evidence,
+            outcome=CollisionEligibilityOutcome.BINDING_MISMATCH,
+            reason=CollisionEligibilityReason.WATERMARK_BINDING_DIFFERS,
+            execution=execution,
+            authority=authority,
+        )
+    binding_reason = _request_binding_reason(request, evidence)
+    if binding_reason is not None:
+        return _decision(
+            request=request,
+            evidence=evidence,
+            outcome=CollisionEligibilityOutcome.BINDING_MISMATCH,
+            reason=binding_reason,
+            execution=execution,
+            authority=authority,
+        )
+
+    if execution.outcome is not NamedAuthorityExecutionOutcome.COMPLETE:
+        mapped = {
+            NamedAuthorityExecutionOutcome.STALE: (
+                CollisionEligibilityOutcome.STALE,
+                CollisionEligibilityReason.AUTHORITY_STALE,
+            ),
+            NamedAuthorityExecutionOutcome.INCOMPLETE: (
+                CollisionEligibilityOutcome.INCOMPLETE,
+                CollisionEligibilityReason.AUTHORITY_INCOMPLETE,
+            ),
+            NamedAuthorityExecutionOutcome.UNAVAILABLE: (
+                CollisionEligibilityOutcome.UNAVAILABLE,
+                CollisionEligibilityReason.AUTHORITY_UNAVAILABLE,
+            ),
+            NamedAuthorityExecutionOutcome.POLICY_BLOCKED: (
+                CollisionEligibilityOutcome.POLICY_BLOCKED,
+                CollisionEligibilityReason.AUTHORITY_POLICY_BLOCKED,
+            ),
+        }.get(execution.outcome)
+        if mapped is None:
+            mapped = (
+                CollisionEligibilityOutcome.INTEGRITY_BLOCKED,
+                CollisionEligibilityReason.EXECUTION_RECEIPT_INVALID,
+            )
+        return _decision(
+            request=request,
+            evidence=evidence,
+            outcome=mapped[0],
+            reason=mapped[1],
+            execution=execution,
+            authority=authority,
+        )
+
+    binding = request.binding
+    state = CollisionState(authority["collision_state"])
+    candidate_id = authority["candidate_id"]
+    if (
+        binding.operation is CandidateUseOperation.ADMIT_NEW_CANDIDATE
+        and state is CollisionState.UNOCCUPIED
+        and candidate_id is None
+    ):
+        return _decision(
+            request=request,
+            evidence=evidence,
+            outcome=CollisionEligibilityOutcome.ELIGIBLE,
+            reason=CollisionEligibilityReason.CURRENT_SLOT_UNOCCUPIED,
+            execution=execution,
+            authority=authority,
+        )
+    if (
+        binding.operation is CandidateUseOperation.USE_CURRENT_CANDIDATE
+        and state is CollisionState.OCCUPIED
+        and candidate_id == binding.expected_candidate_id
+    ):
+        return _decision(
+            request=request,
+            evidence=evidence,
+            outcome=CollisionEligibilityOutcome.ELIGIBLE,
+            reason=CollisionEligibilityReason.CURRENT_CANDIDATE_MATCH,
+            execution=execution,
+            authority=authority,
+        )
+    if binding.operation is CandidateUseOperation.ADMIT_NEW_CANDIDATE:
+        reason = CollisionEligibilityReason.SLOT_ALREADY_OCCUPIED
+    elif state is CollisionState.UNOCCUPIED:
+        reason = CollisionEligibilityReason.EXPECTED_CANDIDATE_ABSENT
+    else:
+        reason = CollisionEligibilityReason.CURRENT_CANDIDATE_DIFFERS
+    return _decision(
+        request=request,
+        evidence=evidence,
+        outcome=CollisionEligibilityOutcome.COLLISION_CONFLICT,
+        reason=reason,
+        execution=execution,
+        authority=authority,
+    )
+
+
+class CurrentCollisionEligibilityBlocked(RuntimeError):
+    """The pre-effect seam rejected one exact Candidate-use operation."""
+
+    def __init__(self, decision: CurrentCollisionEligibilityDecision) -> None:
+        self.decision = decision
+        super().__init__(
+            f"current collision eligibility blocked: {decision.outcome.value}/"
+            f"{decision.reason.value}"
+        )
+
+
+_T = TypeVar("_T")
+
+
+def enforce_current_collision_before_effect(
+    *,
+    request: CurrentCollisionEligibilityRequest,
+    evidence: CurrentCollisionReceiptEvidence,
+    effect: Callable[[CurrentCollisionEligibilityDecision], _T],
+) -> _T:
+    """Invoke ``effect`` only after an exact eligible decision exists."""
+
+    if not callable(effect):
+        raise TypeError("candidate-use effect must be callable")
+    decision = decide_current_collision_eligibility(
+        request=request,
+        evidence=evidence,
+    )
+    if not decision.eligible:
+        raise CurrentCollisionEligibilityBlocked(decision)
+    return effect(decision)
+
+
+__all__ = [
+    "COLLISION_ELIGIBILITY_SCHEMA_VERSION",
+    "CandidateUseCollisionBinding",
+    "CandidateUseOperation",
+    "CollisionEligibilityContractError",
+    "CollisionEligibilityOutcome",
+    "CollisionEligibilityReason",
+    "CollisionState",
+    "CurrentCollisionEligibilityBlocked",
+    "CurrentCollisionEligibilityDecision",
+    "CurrentCollisionEligibilityRequest",
+    "CurrentCollisionReceiptEvidence",
+    "decide_current_collision_eligibility",
+    "enforce_current_collision_before_effect",
+]

--- a/newsroom/increment6/collision.py
+++ b/newsroom/increment6/collision.py
@@ -11,10 +11,10 @@ from __future__ import annotations
 import json
 import re
 from collections.abc import Callable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from enum import StrEnum
-from typing import TypeVar
+from typing import Protocol, TypeVar
 
 from newsroom.authority.canonical import (
     CanonicalizationError,
@@ -92,6 +92,7 @@ class CollisionEligibilityReason(StrEnum):
     CURRENT_SERVING_BOUNDARY_DIFFERS = "CURRENT_SERVING_BOUNDARY_DIFFERS"
     EXECUTION_PROVENANCE_DIFFERS = "EXECUTION_PROVENANCE_DIFFERS"
     AUTHORITY_IDENTITY_DIFFERS = "AUTHORITY_IDENTITY_DIFFERS"
+    CURRENT_AUTHORITY_RECHECK_DIFFERS = "CURRENT_AUTHORITY_RECHECK_DIFFERS"
 
 
 def _require_token(value: object, *, field: str) -> str:
@@ -511,6 +512,68 @@ class TrustedCurrentCollisionAuthorityContext:
             ) from exc
 
 
+@dataclass(frozen=True, slots=True)
+class CurrentCollisionAuthoritySnapshot:
+    """One live snapshot returned by the trusted authority provider."""
+
+    evidence: CurrentCollisionReceiptEvidence
+    trusted_context: TrustedCurrentCollisionAuthorityContext
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.evidence, CurrentCollisionReceiptEvidence):
+            raise CollisionEligibilityContractError(
+                "current authority snapshot evidence must be typed"
+            )
+        if not isinstance(
+            self.trusted_context,
+            TrustedCurrentCollisionAuthorityContext,
+        ):
+            raise CollisionEligibilityContractError(
+                "current authority snapshot context must be typed"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class TrustedCurrentCollisionAuthorityBoundary:
+    """Authority identities fixed by the trusted composition root."""
+
+    authority_scope_id: str
+    authority_profile_id: str
+    adapter_config_digest: str
+    port_registry_digest: str
+    port_id: str
+
+    def __post_init__(self) -> None:
+        for name in (
+            "authority_scope_id",
+            "authority_profile_id",
+            "port_id",
+        ):
+            _require_token(getattr(self, name), field=f"trusted_boundary_{name}")
+        for name in ("adapter_config_digest", "port_registry_digest"):
+            _require_digest(getattr(self, name), field=f"trusted_boundary_{name}")
+
+    def accepts(self, context: TrustedCurrentCollisionAuthorityContext) -> bool:
+        if not isinstance(context, TrustedCurrentCollisionAuthorityContext):
+            return False
+        return (
+            context.authority_scope_id == self.authority_scope_id
+            and context.authority_profile_id == self.authority_profile_id
+            and context.adapter_config_digest == self.adapter_config_digest
+            and context.port_registry_digest == self.port_registry_digest
+            and context.port_id == self.port_id
+        )
+
+
+class CurrentCollisionAuthorityProvider(Protocol):
+    """Composition-root capability for a live current-authority read."""
+
+    def __call__(
+        self,
+        request: CurrentCollisionEligibilityRequest,
+    ) -> CurrentCollisionAuthoritySnapshot: ...
+
+
 _ELIGIBLE_REASONS = frozenset(
     {
         CollisionEligibilityReason.CURRENT_CANDIDATE_MATCH,
@@ -531,6 +594,7 @@ _REASONS_BY_OUTCOME = {
             CollisionEligibilityReason.AUTHORITY_STALE,
             CollisionEligibilityReason.CURRENT_AUTHORITY_ADVANCED,
             CollisionEligibilityReason.CURRENT_SERVING_BOUNDARY_DIFFERS,
+            CollisionEligibilityReason.CURRENT_AUTHORITY_RECHECK_DIFFERS,
         }
     ),
     CollisionEligibilityOutcome.INCOMPLETE: frozenset(
@@ -1175,25 +1239,82 @@ class CurrentCollisionEligibilityBlocked(RuntimeError):
 _T = TypeVar("_T")
 
 
-def enforce_current_collision_before_effect(
-    *,
-    request: CurrentCollisionEligibilityRequest,
-    evidence: CurrentCollisionReceiptEvidence,
-    trusted_context: TrustedCurrentCollisionAuthorityContext,
-    effect: Callable[[CurrentCollisionEligibilityDecision], _T],
-) -> _T:
-    """Invoke ``effect`` only after an exact eligible decision exists."""
+class CurrentCollisionEffectEnforcer:
+    """Pre-effect capability assembled only at the trusted composition root.
 
-    if not callable(effect):
-        raise TypeError("candidate-use effect must be callable")
-    decision = decide_current_collision_eligibility(
-        request=request,
-        evidence=evidence,
-        trusted_context=trusted_context,
-    )
-    if not decision.eligible:
-        raise CurrentCollisionEligibilityBlocked(decision)
-    return effect(decision)
+    Candidate-use callers receive this already-bound capability.  Its public
+    operation accepts only their request and effect; retained evidence and the
+    current authority context are read live from the pre-bound provider.  A
+    second read immediately before the effect is the commit-time recheck.
+    """
+
+    def __init__(
+        self,
+        *,
+        current_authority_provider: CurrentCollisionAuthorityProvider,
+        trusted_boundary: TrustedCurrentCollisionAuthorityBoundary,
+    ) -> None:
+        if not callable(current_authority_provider):
+            raise TypeError("current authority provider must be callable")
+        if not isinstance(
+            trusted_boundary,
+            TrustedCurrentCollisionAuthorityBoundary,
+        ):
+            raise TypeError("trusted current authority boundary must be typed")
+        self._current_authority_provider = current_authority_provider
+        self._trusted_boundary = trusted_boundary
+
+    def _current_decision(
+        self,
+        request: CurrentCollisionEligibilityRequest,
+    ) -> CurrentCollisionEligibilityDecision:
+        snapshot = self._current_authority_provider(request)
+        if not isinstance(snapshot, CurrentCollisionAuthoritySnapshot):
+            raise TypeError(
+                "current authority provider must return a typed snapshot"
+            )
+        decision = decide_current_collision_eligibility(
+            request=request,
+            evidence=snapshot.evidence,
+            trusted_context=snapshot.trusted_context,
+        )
+        if not self._trusted_boundary.accepts(snapshot.trusted_context):
+            return replace(
+                decision,
+                outcome=CollisionEligibilityOutcome.INTEGRITY_BLOCKED,
+                reason=CollisionEligibilityReason.AUTHORITY_IDENTITY_DIFFERS,
+            )
+        return decision
+
+    def enforce(
+        self,
+        *,
+        request: CurrentCollisionEligibilityRequest,
+        effect: Callable[[CurrentCollisionEligibilityDecision], _T],
+    ) -> _T:
+        """Invoke ``effect`` only after two identical live decisions."""
+
+        if not isinstance(request, CurrentCollisionEligibilityRequest):
+            raise TypeError("collision eligibility request must be typed")
+        if not callable(effect):
+            raise TypeError("candidate-use effect must be callable")
+        initial = self._current_decision(request)
+        if not initial.eligible:
+            raise CurrentCollisionEligibilityBlocked(initial)
+        rechecked = self._current_decision(request)
+        if not rechecked.eligible:
+            raise CurrentCollisionEligibilityBlocked(rechecked)
+        if rechecked.decision_digest != initial.decision_digest:
+            raise CurrentCollisionEligibilityBlocked(
+                replace(
+                    rechecked,
+                    outcome=CollisionEligibilityOutcome.STALE,
+                    reason=(
+                        CollisionEligibilityReason.CURRENT_AUTHORITY_RECHECK_DIFFERS
+                    ),
+                )
+            )
+        return effect(rechecked)
 
 
 __all__ = [
@@ -1204,11 +1325,14 @@ __all__ = [
     "CollisionEligibilityOutcome",
     "CollisionEligibilityReason",
     "CollisionState",
+    "CurrentCollisionAuthorityProvider",
+    "CurrentCollisionAuthoritySnapshot",
+    "CurrentCollisionEffectEnforcer",
     "CurrentCollisionEligibilityBlocked",
     "CurrentCollisionEligibilityDecision",
     "CurrentCollisionEligibilityRequest",
     "CurrentCollisionReceiptEvidence",
     "TrustedCurrentCollisionAuthorityContext",
+    "TrustedCurrentCollisionAuthorityBoundary",
     "decide_current_collision_eligibility",
-    "enforce_current_collision_before_effect",
 ]

--- a/newsroom/increment6/collision.py
+++ b/newsroom/increment6/collision.py
@@ -88,6 +88,10 @@ class CollisionEligibilityReason(StrEnum):
     GENERATION_BINDING_DIFFERS = "GENERATION_BINDING_DIFFERS"
     TIME_BINDING_DIFFERS = "TIME_BINDING_DIFFERS"
     WATERMARK_BINDING_DIFFERS = "WATERMARK_BINDING_DIFFERS"
+    CURRENT_AUTHORITY_ADVANCED = "CURRENT_AUTHORITY_ADVANCED"
+    CURRENT_SERVING_BOUNDARY_DIFFERS = "CURRENT_SERVING_BOUNDARY_DIFFERS"
+    EXECUTION_PROVENANCE_DIFFERS = "EXECUTION_PROVENANCE_DIFFERS"
+    AUTHORITY_IDENTITY_DIFFERS = "AUTHORITY_IDENTITY_DIFFERS"
 
 
 def _require_token(value: object, *, field: str) -> str:
@@ -392,6 +396,121 @@ class CurrentCollisionReceiptEvidence:
         return digest_bytes(self.authority_receipt_bytes)
 
 
+@dataclass(frozen=True, slots=True)
+class TrustedCurrentCollisionAuthorityContext:
+    """Trusted current authority position supplied by the enclosing boundary.
+
+    This pure seam deliberately performs no ambient authority read.  The
+    enclosing authoritative boundary must therefore supply the non-caller-
+    selectable current position and the exact execution provenance it trusts.
+    """
+
+    generation_id: str
+    authority_watermark: int
+    query_valid_time: str
+    serving_time: str
+    authority_scope_id: str
+    authority_profile_id: str
+    adapter_config_digest: str
+    authorization_receipt_digest: str
+    authorization_decision_id: str
+    port_registry_digest: str
+    port_id: str
+
+    def __post_init__(self) -> None:
+        for name in (
+            "generation_id",
+            "authority_scope_id",
+            "authority_profile_id",
+            "authorization_decision_id",
+            "port_id",
+        ):
+            _require_token(getattr(self, name), field=f"trusted_current_{name}")
+        for name in (
+            "adapter_config_digest",
+            "authorization_receipt_digest",
+            "port_registry_digest",
+        ):
+            _require_digest(getattr(self, name), field=f"trusted_current_{name}")
+        query_valid = _parse_utc(
+            self.query_valid_time,
+            field="trusted_current_query_valid_time",
+        )
+        serving = _parse_utc(
+            self.serving_time,
+            field="trusted_current_serving_time",
+        )
+        if query_valid > serving:
+            raise CollisionEligibilityContractError(
+                "trusted current query-valid time cannot follow serving time"
+            )
+        if (
+            isinstance(self.authority_watermark, bool)
+            or not isinstance(self.authority_watermark, int)
+            or self.authority_watermark < 0
+        ):
+            raise CollisionEligibilityContractError(
+                "trusted current authority watermark must be non-negative"
+            )
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "generation_id": self.generation_id,
+            "authority_watermark": self.authority_watermark,
+            "query_valid_time": self.query_valid_time,
+            "serving_time": self.serving_time,
+            "authority_scope_id": self.authority_scope_id,
+            "authority_profile_id": self.authority_profile_id,
+            "adapter_config_digest": self.adapter_config_digest,
+            "authorization_receipt_digest": self.authorization_receipt_digest,
+            "authorization_decision_id": self.authorization_decision_id,
+            "port_registry_digest": self.port_registry_digest,
+            "port_id": self.port_id,
+        }
+
+    @property
+    def context_digest(self) -> str:
+        return digest_bytes(
+            canonical_json_bytes(
+                {
+                    "schema_version": COLLISION_ELIGIBILITY_SCHEMA_VERSION,
+                    "record_type": "trusted_current_collision_authority_context",
+                    "context": self.canonical_value(),
+                }
+            )
+        )
+
+    @classmethod
+    def from_mapping(
+        cls,
+        value: Mapping[str, object],
+    ) -> "TrustedCurrentCollisionAuthorityContext":
+        required = {
+            "generation_id",
+            "authority_watermark",
+            "query_valid_time",
+            "serving_time",
+            "authority_scope_id",
+            "authority_profile_id",
+            "adapter_config_digest",
+            "authorization_receipt_digest",
+            "authorization_decision_id",
+            "port_registry_digest",
+            "port_id",
+        }
+        _strict_keys(
+            value,
+            required=required,
+            field="trusted_current_authority_context",
+        )
+        try:
+            return cls(**value)  # type: ignore[arg-type]
+        except (TypeError, ValueError) as exc:
+            raise CollisionEligibilityContractError(
+                "trusted current authority context is malformed"
+            ) from exc
+
+
 _ELIGIBLE_REASONS = frozenset(
     {
         CollisionEligibilityReason.CURRENT_CANDIDATE_MATCH,
@@ -408,7 +527,11 @@ _REASONS_BY_OUTCOME = {
         }
     ),
     CollisionEligibilityOutcome.STALE: frozenset(
-        {CollisionEligibilityReason.AUTHORITY_STALE}
+        {
+            CollisionEligibilityReason.AUTHORITY_STALE,
+            CollisionEligibilityReason.CURRENT_AUTHORITY_ADVANCED,
+            CollisionEligibilityReason.CURRENT_SERVING_BOUNDARY_DIFFERS,
+        }
     ),
     CollisionEligibilityOutcome.INCOMPLETE: frozenset(
         {CollisionEligibilityReason.AUTHORITY_INCOMPLETE}
@@ -426,6 +549,8 @@ _REASONS_BY_OUTCOME = {
         {
             CollisionEligibilityReason.EXECUTION_RECEIPT_INVALID,
             CollisionEligibilityReason.AUTHORITY_RECEIPT_INVALID,
+            CollisionEligibilityReason.EXECUTION_PROVENANCE_DIFFERS,
+            CollisionEligibilityReason.AUTHORITY_IDENTITY_DIFFERS,
         }
     ),
     CollisionEligibilityOutcome.BINDING_MISMATCH: frozenset(
@@ -442,6 +567,7 @@ _REASONS_BY_OUTCOME = {
 @dataclass(frozen=True, slots=True)
 class CurrentCollisionEligibilityDecision:
     request: CurrentCollisionEligibilityRequest
+    trusted_context: TrustedCurrentCollisionAuthorityContext
     outcome: CollisionEligibilityOutcome
     reason: CollisionEligibilityReason
     execution_receipt_digest: str
@@ -458,6 +584,13 @@ class CurrentCollisionEligibilityDecision:
         if not isinstance(self.request, CurrentCollisionEligibilityRequest):
             raise CollisionEligibilityContractError(
                 "eligibility decision request must be typed"
+            )
+        if not isinstance(
+            self.trusted_context,
+            TrustedCurrentCollisionAuthorityContext,
+        ):
+            raise CollisionEligibilityContractError(
+                "eligibility decision trusted context must be typed"
             )
         if not isinstance(self.outcome, CollisionEligibilityOutcome):
             raise CollisionEligibilityContractError(
@@ -508,17 +641,23 @@ class CurrentCollisionEligibilityDecision:
                 "collision eligibility outcome and reason differ"
             )
         if self.outcome is CollisionEligibilityOutcome.ELIGIBLE:
+            binding = self.request.binding
             if (
                 self.authority_execution_outcome
                 is not NamedAuthorityExecutionOutcome.COMPLETE
                 or self.authority_receipt_digest is None
                 or self.observed_authority_watermark
-                != self.request.binding.authority_watermark
+                != binding.authority_watermark
+                or self.trusted_context.generation_id != binding.generation_id
+                or self.trusted_context.authority_watermark
+                != binding.authority_watermark
+                or self.trusted_context.query_valid_time
+                != binding.query_valid_time
+                or self.trusted_context.serving_time != binding.serving_time
             ):
                 raise CollisionEligibilityContractError(
                     "eligible decision lacks exact complete authority evidence"
                 )
-            binding = self.request.binding
             if binding.operation is CandidateUseOperation.ADMIT_NEW_CANDIDATE:
                 exact_operation_match = (
                     self.reason
@@ -555,6 +694,10 @@ class CurrentCollisionEligibilityDecision:
             "schema_version": COLLISION_ELIGIBILITY_SCHEMA_VERSION,
             "eligibility_request": self.request.canonical_value(),
             "eligibility_request_digest": self.request.request_digest,
+            "trusted_current_authority_context": self.trusted_context.canonical_value(),
+            "trusted_current_authority_context_digest": (
+                self.trusted_context.context_digest
+            ),
             "outcome": self.outcome.value,
             "reason": self.reason.value,
             "eligible": self.eligible,
@@ -597,6 +740,8 @@ class CurrentCollisionEligibilityDecision:
                 "schema_version",
                 "eligibility_request",
                 "eligibility_request_digest",
+                "trusted_current_authority_context",
+                "trusted_current_authority_context_digest",
                 "outcome",
                 "reason",
                 "eligible",
@@ -626,11 +771,26 @@ class CurrentCollisionEligibilityDecision:
             raise CollisionEligibilityContractError(
                 "collision eligibility request digest differs"
             )
+        raw_context = value["trusted_current_authority_context"]
+        if not isinstance(raw_context, dict):
+            raise CollisionEligibilityContractError(
+                "trusted current authority context must be an object"
+            )
+        trusted_context = TrustedCurrentCollisionAuthorityContext.from_mapping(
+            raw_context
+        )
+        if value["trusted_current_authority_context_digest"] != (
+            trusted_context.context_digest
+        ):
+            raise CollisionEligibilityContractError(
+                "trusted current authority context digest differs"
+            )
         raw_authority_outcome = value["authority_execution_outcome"]
         raw_state = value["collision_state"]
         try:
             decision = cls(
                 request=request,
+                trusted_context=trusted_context,
                 outcome=CollisionEligibilityOutcome(value["outcome"]),
                 reason=CollisionEligibilityReason(value["reason"]),
                 execution_receipt_digest=value["execution_receipt_digest"],  # type: ignore[arg-type]
@@ -671,6 +831,7 @@ class CurrentCollisionEligibilityDecision:
 def _decision(
     *,
     request: CurrentCollisionEligibilityRequest,
+    trusted_context: TrustedCurrentCollisionAuthorityContext,
     evidence: CurrentCollisionReceiptEvidence,
     outcome: CollisionEligibilityOutcome,
     reason: CollisionEligibilityReason,
@@ -687,6 +848,7 @@ def _decision(
     attribution = None if execution is None else execution.authority_attribution
     return CurrentCollisionEligibilityDecision(
         request=request,
+        trusted_context=trusted_context,
         outcome=outcome,
         reason=reason,
         execution_receipt_digest=evidence.execution_receipt_digest,
@@ -732,6 +894,7 @@ def decide_current_collision_eligibility(
     *,
     request: CurrentCollisionEligibilityRequest,
     evidence: CurrentCollisionReceiptEvidence,
+    trusted_context: TrustedCurrentCollisionAuthorityContext,
 ) -> CurrentCollisionEligibilityDecision:
     """Revalidate exact retained authority evidence and decide fail-closed."""
 
@@ -739,6 +902,11 @@ def decide_current_collision_eligibility(
         raise TypeError("collision eligibility request must be typed")
     if not isinstance(evidence, CurrentCollisionReceiptEvidence):
         raise TypeError("current collision evidence must be typed")
+    if not isinstance(
+        trusted_context,
+        TrustedCurrentCollisionAuthorityContext,
+    ):
+        raise TypeError("trusted current authority context must be typed")
 
     try:
         execution = NamedAuthorityExecutionReceipt.from_canonical_bytes(
@@ -756,6 +924,7 @@ def decide_current_collision_eligibility(
     ):
         return _decision(
             request=request,
+            trusted_context=trusted_context,
             evidence=evidence,
             outcome=CollisionEligibilityOutcome.INTEGRITY_BLOCKED,
             reason=CollisionEligibilityReason.EXECUTION_RECEIPT_INVALID,
@@ -770,9 +939,27 @@ def decide_current_collision_eligibility(
     ):
         return _decision(
             request=request,
+            trusted_context=trusted_context,
             evidence=evidence,
             outcome=CollisionEligibilityOutcome.INTEGRITY_BLOCKED,
             reason=CollisionEligibilityReason.EXECUTION_RECEIPT_INVALID,
+            execution=execution,
+        )
+
+    if (
+        execution.authorization_receipt_digest
+        != trusted_context.authorization_receipt_digest
+        or execution.authorization_decision_id
+        != trusted_context.authorization_decision_id
+        or execution.port_registry_digest != trusted_context.port_registry_digest
+        or execution.port_id != trusted_context.port_id
+    ):
+        return _decision(
+            request=request,
+            trusted_context=trusted_context,
+            evidence=evidence,
+            outcome=CollisionEligibilityOutcome.INTEGRITY_BLOCKED,
+            reason=CollisionEligibilityReason.EXECUTION_PROVENANCE_DIFFERS,
             execution=execution,
         )
 
@@ -780,6 +967,7 @@ def decide_current_collision_eligibility(
     if raw is None or execution.authority_attribution is None:
         return _decision(
             request=request,
+            trusted_context=trusted_context,
             evidence=evidence,
             outcome=CollisionEligibilityOutcome.UNAVAILABLE,
             reason=CollisionEligibilityReason.AUTHORITY_RECEIPT_MISSING,
@@ -801,6 +989,7 @@ def decide_current_collision_eligibility(
     ):
         return _decision(
             request=request,
+            trusted_context=trusted_context,
             evidence=evidence,
             outcome=CollisionEligibilityOutcome.INTEGRITY_BLOCKED,
             reason=CollisionEligibilityReason.AUTHORITY_RECEIPT_INVALID,
@@ -816,6 +1005,7 @@ def decide_current_collision_eligibility(
     ):
         return _decision(
             request=request,
+            trusted_context=trusted_context,
             evidence=evidence,
             outcome=CollisionEligibilityOutcome.INTEGRITY_BLOCKED,
             reason=CollisionEligibilityReason.EXECUTION_RECEIPT_INVALID,
@@ -823,9 +1013,54 @@ def decide_current_collision_eligibility(
             authority=authority,
         )
 
+    if (
+        authority.get("authority_scope_id") != trusted_context.authority_scope_id
+        or attribution.authority_profile_id
+        != trusted_context.authority_profile_id
+        or authority.get("adapter_config_digest")
+        != trusted_context.adapter_config_digest
+    ):
+        return _decision(
+            request=request,
+            trusted_context=trusted_context,
+            evidence=evidence,
+            outcome=CollisionEligibilityOutcome.INTEGRITY_BLOCKED,
+            reason=CollisionEligibilityReason.AUTHORITY_IDENTITY_DIFFERS,
+            execution=execution,
+            authority=authority,
+        )
+
+    if (
+        named.envelope.generation_id != trusted_context.generation_id
+        or attribution.authority_watermark != trusted_context.authority_watermark
+    ):
+        return _decision(
+            request=request,
+            trusted_context=trusted_context,
+            evidence=evidence,
+            outcome=CollisionEligibilityOutcome.STALE,
+            reason=CollisionEligibilityReason.CURRENT_AUTHORITY_ADVANCED,
+            execution=execution,
+            authority=authority,
+        )
+    if (
+        named.envelope.query_valid_time != trusted_context.query_valid_time
+        or named.envelope.serving_time != trusted_context.serving_time
+    ):
+        return _decision(
+            request=request,
+            trusted_context=trusted_context,
+            evidence=evidence,
+            outcome=CollisionEligibilityOutcome.STALE,
+            reason=CollisionEligibilityReason.CURRENT_SERVING_BOUNDARY_DIFFERS,
+            execution=execution,
+            authority=authority,
+        )
+
     if attribution.authority_watermark != request.binding.authority_watermark:
         return _decision(
             request=request,
+            trusted_context=trusted_context,
             evidence=evidence,
             outcome=CollisionEligibilityOutcome.BINDING_MISMATCH,
             reason=CollisionEligibilityReason.WATERMARK_BINDING_DIFFERS,
@@ -836,6 +1071,7 @@ def decide_current_collision_eligibility(
     if binding_reason is not None:
         return _decision(
             request=request,
+            trusted_context=trusted_context,
             evidence=evidence,
             outcome=CollisionEligibilityOutcome.BINDING_MISMATCH,
             reason=binding_reason,
@@ -869,6 +1105,7 @@ def decide_current_collision_eligibility(
             )
         return _decision(
             request=request,
+            trusted_context=trusted_context,
             evidence=evidence,
             outcome=mapped[0],
             reason=mapped[1],
@@ -886,6 +1123,7 @@ def decide_current_collision_eligibility(
     ):
         return _decision(
             request=request,
+            trusted_context=trusted_context,
             evidence=evidence,
             outcome=CollisionEligibilityOutcome.ELIGIBLE,
             reason=CollisionEligibilityReason.CURRENT_SLOT_UNOCCUPIED,
@@ -899,6 +1137,7 @@ def decide_current_collision_eligibility(
     ):
         return _decision(
             request=request,
+            trusted_context=trusted_context,
             evidence=evidence,
             outcome=CollisionEligibilityOutcome.ELIGIBLE,
             reason=CollisionEligibilityReason.CURRENT_CANDIDATE_MATCH,
@@ -913,6 +1152,7 @@ def decide_current_collision_eligibility(
         reason = CollisionEligibilityReason.CURRENT_CANDIDATE_DIFFERS
     return _decision(
         request=request,
+        trusted_context=trusted_context,
         evidence=evidence,
         outcome=CollisionEligibilityOutcome.COLLISION_CONFLICT,
         reason=reason,
@@ -939,6 +1179,7 @@ def enforce_current_collision_before_effect(
     *,
     request: CurrentCollisionEligibilityRequest,
     evidence: CurrentCollisionReceiptEvidence,
+    trusted_context: TrustedCurrentCollisionAuthorityContext,
     effect: Callable[[CurrentCollisionEligibilityDecision], _T],
 ) -> _T:
     """Invoke ``effect`` only after an exact eligible decision exists."""
@@ -948,6 +1189,7 @@ def enforce_current_collision_before_effect(
     decision = decide_current_collision_eligibility(
         request=request,
         evidence=evidence,
+        trusted_context=trusted_context,
     )
     if not decision.eligible:
         raise CurrentCollisionEligibilityBlocked(decision)
@@ -966,6 +1208,7 @@ __all__ = [
     "CurrentCollisionEligibilityDecision",
     "CurrentCollisionEligibilityRequest",
     "CurrentCollisionReceiptEvidence",
+    "TrustedCurrentCollisionAuthorityContext",
     "decide_current_collision_eligibility",
     "enforce_current_collision_before_effect",
 ]

--- a/newsroom/tests/test_increment6e1_collision.py
+++ b/newsroom/tests/test_increment6e1_collision.py
@@ -1,0 +1,627 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from newsroom.authority.canonical import canonical_json_bytes
+from newsroom.increment6.collision import (
+    CandidateUseCollisionBinding,
+    CandidateUseOperation,
+    CollisionEligibilityContractError,
+    CollisionEligibilityReason,
+    CollisionEligibilityOutcome,
+    CollisionState,
+    CurrentCollisionEligibilityBlocked,
+    CurrentCollisionEligibilityDecision,
+    CurrentCollisionEligibilityRequest,
+    CurrentCollisionReceiptEvidence,
+    decide_current_collision_eligibility,
+    enforce_current_collision_before_effect,
+)
+from newsroom.tests.test_increment5c2_named_tool_authority_execution import (
+    COLLISION_DIGEST,
+    QUERY_VALID,
+    SERVING,
+    authority_database,
+    authorize,
+    collision_request,
+    create_schema,
+    digest,
+    executor,
+    ports,
+    seed_object,
+)
+
+
+def _occupied_evidence(tmp_path: Path):
+    binding = CandidateUseCollisionBinding(
+        subject_id="hypothesis:001",
+        subject_version_id="hypothesis-version:001",
+        subject_version_digest=digest("hypothesis-version:001"),
+        operation=CandidateUseOperation.USE_CURRENT_CANDIDATE,
+        expected_candidate_id="candidate:001",
+        collision_namespace="candidate-development",
+        collision_key_digest=COLLISION_DIGEST,
+        generation_id="retrieval-generation-v1",
+        query_valid_time=QUERY_VALID,
+        serving_time=SERVING,
+        authority_watermark=42,
+    )
+    named_request = collision_request(idempotency_key=binding.idempotency_key)
+    result = executor(tmp_path, authority_database(tmp_path)).execute(
+        named_request,
+        authorize(tmp_path, named_request),
+    )
+    assert result.authority_receipt_bytes is not None
+    requirement = CurrentCollisionEligibilityRequest(
+        binding=binding,
+        named_request_digest=named_request.request_digest,
+    )
+    evidence = CurrentCollisionReceiptEvidence(
+        named_request=named_request,
+        execution_receipt_bytes=result.receipt.canonical_bytes,
+        authority_receipt_bytes=result.authority_receipt_bytes,
+    )
+    return requirement, evidence
+
+
+def test_current_matching_candidate_is_eligible_before_effect(tmp_path: Path) -> None:
+    requirement, evidence = _occupied_evidence(tmp_path)
+
+    decision = decide_current_collision_eligibility(
+        request=requirement,
+        evidence=evidence,
+    )
+
+    assert decision.outcome is CollisionEligibilityOutcome.ELIGIBLE
+    assert decision.eligible is True
+    assert decision.collision_state is CollisionState.OCCUPIED
+    assert decision.observed_candidate_id == "candidate:001"
+    effects: list[str] = []
+    result = enforce_current_collision_before_effect(
+        request=requirement,
+        evidence=evidence,
+        effect=lambda permit: effects.append(permit.decision_digest) or "used",
+    )
+    assert result == "used"
+    assert effects == [decision.decision_digest]
+
+
+def test_current_unoccupied_slot_is_eligible_for_new_candidate(
+    tmp_path: Path,
+) -> None:
+    binding = CandidateUseCollisionBinding(
+        subject_id="hypothesis:002",
+        subject_version_id="hypothesis-version:002",
+        subject_version_digest=digest("hypothesis-version:002"),
+        operation=CandidateUseOperation.ADMIT_NEW_CANDIDATE,
+        expected_candidate_id=None,
+        collision_namespace="candidate-development",
+        collision_key_digest=COLLISION_DIGEST,
+        generation_id="retrieval-generation-v2",
+        query_valid_time=QUERY_VALID,
+        serving_time=SERVING,
+        authority_watermark=42,
+    )
+    named_request = collision_request(
+        idempotency_key=binding.idempotency_key,
+        generation_id=binding.generation_id,
+    )
+    database = authority_database(tmp_path)
+    with sqlite3.connect(database) as connection:
+        connection.execute("DELETE FROM development_candidates_v2")
+    result = executor(tmp_path, database).execute(
+        named_request,
+        authorize(tmp_path, named_request),
+    )
+    assert result.authority_receipt_bytes is not None
+    decision = decide_current_collision_eligibility(
+        request=CurrentCollisionEligibilityRequest(
+            binding=binding,
+            named_request_digest=named_request.request_digest,
+        ),
+        evidence=CurrentCollisionReceiptEvidence(
+            named_request=named_request,
+            execution_receipt_bytes=result.receipt.canonical_bytes,
+            authority_receipt_bytes=result.authority_receipt_bytes,
+        ),
+    )
+
+    assert decision.outcome is CollisionEligibilityOutcome.ELIGIBLE
+    assert decision.collision_state is CollisionState.UNOCCUPIED
+    assert decision.observed_candidate_id is None
+
+
+def test_occupied_slot_blocks_new_candidate_before_effect(tmp_path: Path) -> None:
+    binding = CandidateUseCollisionBinding(
+        subject_id="hypothesis:003",
+        subject_version_id="hypothesis-version:003",
+        subject_version_digest=digest("hypothesis-version:003"),
+        operation=CandidateUseOperation.ADMIT_NEW_CANDIDATE,
+        expected_candidate_id=None,
+        collision_namespace="candidate-development",
+        collision_key_digest=COLLISION_DIGEST,
+        generation_id="retrieval-generation-v3",
+        query_valid_time=QUERY_VALID,
+        serving_time=SERVING,
+        authority_watermark=42,
+    )
+    named_request = collision_request(
+        idempotency_key=binding.idempotency_key,
+        generation_id=binding.generation_id,
+    )
+    result = executor(tmp_path, authority_database(tmp_path)).execute(
+        named_request,
+        authorize(tmp_path, named_request),
+    )
+    assert result.authority_receipt_bytes is not None
+    requirement = CurrentCollisionEligibilityRequest(
+        binding=binding,
+        named_request_digest=named_request.request_digest,
+    )
+    evidence = CurrentCollisionReceiptEvidence(
+        named_request=named_request,
+        execution_receipt_bytes=result.receipt.canonical_bytes,
+        authority_receipt_bytes=result.authority_receipt_bytes,
+    )
+    effects: list[str] = []
+
+    with pytest.raises(CurrentCollisionEligibilityBlocked) as caught:
+        enforce_current_collision_before_effect(
+            request=requirement,
+            evidence=evidence,
+            effect=lambda permit: effects.append(permit.decision_digest),
+        )
+
+    assert caught.value.decision.outcome is (
+        CollisionEligibilityOutcome.COLLISION_CONFLICT
+    )
+    assert caught.value.decision.reason is (
+        CollisionEligibilityReason.SLOT_ALREADY_OCCUPIED
+    )
+    assert effects == []
+
+
+def test_stale_authority_receipt_never_becomes_candidate_eligibility(
+    tmp_path: Path,
+) -> None:
+    binding = CandidateUseCollisionBinding(
+        subject_id="hypothesis:004",
+        subject_version_id="hypothesis-version:004",
+        subject_version_digest=digest("hypothesis-version:004"),
+        operation=CandidateUseOperation.USE_CURRENT_CANDIDATE,
+        expected_candidate_id="candidate:001",
+        collision_namespace="candidate-development",
+        collision_key_digest=COLLISION_DIGEST,
+        generation_id="retrieval-generation-v4",
+        query_valid_time=QUERY_VALID,
+        serving_time=SERVING,
+        authority_watermark=42,
+    )
+    named_request = collision_request(
+        idempotency_key=binding.idempotency_key,
+        generation_id=binding.generation_id,
+    )
+    database = authority_database(tmp_path)
+    result = executor(
+        tmp_path,
+        database,
+        selected_ports=ports(database, minimum_ledger_seq=43),
+    ).execute(named_request, authorize(tmp_path, named_request))
+    assert result.authority_receipt_bytes is not None
+
+    decision = decide_current_collision_eligibility(
+        request=CurrentCollisionEligibilityRequest(
+            binding=binding,
+            named_request_digest=named_request.request_digest,
+        ),
+        evidence=CurrentCollisionReceiptEvidence(
+            named_request=named_request,
+            execution_receipt_bytes=result.receipt.canonical_bytes,
+            authority_receipt_bytes=result.authority_receipt_bytes,
+        ),
+    )
+
+    assert decision.outcome is CollisionEligibilityOutcome.STALE
+    assert decision.reason is CollisionEligibilityReason.AUTHORITY_STALE
+    assert decision.eligible is False
+    assert decision.collision_state is CollisionState.UNKNOWN
+    assert decision.candidate_effect_performed is False
+
+
+def test_incomplete_collision_receipt_never_becomes_candidate_eligibility(
+    tmp_path: Path,
+) -> None:
+    binding = CandidateUseCollisionBinding(
+        subject_id="hypothesis:005",
+        subject_version_id="hypothesis-version:005",
+        subject_version_digest=digest("hypothesis-version:005"),
+        operation=CandidateUseOperation.USE_CURRENT_CANDIDATE,
+        expected_candidate_id="candidate:001",
+        collision_namespace="candidate-development",
+        collision_key_digest=COLLISION_DIGEST,
+        generation_id="retrieval-generation-v5",
+        query_valid_time=QUERY_VALID,
+        serving_time=SERVING,
+        authority_watermark=42,
+    )
+    named_request = collision_request(
+        idempotency_key=binding.idempotency_key,
+        generation_id=binding.generation_id,
+        result_limit=2,
+    )
+    result = executor(tmp_path, authority_database(tmp_path)).execute(
+        named_request,
+        authorize(tmp_path, named_request),
+    )
+    assert result.authority_receipt_bytes is not None
+
+    decision = decide_current_collision_eligibility(
+        request=CurrentCollisionEligibilityRequest(
+            binding=binding,
+            named_request_digest=named_request.request_digest,
+        ),
+        evidence=CurrentCollisionReceiptEvidence(
+            named_request=named_request,
+            execution_receipt_bytes=result.receipt.canonical_bytes,
+            authority_receipt_bytes=result.authority_receipt_bytes,
+        ),
+    )
+
+    assert decision.outcome is CollisionEligibilityOutcome.INCOMPLETE
+    assert decision.reason is CollisionEligibilityReason.AUTHORITY_INCOMPLETE
+    assert decision.eligible is False
+
+
+def test_policy_blocked_collision_receipt_never_becomes_eligibility(
+    tmp_path: Path,
+) -> None:
+    binding = CandidateUseCollisionBinding(
+        subject_id="hypothesis:006",
+        subject_version_id="hypothesis-version:006",
+        subject_version_digest=digest("hypothesis-version:006"),
+        operation=CandidateUseOperation.USE_CURRENT_CANDIDATE,
+        expected_candidate_id="candidate:001",
+        collision_namespace="candidate-development",
+        collision_key_digest=COLLISION_DIGEST,
+        generation_id="retrieval-generation-v6",
+        query_valid_time=QUERY_VALID,
+        serving_time=SERVING,
+        authority_watermark=42,
+    )
+    named_request = collision_request(
+        idempotency_key=binding.idempotency_key,
+        generation_id=binding.generation_id,
+    )
+    database = tmp_path / "policy-blocked.sqlite"
+    with sqlite3.connect(database) as connection:
+        create_schema(connection)
+        seed_object(connection, allowed=0)
+        connection.execute(
+            "INSERT INTO development_candidates_v2 VALUES(?,?)",
+            ("candidate:001", COLLISION_DIGEST),
+        )
+    result = executor(tmp_path, database).execute(
+        named_request,
+        authorize(tmp_path, named_request),
+    )
+    assert result.authority_receipt_bytes is not None
+
+    decision = decide_current_collision_eligibility(
+        request=CurrentCollisionEligibilityRequest(
+            binding=binding,
+            named_request_digest=named_request.request_digest,
+        ),
+        evidence=CurrentCollisionReceiptEvidence(
+            named_request=named_request,
+            execution_receipt_bytes=result.receipt.canonical_bytes,
+            authority_receipt_bytes=result.authority_receipt_bytes,
+        ),
+    )
+
+    assert decision.outcome is CollisionEligibilityOutcome.POLICY_BLOCKED
+    assert decision.reason is CollisionEligibilityReason.AUTHORITY_POLICY_BLOCKED
+    assert decision.eligible is False
+
+
+def test_unavailable_collision_receipt_never_becomes_eligibility(
+    tmp_path: Path,
+) -> None:
+    binding = CandidateUseCollisionBinding(
+        subject_id="hypothesis:007",
+        subject_version_id="hypothesis-version:007",
+        subject_version_digest=digest("hypothesis-version:007"),
+        operation=CandidateUseOperation.USE_CURRENT_CANDIDATE,
+        expected_candidate_id="candidate:001",
+        collision_namespace="candidate-development",
+        collision_key_digest=COLLISION_DIGEST,
+        generation_id="retrieval-generation-v7",
+        query_valid_time=QUERY_VALID,
+        serving_time=SERVING,
+        authority_watermark=42,
+    )
+    named_request = collision_request(
+        idempotency_key=binding.idempotency_key,
+        generation_id=binding.generation_id,
+    )
+    database = tmp_path / "unavailable.sqlite"
+    with sqlite3.connect(database) as connection:
+        create_schema(connection)
+        seed_object(connection, rights_object_class="WRONG_CLASS")
+        connection.execute(
+            "INSERT INTO development_candidates_v2 VALUES(?,?)",
+            ("candidate:001", COLLISION_DIGEST),
+        )
+    result = executor(tmp_path, database).execute(
+        named_request,
+        authorize(tmp_path, named_request),
+    )
+    assert result.authority_receipt_bytes is not None
+
+    decision = decide_current_collision_eligibility(
+        request=CurrentCollisionEligibilityRequest(
+            binding=binding,
+            named_request_digest=named_request.request_digest,
+        ),
+        evidence=CurrentCollisionReceiptEvidence(
+            named_request=named_request,
+            execution_receipt_bytes=result.receipt.canonical_bytes,
+            authority_receipt_bytes=result.authority_receipt_bytes,
+        ),
+    )
+
+    assert decision.outcome is CollisionEligibilityOutcome.UNAVAILABLE
+    assert decision.reason is CollisionEligibilityReason.AUTHORITY_UNAVAILABLE
+    assert decision.eligible is False
+
+
+def test_tampered_authority_receipt_is_integrity_blocked_before_effect(
+    tmp_path: Path,
+) -> None:
+    requirement, evidence = _occupied_evidence(tmp_path)
+    assert evidence.authority_receipt_bytes is not None
+    payload = json.loads(evidence.authority_receipt_bytes)
+    payload["candidate_id"] = "candidate:tampered"
+    tampered = CurrentCollisionReceiptEvidence(
+        named_request=evidence.named_request,
+        execution_receipt_bytes=evidence.execution_receipt_bytes,
+        authority_receipt_bytes=canonical_json_bytes(payload),
+    )
+    effects: list[str] = []
+
+    with pytest.raises(CurrentCollisionEligibilityBlocked) as caught:
+        enforce_current_collision_before_effect(
+            request=requirement,
+            evidence=tampered,
+            effect=lambda permit: effects.append(permit.decision_digest),
+        )
+
+    assert caught.value.decision.outcome is (
+        CollisionEligibilityOutcome.INTEGRITY_BLOCKED
+    )
+    assert caught.value.decision.reason is (
+        CollisionEligibilityReason.AUTHORITY_RECEIPT_INVALID
+    )
+    assert effects == []
+
+
+@pytest.mark.parametrize(
+    ("binding_changes", "expected_reason"),
+    (
+        (
+            {"subject_id": "hypothesis:other"},
+            CollisionEligibilityReason.NAMED_REQUEST_BINDING_DIFFERS,
+        ),
+        (
+            {"generation_id": "retrieval-generation-other"},
+            CollisionEligibilityReason.GENERATION_BINDING_DIFFERS,
+        ),
+        (
+            {"query_valid_time": "2026-08-06T08:58:00Z"},
+            CollisionEligibilityReason.TIME_BINDING_DIFFERS,
+        ),
+        (
+            {"authority_watermark": 41},
+            CollisionEligibilityReason.WATERMARK_BINDING_DIFFERS,
+        ),
+    ),
+)
+def test_complete_receipt_cannot_be_rebound_or_accepted_from_cached_state(
+    tmp_path: Path,
+    binding_changes: dict[str, object],
+    expected_reason: CollisionEligibilityReason,
+) -> None:
+    requirement, evidence = _occupied_evidence(tmp_path)
+    rebound = CurrentCollisionEligibilityRequest(
+        binding=replace(requirement.binding, **binding_changes),
+        named_request_digest=requirement.named_request_digest,
+    )
+
+    decision = decide_current_collision_eligibility(
+        request=rebound,
+        evidence=evidence,
+    )
+
+    assert decision.outcome is CollisionEligibilityOutcome.BINDING_MISMATCH
+    assert decision.reason is expected_reason
+    assert decision.eligible is False
+
+
+def test_exact_replay_is_byte_stable_and_decision_round_trips(
+    tmp_path: Path,
+) -> None:
+    requirement, evidence = _occupied_evidence(tmp_path)
+
+    first = decide_current_collision_eligibility(
+        request=requirement,
+        evidence=evidence,
+    )
+    replay = decide_current_collision_eligibility(
+        request=requirement,
+        evidence=evidence,
+    )
+    restored = CurrentCollisionEligibilityDecision.from_canonical_bytes(
+        first.canonical_bytes
+    )
+
+    assert replay.canonical_bytes == first.canonical_bytes
+    assert replay.decision_digest == first.decision_digest
+    assert restored == first
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    (
+        lambda value: value.__setitem__("eligible", False),
+        lambda value: value.__setitem__(
+            "schema_version",
+            "newsroom.increment6.candidate-collision-eligibility.v2",
+        ),
+        lambda value: value.__setitem__("unexpected", "field"),
+    ),
+)
+def test_decision_parser_rejects_tamper_and_schema_widening(
+    tmp_path: Path,
+    mutate,
+) -> None:
+    requirement, evidence = _occupied_evidence(tmp_path)
+    decision = decide_current_collision_eligibility(
+        request=requirement,
+        evidence=evidence,
+    )
+    value = json.loads(decision.canonical_bytes)
+    mutate(value)
+
+    with pytest.raises(CollisionEligibilityContractError):
+        CurrentCollisionEligibilityDecision.from_canonical_bytes(
+            canonical_json_bytes(value)
+        )
+
+
+def test_decision_parser_rejects_duplicate_json_keys(tmp_path: Path) -> None:
+    requirement, evidence = _occupied_evidence(tmp_path)
+    decision = decide_current_collision_eligibility(
+        request=requirement,
+        evidence=evidence,
+    )
+    duplicate = decision.canonical_bytes.replace(
+        b'"eligible":true,',
+        b'"eligible":true,"eligible":true,',
+        1,
+    )
+    assert duplicate != decision.canonical_bytes
+
+    with pytest.raises(CollisionEligibilityContractError, match="duplicate JSON key"):
+        CurrentCollisionEligibilityDecision.from_canonical_bytes(duplicate)
+
+
+def test_different_current_candidate_is_not_eligible_for_use(tmp_path: Path) -> None:
+    binding = CandidateUseCollisionBinding(
+        subject_id="hypothesis:008",
+        subject_version_id="hypothesis-version:008",
+        subject_version_digest=digest("hypothesis-version:008"),
+        operation=CandidateUseOperation.USE_CURRENT_CANDIDATE,
+        expected_candidate_id="candidate:other",
+        collision_namespace="candidate-development",
+        collision_key_digest=COLLISION_DIGEST,
+        generation_id="retrieval-generation-v8",
+        query_valid_time=QUERY_VALID,
+        serving_time=SERVING,
+        authority_watermark=42,
+    )
+    named_request = collision_request(
+        idempotency_key=binding.idempotency_key,
+        generation_id=binding.generation_id,
+    )
+    result = executor(tmp_path, authority_database(tmp_path)).execute(
+        named_request,
+        authorize(tmp_path, named_request),
+    )
+    assert result.authority_receipt_bytes is not None
+
+    decision = decide_current_collision_eligibility(
+        request=CurrentCollisionEligibilityRequest(
+            binding=binding,
+            named_request_digest=named_request.request_digest,
+        ),
+        evidence=CurrentCollisionReceiptEvidence(
+            named_request=named_request,
+            execution_receipt_bytes=result.receipt.canonical_bytes,
+            authority_receipt_bytes=result.authority_receipt_bytes,
+        ),
+    )
+
+    assert decision.outcome is CollisionEligibilityOutcome.COLLISION_CONFLICT
+    assert decision.reason is (
+        CollisionEligibilityReason.CURRENT_CANDIDATE_DIFFERS
+    )
+    assert decision.eligible is False
+
+
+def test_missing_retained_authority_bytes_fail_closed_as_unavailable(
+    tmp_path: Path,
+) -> None:
+    requirement, evidence = _occupied_evidence(tmp_path)
+    missing = CurrentCollisionReceiptEvidence(
+        named_request=evidence.named_request,
+        execution_receipt_bytes=evidence.execution_receipt_bytes,
+        authority_receipt_bytes=None,
+    )
+
+    decision = decide_current_collision_eligibility(
+        request=requirement,
+        evidence=missing,
+    )
+
+    assert decision.outcome is CollisionEligibilityOutcome.UNAVAILABLE
+    assert decision.reason is CollisionEligibilityReason.AUTHORITY_RECEIPT_MISSING
+    assert decision.eligible is False
+
+
+def test_tampered_execution_binding_is_integrity_blocked(tmp_path: Path) -> None:
+    requirement, evidence = _occupied_evidence(tmp_path)
+    execution = json.loads(evidence.execution_receipt_bytes)
+    execution["tool_request_digest"] = digest("different-request")
+    tampered = CurrentCollisionReceiptEvidence(
+        named_request=evidence.named_request,
+        execution_receipt_bytes=canonical_json_bytes(execution),
+        authority_receipt_bytes=evidence.authority_receipt_bytes,
+    )
+
+    decision = decide_current_collision_eligibility(
+        request=requirement,
+        evidence=tampered,
+    )
+
+    assert decision.outcome is CollisionEligibilityOutcome.INTEGRITY_BLOCKED
+    assert decision.reason is (
+        CollisionEligibilityReason.EXECUTION_RECEIPT_INVALID
+    )
+    assert decision.eligible is False
+
+
+def test_parser_cannot_rebind_eligible_decision_to_another_candidate(
+    tmp_path: Path,
+) -> None:
+    requirement, evidence = _occupied_evidence(tmp_path)
+    decision = decide_current_collision_eligibility(
+        request=requirement,
+        evidence=evidence,
+    )
+    value = json.loads(decision.canonical_bytes)
+    value["eligibility_request"]["binding"]["expected_candidate_id"] = (
+        "candidate:other"
+    )
+    rebound = CurrentCollisionEligibilityRequest.from_mapping(
+        value["eligibility_request"]
+    )
+    value["eligibility_request_digest"] = rebound.request_digest
+
+    with pytest.raises(CollisionEligibilityContractError):
+        CurrentCollisionEligibilityDecision.from_canonical_bytes(
+            canonical_json_bytes(value)
+        )

--- a/newsroom/tests/test_increment6e1_collision.py
+++ b/newsroom/tests/test_increment6e1_collision.py
@@ -23,13 +23,15 @@ from newsroom.increment6.collision import (
     CollisionEligibilityReason,
     CollisionEligibilityOutcome,
     CollisionState,
+    CurrentCollisionAuthoritySnapshot,
+    CurrentCollisionEffectEnforcer,
     CurrentCollisionEligibilityBlocked,
     CurrentCollisionEligibilityDecision,
     CurrentCollisionEligibilityRequest,
     CurrentCollisionReceiptEvidence,
     TrustedCurrentCollisionAuthorityContext,
+    TrustedCurrentCollisionAuthorityBoundary,
     decide_current_collision_eligibility as _decide_current_collision_eligibility,
-    enforce_current_collision_before_effect,
 )
 from newsroom.tests.test_increment5c2_named_tool_authority_execution import (
     COLLISION_DIGEST,
@@ -119,6 +121,28 @@ def _decide(
     )
 
 
+def _enforcer(
+    evidence: CurrentCollisionReceiptEvidence,
+    *,
+    provider=None,
+) -> CurrentCollisionEffectEnforcer:
+    context = _trusted_context(evidence)
+    snapshot = CurrentCollisionAuthoritySnapshot(
+        evidence=evidence,
+        trusted_context=context,
+    )
+    return CurrentCollisionEffectEnforcer(
+        current_authority_provider=provider or (lambda request: snapshot),
+        trusted_boundary=TrustedCurrentCollisionAuthorityBoundary(
+            authority_scope_id=context.authority_scope_id,
+            authority_profile_id=context.authority_profile_id,
+            adapter_config_digest=context.adapter_config_digest,
+            port_registry_digest=context.port_registry_digest,
+            port_id=context.port_id,
+        ),
+    )
+
+
 def test_current_matching_candidate_is_eligible_before_effect(tmp_path: Path) -> None:
     requirement, evidence = _occupied_evidence(tmp_path)
 
@@ -132,10 +156,8 @@ def test_current_matching_candidate_is_eligible_before_effect(tmp_path: Path) ->
     assert decision.collision_state is CollisionState.OCCUPIED
     assert decision.observed_candidate_id == "candidate:001"
     effects: list[str] = []
-    result = enforce_current_collision_before_effect(
+    result = _enforcer(evidence).enforce(
         request=requirement,
-        evidence=evidence,
-        trusted_context=_trusted_context(evidence),
         effect=lambda permit: effects.append(permit.decision_digest) or "used",
     )
     assert result == "used"
@@ -222,10 +244,8 @@ def test_occupied_slot_blocks_new_candidate_before_effect(tmp_path: Path) -> Non
     effects: list[str] = []
 
     with pytest.raises(CurrentCollisionEligibilityBlocked) as caught:
-        enforce_current_collision_before_effect(
+        _enforcer(evidence).enforce(
             request=requirement,
-            evidence=evidence,
-            trusted_context=_trusted_context(evidence),
             effect=lambda permit: effects.append(permit.decision_digest),
         )
 
@@ -446,10 +466,15 @@ def test_tampered_authority_receipt_is_integrity_blocked_before_effect(
     effects: list[str] = []
 
     with pytest.raises(CurrentCollisionEligibilityBlocked) as caught:
-        enforce_current_collision_before_effect(
-            request=requirement,
+        tampered_snapshot = CurrentCollisionAuthoritySnapshot(
             evidence=tampered,
             trusted_context=_trusted_context(evidence),
+        )
+        _enforcer(
+            evidence,
+            provider=lambda request: tampered_snapshot,
+        ).enforce(
+            request=requirement,
             effect=lambda permit: effects.append(permit.decision_digest),
         )
 
@@ -518,12 +543,26 @@ def test_cached_complete_receipt_blocks_when_trusted_authority_advances(
 ) -> None:
     requirement, evidence = _occupied_evidence(tmp_path)
     effects: list[str] = []
+    advanced_snapshot = CurrentCollisionAuthoritySnapshot(
+        evidence=evidence,
+        trusted_context=_trusted_context(evidence, **current_changes),
+    )
+    snapshots = iter(
+        (
+            CurrentCollisionAuthoritySnapshot(
+                evidence=evidence,
+                trusted_context=_trusted_context(evidence),
+            ),
+            advanced_snapshot,
+        )
+    )
 
     with pytest.raises(CurrentCollisionEligibilityBlocked) as caught:
-        enforce_current_collision_before_effect(
+        _enforcer(
+            evidence,
+            provider=lambda request: next(snapshots),
+        ).enforce(
             request=requirement,
-            evidence=evidence,
-            trusted_context=_trusted_context(evidence, **current_changes),
             effect=lambda permit: effects.append(permit.decision_digest),
         )
 
@@ -532,6 +571,41 @@ def test_cached_complete_receipt_blocks_when_trusted_authority_advances(
         CollisionEligibilityReason.CURRENT_AUTHORITY_ADVANCED,
         CollisionEligibilityReason.CURRENT_SERVING_BOUNDARY_DIFFERS,
     }
+    assert effects == []
+
+
+def test_candidate_caller_cannot_submit_cached_evidence_or_context_to_effect_gate(
+    tmp_path: Path,
+) -> None:
+    requirement, old_evidence = _occupied_evidence(tmp_path)
+    old_context = _trusted_context(old_evidence)
+    live_snapshot = CurrentCollisionAuthoritySnapshot(
+        evidence=old_evidence,
+        trusted_context=replace(old_context, authority_watermark=43),
+    )
+    enforcer = _enforcer(
+        old_evidence,
+        provider=lambda request: live_snapshot,
+    )
+    effects: list[str] = []
+
+    with pytest.raises(TypeError):
+        enforcer.enforce(
+            request=requirement,
+            effect=lambda permit: effects.append(permit.decision_digest),
+            evidence=old_evidence,  # type: ignore[call-arg]
+            trusted_context=old_context,  # type: ignore[call-arg]
+        )
+    with pytest.raises(CurrentCollisionEligibilityBlocked) as caught:
+        enforcer.enforce(
+            request=requirement,
+            effect=lambda permit: effects.append(permit.decision_digest),
+        )
+
+    assert caught.value.decision.outcome is CollisionEligibilityOutcome.STALE
+    assert caught.value.decision.reason is (
+        CollisionEligibilityReason.CURRENT_AUTHORITY_ADVANCED
+    )
     assert effects == []
 
 
@@ -594,7 +668,7 @@ def test_self_consistent_receipt_cannot_select_untrusted_authority_identity(
     assert decision.reason is CollisionEligibilityReason.AUTHORITY_IDENTITY_DIFFERS
 
 
-def test_self_consistent_unexpected_scope_and_adapter_are_integrity_blocked(
+def test_effect_gate_rejects_self_consistent_unexpected_authority_provider(
     tmp_path: Path,
 ) -> None:
     requirement, standard_evidence = _occupied_evidence(tmp_path)
@@ -628,23 +702,146 @@ def test_self_consistent_unexpected_scope_and_adapter_are_integrity_blocked(
         execution_receipt_bytes=result.receipt.canonical_bytes,
         authority_receipt_bytes=result.authority_receipt_bytes,
     )
-    standard_config = NamedAuthorityAdapterConfig(
-        authority_scope_id="authority:fixture",
-    )
-    trusted_context = _trusted_context(
-        unexpected_evidence,
-        authority_scope_id="authority:fixture",
-        adapter_config_digest=standard_config.config_digest,
-    )
-
-    decision = _decide(
+    matching_unexpected_context = _trusted_context(unexpected_evidence)
+    assert _decide(
         request=requirement,
         evidence=unexpected_evidence,
-        trusted_context=trusted_context,
+        trusted_context=matching_unexpected_context,
+    ).eligible
+    standard_context = _trusted_context(standard_evidence)
+    unexpected_snapshot = CurrentCollisionAuthoritySnapshot(
+        evidence=unexpected_evidence,
+        trusted_context=matching_unexpected_context,
     )
+    enforcer = CurrentCollisionEffectEnforcer(
+        current_authority_provider=lambda request: unexpected_snapshot,
+        trusted_boundary=TrustedCurrentCollisionAuthorityBoundary(
+            authority_scope_id=standard_context.authority_scope_id,
+            authority_profile_id=standard_context.authority_profile_id,
+            adapter_config_digest=standard_context.adapter_config_digest,
+            port_registry_digest=standard_context.port_registry_digest,
+            port_id=standard_context.port_id,
+        ),
+    )
+    effects: list[str] = []
 
-    assert decision.outcome is CollisionEligibilityOutcome.INTEGRITY_BLOCKED
-    assert decision.reason is CollisionEligibilityReason.AUTHORITY_IDENTITY_DIFFERS
+    with pytest.raises(CurrentCollisionEligibilityBlocked) as caught:
+        enforcer.enforce(
+            request=requirement,
+            effect=lambda permit: effects.append(permit.decision_digest),
+        )
+
+    assert caught.value.decision.outcome is (
+        CollisionEligibilityOutcome.INTEGRITY_BLOCKED
+    )
+    assert caught.value.decision.reason is (
+        CollisionEligibilityReason.AUTHORITY_IDENTITY_DIFFERS
+    )
+    assert effects == []
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement"),
+    (
+        ("authorization_receipt_digest", digest("advanced-authorization")),
+        ("authorization_decision_id", "00000000-0000-4000-8000-000000000099"),
+        ("port_registry_digest", digest("advanced-port-registry")),
+        ("port_id", "increment5.named.collision-hydration.advanced"),
+    ),
+)
+def test_commit_time_recheck_blocks_execution_provenance_drift(
+    tmp_path: Path,
+    field: str,
+    replacement: str,
+) -> None:
+    requirement, evidence = _occupied_evidence(tmp_path)
+    initial_snapshot = CurrentCollisionAuthoritySnapshot(
+        evidence=evidence,
+        trusted_context=_trusted_context(evidence),
+    )
+    execution = json.loads(evidence.execution_receipt_bytes)
+    execution[field] = replacement
+    changed_evidence = CurrentCollisionReceiptEvidence(
+        named_request=evidence.named_request,
+        execution_receipt_bytes=canonical_json_bytes(execution),
+        authority_receipt_bytes=evidence.authority_receipt_bytes,
+    )
+    changed_snapshot = CurrentCollisionAuthoritySnapshot(
+        evidence=changed_evidence,
+        trusted_context=replace(
+            initial_snapshot.trusted_context,
+            **{field: replacement},
+        ),
+    )
+    snapshots = iter((initial_snapshot, changed_snapshot))
+    effects: list[str] = []
+
+    with pytest.raises(CurrentCollisionEligibilityBlocked) as caught:
+        _enforcer(
+            evidence,
+            provider=lambda request: next(snapshots),
+        ).enforce(
+            request=requirement,
+            effect=lambda permit: effects.append(permit.decision_digest),
+        )
+
+    assert caught.value.decision.outcome in {
+        CollisionEligibilityOutcome.INTEGRITY_BLOCKED,
+        CollisionEligibilityOutcome.STALE,
+    }
+    assert effects == []
+
+
+def test_commit_time_recheck_blocks_current_candidate_drift(tmp_path: Path) -> None:
+    requirement, evidence = _occupied_evidence(tmp_path)
+    changed_root = tmp_path / "candidate-drift"
+    changed_root.mkdir()
+    database = authority_database(changed_root)
+    with sqlite3.connect(database) as connection:
+        connection.execute(
+            "UPDATE development_candidates_v2 SET candidate_id = ?",
+            ("candidate:other",),
+        )
+    result = executor(changed_root, database).execute(
+        evidence.named_request,
+        authorize(changed_root, evidence.named_request),
+    )
+    assert result.authority_receipt_bytes is not None
+    changed_evidence = CurrentCollisionReceiptEvidence(
+        named_request=evidence.named_request,
+        execution_receipt_bytes=result.receipt.canonical_bytes,
+        authority_receipt_bytes=result.authority_receipt_bytes,
+    )
+    snapshots = iter(
+        (
+            CurrentCollisionAuthoritySnapshot(
+                evidence=evidence,
+                trusted_context=_trusted_context(evidence),
+            ),
+            CurrentCollisionAuthoritySnapshot(
+                evidence=changed_evidence,
+                trusted_context=_trusted_context(changed_evidence),
+            ),
+        )
+    )
+    effects: list[str] = []
+
+    with pytest.raises(CurrentCollisionEligibilityBlocked) as caught:
+        _enforcer(
+            evidence,
+            provider=lambda request: next(snapshots),
+        ).enforce(
+            request=requirement,
+            effect=lambda permit: effects.append(permit.decision_digest),
+        )
+
+    assert caught.value.decision.outcome is (
+        CollisionEligibilityOutcome.COLLISION_CONFLICT
+    )
+    assert caught.value.decision.reason is (
+        CollisionEligibilityReason.CURRENT_CANDIDATE_DIFFERS
+    )
+    assert effects == []
 
 
 def test_exact_replay_is_byte_stable_and_decision_round_trips(

--- a/newsroom/tests/test_increment6e1_collision.py
+++ b/newsroom/tests/test_increment6e1_collision.py
@@ -8,6 +8,14 @@ from pathlib import Path
 import pytest
 
 from newsroom.authority.canonical import canonical_json_bytes
+from newsroom.increment5.named_tool_authority_adapters import (
+    CollisionHydrationNamedToolPort,
+    NamedAuthorityAdapterConfig,
+    SourceRevisionImpactNamedToolPort,
+)
+from newsroom.increment5.named_tool_authority_execution import (
+    NamedAuthorityExecutionReceipt,
+)
 from newsroom.increment6.collision import (
     CandidateUseCollisionBinding,
     CandidateUseOperation,
@@ -19,7 +27,8 @@ from newsroom.increment6.collision import (
     CurrentCollisionEligibilityDecision,
     CurrentCollisionEligibilityRequest,
     CurrentCollisionReceiptEvidence,
-    decide_current_collision_eligibility,
+    TrustedCurrentCollisionAuthorityContext,
+    decide_current_collision_eligibility as _decide_current_collision_eligibility,
     enforce_current_collision_before_effect,
 )
 from newsroom.tests.test_increment5c2_named_tool_authority_execution import (
@@ -69,10 +78,51 @@ def _occupied_evidence(tmp_path: Path):
     return requirement, evidence
 
 
+def _trusted_context(
+    evidence: CurrentCollisionReceiptEvidence,
+    **changes: object,
+) -> TrustedCurrentCollisionAuthorityContext:
+    execution = NamedAuthorityExecutionReceipt.from_canonical_bytes(
+        evidence.execution_receipt_bytes
+    )
+    assert execution.authority_attribution is not None
+    assert execution.port_id is not None
+    assert evidence.authority_receipt_bytes is not None
+    authority = json.loads(evidence.authority_receipt_bytes)
+    values: dict[str, object] = {
+        "generation_id": evidence.named_request.envelope.generation_id,
+        "authority_watermark": execution.authority_attribution.authority_watermark,
+        "query_valid_time": evidence.named_request.envelope.query_valid_time,
+        "serving_time": evidence.named_request.envelope.serving_time,
+        "authority_scope_id": authority["authority_scope_id"],
+        "authority_profile_id": execution.authority_attribution.authority_profile_id,
+        "adapter_config_digest": authority["adapter_config_digest"],
+        "authorization_receipt_digest": execution.authorization_receipt_digest,
+        "authorization_decision_id": execution.authorization_decision_id,
+        "port_registry_digest": execution.port_registry_digest,
+        "port_id": execution.port_id,
+    }
+    values.update(changes)
+    return TrustedCurrentCollisionAuthorityContext(**values)  # type: ignore[arg-type]
+
+
+def _decide(
+    *,
+    request: CurrentCollisionEligibilityRequest,
+    evidence: CurrentCollisionReceiptEvidence,
+    trusted_context: TrustedCurrentCollisionAuthorityContext | None = None,
+) -> CurrentCollisionEligibilityDecision:
+    return _decide_current_collision_eligibility(
+        request=request,
+        evidence=evidence,
+        trusted_context=trusted_context or _trusted_context(evidence),
+    )
+
+
 def test_current_matching_candidate_is_eligible_before_effect(tmp_path: Path) -> None:
     requirement, evidence = _occupied_evidence(tmp_path)
 
-    decision = decide_current_collision_eligibility(
+    decision = _decide(
         request=requirement,
         evidence=evidence,
     )
@@ -85,6 +135,7 @@ def test_current_matching_candidate_is_eligible_before_effect(tmp_path: Path) ->
     result = enforce_current_collision_before_effect(
         request=requirement,
         evidence=evidence,
+        trusted_context=_trusted_context(evidence),
         effect=lambda permit: effects.append(permit.decision_digest) or "used",
     )
     assert result == "used"
@@ -119,7 +170,7 @@ def test_current_unoccupied_slot_is_eligible_for_new_candidate(
         authorize(tmp_path, named_request),
     )
     assert result.authority_receipt_bytes is not None
-    decision = decide_current_collision_eligibility(
+    decision = _decide(
         request=CurrentCollisionEligibilityRequest(
             binding=binding,
             named_request_digest=named_request.request_digest,
@@ -174,6 +225,7 @@ def test_occupied_slot_blocks_new_candidate_before_effect(tmp_path: Path) -> Non
         enforce_current_collision_before_effect(
             request=requirement,
             evidence=evidence,
+            trusted_context=_trusted_context(evidence),
             effect=lambda permit: effects.append(permit.decision_digest),
         )
 
@@ -214,7 +266,7 @@ def test_stale_authority_receipt_never_becomes_candidate_eligibility(
     ).execute(named_request, authorize(tmp_path, named_request))
     assert result.authority_receipt_bytes is not None
 
-    decision = decide_current_collision_eligibility(
+    decision = _decide(
         request=CurrentCollisionEligibilityRequest(
             binding=binding,
             named_request_digest=named_request.request_digest,
@@ -260,7 +312,7 @@ def test_incomplete_collision_receipt_never_becomes_candidate_eligibility(
     )
     assert result.authority_receipt_bytes is not None
 
-    decision = decide_current_collision_eligibility(
+    decision = _decide(
         request=CurrentCollisionEligibilityRequest(
             binding=binding,
             named_request_digest=named_request.request_digest,
@@ -311,7 +363,7 @@ def test_policy_blocked_collision_receipt_never_becomes_eligibility(
     )
     assert result.authority_receipt_bytes is not None
 
-    decision = decide_current_collision_eligibility(
+    decision = _decide(
         request=CurrentCollisionEligibilityRequest(
             binding=binding,
             named_request_digest=named_request.request_digest,
@@ -362,7 +414,7 @@ def test_unavailable_collision_receipt_never_becomes_eligibility(
     )
     assert result.authority_receipt_bytes is not None
 
-    decision = decide_current_collision_eligibility(
+    decision = _decide(
         request=CurrentCollisionEligibilityRequest(
             binding=binding,
             named_request_digest=named_request.request_digest,
@@ -397,6 +449,7 @@ def test_tampered_authority_receipt_is_integrity_blocked_before_effect(
         enforce_current_collision_before_effect(
             request=requirement,
             evidence=tampered,
+            trusted_context=_trusted_context(evidence),
             effect=lambda permit: effects.append(permit.decision_digest),
         )
 
@@ -441,7 +494,7 @@ def test_complete_receipt_cannot_be_rebound_or_accepted_from_cached_state(
         named_request_digest=requirement.named_request_digest,
     )
 
-    decision = decide_current_collision_eligibility(
+    decision = _decide(
         request=rebound,
         evidence=evidence,
     )
@@ -451,16 +504,159 @@ def test_complete_receipt_cannot_be_rebound_or_accepted_from_cached_state(
     assert decision.eligible is False
 
 
+@pytest.mark.parametrize(
+    "current_changes",
+    (
+        {"authority_watermark": 43},
+        {"generation_id": "retrieval-generation-current"},
+        {"serving_time": "2026-08-06T09:00:01Z"},
+    ),
+)
+def test_cached_complete_receipt_blocks_when_trusted_authority_advances(
+    tmp_path: Path,
+    current_changes: dict[str, object],
+) -> None:
+    requirement, evidence = _occupied_evidence(tmp_path)
+    effects: list[str] = []
+
+    with pytest.raises(CurrentCollisionEligibilityBlocked) as caught:
+        enforce_current_collision_before_effect(
+            request=requirement,
+            evidence=evidence,
+            trusted_context=_trusted_context(evidence, **current_changes),
+            effect=lambda permit: effects.append(permit.decision_digest),
+        )
+
+    assert caught.value.decision.outcome is CollisionEligibilityOutcome.STALE
+    assert caught.value.decision.reason in {
+        CollisionEligibilityReason.CURRENT_AUTHORITY_ADVANCED,
+        CollisionEligibilityReason.CURRENT_SERVING_BOUNDARY_DIFFERS,
+    }
+    assert effects == []
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement"),
+    (
+        ("authorization_receipt_digest", digest("different-authorization")),
+        ("port_registry_digest", digest("different-registry")),
+        ("port_id", "increment5.named.collision-hydration.other"),
+    ),
+)
+def test_execution_provenance_tamper_is_integrity_blocked(
+    tmp_path: Path,
+    field: str,
+    replacement: str,
+) -> None:
+    requirement, evidence = _occupied_evidence(tmp_path)
+    trusted_context = _trusted_context(evidence)
+    execution = json.loads(evidence.execution_receipt_bytes)
+    execution[field] = replacement
+    tampered = CurrentCollisionReceiptEvidence(
+        named_request=evidence.named_request,
+        execution_receipt_bytes=canonical_json_bytes(execution),
+        authority_receipt_bytes=evidence.authority_receipt_bytes,
+    )
+
+    decision = _decide(
+        request=requirement,
+        evidence=tampered,
+        trusted_context=trusted_context,
+    )
+
+    assert decision.outcome is CollisionEligibilityOutcome.INTEGRITY_BLOCKED
+    assert decision.reason is (
+        CollisionEligibilityReason.EXECUTION_PROVENANCE_DIFFERS
+    )
+
+
+@pytest.mark.parametrize(
+    "identity_changes",
+    (
+        {"authority_scope_id": "authority:unexpected"},
+        {"authority_profile_id": "unexpected-authority-profile"},
+        {"adapter_config_digest": digest("unexpected-adapter-config")},
+    ),
+)
+def test_self_consistent_receipt_cannot_select_untrusted_authority_identity(
+    tmp_path: Path,
+    identity_changes: dict[str, object],
+) -> None:
+    requirement, evidence = _occupied_evidence(tmp_path)
+
+    decision = _decide(
+        request=requirement,
+        evidence=evidence,
+        trusted_context=_trusted_context(evidence, **identity_changes),
+    )
+
+    assert decision.outcome is CollisionEligibilityOutcome.INTEGRITY_BLOCKED
+    assert decision.reason is CollisionEligibilityReason.AUTHORITY_IDENTITY_DIFFERS
+
+
+def test_self_consistent_unexpected_scope_and_adapter_are_integrity_blocked(
+    tmp_path: Path,
+) -> None:
+    requirement, standard_evidence = _occupied_evidence(tmp_path)
+    unexpected_config = NamedAuthorityAdapterConfig(
+        authority_scope_id="authority:unexpected",
+    )
+    unexpected_root = tmp_path / "unexpected"
+    unexpected_root.mkdir()
+    database = authority_database(unexpected_root)
+    unexpected_ports = (
+        CollisionHydrationNamedToolPort(
+            authority_database=database,
+            config=unexpected_config,
+        ),
+        SourceRevisionImpactNamedToolPort(
+            authority_database=database,
+            config=unexpected_config,
+        ),
+    )
+    result = executor(
+        unexpected_root,
+        database,
+        selected_ports=unexpected_ports,
+    ).execute(
+        standard_evidence.named_request,
+        authorize(unexpected_root, standard_evidence.named_request),
+    )
+    assert result.authority_receipt_bytes is not None
+    unexpected_evidence = CurrentCollisionReceiptEvidence(
+        named_request=standard_evidence.named_request,
+        execution_receipt_bytes=result.receipt.canonical_bytes,
+        authority_receipt_bytes=result.authority_receipt_bytes,
+    )
+    standard_config = NamedAuthorityAdapterConfig(
+        authority_scope_id="authority:fixture",
+    )
+    trusted_context = _trusted_context(
+        unexpected_evidence,
+        authority_scope_id="authority:fixture",
+        adapter_config_digest=standard_config.config_digest,
+    )
+
+    decision = _decide(
+        request=requirement,
+        evidence=unexpected_evidence,
+        trusted_context=trusted_context,
+    )
+
+    assert decision.outcome is CollisionEligibilityOutcome.INTEGRITY_BLOCKED
+    assert decision.reason is CollisionEligibilityReason.AUTHORITY_IDENTITY_DIFFERS
+
+
 def test_exact_replay_is_byte_stable_and_decision_round_trips(
     tmp_path: Path,
 ) -> None:
     requirement, evidence = _occupied_evidence(tmp_path)
 
-    first = decide_current_collision_eligibility(
+    first = _decide(
         request=requirement,
         evidence=evidence,
     )
-    replay = decide_current_collision_eligibility(
+    replay = _decide(
         request=requirement,
         evidence=evidence,
     )
@@ -489,7 +685,7 @@ def test_decision_parser_rejects_tamper_and_schema_widening(
     mutate,
 ) -> None:
     requirement, evidence = _occupied_evidence(tmp_path)
-    decision = decide_current_collision_eligibility(
+    decision = _decide(
         request=requirement,
         evidence=evidence,
     )
@@ -504,7 +700,7 @@ def test_decision_parser_rejects_tamper_and_schema_widening(
 
 def test_decision_parser_rejects_duplicate_json_keys(tmp_path: Path) -> None:
     requirement, evidence = _occupied_evidence(tmp_path)
-    decision = decide_current_collision_eligibility(
+    decision = _decide(
         request=requirement,
         evidence=evidence,
     )
@@ -543,7 +739,7 @@ def test_different_current_candidate_is_not_eligible_for_use(tmp_path: Path) -> 
     )
     assert result.authority_receipt_bytes is not None
 
-    decision = decide_current_collision_eligibility(
+    decision = _decide(
         request=CurrentCollisionEligibilityRequest(
             binding=binding,
             named_request_digest=named_request.request_digest,
@@ -572,9 +768,10 @@ def test_missing_retained_authority_bytes_fail_closed_as_unavailable(
         authority_receipt_bytes=None,
     )
 
-    decision = decide_current_collision_eligibility(
+    decision = _decide(
         request=requirement,
         evidence=missing,
+        trusted_context=_trusted_context(evidence),
     )
 
     assert decision.outcome is CollisionEligibilityOutcome.UNAVAILABLE
@@ -592,7 +789,7 @@ def test_tampered_execution_binding_is_integrity_blocked(tmp_path: Path) -> None
         authority_receipt_bytes=evidence.authority_receipt_bytes,
     )
 
-    decision = decide_current_collision_eligibility(
+    decision = _decide(
         request=requirement,
         evidence=tampered,
     )
@@ -608,7 +805,7 @@ def test_parser_cannot_rebind_eligible_decision_to_another_candidate(
     tmp_path: Path,
 ) -> None:
     requirement, evidence = _occupied_evidence(tmp_path)
-    decision = decide_current_collision_eligibility(
+    decision = _decide(
         request=requirement,
         evidence=evidence,
     )


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-6e1
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

## Summary

- add the migration-free `newsroom.increment6.collision` seam for exact current-collision eligibility and pre-effect enforcement
- retain a pure canonical evaluator for exact request/evidence/context validation, with no effect authority
- replace the caller-supplied effect gate with `CurrentCollisionEffectEnforcer`, a capability assembled at the trusted composition root with a live current-authority provider and fixed trusted authority boundary
- expose only `request` and `effect` on the Candidate caller's bound `enforce` operation; raw retained evidence and current-authority context cannot be submitted or widened at the effect call
- read current authority inside every enforcement and perform an immediate second live commit-time recheck; generation, watermark, serving boundary, current Candidate, authorisation receipt/decision, registry, port, scope, profile, adapter, or complete-decision drift blocks before effect
- bind each pure decision to one exact subject/version digest, operation, collision namespace/key, named request, idempotency key, generation, query-valid time, serving time, authority watermark, authority identity, and execution provenance
- reject cached old `COMPLETE` receipts and self-consistent unexpected authority receipts at the bound effect capability, while exact unchanged replay remains byte-stable
- retain stale, incomplete, unavailable, policy-blocked, mismatched, identity-different, provenance-different, and integrity-failed outcomes as ineligible
- add no migration, persistence, caller-selected ambient authority, Candidate mutation, publication, production activation, or external effect beyond the supplied callback after the live recheck

## Accepted 6R allocation

- Contract digest: `sha256:13b43c927e4222c143b8691eaf179eb956096c19a72f4cc29cae13008d6e0590`
- Accepted 6R merge: `main@a44a073e3d798521a373115aa2c54f104b58a4cd`
- Effective wave: 1
- Dependency: #354
- Gate tier: **Tier S**
- Sole public module: `newsroom.increment6.collision`
- Schema identity: exactly `newsroom.increment6.candidate-collision-eligibility.v1`
- Sole interface ownership: `CURRENT_COLLISION_ELIGIBILITY_DECISION`, `PRE_EFFECT_COLLISION_ENFORCEMENT`
- Migration allocation: none
- Implementation commit: `c63e76c906979ffd59edc43519ab20bc4b76ec80`
- Source digest: `newsroom/increment6/collision.py` = `sha256:6601900b0c304c37d59fcca471b4b26802248970dbcac1d964c69d3fa19ebeb2`

## Verification

- `uv run pytest -q newsroom/tests/test_increment6e1_collision.py` — **37 passed**
- focused plus inherited execution/receipt/retrieval/readiness selection — **103 passed**
- `uv run python -m compileall -q newsroom/increment6/collision.py newsroom/tests/test_increment6e1_collision.py` — passed
- `git diff --check` and staged/base-range diff checks — passed
- repository-wide `uv run pytest -q` — **2535 passed, 41 skipped, 20 environment-bound failures** on macOS: 16 trusted-system-Python boundary tests, 3 Linux `renameat2` boundary tests, and 1 `/bin/true` platform-path watchdog test; none imports or exercises this module
- remote branch proof: `refs/heads/codex/increment-6e1-collision` = `c63e76c906979ffd59edc43519ab20bc4b76ec80`

Issue: #360
