### PR TITLE
Increment 6B2: add deterministic scheduling policy

### DIFF
--- a/newsroom/increment6/scheduling.py
+++ b/newsroom/increment6/scheduling.py
@@ -10,10 +10,10 @@ from __future__ import annotations
 
 import json
 import re
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
-from typing import Mapping
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from newsroom.authority.canonical import (
@@ -23,10 +23,7 @@ from newsroom.authority.canonical import (
 )
 from newsroom.increment6.outcomes import PriorityLane, PrioritySelection
 
-
-SCHEDULING_POLICY_SCHEMA_VERSION = (
-    "newsroom.increment6.triage-scheduling-policy.v1"
-)
+SCHEDULING_POLICY_SCHEMA_VERSION = "newsroom.increment6.triage-scheduling-policy.v1"
 
 _TOKEN_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:\-]{0,255}\Z")
 _ZONE_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._+\-/]{0,255}\Z")
@@ -34,6 +31,11 @@ _DIGEST_RE = re.compile(r"sha256:[0-9a-f]{64}\Z")
 _LOCAL_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S"
 _UTC_TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 _TIE_BREAK = "WORK_ITEM_VERSION_ID_ASC"
+_MAX_CANONICAL_BYTES = 1_000_000
+_MAX_CAPACITY_ITEM_BYTES = 16_384
+_MAX_CAPACITY_POPULATION = 48
+_MAX_INTEGER = 2_147_483_647
+_MAX_DURATION_SECONDS = 315_576_000  # ten years, including leap-day headroom
 
 
 class SchedulingContractError(ValueError):
@@ -53,8 +55,13 @@ def _require_digest(value: object, *, field: str) -> str:
 
 
 def _require_non_negative_int(value: object, *, field: str) -> int:
-    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
-        raise SchedulingContractError(f"{field} must be a non-negative integer")
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value < 0
+        or value > _MAX_INTEGER
+    ):
+        raise SchedulingContractError(f"{field} must be a bounded non-negative integer")
     return value
 
 
@@ -98,17 +105,17 @@ def _unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
 
 
 def _decode_canonical_object(raw: bytes, *, field: str) -> dict[str, object]:
-    if not isinstance(raw, bytes) or not raw:
-        raise SchedulingContractError(f"{field} bytes are required")
+    if not isinstance(raw, bytes) or not raw or len(raw) > _MAX_CANONICAL_BYTES:
+        raise SchedulingContractError(f"{field} bounded bytes are required")
     try:
         value = json.loads(raw.decode("utf-8"), object_pairs_hook=_unique_object)
-    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError, MemoryError) as exc:
         raise SchedulingContractError(f"{field} is not JSON") from exc
     if not isinstance(value, dict):
         raise SchedulingContractError(f"{field} must be an object")
     try:
         canonical = canonical_json_bytes(value)
-    except CanonicalizationError as exc:
+    except (CanonicalizationError, ValueError, OverflowError, MemoryError) as exc:
         raise SchedulingContractError(f"{field} is not canonical JSON") from exc
     if canonical != raw:
         raise SchedulingContractError(f"{field} is not canonical JSON")
@@ -151,15 +158,15 @@ class DeadlineBoundary:
                 "deadline source time zone is not available"
             ) from exc
         try:
-            local = datetime.strptime(self.source_local_time, _LOCAL_TIME_FORMAT)
+            local = datetime.strptime(  # noqa: DTZ007 - local wall time by contract
+                self.source_local_time, _LOCAL_TIME_FORMAT
+            )
         except (TypeError, ValueError) as exc:
             raise SchedulingContractError(
                 "deadline source local time is not canonical"
             ) from exc
         if local.strftime(_LOCAL_TIME_FORMAT) != self.source_local_time:
-            raise SchedulingContractError(
-                "deadline source local time is not canonical"
-            )
+            raise SchedulingContractError("deadline source local time is not canonical")
         if self.source_fold not in (0, 1) or isinstance(self.source_fold, bool):
             raise SchedulingContractError("deadline fold must be zero or one")
         if (
@@ -168,15 +175,20 @@ class DeadlineBoundary:
             or not -24 * 60 < self.source_utc_offset_minutes < 24 * 60
         ):
             raise SchedulingContractError("deadline UTC offset is invalid")
-        aware = local.replace(tzinfo=zone, fold=self.source_fold)
-        offset = aware.utcoffset()
-        if offset is None or offset.total_seconds() % 60 != 0:
-            raise SchedulingContractError("deadline UTC offset cannot be resolved")
-        if int(offset.total_seconds() // 60) != self.source_utc_offset_minutes:
-            raise SchedulingContractError("deadline UTC offset differs")
-        if aware.astimezone(UTC) != due:
-            raise SchedulingContractError("deadline UTC and local boundary differ")
-        round_trip = due.astimezone(zone)
+        try:
+            aware = local.replace(tzinfo=zone, fold=self.source_fold)
+            offset = aware.utcoffset()
+            if offset is None or offset.total_seconds() % 60 != 0:
+                raise SchedulingContractError("deadline UTC offset cannot be resolved")
+            if int(offset.total_seconds() // 60) != self.source_utc_offset_minutes:
+                raise SchedulingContractError("deadline UTC offset differs")
+            if aware.astimezone(UTC) != due:
+                raise SchedulingContractError("deadline UTC and local boundary differ")
+            round_trip = due.astimezone(zone)
+        except (OverflowError, OSError, ValueError) as exc:
+            raise SchedulingContractError(
+                "deadline boundary is not representable"
+            ) from exc
         if (
             round_trip.strftime(_LOCAL_TIME_FORMAT) != self.source_local_time
             or round_trip.fold != self.source_fold
@@ -196,7 +208,7 @@ class DeadlineBoundary:
         }
 
     @classmethod
-    def from_mapping(cls, value: Mapping[str, object]) -> "DeadlineBoundary":
+    def from_mapping(cls, value: Mapping[str, object]) -> DeadlineBoundary:
         _strict_keys(
             value,
             required={
@@ -244,6 +256,10 @@ class LaneTimingRule:
             raise SchedulingContractError(
                 "starvation warning must precede the starvation limit"
             )
+        if limit > _MAX_DURATION_SECONDS:
+            raise SchedulingContractError(
+                "starvation duration exceeds the representable policy bound"
+            )
         if type(self.explicit_deadline_required) is not bool:
             raise SchedulingContractError(
                 "explicit deadline requirement must be boolean"
@@ -259,7 +275,7 @@ class LaneTimingRule:
         }
 
     @classmethod
-    def from_mapping(cls, value: Mapping[str, object]) -> "LaneTimingRule":
+    def from_mapping(cls, value: Mapping[str, object]) -> LaneTimingRule:
         _strict_keys(
             value,
             required={
@@ -281,7 +297,11 @@ class LaneTimingRule:
             )
         except (TypeError, ValueError) as exc:
             raise SchedulingContractError("lane timing rule is malformed") from exc
-        if value["lane_ordinal"] != lane.ordinal:
+        if (
+            isinstance(value["lane_ordinal"], bool)
+            or not isinstance(value["lane_ordinal"], int)
+            or value["lane_ordinal"] != lane.ordinal
+        ):
             raise SchedulingContractError("lane timing ordinal differs")
         return result
 
@@ -345,9 +365,7 @@ class UrgencyDeadlinePolicy:
             "lane_rules": [item.canonical_value() for item in self.lane_rules],
             "authority": self.authority,
             "effect": self.effect,
-            "production_activation_authorised": (
-                self.production_activation_authorised
-            ),
+            "production_activation_authorised": (self.production_activation_authorised),
         }
 
     @property
@@ -359,7 +377,7 @@ class UrgencyDeadlinePolicy:
         return digest_bytes(self.canonical_bytes)
 
     @classmethod
-    def from_mapping(cls, value: Mapping[str, object]) -> "UrgencyDeadlinePolicy":
+    def from_mapping(cls, value: Mapping[str, object]) -> UrgencyDeadlinePolicy:
         _strict_keys(
             value,
             required={
@@ -392,9 +410,7 @@ class UrgencyDeadlinePolicy:
             schema_version=value["schema_version"],  # type: ignore[arg-type]
             authority=value["authority"],  # type: ignore[arg-type]
             effect=value["effect"],  # type: ignore[arg-type]
-            production_activation_authorised=value[
-                "production_activation_authorised"
-            ],  # type: ignore[arg-type]
+            production_activation_authorised=value["production_activation_authorised"],  # type: ignore[arg-type]
         )
 
 
@@ -432,9 +448,7 @@ class UrgencyDeadlineInput:
             field="scheduling_work_item_version_digest",
         )
         if not isinstance(self.priority_selection, PrioritySelection):
-            raise SchedulingContractError(
-                "scheduling priority selection must be typed"
-            )
+            raise SchedulingContractError("scheduling priority selection must be typed")
         if not isinstance(self.lane, PriorityLane):
             raise SchedulingContractError("scheduling input lane must be typed")
         if (
@@ -482,7 +496,9 @@ class UrgencyDeadlineInput:
             "lane_ordinal": self.lane.ordinal,
             "enqueued_at": self.enqueued_at,
             "observed_at": self.observed_at,
-            "deadline": None if self.deadline is None else self.deadline.canonical_value(),
+            "deadline": None
+            if self.deadline is None
+            else self.deadline.canonical_value(),
             "eligibility": self.eligibility.value,
             "delay_consequence_ordinal": self.delay_consequence_ordinal,
             "staleness_risk_ordinal": self.staleness_risk_ordinal,
@@ -502,7 +518,7 @@ class UrgencyDeadlineInput:
         )
 
     @classmethod
-    def from_mapping(cls, value: Mapping[str, object]) -> "UrgencyDeadlineInput":
+    def from_mapping(cls, value: Mapping[str, object]) -> UrgencyDeadlineInput:
         _strict_keys(
             value,
             required={
@@ -525,7 +541,9 @@ class UrgencyDeadlineInput:
         )
         raw_deadline = value["deadline"]
         if raw_deadline is not None and not isinstance(raw_deadline, dict):
-            raise SchedulingContractError("scheduling deadline must be an object or null")
+            raise SchedulingContractError(
+                "scheduling deadline must be an object or null"
+            )
         raw_priority = value["priority_selection"]
         if not isinstance(raw_priority, dict):
             raise SchedulingContractError(
@@ -553,12 +571,16 @@ class UrgencyDeadlineInput:
                 dependency_ready=value["dependency_ready"],  # type: ignore[arg-type]
             )
         except (TypeError, ValueError) as exc:
-            raise SchedulingContractError("urgency deadline input is malformed") from exc
-        if value["lane_ordinal"] != lane.ordinal:
-            raise SchedulingContractError("scheduling lane ordinal differs")
-        if value["priority_selection_digest"] != digest_bytes(
-            priority.canonical_bytes
+            raise SchedulingContractError(
+                "urgency deadline input is malformed"
+            ) from exc
+        if (
+            isinstance(value["lane_ordinal"], bool)
+            or not isinstance(value["lane_ordinal"], int)
+            or value["lane_ordinal"] != lane.ordinal
         ):
+            raise SchedulingContractError("scheduling lane ordinal differs")
+        if value["priority_selection_digest"] != digest_bytes(priority.canonical_bytes):
             raise SchedulingContractError("priority selection digest differs")
         return result
 
@@ -589,12 +611,20 @@ def _urgency_deadline_values(
     enqueued = _parse_utc(item.enqueued_at, field="scheduling_enqueued_at")
     observed = _parse_utc(item.observed_at, field="scheduling_observed_at")
     queue_age = int((observed - enqueued).total_seconds())
+    if queue_age > _MAX_INTEGER:
+        raise SchedulingContractError(
+            "queue age exceeds the representable policy bound"
+        )
     explicit = item.deadline is not None
-    effective = (
-        _parse_utc(item.deadline.due_at, field="deadline_due_at")
-        if item.deadline is not None
-        else enqueued + timedelta(seconds=rule.starvation_limit_seconds)
-    )
+    if item.deadline is not None:
+        effective = _parse_utc(item.deadline.due_at, field="deadline_due_at")
+    else:
+        try:
+            effective = enqueued + timedelta(seconds=rule.starvation_limit_seconds)
+        except (OverflowError, ValueError) as exc:
+            raise SchedulingContractError(
+                "derived starvation deadline is not representable"
+            ) from exc
     if item.eligibility is SchedulingEligibility.STALE:
         starvation = StarvationState.NOT_CURRENT
     elif item.eligibility in {
@@ -620,14 +650,21 @@ def _urgency_deadline_values(
     )
     order_key: tuple[int | str, ...] | None = None
     if schedulable:
+        try:
+            effective_epoch = int(effective.timestamp())
+            enqueued_epoch = int(enqueued.timestamp())
+        except (OverflowError, OSError, ValueError) as exc:
+            raise SchedulingContractError(
+                "scheduling timestamp is not representable"
+            ) from exc
         order_key = (
             item.lane.ordinal,
             0 if explicit else 1,
-            int(effective.timestamp()),
+            effective_epoch,
             -item.delay_consequence_ordinal,
             -item.staleness_risk_ordinal,
             _STARVATION_ORDER[starvation],
-            int(enqueued.timestamp()),
+            enqueued_epoch,
             0 if item.dependency_ready else 1,
             item.work_item_version_id,
         )
@@ -637,9 +674,7 @@ def _urgency_deadline_values(
         "queue_age_seconds": queue_age,
         "deadline_overdue": deadline_overdue,
         "starvation_state": starvation,
-        "starvation_overrun_seconds": max(
-            0, queue_age - rule.starvation_limit_seconds
-        ),
+        "starvation_overrun_seconds": max(0, queue_age - rule.starvation_limit_seconds),
         "revalidation_required": revalidation_required,
         "schedulable": schedulable,
         "order_key": order_key,
@@ -753,9 +788,7 @@ class StarvationObservation:
             "order_key": None if self.order_key is None else list(self.order_key),
             "authority": self.authority,
             "effect": self.effect,
-            "production_activation_authorised": (
-                self.production_activation_authorised
-            ),
+            "production_activation_authorised": (self.production_activation_authorised),
         }
 
     @property
@@ -767,7 +800,7 @@ class StarvationObservation:
         return digest_bytes(self.canonical_bytes)
 
     @classmethod
-    def from_canonical_bytes(cls, raw: bytes) -> "StarvationObservation":
+    def from_canonical_bytes(cls, raw: bytes) -> StarvationObservation:
         value = _decode_canonical_object(raw, field="starvation_observation")
         _strict_keys(
             value,
@@ -850,9 +883,9 @@ def calculate_urgency_deadline(
     """Calculate one pure observation using no ambient clock or queue state."""
 
     if not isinstance(policy, UrgencyDeadlinePolicy):
-        raise TypeError("urgency deadline policy must be typed")
+        raise SchedulingContractError("urgency deadline policy must be typed")
     if not isinstance(item, UrgencyDeadlineInput):
-        raise TypeError("urgency deadline input must be typed")
+        raise SchedulingContractError("urgency deadline input must be typed")
     values = _urgency_deadline_values(policy=policy, item=item)
     return StarvationObservation(policy=policy, item=item, **values)  # type: ignore[arg-type]
 
@@ -869,7 +902,7 @@ class CapacityClass(StrEnum):
 
 
 def capacity_class_for_lane(lane: PriorityLane) -> CapacityClass:
-    """Map only canonical lanes; this classification grants no admission."""
+    """Derive capacity only from the canonical Priority Selection lane."""
 
     if not isinstance(lane, PriorityLane):
         raise SchedulingContractError("capacity classification lane must be typed")
@@ -883,6 +916,25 @@ class ReservedCapacityDisposition(StrEnum):
     NO_PENDING_WORK = "NO_PENDING_WORK"
     CAPACITY_DEFERRED = "CAPACITY_DEFERRED"
     URGENT_VISIBLE_OPERATIONAL_HOLD = "URGENT_VISIBLE_OPERATIONAL_HOLD"
+    REVALIDATION_REQUIRED = "REVALIDATION_REQUIRED"
+
+
+class CapacityWorkState(StrEnum):
+    ACTIVE = "ACTIVE"
+    PENDING = "PENDING"
+
+
+class CapacityRevalidationDisposition(StrEnum):
+    NOT_REQUIRED = "NOT_REQUIRED"
+    REVALIDATED = "REVALIDATED"
+    REVALIDATION_REQUIRED = "REVALIDATION_REQUIRED"
+
+
+class CapacityAllocationDisposition(StrEnum):
+    GRANTED = "GRANTED"
+    CAPACITY_DEFERRED = "CAPACITY_DEFERRED"
+    URGENT_VISIBLE_OPERATIONAL_HOLD = "URGENT_VISIBLE_OPERATIONAL_HOLD"
+    REVALIDATION_REQUIRED = "REVALIDATION_REQUIRED"
 
 
 @dataclass(frozen=True, slots=True)
@@ -903,12 +955,10 @@ class ReservedCapacityPolicy:
         _require_token(self.policy_version, field="capacity_policy_version")
         total = _require_positive_int(self.total_slots, field="capacity_total_slots")
         urgent = _require_positive_int(
-            self.urgent_reserved_slots,
-            field="urgent_reserved_slots",
+            self.urgent_reserved_slots, field="urgent_reserved_slots"
         )
         ordinary = _require_positive_int(
-            self.minimum_ordinary_slots,
-            field="minimum_ordinary_slots",
+            self.minimum_ordinary_slots, field="minimum_ordinary_slots"
         )
         if urgent + ordinary > total:
             raise SchedulingContractError(
@@ -954,9 +1004,7 @@ class ReservedCapacityPolicy:
             "degraded_urgent_disposition": self.degraded_urgent_disposition.value,
             "authority": self.authority,
             "effect": self.effect,
-            "production_activation_authorised": (
-                self.production_activation_authorised
-            ),
+            "production_activation_authorised": self.production_activation_authorised,
         }
 
     @property
@@ -968,7 +1016,7 @@ class ReservedCapacityPolicy:
         return digest_bytes(self.canonical_bytes)
 
     @classmethod
-    def from_mapping(cls, value: Mapping[str, object]) -> "ReservedCapacityPolicy":
+    def from_mapping(cls, value: Mapping[str, object]) -> ReservedCapacityPolicy:
         _strict_keys(
             value,
             required={
@@ -992,185 +1040,423 @@ class ReservedCapacityPolicy:
             raise SchedulingContractError("reserved capacity record type differs")
         try:
             result = cls(
-                policy_id=value["policy_id"],  # type: ignore[arg-type]
-                policy_version=value["policy_version"],  # type: ignore[arg-type]
-                total_slots=value["total_slots"],  # type: ignore[arg-type]
-                urgent_reserved_slots=value["urgent_reserved_slots"],  # type: ignore[arg-type]
-                minimum_ordinary_slots=value["minimum_ordinary_slots"],  # type: ignore[arg-type]
+                policy_id=value["policy_id"],
+                policy_version=value["policy_version"],
+                total_slots=value["total_slots"],
+                urgent_reserved_slots=value["urgent_reserved_slots"],
+                minimum_ordinary_slots=value["minimum_ordinary_slots"],
                 degraded_urgent_disposition=ReservedCapacityDisposition(
                     value["degraded_urgent_disposition"]
                 ),
-                schema_version=value["schema_version"],  # type: ignore[arg-type]
-                authority=value["authority"],  # type: ignore[arg-type]
-                effect=value["effect"],  # type: ignore[arg-type]
+                schema_version=value["schema_version"],
+                authority=value["authority"],
+                effect=value["effect"],
                 production_activation_authorised=value[
                     "production_activation_authorised"
-                ],  # type: ignore[arg-type]
-            )
+                ],
+            )  # type: ignore[arg-type]
         except (TypeError, ValueError) as exc:
-            raise SchedulingContractError("reserved capacity policy is malformed") from exc
-        if (
-            value["max_urgent_slots"] != result.max_urgent_slots
-            or value["ordinary_capacity_ceiling"]
-            != result.ordinary_capacity_ceiling
+            raise SchedulingContractError(
+                "reserved capacity policy is malformed"
+            ) from exc
+        for field, expected in (
+            ("max_urgent_slots", result.max_urgent_slots),
+            ("ordinary_capacity_ceiling", result.ordinary_capacity_ceiling),
         ):
-            raise SchedulingContractError("reserved capacity derived bounds differ")
+            actual = value[field]
+            if (
+                isinstance(actual, bool)
+                or not isinstance(actual, int)
+                or actual != expected
+            ):
+                raise SchedulingContractError("reserved capacity derived bounds differ")
+        return result
+
+
+@dataclass(frozen=True, slots=True)
+class CapacityPopulationItem:
+    """One immutable population member bound to its canonical priority observation."""
+
+    work_item_id: str
+    work_item_version_id: str
+    work_item_version_digest: str
+    priority_selection: PrioritySelection
+    observation: StarvationObservation
+    state: CapacityWorkState
+    revalidation: CapacityRevalidationDisposition
+
+    def __post_init__(self) -> None:
+        _require_token(self.work_item_id, field="capacity_work_item_id")
+        _require_token(self.work_item_version_id, field="capacity_work_item_version_id")
+        _require_digest(
+            self.work_item_version_digest, field="capacity_work_item_version_digest"
+        )
+        if not isinstance(self.priority_selection, PrioritySelection) or not isinstance(
+            self.observation, StarvationObservation
+        ):
+            raise SchedulingContractError(
+                "capacity item priority and observation must be typed"
+            )
+        try:
+            if (
+                len(self.priority_selection.canonical_bytes) > _MAX_CAPACITY_ITEM_BYTES
+                or len(self.observation.canonical_bytes) > _MAX_CAPACITY_ITEM_BYTES
+            ):
+                raise SchedulingContractError(
+                    "capacity item exceeds the canonical byte bound"
+                )
+        except (CanonicalizationError, ValueError, OverflowError, MemoryError) as exc:
+            raise SchedulingContractError(
+                "capacity item is not canonically representable"
+            ) from exc
+        source = self.observation.item
+        if (
+            self.work_item_id != source.work_item_id
+            or self.work_item_version_id != source.work_item_version_id
+            or self.work_item_version_digest != source.work_item_version_digest
+            or self.priority_selection != source.priority_selection
+        ):
+            raise SchedulingContractError(
+                "capacity item differs from its exact scheduling observation"
+            )
+        if not isinstance(self.state, CapacityWorkState) or not isinstance(
+            self.revalidation, CapacityRevalidationDisposition
+        ):
+            raise SchedulingContractError(
+                "capacity item state and revalidation must be typed"
+            )
+        if not self.observation.schedulable:
+            raise SchedulingContractError(
+                "capacity population may contain only canonical schedulable work"
+            )
+        required = self.observation.revalidation_required
+        if required and self.revalidation not in {
+            CapacityRevalidationDisposition.REVALIDATED,
+            CapacityRevalidationDisposition.REVALIDATION_REQUIRED,
+        }:
+            raise SchedulingContractError(
+                "capacity item must expose required revalidation"
+            )
+        if (
+            not required
+            and self.revalidation is not CapacityRevalidationDisposition.NOT_REQUIRED
+        ):
+            raise SchedulingContractError(
+                "capacity item has a conflicting revalidation state"
+            )
+        if (
+            self.state is CapacityWorkState.ACTIVE
+            and self.revalidation
+            is CapacityRevalidationDisposition.REVALIDATION_REQUIRED
+        ):
+            raise SchedulingContractError(
+                "active work cannot still require revalidation"
+            )
+
+    @property
+    def lane(self) -> PriorityLane:
+        return self.priority_selection.lane
+
+    @property
+    def capacity_class(self) -> CapacityClass:
+        return capacity_class_for_lane(self.lane)
+
+    @property
+    def identity_key(self) -> tuple[str, str]:
+        return (self.work_item_id, self.work_item_version_id)
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "work_item_id": self.work_item_id,
+            "work_item_version_id": self.work_item_version_id,
+            "work_item_version_digest": self.work_item_version_digest,
+            "priority_selection": self.priority_selection.canonical_value(),
+            "priority_selection_digest": digest_bytes(
+                self.priority_selection.canonical_bytes
+            ),
+            "observation": self.observation.canonical_value(),
+            "observation_digest": self.observation.decision_digest,
+            "state": self.state.value,
+            "revalidation": self.revalidation.value,
+            "lane": self.lane.value,
+            "capacity_class": self.capacity_class.value,
+        }
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> CapacityPopulationItem:
+        _strict_keys(
+            value,
+            required={
+                "work_item_id",
+                "work_item_version_id",
+                "work_item_version_digest",
+                "priority_selection",
+                "priority_selection_digest",
+                "observation",
+                "observation_digest",
+                "state",
+                "revalidation",
+                "lane",
+                "capacity_class",
+            },
+            field="capacity_population_item",
+        )
+        raw_priority, raw_observation = (
+            value["priority_selection"],
+            value["observation"],
+        )
+        if not isinstance(raw_priority, dict) or not isinstance(raw_observation, dict):
+            raise SchedulingContractError(
+                "capacity item priority and observation must be objects"
+            )
+        try:
+            priority = PrioritySelection.from_mapping(raw_priority)
+            observation = StarvationObservation.from_canonical_bytes(
+                canonical_json_bytes(raw_observation)
+            )
+            result = cls(
+                work_item_id=value["work_item_id"],
+                work_item_version_id=value["work_item_version_id"],
+                work_item_version_digest=value["work_item_version_digest"],
+                priority_selection=priority,
+                observation=observation,
+                state=CapacityWorkState(value["state"]),
+                revalidation=CapacityRevalidationDisposition(value["revalidation"]),
+            )  # type: ignore[arg-type]
+        except (
+            TypeError,
+            ValueError,
+            CanonicalizationError,
+            MemoryError,
+            OverflowError,
+        ) as exc:
+            raise SchedulingContractError(
+                "capacity population item is malformed"
+            ) from exc
+        if (
+            value["priority_selection_digest"] != digest_bytes(priority.canonical_bytes)
+            or value["observation_digest"] != observation.decision_digest
+            or value["lane"] != result.lane.value
+            or value["capacity_class"] != result.capacity_class.value
+        ):
+            raise SchedulingContractError("capacity item derived binding differs")
         return result
 
 
 @dataclass(frozen=True, slots=True)
 class CapacitySnapshot:
     observed_at: str
-    active_urgent_slots: int
-    active_ordinary_slots: int
-    pending_urgent: int
-    pending_ordinary: int
+    population: tuple[CapacityPopulationItem, ...]
     urgent_path_state: CapacityPathState
 
     def __post_init__(self) -> None:
         _parse_utc(self.observed_at, field="capacity_observed_at")
+        if not isinstance(self.population, tuple) or any(
+            not isinstance(item, CapacityPopulationItem) for item in self.population
+        ):
+            raise SchedulingContractError(
+                "capacity population must be a typed immutable tuple"
+            )
+        if len(self.population) > _MAX_CAPACITY_POPULATION:
+            raise SchedulingContractError(
+                "capacity population exceeds the bounded size"
+            )
+        if not isinstance(self.urgent_path_state, CapacityPathState):
+            raise SchedulingContractError("Urgent capacity path state must be typed")
+        identities: set[str] = set()
+        versions: set[tuple[str, str]] = set()
+        for item in self.population:
+            if item.observation.item.observed_at != self.observed_at:
+                raise SchedulingContractError(
+                    "capacity item observation time differs from snapshot"
+                )
+            if item.work_item_id in identities or item.identity_key in versions:
+                raise SchedulingContractError(
+                    "duplicate or conflicting capacity population identity"
+                )
+            identities.add(item.work_item_id)
+            versions.add(item.identity_key)
+        if tuple(item.identity_key for item in self.population) != tuple(
+            sorted(item.identity_key for item in self.population)
+        ):
+            raise SchedulingContractError(
+                "capacity population must use canonical identity order"
+            )
+
+    def items(
+        self, *, state: CapacityWorkState, capacity_class: CapacityClass
+    ) -> tuple[CapacityPopulationItem, ...]:
+        return tuple(
+            item
+            for item in self.population
+            if item.state is state and item.capacity_class is capacity_class
+        )
+
+    @property
+    def active_urgent_slots(self) -> int:
+        return len(
+            self.items(
+                state=CapacityWorkState.ACTIVE,
+                capacity_class=CapacityClass.URGENT_RESERVED,
+            )
+        )
+
+    @property
+    def active_ordinary_slots(self) -> int:
+        return len(
+            self.items(
+                state=CapacityWorkState.ACTIVE, capacity_class=CapacityClass.ORDINARY
+            )
+        )
+
+    @property
+    def pending_urgent(self) -> int:
+        return len(
+            self.items(
+                state=CapacityWorkState.PENDING,
+                capacity_class=CapacityClass.URGENT_RESERVED,
+            )
+        )
+
+    @property
+    def pending_ordinary(self) -> int:
+        return len(
+            self.items(
+                state=CapacityWorkState.PENDING, capacity_class=CapacityClass.ORDINARY
+            )
+        )
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "observed_at": self.observed_at,
+            "population": [item.canonical_value() for item in self.population],
+            "urgent_path_state": self.urgent_path_state.value,
+            "active_urgent_slots": self.active_urgent_slots,
+            "active_ordinary_slots": self.active_ordinary_slots,
+            "pending_urgent": self.pending_urgent,
+            "pending_ordinary": self.pending_ordinary,
+        }
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> CapacitySnapshot:
+        _strict_keys(
+            value,
+            required={
+                "observed_at",
+                "population",
+                "urgent_path_state",
+                "active_urgent_slots",
+                "active_ordinary_slots",
+                "pending_urgent",
+                "pending_ordinary",
+            },
+            field="capacity_snapshot",
+        )
+        raw_population = value["population"]
+        if not isinstance(raw_population, list) or any(
+            not isinstance(item, dict) for item in raw_population
+        ):
+            raise SchedulingContractError(
+                "capacity population must be an array of objects"
+            )
+        try:
+            result = cls(
+                observed_at=value["observed_at"],
+                population=tuple(
+                    CapacityPopulationItem.from_mapping(item) for item in raw_population
+                ),
+                urgent_path_state=CapacityPathState(value["urgent_path_state"]),
+            )  # type: ignore[arg-type]
+        except (TypeError, ValueError) as exc:
+            raise SchedulingContractError("capacity snapshot is malformed") from exc
         for field in (
             "active_urgent_slots",
             "active_ordinary_slots",
             "pending_urgent",
             "pending_ordinary",
         ):
-            _require_non_negative_int(getattr(self, field), field=field)
-        if not isinstance(self.urgent_path_state, CapacityPathState):
-            raise SchedulingContractError("Urgent capacity path state must be typed")
+            actual = value[field]
+            if (
+                isinstance(actual, bool)
+                or not isinstance(actual, int)
+                or actual != getattr(result, field)
+            ):
+                raise SchedulingContractError("capacity snapshot derived count differs")
+        return result
+
+
+@dataclass(frozen=True, slots=True)
+class CapacityItemAllocation:
+    item: CapacityPopulationItem
+    disposition: CapacityAllocationDisposition
+    protected_routine_grant: bool
+
+    def __post_init__(self) -> None:
+        if (
+            not isinstance(self.item, CapacityPopulationItem)
+            or self.item.state is not CapacityWorkState.PENDING
+        ):
+            raise SchedulingContractError(
+                "capacity allocation must bind one pending item"
+            )
+        if (
+            not isinstance(self.disposition, CapacityAllocationDisposition)
+            or type(self.protected_routine_grant) is not bool
+        ):
+            raise SchedulingContractError(
+                "capacity allocation disposition must be typed"
+            )
+        if self.protected_routine_grant and (
+            self.disposition is not CapacityAllocationDisposition.GRANTED
+            or self.item.lane is not PriorityLane.ROUTINE
+            or self.item.observation.starvation_state is not StarvationState.STARVED
+            or self.item.revalidation is not CapacityRevalidationDisposition.REVALIDATED
+        ):
+            raise SchedulingContractError("protected Routine grant is not eligible")
 
     def canonical_value(self) -> dict[str, object]:
         return {
-            "observed_at": self.observed_at,
-            "active_urgent_slots": self.active_urgent_slots,
-            "active_ordinary_slots": self.active_ordinary_slots,
-            "pending_urgent": self.pending_urgent,
-            "pending_ordinary": self.pending_ordinary,
-            "urgent_path_state": self.urgent_path_state.value,
+            "work_item_id": self.item.work_item_id,
+            "work_item_version_id": self.item.work_item_version_id,
+            "work_item_version_digest": self.item.work_item_version_digest,
+            "priority_selection_digest": digest_bytes(
+                self.item.priority_selection.canonical_bytes
+            ),
+            "observation_digest": self.item.observation.decision_digest,
+            "lane": self.item.lane.value,
+            "capacity_class": self.item.capacity_class.value,
+            "disposition": self.disposition.value,
+            "protected_routine_grant": self.protected_routine_grant,
         }
-
-    @classmethod
-    def from_mapping(cls, value: Mapping[str, object]) -> "CapacitySnapshot":
-        _strict_keys(
-            value,
-            required={
-                "observed_at",
-                "active_urgent_slots",
-                "active_ordinary_slots",
-                "pending_urgent",
-                "pending_ordinary",
-                "urgent_path_state",
-            },
-            field="capacity_snapshot",
-        )
-        try:
-            return cls(
-                observed_at=value["observed_at"],  # type: ignore[arg-type]
-                active_urgent_slots=value["active_urgent_slots"],  # type: ignore[arg-type]
-                active_ordinary_slots=value["active_ordinary_slots"],  # type: ignore[arg-type]
-                pending_urgent=value["pending_urgent"],  # type: ignore[arg-type]
-                pending_ordinary=value["pending_ordinary"],  # type: ignore[arg-type]
-                urgent_path_state=CapacityPathState(value["urgent_path_state"]),
-            )
-        except (TypeError, ValueError) as exc:
-            raise SchedulingContractError("capacity snapshot is malformed") from exc
-
-
-def _capacity_values(
-    *, policy: ReservedCapacityPolicy, snapshot: CapacitySnapshot
-) -> dict[str, object]:
-    active_total = snapshot.active_urgent_slots + snapshot.active_ordinary_slots
-    if active_total > policy.total_slots:
-        raise SchedulingContractError("active work exceeds total capacity")
-    if snapshot.active_urgent_slots > policy.max_urgent_slots:
-        raise SchedulingContractError("active Urgent work consumed ordinary reserve")
-    if snapshot.active_ordinary_slots > policy.ordinary_capacity_ceiling:
-        raise SchedulingContractError("active ordinary work consumed Urgent reserve")
-    available = policy.total_slots - active_total
-    if snapshot.pending_urgent == 0:
-        urgent_grants = 0
-        urgent_disposition = ReservedCapacityDisposition.NO_PENDING_WORK
-    elif snapshot.urgent_path_state is not CapacityPathState.AVAILABLE:
-        urgent_grants = 0
-        urgent_disposition = policy.degraded_urgent_disposition
-    else:
-        urgent_grants = min(
-            snapshot.pending_urgent,
-            available,
-            policy.max_urgent_slots - snapshot.active_urgent_slots,
-        )
-        urgent_disposition = (
-            ReservedCapacityDisposition.ADMITTED
-            if urgent_grants
-            else ReservedCapacityDisposition.CAPACITY_DEFERRED
-        )
-    remaining = available - urgent_grants
-    ordinary_grants = min(
-        snapshot.pending_ordinary,
-        remaining,
-        policy.ordinary_capacity_ceiling - snapshot.active_ordinary_slots,
-    )
-    if snapshot.pending_ordinary == 0:
-        ordinary_disposition = ReservedCapacityDisposition.NO_PENDING_WORK
-    elif ordinary_grants:
-        ordinary_disposition = ReservedCapacityDisposition.ADMITTED
-    else:
-        ordinary_disposition = ReservedCapacityDisposition.CAPACITY_DEFERRED
-    return {
-        "urgent_grants": urgent_grants,
-        "ordinary_grants": ordinary_grants,
-        "unallocated_slots": remaining - ordinary_grants,
-        "urgent_disposition": urgent_disposition,
-        "ordinary_disposition": ordinary_disposition,
-        "downgraded_urgent_to_ordinary": False,
-    }
 
 
 @dataclass(frozen=True, slots=True)
 class ReservedCapacityDecision:
     policy: ReservedCapacityPolicy
     snapshot: CapacitySnapshot
-    urgent_grants: int
-    ordinary_grants: int
+    allocations: tuple[CapacityItemAllocation, ...]
     unallocated_slots: int
-    urgent_disposition: ReservedCapacityDisposition
-    ordinary_disposition: ReservedCapacityDisposition
-    downgraded_urgent_to_ordinary: bool
     authority: str = "NONE"
     effect: str = "NONE"
     production_activation_authorised: bool = False
 
     def __post_init__(self) -> None:
-        if not isinstance(self.policy, ReservedCapacityPolicy):
-            raise SchedulingContractError("capacity decision policy must be typed")
-        if not isinstance(self.snapshot, CapacitySnapshot):
-            raise SchedulingContractError("capacity decision snapshot must be typed")
-        for field in (
-            "urgent_grants",
-            "ordinary_grants",
-            "unallocated_slots",
+        if not isinstance(self.policy, ReservedCapacityPolicy) or not isinstance(
+            self.snapshot, CapacitySnapshot
         ):
-            _require_non_negative_int(getattr(self, field), field=field)
-        if not isinstance(
-            self.urgent_disposition, ReservedCapacityDisposition
-        ) or not isinstance(
-            self.ordinary_disposition, ReservedCapacityDisposition
+            raise SchedulingContractError("capacity decision inputs must be typed")
+        if not isinstance(self.allocations, tuple) or any(
+            not isinstance(item, CapacityItemAllocation) for item in self.allocations
         ):
-            raise SchedulingContractError("capacity dispositions must be typed")
-        if type(self.downgraded_urgent_to_ordinary) is not bool:
             raise SchedulingContractError(
-                "Urgent downgrade indicator must be boolean"
+                "capacity allocations must be a typed immutable tuple"
             )
+        _require_non_negative_int(self.unallocated_slots, field="unallocated_slots")
         expected = _capacity_values(policy=self.policy, snapshot=self.snapshot)
-        actual = {
-            "urgent_grants": self.urgent_grants,
-            "ordinary_grants": self.ordinary_grants,
-            "unallocated_slots": self.unallocated_slots,
-            "urgent_disposition": self.urgent_disposition,
-            "ordinary_disposition": self.ordinary_disposition,
-            "downgraded_urgent_to_ordinary": self.downgraded_urgent_to_ordinary,
-        }
-        if actual != expected:
+        if (
+            self.allocations != expected["allocations"]
+            or self.unallocated_slots != expected["unallocated_slots"]
+        ):
             raise SchedulingContractError(
                 "capacity decision differs from deterministic policy"
             )
@@ -1184,12 +1470,79 @@ class ReservedCapacityDecision:
             )
 
     @property
+    def granted_items(self) -> tuple[CapacityPopulationItem, ...]:
+        return tuple(
+            allocation.item
+            for allocation in self.allocations
+            if allocation.disposition is CapacityAllocationDisposition.GRANTED
+        )
+
+    @property
+    def urgent_grants(self) -> int:
+        return sum(
+            item.capacity_class is CapacityClass.URGENT_RESERVED
+            for item in self.granted_items
+        )
+
+    @property
+    def ordinary_grants(self) -> int:
+        return sum(
+            item.capacity_class is CapacityClass.ORDINARY for item in self.granted_items
+        )
+
+    @property
     def active_after_urgent(self) -> int:
         return self.snapshot.active_urgent_slots + self.urgent_grants
 
     @property
     def active_after_ordinary(self) -> int:
         return self.snapshot.active_ordinary_slots + self.ordinary_grants
+
+    @property
+    def urgent_disposition(self) -> ReservedCapacityDisposition:
+        pending = [
+            a
+            for a in self.allocations
+            if a.item.capacity_class is CapacityClass.URGENT_RESERVED
+        ]
+        if not pending:
+            return ReservedCapacityDisposition.NO_PENDING_WORK
+        if any(a.disposition is CapacityAllocationDisposition.GRANTED for a in pending):
+            return ReservedCapacityDisposition.ADMITTED
+        if any(
+            a.disposition
+            is CapacityAllocationDisposition.URGENT_VISIBLE_OPERATIONAL_HOLD
+            for a in pending
+        ):
+            return ReservedCapacityDisposition.URGENT_VISIBLE_OPERATIONAL_HOLD
+        if all(
+            a.disposition is CapacityAllocationDisposition.REVALIDATION_REQUIRED
+            for a in pending
+        ):
+            return ReservedCapacityDisposition.REVALIDATION_REQUIRED
+        return ReservedCapacityDisposition.CAPACITY_DEFERRED
+
+    @property
+    def ordinary_disposition(self) -> ReservedCapacityDisposition:
+        pending = [
+            a
+            for a in self.allocations
+            if a.item.capacity_class is CapacityClass.ORDINARY
+        ]
+        if not pending:
+            return ReservedCapacityDisposition.NO_PENDING_WORK
+        if any(a.disposition is CapacityAllocationDisposition.GRANTED for a in pending):
+            return ReservedCapacityDisposition.ADMITTED
+        if all(
+            a.disposition is CapacityAllocationDisposition.REVALIDATION_REQUIRED
+            for a in pending
+        ):
+            return ReservedCapacityDisposition.REVALIDATION_REQUIRED
+        return ReservedCapacityDisposition.CAPACITY_DEFERRED
+
+    @property
+    def downgraded_urgent_to_ordinary(self) -> bool:
+        return False
 
     @property
     def schema_version(self) -> str:
@@ -1202,6 +1555,15 @@ class ReservedCapacityDecision:
             "policy": self.policy.canonical_value(),
             "policy_digest": self.policy.policy_digest,
             "snapshot": self.snapshot.canonical_value(),
+            "allocations": [item.canonical_value() for item in self.allocations],
+            "granted_item_keys": [
+                [
+                    item.work_item_id,
+                    item.work_item_version_id,
+                    item.work_item_version_digest,
+                ]
+                for item in self.granted_items
+            ],
             "urgent_grants": self.urgent_grants,
             "ordinary_grants": self.ordinary_grants,
             "unallocated_slots": self.unallocated_slots,
@@ -1209,12 +1571,10 @@ class ReservedCapacityDecision:
             "active_after_ordinary": self.active_after_ordinary,
             "urgent_disposition": self.urgent_disposition.value,
             "ordinary_disposition": self.ordinary_disposition.value,
-            "downgraded_urgent_to_ordinary": self.downgraded_urgent_to_ordinary,
+            "downgraded_urgent_to_ordinary": False,
             "authority": self.authority,
             "effect": self.effect,
-            "production_activation_authorised": (
-                self.production_activation_authorised
-            ),
+            "production_activation_authorised": self.production_activation_authorised,
         }
 
     @property
@@ -1226,7 +1586,7 @@ class ReservedCapacityDecision:
         return digest_bytes(self.canonical_bytes)
 
     @classmethod
-    def from_canonical_bytes(cls, raw: bytes) -> "ReservedCapacityDecision":
+    def from_canonical_bytes(cls, raw: bytes) -> ReservedCapacityDecision:
         value = _decode_canonical_object(raw, field="reserved_capacity_decision")
         _strict_keys(
             value,
@@ -1236,6 +1596,8 @@ class ReservedCapacityDecision:
                 "policy",
                 "policy_digest",
                 "snapshot",
+                "allocations",
+                "granted_item_keys",
                 "urgent_grants",
                 "ordinary_grants",
                 "unallocated_slots",
@@ -1255,63 +1617,152 @@ class ReservedCapacityDecision:
             or value["record_type"] != "reserved_capacity_decision"
         ):
             raise SchedulingContractError("reserved capacity decision schema differs")
-        raw_policy = value["policy"]
-        raw_snapshot = value["snapshot"]
-        if not isinstance(raw_policy, dict) or not isinstance(raw_snapshot, dict):
+        raw_policy, raw_snapshot = value["policy"], value["snapshot"]
+        if (
+            not isinstance(raw_policy, dict)
+            or not isinstance(raw_snapshot, dict)
+            or not isinstance(value["allocations"], list)
+        ):
             raise SchedulingContractError(
-                "capacity decision policy and snapshot must be objects"
+                "capacity decision nested values are malformed"
             )
         policy = ReservedCapacityPolicy.from_mapping(raw_policy)
         snapshot = CapacitySnapshot.from_mapping(raw_snapshot)
         if value["policy_digest"] != policy.policy_digest:
             raise SchedulingContractError("capacity policy digest differs")
+        # Allocations are policy-derived, never trusted from the caller.
+        expected = _capacity_values(policy=policy, snapshot=snapshot)
         try:
             result = cls(
                 policy=policy,
                 snapshot=snapshot,
-                urgent_grants=value["urgent_grants"],  # type: ignore[arg-type]
-                ordinary_grants=value["ordinary_grants"],  # type: ignore[arg-type]
-                unallocated_slots=value["unallocated_slots"],  # type: ignore[arg-type]
-                urgent_disposition=ReservedCapacityDisposition(
-                    value["urgent_disposition"]
-                ),
-                ordinary_disposition=ReservedCapacityDisposition(
-                    value["ordinary_disposition"]
-                ),
-                downgraded_urgent_to_ordinary=value[
-                    "downgraded_urgent_to_ordinary"
-                ],  # type: ignore[arg-type]
-                authority=value["authority"],  # type: ignore[arg-type]
-                effect=value["effect"],  # type: ignore[arg-type]
+                allocations=expected["allocations"],
+                unallocated_slots=value["unallocated_slots"],
+                authority=value["authority"],
+                effect=value["effect"],
                 production_activation_authorised=value[
                     "production_activation_authorised"
-                ],  # type: ignore[arg-type]
-            )
+                ],
+            )  # type: ignore[arg-type]
         except (TypeError, ValueError) as exc:
             raise SchedulingContractError(
                 "reserved capacity decision is malformed"
             ) from exc
-        if (
-            value["active_after_urgent"] != result.active_after_urgent
-            or value["active_after_ordinary"] != result.active_after_ordinary
-        ):
-            raise SchedulingContractError("capacity active totals differ")
         if result.canonical_bytes != raw:
-            raise SchedulingContractError(
-                "reserved capacity decision is not canonical"
-            )
+            raise SchedulingContractError("reserved capacity decision is not canonical")
         return result
+
+
+def _canonical_pending(
+    items: tuple[CapacityPopulationItem, ...],
+) -> list[CapacityPopulationItem]:
+    return sorted(items, key=lambda item: item.observation.order_key or ())
+
+
+def _capacity_values(
+    *, policy: ReservedCapacityPolicy, snapshot: CapacitySnapshot
+) -> dict[str, object]:
+    active_total = snapshot.active_urgent_slots + snapshot.active_ordinary_slots
+    if active_total > policy.total_slots:
+        raise SchedulingContractError("active work exceeds total capacity")
+    if snapshot.active_urgent_slots > policy.max_urgent_slots:
+        raise SchedulingContractError("active Urgent work consumed ordinary reserve")
+    if snapshot.active_ordinary_slots > policy.ordinary_capacity_ceiling:
+        raise SchedulingContractError("active ordinary work consumed Urgent reserve")
+    available = policy.total_slots - active_total
+    urgent = _canonical_pending(
+        snapshot.items(
+            state=CapacityWorkState.PENDING,
+            capacity_class=CapacityClass.URGENT_RESERVED,
+        )
+    )
+    ordinary = _canonical_pending(
+        snapshot.items(
+            state=CapacityWorkState.PENDING, capacity_class=CapacityClass.ORDINARY
+        )
+    )
+    urgent_eligible = [
+        item
+        for item in urgent
+        if item.revalidation
+        is not CapacityRevalidationDisposition.REVALIDATION_REQUIRED
+    ]
+    urgent_limit = (
+        0
+        if snapshot.urgent_path_state is not CapacityPathState.AVAILABLE
+        else min(available, policy.max_urgent_slots - snapshot.active_urgent_slots)
+    )
+    urgent_selected = {item.identity_key for item in urgent_eligible[:urgent_limit]}
+    remaining = available - len(urgent_selected)
+    ordinary_limit = min(
+        remaining, policy.ordinary_capacity_ceiling - snapshot.active_ordinary_slots
+    )
+    ordinary_eligible = [
+        item
+        for item in ordinary
+        if item.revalidation
+        is not CapacityRevalidationDisposition.REVALIDATION_REQUIRED
+    ]
+    protected = next(
+        (
+            item
+            for item in ordinary_eligible
+            if item.lane is PriorityLane.ROUTINE
+            and item.observation.starvation_state is StarvationState.STARVED
+            and item.revalidation is CapacityRevalidationDisposition.REVALIDATED
+        ),
+        None,
+    )
+    selected_ordinary: list[CapacityPopulationItem] = []
+    if ordinary_limit and protected is not None:
+        selected_ordinary.append(protected)
+    selected_ordinary.extend(
+        item for item in ordinary_eligible if item is not protected
+    )
+    selected_ordinary = selected_ordinary[:ordinary_limit]
+    ordinary_selected = {item.identity_key for item in selected_ordinary}
+    allocations: list[CapacityItemAllocation] = []
+    for item in urgent + ordinary:
+        if item.revalidation is CapacityRevalidationDisposition.REVALIDATION_REQUIRED:
+            disposition = CapacityAllocationDisposition.REVALIDATION_REQUIRED
+        elif (
+            item.capacity_class is CapacityClass.URGENT_RESERVED
+            and snapshot.urgent_path_state is not CapacityPathState.AVAILABLE
+        ):
+            disposition = CapacityAllocationDisposition.URGENT_VISIBLE_OPERATIONAL_HOLD
+        elif (
+            item.identity_key in urgent_selected
+            or item.identity_key in ordinary_selected
+        ):
+            disposition = CapacityAllocationDisposition.GRANTED
+        else:
+            disposition = CapacityAllocationDisposition.CAPACITY_DEFERRED
+        allocations.append(
+            CapacityItemAllocation(
+                item=item,
+                disposition=disposition,
+                protected_routine_grant=(
+                    protected is item
+                    and disposition is CapacityAllocationDisposition.GRANTED
+                ),
+            )
+        )
+    grants = sum(
+        item.disposition is CapacityAllocationDisposition.GRANTED
+        for item in allocations
+    )
+    return {"allocations": tuple(allocations), "unallocated_slots": available - grants}
 
 
 def allocate_reserved_capacity(
     *, policy: ReservedCapacityPolicy, snapshot: CapacitySnapshot
 ) -> ReservedCapacityDecision:
-    """Return grants only; this pure function owns no queue admission effect."""
+    """Select exact population members; this pure function owns no queue effect."""
 
-    if not isinstance(policy, ReservedCapacityPolicy):
-        raise TypeError("reserved capacity policy must be typed")
-    if not isinstance(snapshot, CapacitySnapshot):
-        raise TypeError("capacity snapshot must be typed")
+    if not isinstance(policy, ReservedCapacityPolicy) or not isinstance(
+        snapshot, CapacitySnapshot
+    ):
+        raise SchedulingContractError("reserved capacity inputs must be typed")
     values = _capacity_values(policy=policy, snapshot=snapshot)
     return ReservedCapacityDecision(policy=policy, snapshot=snapshot, **values)  # type: ignore[arg-type]
 
@@ -1326,9 +1777,14 @@ __all__ = [
     "SCHEDULING_POLICY_SCHEMA_VERSION",
     "STARVATION_OBSERVATION",
     "URGENCY_DEADLINE_POLICY",
-    "CapacityPathState",
+    "CapacityAllocationDisposition",
     "CapacityClass",
+    "CapacityItemAllocation",
+    "CapacityPathState",
+    "CapacityPopulationItem",
+    "CapacityRevalidationDisposition",
     "CapacitySnapshot",
+    "CapacityWorkState",
     "DeadlineBoundary",
     "DeadlineKind",
     "LaneTimingRule",
@@ -1343,6 +1799,6 @@ __all__ = [
     "UrgencyDeadlineInput",
     "UrgencyDeadlinePolicy",
     "allocate_reserved_capacity",
-    "capacity_class_for_lane",
     "calculate_urgency_deadline",
+    "capacity_class_for_lane",
 ]

--- a/newsroom/increment6/scheduling.py
+++ b/newsroom/increment6/scheduling.py
@@ -21,7 +21,11 @@ from newsroom.authority.canonical import (
     canonical_json_bytes,
     digest_bytes,
 )
-from newsroom.increment6.outcomes import PriorityLane, PrioritySelection
+from newsroom.increment6.outcomes import (
+    PriorityLane,
+    PrioritySelection,
+    ReasonReference,
+)
 
 SCHEDULING_POLICY_SCHEMA_VERSION = "newsroom.increment6.triage-scheduling-policy.v1"
 
@@ -31,9 +35,13 @@ _DIGEST_RE = re.compile(r"sha256:[0-9a-f]{64}\Z")
 _LOCAL_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S"
 _UTC_TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 _TIE_BREAK = "WORK_ITEM_VERSION_ID_ASC"
-_MAX_CANONICAL_BYTES = 1_000_000
 _MAX_CAPACITY_ITEM_BYTES = 16_384
 _MAX_CAPACITY_POPULATION = 48
+_MAX_CANONICAL_OVERHEAD_BYTES = 131_072
+_MAX_JSON_DEPTH = 64
+_MAX_CANONICAL_BYTES = (
+    _MAX_CAPACITY_POPULATION * _MAX_CAPACITY_ITEM_BYTES + _MAX_CANONICAL_OVERHEAD_BYTES
+)
 _MAX_INTEGER = 2_147_483_647
 _MAX_DURATION_SECONDS = 315_576_000  # ten years, including leap-day headroom
 
@@ -107,15 +115,48 @@ def _unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
 def _decode_canonical_object(raw: bytes, *, field: str) -> dict[str, object]:
     if not isinstance(raw, bytes) or not raw or len(raw) > _MAX_CANONICAL_BYTES:
         raise SchedulingContractError(f"{field} bounded bytes are required")
+    depth = 0
+    in_string = False
+    escaped = False
+    for byte in raw:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif byte == ord("\\"):
+                escaped = True
+            elif byte == ord('"'):
+                in_string = False
+        elif byte == ord('"'):
+            in_string = True
+        elif byte in {ord("{"), ord("[")}:
+            depth += 1
+            if depth > _MAX_JSON_DEPTH:
+                raise SchedulingContractError(f"{field} exceeds the JSON depth bound")
+        elif byte in {ord("}"), ord("]")}:
+            depth -= 1
+            if depth < 0:
+                raise SchedulingContractError(f"{field} has invalid JSON depth")
     try:
         value = json.loads(raw.decode("utf-8"), object_pairs_hook=_unique_object)
-    except (UnicodeDecodeError, json.JSONDecodeError, ValueError, MemoryError) as exc:
+    except (
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        ValueError,
+        MemoryError,
+        RecursionError,
+    ) as exc:
         raise SchedulingContractError(f"{field} is not JSON") from exc
     if not isinstance(value, dict):
         raise SchedulingContractError(f"{field} must be an object")
     try:
         canonical = canonical_json_bytes(value)
-    except (CanonicalizationError, ValueError, OverflowError, MemoryError) as exc:
+    except (
+        CanonicalizationError,
+        ValueError,
+        OverflowError,
+        MemoryError,
+        RecursionError,
+    ) as exc:
         raise SchedulingContractError(f"{field} is not canonical JSON") from exc
     if canonical != raw:
         raise SchedulingContractError(f"{field} is not canonical JSON")
@@ -916,7 +957,6 @@ class ReservedCapacityDisposition(StrEnum):
     NO_PENDING_WORK = "NO_PENDING_WORK"
     CAPACITY_DEFERRED = "CAPACITY_DEFERRED"
     URGENT_VISIBLE_OPERATIONAL_HOLD = "URGENT_VISIBLE_OPERATIONAL_HOLD"
-    REVALIDATION_REQUIRED = "REVALIDATION_REQUIRED"
 
 
 class CapacityWorkState(StrEnum):
@@ -924,17 +964,16 @@ class CapacityWorkState(StrEnum):
     PENDING = "PENDING"
 
 
-class CapacityRevalidationDisposition(StrEnum):
-    NOT_REQUIRED = "NOT_REQUIRED"
+class CapacityRevalidationResult(StrEnum):
     REVALIDATED = "REVALIDATED"
-    REVALIDATION_REQUIRED = "REVALIDATION_REQUIRED"
+    EXPIRED = "EXPIRED"
+    CLOSED = "CLOSED"
 
 
 class CapacityAllocationDisposition(StrEnum):
     GRANTED = "GRANTED"
     CAPACITY_DEFERRED = "CAPACITY_DEFERRED"
     URGENT_VISIBLE_OPERATIONAL_HOLD = "URGENT_VISIBLE_OPERATIONAL_HOLD"
-    REVALIDATION_REQUIRED = "REVALIDATION_REQUIRED"
 
 
 @dataclass(frozen=True, slots=True)
@@ -1074,84 +1113,251 @@ class ReservedCapacityPolicy:
 
 
 @dataclass(frozen=True, slots=True)
-class CapacityPopulationItem:
-    """One immutable population member bound to its canonical priority observation."""
+class CapacityRevalidationEvidence:
+    """Bounded input seam for a downstream authoritative currentness receipt.
+
+    This pure contract carries no authority itself.  A downstream authority may
+    bind its receipt to these exact bytes before presenting it to allocation.
+    """
 
     work_item_id: str
     work_item_version_id: str
     work_item_version_digest: str
-    priority_selection: PrioritySelection
-    observation: StarvationObservation
-    state: CapacityWorkState
-    revalidation: CapacityRevalidationDisposition
+    starvation_observation_digest: str
+    governing_policy_digest: str
+    snapshot_observed_at: str
+    currentness_basis: tuple[ReasonReference, ...]
+    result: CapacityRevalidationResult
+    authority: str = "NONE"
+    effect: str = "NONE"
 
     def __post_init__(self) -> None:
-        _require_token(self.work_item_id, field="capacity_work_item_id")
-        _require_token(self.work_item_version_id, field="capacity_work_item_version_id")
-        _require_digest(
-            self.work_item_version_digest, field="capacity_work_item_version_digest"
+        _require_token(self.work_item_id, field="revalidation_work_item_id")
+        _require_token(
+            self.work_item_version_id,
+            field="revalidation_work_item_version_id",
         )
-        if not isinstance(self.priority_selection, PrioritySelection) or not isinstance(
-            self.observation, StarvationObservation
+        _require_digest(
+            self.work_item_version_digest,
+            field="revalidation_work_item_version_digest",
+        )
+        _require_digest(
+            self.starvation_observation_digest,
+            field="revalidation_starvation_observation_digest",
+        )
+        _require_digest(
+            self.governing_policy_digest,
+            field="revalidation_governing_policy_digest",
+        )
+        _parse_utc(
+            self.snapshot_observed_at,
+            field="revalidation_snapshot_observed_at",
+        )
+        if (
+            not isinstance(self.currentness_basis, tuple)
+            or len(self.currentness_basis) != 1
+            or any(
+                not isinstance(item, ReasonReference) for item in self.currentness_basis
+            )
         ):
             raise SchedulingContractError(
-                "capacity item priority and observation must be typed"
+                "revalidation currentness basis must be an immutable typed tuple"
+            )
+        basis_bytes = tuple(
+            canonical_json_bytes(item.canonical_value())
+            for item in self.currentness_basis
+        )
+        if basis_bytes != tuple(sorted(basis_bytes)) or len(basis_bytes) != len(
+            set(basis_bytes)
+        ):
+            raise SchedulingContractError(
+                "revalidation currentness basis must be sorted and unique"
+            )
+        if not isinstance(self.result, CapacityRevalidationResult):
+            raise SchedulingContractError("revalidation result must be typed")
+        expected_basis_type = f"revalidation-{self.result.value.lower()}"
+        if self.currentness_basis[0].reference_type != expected_basis_type:
+            raise SchedulingContractError(
+                "revalidation result differs from its currentness basis"
+            )
+        if self.authority != "NONE" or self.effect != "NONE":
+            raise SchedulingContractError(
+                "revalidation evidence cannot claim authority or effect"
+            )
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "work_item_id": self.work_item_id,
+            "work_item_version_id": self.work_item_version_id,
+            "work_item_version_digest": self.work_item_version_digest,
+            "starvation_observation_digest": self.starvation_observation_digest,
+            "governing_policy_digest": self.governing_policy_digest,
+            "snapshot_observed_at": self.snapshot_observed_at,
+            "currentness_basis": [
+                item.canonical_value() for item in self.currentness_basis
+            ],
+            "result": self.result.value,
+            "authority": self.authority,
+            "effect": self.effect,
+        }
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return canonical_json_bytes(self.canonical_value())
+
+    @property
+    def evidence_digest(self) -> str:
+        return digest_bytes(self.canonical_bytes)
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> CapacityRevalidationEvidence:
+        _strict_keys(
+            value,
+            required={
+                "work_item_id",
+                "work_item_version_id",
+                "work_item_version_digest",
+                "starvation_observation_digest",
+                "governing_policy_digest",
+                "snapshot_observed_at",
+                "currentness_basis",
+                "result",
+                "authority",
+                "effect",
+            },
+            field="capacity_revalidation_evidence",
+        )
+        raw_basis = value["currentness_basis"]
+        if not isinstance(raw_basis, list) or any(
+            not isinstance(item, dict) for item in raw_basis
+        ):
+            raise SchedulingContractError(
+                "revalidation currentness basis must be an array of objects"
             )
         try:
-            if (
-                len(self.priority_selection.canonical_bytes) > _MAX_CAPACITY_ITEM_BYTES
-                or len(self.observation.canonical_bytes) > _MAX_CAPACITY_ITEM_BYTES
-            ):
+            return cls(
+                work_item_id=value["work_item_id"],
+                work_item_version_id=value["work_item_version_id"],
+                work_item_version_digest=value["work_item_version_digest"],
+                starvation_observation_digest=value["starvation_observation_digest"],
+                governing_policy_digest=value["governing_policy_digest"],
+                snapshot_observed_at=value["snapshot_observed_at"],
+                currentness_basis=tuple(
+                    ReasonReference.from_mapping(item) for item in raw_basis
+                ),
+                result=CapacityRevalidationResult(value["result"]),
+                authority=value["authority"],
+                effect=value["effect"],
+            )  # type: ignore[arg-type]
+        except (TypeError, ValueError) as exc:
+            raise SchedulingContractError(
+                "capacity revalidation evidence is malformed"
+            ) from exc
+
+
+@dataclass(frozen=True, slots=True)
+class CapacityPopulationItem:
+    """One immutable population member with no duplicated identity or lane state."""
+
+    observation: StarvationObservation
+    state: CapacityWorkState
+    revalidation_evidence: CapacityRevalidationEvidence | None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.observation, StarvationObservation):
+            raise SchedulingContractError("capacity item observation must be typed")
+        try:
+            if len(self.observation.canonical_bytes) > _MAX_CAPACITY_ITEM_BYTES:
                 raise SchedulingContractError(
                     "capacity item exceeds the canonical byte bound"
                 )
-        except (CanonicalizationError, ValueError, OverflowError, MemoryError) as exc:
+        except (
+            CanonicalizationError,
+            ValueError,
+            OverflowError,
+            MemoryError,
+            RecursionError,
+        ) as exc:
             raise SchedulingContractError(
                 "capacity item is not canonically representable"
             ) from exc
-        source = self.observation.item
-        if (
-            self.work_item_id != source.work_item_id
-            or self.work_item_version_id != source.work_item_version_id
-            or self.work_item_version_digest != source.work_item_version_digest
-            or self.priority_selection != source.priority_selection
+        if not isinstance(self.state, CapacityWorkState):
+            raise SchedulingContractError("capacity item state must be typed")
+        if self.revalidation_evidence is not None and not isinstance(
+            self.revalidation_evidence, CapacityRevalidationEvidence
         ):
             raise SchedulingContractError(
-                "capacity item differs from its exact scheduling observation"
-            )
-        if not isinstance(self.state, CapacityWorkState) or not isinstance(
-            self.revalidation, CapacityRevalidationDisposition
-        ):
-            raise SchedulingContractError(
-                "capacity item state and revalidation must be typed"
+                "capacity item revalidation evidence must be typed or null"
             )
         if not self.observation.schedulable:
             raise SchedulingContractError(
                 "capacity population may contain only canonical schedulable work"
             )
-        required = self.observation.revalidation_required
-        if required and self.revalidation not in {
-            CapacityRevalidationDisposition.REVALIDATED,
-            CapacityRevalidationDisposition.REVALIDATION_REQUIRED,
-        }:
+        evidence = self.revalidation_evidence
+        if self.observation.revalidation_required and evidence is None:
             raise SchedulingContractError(
-                "capacity item must expose required revalidation"
+                "capacity item must expose exact revalidation evidence"
             )
-        if (
-            not required
-            and self.revalidation is not CapacityRevalidationDisposition.NOT_REQUIRED
-        ):
+        if not self.observation.revalidation_required and evidence is not None:
             raise SchedulingContractError(
-                "capacity item has a conflicting revalidation state"
+                "capacity item has conflicting revalidation evidence"
             )
-        if (
-            self.state is CapacityWorkState.ACTIVE
-            and self.revalidation
-            is CapacityRevalidationDisposition.REVALIDATION_REQUIRED
-        ):
+        if evidence is not None:
+            source = self.observation.item
+            if (
+                evidence.work_item_id != source.work_item_id
+                or evidence.work_item_version_id != source.work_item_version_id
+                or evidence.work_item_version_digest != source.work_item_version_digest
+                or evidence.starvation_observation_digest
+                != self.observation.decision_digest
+                or evidence.governing_policy_digest
+                != self.observation.policy.policy_digest
+                or evidence.snapshot_observed_at != source.observed_at
+            ):
+                raise SchedulingContractError(
+                    "revalidation evidence differs from its exact observation"
+                )
+            if (
+                self.state is CapacityWorkState.ACTIVE
+                and evidence.result is not CapacityRevalidationResult.REVALIDATED
+            ):
+                raise SchedulingContractError(
+                    "active work requires current revalidated evidence"
+                )
+        try:
+            if (
+                len(canonical_json_bytes(self.canonical_value()))
+                > _MAX_CAPACITY_ITEM_BYTES
+            ):
+                raise SchedulingContractError(
+                    "capacity item exceeds the canonical byte bound"
+                )
+        except (
+            CanonicalizationError,
+            ValueError,
+            OverflowError,
+            MemoryError,
+            RecursionError,
+        ) as exc:
             raise SchedulingContractError(
-                "active work cannot still require revalidation"
-            )
+                "capacity item is not canonically representable"
+            ) from exc
+
+    @property
+    def work_item_id(self) -> str:
+        return self.observation.item.work_item_id
+
+    @property
+    def work_item_version_id(self) -> str:
+        return self.observation.item.work_item_version_id
+
+    @property
+    def work_item_version_digest(self) -> str:
+        return self.observation.item.work_item_version_digest
+
+    @property
+    def priority_selection(self) -> PrioritySelection:
+        return self.observation.item.priority_selection
 
     @property
     def lane(self) -> PriorityLane:
@@ -1165,21 +1371,29 @@ class CapacityPopulationItem:
     def identity_key(self) -> tuple[str, str]:
         return (self.work_item_id, self.work_item_version_id)
 
+    @property
+    def revalidation_result(self) -> CapacityRevalidationResult | None:
+        return (
+            None
+            if self.revalidation_evidence is None
+            else self.revalidation_evidence.result
+        )
+
     def canonical_value(self) -> dict[str, object]:
         return {
-            "work_item_id": self.work_item_id,
-            "work_item_version_id": self.work_item_version_id,
-            "work_item_version_digest": self.work_item_version_digest,
-            "priority_selection": self.priority_selection.canonical_value(),
-            "priority_selection_digest": digest_bytes(
-                self.priority_selection.canonical_bytes
-            ),
             "observation": self.observation.canonical_value(),
             "observation_digest": self.observation.decision_digest,
             "state": self.state.value,
-            "revalidation": self.revalidation.value,
-            "lane": self.lane.value,
-            "capacity_class": self.capacity_class.value,
+            "revalidation_evidence": (
+                None
+                if self.revalidation_evidence is None
+                else self.revalidation_evidence.canonical_value()
+            ),
+            "revalidation_evidence_digest": (
+                None
+                if self.revalidation_evidence is None
+                else self.revalidation_evidence.evidence_digest
+            ),
         }
 
     @classmethod
@@ -1187,58 +1401,50 @@ class CapacityPopulationItem:
         _strict_keys(
             value,
             required={
-                "work_item_id",
-                "work_item_version_id",
-                "work_item_version_digest",
-                "priority_selection",
-                "priority_selection_digest",
                 "observation",
                 "observation_digest",
                 "state",
-                "revalidation",
-                "lane",
-                "capacity_class",
+                "revalidation_evidence",
+                "revalidation_evidence_digest",
             },
             field="capacity_population_item",
         )
-        raw_priority, raw_observation = (
-            value["priority_selection"],
-            value["observation"],
-        )
-        if not isinstance(raw_priority, dict) or not isinstance(raw_observation, dict):
+        raw_observation = value["observation"]
+        raw_evidence = value["revalidation_evidence"]
+        if not isinstance(raw_observation, dict) or (
+            raw_evidence is not None and not isinstance(raw_evidence, dict)
+        ):
             raise SchedulingContractError(
-                "capacity item priority and observation must be objects"
+                "capacity item observation and evidence are malformed"
             )
         try:
-            priority = PrioritySelection.from_mapping(raw_priority)
             observation = StarvationObservation.from_canonical_bytes(
                 canonical_json_bytes(raw_observation)
             )
+            evidence = (
+                None
+                if raw_evidence is None
+                else CapacityRevalidationEvidence.from_mapping(raw_evidence)
+            )
             result = cls(
-                work_item_id=value["work_item_id"],
-                work_item_version_id=value["work_item_version_id"],
-                work_item_version_digest=value["work_item_version_digest"],
-                priority_selection=priority,
                 observation=observation,
                 state=CapacityWorkState(value["state"]),
-                revalidation=CapacityRevalidationDisposition(value["revalidation"]),
-            )  # type: ignore[arg-type]
+                revalidation_evidence=evidence,
+            )
         except (
             TypeError,
             ValueError,
             CanonicalizationError,
             MemoryError,
             OverflowError,
+            RecursionError,
         ) as exc:
             raise SchedulingContractError(
                 "capacity population item is malformed"
             ) from exc
-        if (
-            value["priority_selection_digest"] != digest_bytes(priority.canonical_bytes)
-            or value["observation_digest"] != observation.decision_digest
-            or value["lane"] != result.lane.value
-            or value["capacity_class"] != result.capacity_class.value
-        ):
+        if value["observation_digest"] != observation.decision_digest or value[
+            "revalidation_evidence_digest"
+        ] != (None if evidence is None else evidence.evidence_digest):
             raise SchedulingContractError("capacity item derived binding differs")
         return result
 
@@ -1246,11 +1452,16 @@ class CapacityPopulationItem:
 @dataclass(frozen=True, slots=True)
 class CapacitySnapshot:
     observed_at: str
+    urgency_policy: UrgencyDeadlinePolicy
     population: tuple[CapacityPopulationItem, ...]
     urgent_path_state: CapacityPathState
 
     def __post_init__(self) -> None:
         _parse_utc(self.observed_at, field="capacity_observed_at")
+        if not isinstance(self.urgency_policy, UrgencyDeadlinePolicy):
+            raise SchedulingContractError(
+                "capacity snapshot urgency policy must be typed"
+            )
         if not isinstance(self.population, tuple) or any(
             not isinstance(item, CapacityPopulationItem) for item in self.population
         ):
@@ -1266,6 +1477,10 @@ class CapacitySnapshot:
         identities: set[str] = set()
         versions: set[tuple[str, str]] = set()
         for item in self.population:
+            if item.observation.policy != self.urgency_policy:
+                raise SchedulingContractError(
+                    "capacity item uses a different exact urgency policy"
+                )
             if item.observation.item.observed_at != self.observed_at:
                 raise SchedulingContractError(
                     "capacity item observation time differs from snapshot"
@@ -1329,6 +1544,8 @@ class CapacitySnapshot:
     def canonical_value(self) -> dict[str, object]:
         return {
             "observed_at": self.observed_at,
+            "urgency_policy": self.urgency_policy.canonical_value(),
+            "urgency_policy_digest": self.urgency_policy.policy_digest,
             "population": [item.canonical_value() for item in self.population],
             "urgent_path_state": self.urgent_path_state.value,
             "active_urgent_slots": self.active_urgent_slots,
@@ -1343,6 +1560,8 @@ class CapacitySnapshot:
             value,
             required={
                 "observed_at",
+                "urgency_policy",
+                "urgency_policy_digest",
                 "population",
                 "urgent_path_state",
                 "active_urgent_slots",
@@ -1353,6 +1572,11 @@ class CapacitySnapshot:
             field="capacity_snapshot",
         )
         raw_population = value["population"]
+        raw_urgency_policy = value["urgency_policy"]
+        if not isinstance(raw_urgency_policy, dict):
+            raise SchedulingContractError(
+                "capacity snapshot urgency policy must be an object"
+            )
         if not isinstance(raw_population, list) or any(
             not isinstance(item, dict) for item in raw_population
         ):
@@ -1360,8 +1584,10 @@ class CapacitySnapshot:
                 "capacity population must be an array of objects"
             )
         try:
+            urgency_policy = UrgencyDeadlinePolicy.from_mapping(raw_urgency_policy)
             result = cls(
                 observed_at=value["observed_at"],
+                urgency_policy=urgency_policy,
                 population=tuple(
                     CapacityPopulationItem.from_mapping(item) for item in raw_population
                 ),
@@ -1369,6 +1595,10 @@ class CapacitySnapshot:
             )  # type: ignore[arg-type]
         except (TypeError, ValueError) as exc:
             raise SchedulingContractError("capacity snapshot is malformed") from exc
+        if value["urgency_policy_digest"] != urgency_policy.policy_digest:
+            raise SchedulingContractError(
+                "capacity snapshot urgency policy digest differs"
+            )
         for field in (
             "active_urgent_slots",
             "active_ordinary_slots",
@@ -1410,7 +1640,8 @@ class CapacityItemAllocation:
             self.disposition is not CapacityAllocationDisposition.GRANTED
             or self.item.lane is not PriorityLane.ROUTINE
             or self.item.observation.starvation_state is not StarvationState.STARVED
-            or self.item.revalidation is not CapacityRevalidationDisposition.REVALIDATED
+            or self.item.revalidation_result
+            is not CapacityRevalidationResult.REVALIDATED
         ):
             raise SchedulingContractError("protected Routine grant is not eligible")
 
@@ -1426,8 +1657,22 @@ class CapacityItemAllocation:
             "lane": self.item.lane.value,
             "capacity_class": self.item.capacity_class.value,
             "disposition": self.disposition.value,
+            "revalidation_result": (
+                None
+                if self.revalidation_result is None
+                else self.revalidation_result.value
+            ),
+            "revalidation_evidence_digest": (
+                None
+                if self.item.revalidation_evidence is None
+                else self.item.revalidation_evidence.evidence_digest
+            ),
             "protected_routine_grant": self.protected_routine_grant,
         }
+
+    @property
+    def revalidation_result(self) -> CapacityRevalidationResult | None:
+        return self.item.revalidation_result
 
 
 @dataclass(frozen=True, slots=True)
@@ -1515,11 +1760,6 @@ class ReservedCapacityDecision:
             for a in pending
         ):
             return ReservedCapacityDisposition.URGENT_VISIBLE_OPERATIONAL_HOLD
-        if all(
-            a.disposition is CapacityAllocationDisposition.REVALIDATION_REQUIRED
-            for a in pending
-        ):
-            return ReservedCapacityDisposition.REVALIDATION_REQUIRED
         return ReservedCapacityDisposition.CAPACITY_DEFERRED
 
     @property
@@ -1533,11 +1773,6 @@ class ReservedCapacityDecision:
             return ReservedCapacityDisposition.NO_PENDING_WORK
         if any(a.disposition is CapacityAllocationDisposition.GRANTED for a in pending):
             return ReservedCapacityDisposition.ADMITTED
-        if all(
-            a.disposition is CapacityAllocationDisposition.REVALIDATION_REQUIRED
-            for a in pending
-        ):
-            return ReservedCapacityDisposition.REVALIDATION_REQUIRED
         return ReservedCapacityDisposition.CAPACITY_DEFERRED
 
     @property
@@ -1684,8 +1919,7 @@ def _capacity_values(
     urgent_eligible = [
         item
         for item in urgent
-        if item.revalidation
-        is not CapacityRevalidationDisposition.REVALIDATION_REQUIRED
+        if item.revalidation_result in {None, CapacityRevalidationResult.REVALIDATED}
     ]
     urgent_limit = (
         0
@@ -1700,8 +1934,7 @@ def _capacity_values(
     ordinary_eligible = [
         item
         for item in ordinary
-        if item.revalidation
-        is not CapacityRevalidationDisposition.REVALIDATION_REQUIRED
+        if item.revalidation_result in {None, CapacityRevalidationResult.REVALIDATED}
     ]
     protected = next(
         (
@@ -1709,7 +1942,7 @@ def _capacity_values(
             for item in ordinary_eligible
             if item.lane is PriorityLane.ROUTINE
             and item.observation.starvation_state is StarvationState.STARVED
-            and item.revalidation is CapacityRevalidationDisposition.REVALIDATED
+            and item.revalidation_result is CapacityRevalidationResult.REVALIDATED
         ),
         None,
     )
@@ -1723,9 +1956,7 @@ def _capacity_values(
     ordinary_selected = {item.identity_key for item in selected_ordinary}
     allocations: list[CapacityItemAllocation] = []
     for item in urgent + ordinary:
-        if item.revalidation is CapacityRevalidationDisposition.REVALIDATION_REQUIRED:
-            disposition = CapacityAllocationDisposition.REVALIDATION_REQUIRED
-        elif (
+        if (
             item.capacity_class is CapacityClass.URGENT_RESERVED
             and snapshot.urgent_path_state is not CapacityPathState.AVAILABLE
         ):
@@ -1782,7 +2013,8 @@ __all__ = [
     "CapacityItemAllocation",
     "CapacityPathState",
     "CapacityPopulationItem",
-    "CapacityRevalidationDisposition",
+    "CapacityRevalidationEvidence",
+    "CapacityRevalidationResult",
     "CapacitySnapshot",
     "CapacityWorkState",
     "DeadlineBoundary",

--- a/newsroom/increment6/scheduling.py
+++ b/newsroom/increment6/scheduling.py
@@ -42,6 +42,7 @@ _MAX_JSON_DEPTH = 64
 _MAX_CANONICAL_BYTES = (
     _MAX_CAPACITY_POPULATION * _MAX_CAPACITY_ITEM_BYTES + _MAX_CANONICAL_OVERHEAD_BYTES
 )
+_MAX_STARVATION_OBSERVATION_BYTES = _MAX_CANONICAL_BYTES
 _MAX_INTEGER = 2_147_483_647
 _MAX_DURATION_SECONDS = 315_576_000  # ten years, including leap-day headroom
 
@@ -805,6 +806,22 @@ class StarvationObservation:
             raise SchedulingContractError(
                 "starvation observation cannot claim authority, effect or activation"
             )
+        try:
+            canonical = canonical_json_bytes(self.canonical_value())
+        except (
+            CanonicalizationError,
+            ValueError,
+            OverflowError,
+            MemoryError,
+            RecursionError,
+        ) as exc:
+            raise SchedulingContractError(
+                "starvation observation is not canonically representable"
+            ) from exc
+        if len(canonical) > _MAX_STARVATION_OBSERVATION_BYTES:
+            raise SchedulingContractError(
+                "starvation observation exceeds the canonical byte bound"
+            )
 
     @property
     def schema_version(self) -> str:
@@ -842,6 +859,10 @@ class StarvationObservation:
 
     @classmethod
     def from_canonical_bytes(cls, raw: bytes) -> StarvationObservation:
+        if not isinstance(raw, bytes) or len(raw) > _MAX_STARVATION_OBSERVATION_BYTES:
+            raise SchedulingContractError(
+                "starvation observation exceeds the canonical byte bound"
+            )
         value = _decode_canonical_object(raw, field="starvation_observation")
         _strict_keys(
             value,

--- a/newsroom/increment6/scheduling.py
+++ b/newsroom/increment6/scheduling.py
@@ -1,0 +1,1348 @@
+"""Pure urgency, deadline, reserved-capacity and starvation policy.
+
+The module calculates an inspectable scheduling order from exact caller-supplied
+UTC observations.  It owns no queue, clock, Work Item state, authority read or
+effect.  Priority can order only explicitly current and eligible work; it cannot
+turn stale, closed, blocked or dependency-bound work into schedulable work.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum
+from typing import Mapping
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from newsroom.authority.canonical import (
+    CanonicalizationError,
+    canonical_json_bytes,
+    digest_bytes,
+)
+from newsroom.increment6.outcomes import PriorityLane, PrioritySelection
+
+
+SCHEDULING_POLICY_SCHEMA_VERSION = (
+    "newsroom.increment6.triage-scheduling-policy.v1"
+)
+
+_TOKEN_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:\-]{0,255}\Z")
+_ZONE_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._+\-/]{0,255}\Z")
+_DIGEST_RE = re.compile(r"sha256:[0-9a-f]{64}\Z")
+_LOCAL_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S"
+_UTC_TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+_TIE_BREAK = "WORK_ITEM_VERSION_ID_ASC"
+
+
+class SchedulingContractError(ValueError):
+    """A scheduling policy, input, observation or decision is malformed."""
+
+
+def _require_token(value: object, *, field: str) -> str:
+    if not isinstance(value, str) or _TOKEN_RE.fullmatch(value) is None:
+        raise SchedulingContractError(f"{field} must be a bounded canonical token")
+    return value
+
+
+def _require_digest(value: object, *, field: str) -> str:
+    if not isinstance(value, str) or _DIGEST_RE.fullmatch(value) is None:
+        raise SchedulingContractError(f"{field} must be a canonical SHA-256 digest")
+    return value
+
+
+def _require_non_negative_int(value: object, *, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise SchedulingContractError(f"{field} must be a non-negative integer")
+    return value
+
+
+def _require_positive_int(value: object, *, field: str) -> int:
+    result = _require_non_negative_int(value, field=field)
+    if result == 0:
+        raise SchedulingContractError(f"{field} must be positive")
+    return result
+
+
+def _parse_utc(value: object, *, field: str) -> datetime:
+    if not isinstance(value, str):
+        raise SchedulingContractError(f"{field} must be canonical UTC")
+    try:
+        parsed = datetime.strptime(value, _UTC_TIME_FORMAT).replace(tzinfo=UTC)
+    except ValueError as exc:
+        raise SchedulingContractError(f"{field} must be canonical UTC") from exc
+    if parsed.strftime(_UTC_TIME_FORMAT) != value:
+        raise SchedulingContractError(f"{field} must be canonical UTC")
+    return parsed
+
+
+def _format_utc(value: datetime) -> str:
+    return value.astimezone(UTC).strftime(_UTC_TIME_FORMAT)
+
+
+def _strict_keys(
+    value: Mapping[str, object], *, required: set[str], field: str
+) -> None:
+    if set(value) != required:
+        raise SchedulingContractError(f"{field} keys are not exact")
+
+
+def _unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    value: dict[str, object] = {}
+    for name, item in pairs:
+        if name in value:
+            raise SchedulingContractError(f"duplicate JSON key: {name}")
+        value[name] = item
+    return value
+
+
+def _decode_canonical_object(raw: bytes, *, field: str) -> dict[str, object]:
+    if not isinstance(raw, bytes) or not raw:
+        raise SchedulingContractError(f"{field} bytes are required")
+    try:
+        value = json.loads(raw.decode("utf-8"), object_pairs_hook=_unique_object)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise SchedulingContractError(f"{field} is not JSON") from exc
+    if not isinstance(value, dict):
+        raise SchedulingContractError(f"{field} must be an object")
+    try:
+        canonical = canonical_json_bytes(value)
+    except CanonicalizationError as exc:
+        raise SchedulingContractError(f"{field} is not canonical JSON") from exc
+    if canonical != raw:
+        raise SchedulingContractError(f"{field} is not canonical JSON")
+    return value
+
+
+class DeadlineKind(StrEnum):
+    HARD_ACTION = "HARD_ACTION"
+    LEGAL_OR_REGULATORY = "LEGAL_OR_REGULATORY"
+    PLANNED_WINDOW_END = "PLANNED_WINDOW_END"
+    WATCH_REVIEW = "WATCH_REVIEW"
+
+
+@dataclass(frozen=True, slots=True)
+class DeadlineBoundary:
+    """One exact local-time boundary resolved to one canonical UTC instant."""
+
+    kind: DeadlineKind
+    due_at: str
+    source_time_zone: str
+    source_local_time: str
+    source_utc_offset_minutes: int
+    source_fold: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.kind, DeadlineKind):
+            raise SchedulingContractError("deadline kind must be typed")
+        due = _parse_utc(self.due_at, field="deadline_due_at")
+        if (
+            not isinstance(self.source_time_zone, str)
+            or _ZONE_RE.fullmatch(self.source_time_zone) is None
+        ):
+            raise SchedulingContractError(
+                "deadline source time zone must be a canonical IANA name"
+            )
+        try:
+            zone = ZoneInfo(self.source_time_zone)
+        except ZoneInfoNotFoundError as exc:
+            raise SchedulingContractError(
+                "deadline source time zone is not available"
+            ) from exc
+        try:
+            local = datetime.strptime(self.source_local_time, _LOCAL_TIME_FORMAT)
+        except (TypeError, ValueError) as exc:
+            raise SchedulingContractError(
+                "deadline source local time is not canonical"
+            ) from exc
+        if local.strftime(_LOCAL_TIME_FORMAT) != self.source_local_time:
+            raise SchedulingContractError(
+                "deadline source local time is not canonical"
+            )
+        if self.source_fold not in (0, 1) or isinstance(self.source_fold, bool):
+            raise SchedulingContractError("deadline fold must be zero or one")
+        if (
+            isinstance(self.source_utc_offset_minutes, bool)
+            or not isinstance(self.source_utc_offset_minutes, int)
+            or not -24 * 60 < self.source_utc_offset_minutes < 24 * 60
+        ):
+            raise SchedulingContractError("deadline UTC offset is invalid")
+        aware = local.replace(tzinfo=zone, fold=self.source_fold)
+        offset = aware.utcoffset()
+        if offset is None or offset.total_seconds() % 60 != 0:
+            raise SchedulingContractError("deadline UTC offset cannot be resolved")
+        if int(offset.total_seconds() // 60) != self.source_utc_offset_minutes:
+            raise SchedulingContractError("deadline UTC offset differs")
+        if aware.astimezone(UTC) != due:
+            raise SchedulingContractError("deadline UTC and local boundary differ")
+        round_trip = due.astimezone(zone)
+        if (
+            round_trip.strftime(_LOCAL_TIME_FORMAT) != self.source_local_time
+            or round_trip.fold != self.source_fold
+        ):
+            raise SchedulingContractError(
+                "deadline local boundary is ambiguous or nonexistent"
+            )
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "kind": self.kind.value,
+            "due_at": self.due_at,
+            "source_time_zone": self.source_time_zone,
+            "source_local_time": self.source_local_time,
+            "source_utc_offset_minutes": self.source_utc_offset_minutes,
+            "source_fold": self.source_fold,
+        }
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> "DeadlineBoundary":
+        _strict_keys(
+            value,
+            required={
+                "kind",
+                "due_at",
+                "source_time_zone",
+                "source_local_time",
+                "source_utc_offset_minutes",
+                "source_fold",
+            },
+            field="deadline_boundary",
+        )
+        try:
+            return cls(
+                kind=DeadlineKind(value["kind"]),
+                due_at=value["due_at"],  # type: ignore[arg-type]
+                source_time_zone=value["source_time_zone"],  # type: ignore[arg-type]
+                source_local_time=value["source_local_time"],  # type: ignore[arg-type]
+                source_utc_offset_minutes=value["source_utc_offset_minutes"],  # type: ignore[arg-type]
+                source_fold=value["source_fold"],  # type: ignore[arg-type]
+            )
+        except (TypeError, ValueError) as exc:
+            raise SchedulingContractError("deadline boundary is malformed") from exc
+
+
+@dataclass(frozen=True, slots=True)
+class LaneTimingRule:
+    lane: PriorityLane
+    starvation_warning_seconds: int
+    starvation_limit_seconds: int
+    explicit_deadline_required: bool
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.lane, PriorityLane):
+            raise SchedulingContractError("lane timing rule lane must be typed")
+        warning = _require_positive_int(
+            self.starvation_warning_seconds,
+            field="starvation_warning_seconds",
+        )
+        limit = _require_positive_int(
+            self.starvation_limit_seconds,
+            field="starvation_limit_seconds",
+        )
+        if warning >= limit:
+            raise SchedulingContractError(
+                "starvation warning must precede the starvation limit"
+            )
+        if type(self.explicit_deadline_required) is not bool:
+            raise SchedulingContractError(
+                "explicit deadline requirement must be boolean"
+            )
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "lane": self.lane.value,
+            "lane_ordinal": self.lane.ordinal,
+            "starvation_warning_seconds": self.starvation_warning_seconds,
+            "starvation_limit_seconds": self.starvation_limit_seconds,
+            "explicit_deadline_required": self.explicit_deadline_required,
+        }
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> "LaneTimingRule":
+        _strict_keys(
+            value,
+            required={
+                "lane",
+                "lane_ordinal",
+                "starvation_warning_seconds",
+                "starvation_limit_seconds",
+                "explicit_deadline_required",
+            },
+            field="lane_timing_rule",
+        )
+        try:
+            lane = PriorityLane(value["lane"])
+            result = cls(
+                lane=lane,
+                starvation_warning_seconds=value["starvation_warning_seconds"],  # type: ignore[arg-type]
+                starvation_limit_seconds=value["starvation_limit_seconds"],  # type: ignore[arg-type]
+                explicit_deadline_required=value["explicit_deadline_required"],  # type: ignore[arg-type]
+            )
+        except (TypeError, ValueError) as exc:
+            raise SchedulingContractError("lane timing rule is malformed") from exc
+        if value["lane_ordinal"] != lane.ordinal:
+            raise SchedulingContractError("lane timing ordinal differs")
+        return result
+
+
+@dataclass(frozen=True, slots=True)
+class UrgencyDeadlinePolicy:
+    policy_id: str
+    policy_version: str
+    clock_time_zone: str
+    tie_break: str
+    lane_rules: tuple[LaneTimingRule, ...]
+    schema_version: str = SCHEDULING_POLICY_SCHEMA_VERSION
+    authority: str = "NONE"
+    effect: str = "NONE"
+    production_activation_authorised: bool = False
+
+    def __post_init__(self) -> None:
+        _require_token(self.policy_id, field="scheduling_policy_id")
+        _require_token(self.policy_version, field="scheduling_policy_version")
+        if self.schema_version != SCHEDULING_POLICY_SCHEMA_VERSION:
+            raise SchedulingContractError("scheduling policy schema differs")
+        if self.clock_time_zone != "UTC":
+            raise SchedulingContractError(
+                "scheduling calculation clock must be exact UTC"
+            )
+        if self.tie_break != _TIE_BREAK:
+            raise SchedulingContractError(
+                "scheduling policy tie-break must remain exact"
+            )
+        if not isinstance(self.lane_rules, tuple) or not all(
+            isinstance(item, LaneTimingRule) for item in self.lane_rules
+        ):
+            raise SchedulingContractError("lane timing rules must be typed")
+        expected = tuple(PriorityLane)
+        if tuple(item.lane for item in self.lane_rules) != expected:
+            raise SchedulingContractError(
+                "lane timing rules must cover every lane in ordinal order"
+            )
+        if (
+            self.authority != "NONE"
+            or self.effect != "NONE"
+            or self.production_activation_authorised is not False
+        ):
+            raise SchedulingContractError(
+                "scheduling policy cannot claim authority, effect or activation"
+            )
+
+    def rule_for(self, lane: PriorityLane) -> LaneTimingRule:
+        if not isinstance(lane, PriorityLane):
+            raise SchedulingContractError("scheduling lane must be typed")
+        return self.lane_rules[lane.ordinal - 1]
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "record_type": "urgency_deadline_policy",
+            "policy_id": self.policy_id,
+            "policy_version": self.policy_version,
+            "clock_time_zone": self.clock_time_zone,
+            "tie_break": self.tie_break,
+            "lane_rules": [item.canonical_value() for item in self.lane_rules],
+            "authority": self.authority,
+            "effect": self.effect,
+            "production_activation_authorised": (
+                self.production_activation_authorised
+            ),
+        }
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return canonical_json_bytes(self.canonical_value())
+
+    @property
+    def policy_digest(self) -> str:
+        return digest_bytes(self.canonical_bytes)
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> "UrgencyDeadlinePolicy":
+        _strict_keys(
+            value,
+            required={
+                "schema_version",
+                "record_type",
+                "policy_id",
+                "policy_version",
+                "clock_time_zone",
+                "tie_break",
+                "lane_rules",
+                "authority",
+                "effect",
+                "production_activation_authorised",
+            },
+            field="urgency_deadline_policy",
+        )
+        if value["record_type"] != "urgency_deadline_policy":
+            raise SchedulingContractError("urgency deadline record type differs")
+        raw_rules = value["lane_rules"]
+        if not isinstance(raw_rules, list) or not all(
+            isinstance(item, dict) for item in raw_rules
+        ):
+            raise SchedulingContractError("lane timing rules must be objects")
+        return cls(
+            policy_id=value["policy_id"],  # type: ignore[arg-type]
+            policy_version=value["policy_version"],  # type: ignore[arg-type]
+            clock_time_zone=value["clock_time_zone"],  # type: ignore[arg-type]
+            tie_break=value["tie_break"],  # type: ignore[arg-type]
+            lane_rules=tuple(LaneTimingRule.from_mapping(item) for item in raw_rules),
+            schema_version=value["schema_version"],  # type: ignore[arg-type]
+            authority=value["authority"],  # type: ignore[arg-type]
+            effect=value["effect"],  # type: ignore[arg-type]
+            production_activation_authorised=value[
+                "production_activation_authorised"
+            ],  # type: ignore[arg-type]
+        )
+
+
+class SchedulingEligibility(StrEnum):
+    CURRENT_ELIGIBLE = "CURRENT_ELIGIBLE"
+    CURRENT_DEPENDENCY_BLOCKED = "CURRENT_DEPENDENCY_BLOCKED"
+    STALE = "STALE"
+    CLOSED = "CLOSED"
+    POLICY_BLOCKED = "POLICY_BLOCKED"
+
+
+@dataclass(frozen=True, slots=True)
+class UrgencyDeadlineInput:
+    work_item_id: str
+    work_item_version_id: str
+    work_item_version_digest: str
+    priority_selection: PrioritySelection
+    lane: PriorityLane
+    enqueued_at: str
+    observed_at: str
+    deadline: DeadlineBoundary | None
+    eligibility: SchedulingEligibility
+    delay_consequence_ordinal: int
+    staleness_risk_ordinal: int
+    dependency_ready: bool
+
+    def __post_init__(self) -> None:
+        _require_token(self.work_item_id, field="scheduling_work_item_id")
+        _require_token(
+            self.work_item_version_id,
+            field="scheduling_work_item_version_id",
+        )
+        _require_digest(
+            self.work_item_version_digest,
+            field="scheduling_work_item_version_digest",
+        )
+        if not isinstance(self.priority_selection, PrioritySelection):
+            raise SchedulingContractError(
+                "scheduling priority selection must be typed"
+            )
+        if not isinstance(self.lane, PriorityLane):
+            raise SchedulingContractError("scheduling input lane must be typed")
+        if (
+            self.priority_selection.work_identity != self.work_item_id
+            or self.priority_selection.work_version != self.work_item_version_id
+            or self.priority_selection.lane is not self.lane
+        ):
+            raise SchedulingContractError(
+                "scheduling input differs from its exact priority selection"
+            )
+        enqueued = _parse_utc(self.enqueued_at, field="scheduling_enqueued_at")
+        observed = _parse_utc(self.observed_at, field="scheduling_observed_at")
+        if observed < enqueued:
+            raise SchedulingContractError(
+                "scheduling observation cannot precede queue admission"
+            )
+        if self.deadline is not None and not isinstance(
+            self.deadline, DeadlineBoundary
+        ):
+            raise SchedulingContractError("scheduling deadline must be typed or null")
+        if not isinstance(self.eligibility, SchedulingEligibility):
+            raise SchedulingContractError("scheduling eligibility must be typed")
+        for field, value in (
+            ("delay_consequence_ordinal", self.delay_consequence_ordinal),
+            ("staleness_risk_ordinal", self.staleness_risk_ordinal),
+        ):
+            number = _require_non_negative_int(value, field=field)
+            if number > 3:
+                raise SchedulingContractError(f"{field} must be between zero and three")
+        if type(self.dependency_ready) is not bool:
+            raise SchedulingContractError(
+                "scheduling dependency readiness must be boolean"
+            )
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "work_item_id": self.work_item_id,
+            "work_item_version_id": self.work_item_version_id,
+            "work_item_version_digest": self.work_item_version_digest,
+            "priority_selection": self.priority_selection.canonical_value(),
+            "priority_selection_digest": digest_bytes(
+                self.priority_selection.canonical_bytes
+            ),
+            "lane": self.lane.value,
+            "lane_ordinal": self.lane.ordinal,
+            "enqueued_at": self.enqueued_at,
+            "observed_at": self.observed_at,
+            "deadline": None if self.deadline is None else self.deadline.canonical_value(),
+            "eligibility": self.eligibility.value,
+            "delay_consequence_ordinal": self.delay_consequence_ordinal,
+            "staleness_risk_ordinal": self.staleness_risk_ordinal,
+            "dependency_ready": self.dependency_ready,
+        }
+
+    @property
+    def input_digest(self) -> str:
+        return digest_bytes(
+            canonical_json_bytes(
+                {
+                    "schema_version": SCHEDULING_POLICY_SCHEMA_VERSION,
+                    "record_type": "urgency_deadline_input",
+                    "input": self.canonical_value(),
+                }
+            )
+        )
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> "UrgencyDeadlineInput":
+        _strict_keys(
+            value,
+            required={
+                "work_item_id",
+                "work_item_version_id",
+                "work_item_version_digest",
+                "priority_selection",
+                "priority_selection_digest",
+                "lane",
+                "lane_ordinal",
+                "enqueued_at",
+                "observed_at",
+                "deadline",
+                "eligibility",
+                "delay_consequence_ordinal",
+                "staleness_risk_ordinal",
+                "dependency_ready",
+            },
+            field="urgency_deadline_input",
+        )
+        raw_deadline = value["deadline"]
+        if raw_deadline is not None and not isinstance(raw_deadline, dict):
+            raise SchedulingContractError("scheduling deadline must be an object or null")
+        raw_priority = value["priority_selection"]
+        if not isinstance(raw_priority, dict):
+            raise SchedulingContractError(
+                "scheduling priority selection must be an object"
+            )
+        try:
+            lane = PriorityLane(value["lane"])
+            priority = PrioritySelection.from_mapping(raw_priority)
+            result = cls(
+                work_item_id=value["work_item_id"],  # type: ignore[arg-type]
+                work_item_version_id=value["work_item_version_id"],  # type: ignore[arg-type]
+                work_item_version_digest=value["work_item_version_digest"],  # type: ignore[arg-type]
+                priority_selection=priority,
+                lane=lane,
+                enqueued_at=value["enqueued_at"],  # type: ignore[arg-type]
+                observed_at=value["observed_at"],  # type: ignore[arg-type]
+                deadline=(
+                    None
+                    if raw_deadline is None
+                    else DeadlineBoundary.from_mapping(raw_deadline)
+                ),
+                eligibility=SchedulingEligibility(value["eligibility"]),
+                delay_consequence_ordinal=value["delay_consequence_ordinal"],  # type: ignore[arg-type]
+                staleness_risk_ordinal=value["staleness_risk_ordinal"],  # type: ignore[arg-type]
+                dependency_ready=value["dependency_ready"],  # type: ignore[arg-type]
+            )
+        except (TypeError, ValueError) as exc:
+            raise SchedulingContractError("urgency deadline input is malformed") from exc
+        if value["lane_ordinal"] != lane.ordinal:
+            raise SchedulingContractError("scheduling lane ordinal differs")
+        if value["priority_selection_digest"] != digest_bytes(
+            priority.canonical_bytes
+        ):
+            raise SchedulingContractError("priority selection digest differs")
+        return result
+
+
+class StarvationState(StrEnum):
+    WITHIN_BOUND = "WITHIN_BOUND"
+    AT_RISK = "AT_RISK"
+    STARVED = "STARVED"
+    NOT_CURRENT = "NOT_CURRENT"
+    NOT_APPLICABLE = "NOT_APPLICABLE"
+
+
+_STARVATION_ORDER = {
+    StarvationState.STARVED: 0,
+    StarvationState.AT_RISK: 1,
+    StarvationState.WITHIN_BOUND: 2,
+}
+
+
+def _urgency_deadline_values(
+    *, policy: UrgencyDeadlinePolicy, item: UrgencyDeadlineInput
+) -> dict[str, object]:
+    rule = policy.rule_for(item.lane)
+    if rule.explicit_deadline_required and item.deadline is None:
+        raise SchedulingContractError(
+            f"{item.lane.value} requires an exact deadline boundary"
+        )
+    enqueued = _parse_utc(item.enqueued_at, field="scheduling_enqueued_at")
+    observed = _parse_utc(item.observed_at, field="scheduling_observed_at")
+    queue_age = int((observed - enqueued).total_seconds())
+    explicit = item.deadline is not None
+    effective = (
+        _parse_utc(item.deadline.due_at, field="deadline_due_at")
+        if item.deadline is not None
+        else enqueued + timedelta(seconds=rule.starvation_limit_seconds)
+    )
+    if item.eligibility is SchedulingEligibility.STALE:
+        starvation = StarvationState.NOT_CURRENT
+    elif item.eligibility in {
+        SchedulingEligibility.CLOSED,
+        SchedulingEligibility.POLICY_BLOCKED,
+    }:
+        starvation = StarvationState.NOT_APPLICABLE
+    elif queue_age >= rule.starvation_limit_seconds:
+        starvation = StarvationState.STARVED
+    elif queue_age >= rule.starvation_warning_seconds:
+        starvation = StarvationState.AT_RISK
+    else:
+        starvation = StarvationState.WITHIN_BOUND
+    deadline_overdue = observed > effective
+    revalidation_required = (
+        item.eligibility is SchedulingEligibility.STALE
+        or starvation is StarvationState.STARVED
+        or deadline_overdue
+    )
+    schedulable = (
+        item.eligibility is SchedulingEligibility.CURRENT_ELIGIBLE
+        and item.dependency_ready
+    )
+    order_key: tuple[int | str, ...] | None = None
+    if schedulable:
+        order_key = (
+            item.lane.ordinal,
+            0 if explicit else 1,
+            int(effective.timestamp()),
+            -item.delay_consequence_ordinal,
+            -item.staleness_risk_ordinal,
+            _STARVATION_ORDER[starvation],
+            int(enqueued.timestamp()),
+            0 if item.dependency_ready else 1,
+            item.work_item_version_id,
+        )
+    return {
+        "effective_deadline": _format_utc(effective),
+        "deadline_source": "EXPLICIT" if explicit else "STARVATION_LIMIT",
+        "queue_age_seconds": queue_age,
+        "deadline_overdue": deadline_overdue,
+        "starvation_state": starvation,
+        "starvation_overrun_seconds": max(
+            0, queue_age - rule.starvation_limit_seconds
+        ),
+        "revalidation_required": revalidation_required,
+        "schedulable": schedulable,
+        "order_key": order_key,
+    }
+
+
+@dataclass(frozen=True, slots=True)
+class StarvationObservation:
+    policy: UrgencyDeadlinePolicy
+    item: UrgencyDeadlineInput
+    effective_deadline: str
+    deadline_source: str
+    queue_age_seconds: int
+    deadline_overdue: bool
+    starvation_state: StarvationState
+    starvation_overrun_seconds: int
+    revalidation_required: bool
+    schedulable: bool
+    order_key: tuple[int | str, ...] | None
+    authority: str = "NONE"
+    effect: str = "NONE"
+    production_activation_authorised: bool = False
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.policy, UrgencyDeadlinePolicy):
+            raise SchedulingContractError("starvation observation policy must be typed")
+        if not isinstance(self.item, UrgencyDeadlineInput):
+            raise SchedulingContractError("starvation observation input must be typed")
+        _parse_utc(
+            self.effective_deadline,
+            field="starvation_effective_deadline",
+        )
+        if self.deadline_source not in {"EXPLICIT", "STARVATION_LIMIT"}:
+            raise SchedulingContractError("starvation deadline source differs")
+        _require_non_negative_int(
+            self.queue_age_seconds,
+            field="starvation_queue_age_seconds",
+        )
+        _require_non_negative_int(
+            self.starvation_overrun_seconds,
+            field="starvation_overrun_seconds",
+        )
+        if not isinstance(self.starvation_state, StarvationState):
+            raise SchedulingContractError("starvation state must be typed")
+        for field in (
+            "deadline_overdue",
+            "revalidation_required",
+            "schedulable",
+        ):
+            if type(getattr(self, field)) is not bool:
+                raise SchedulingContractError(f"{field} must be boolean")
+        if self.order_key is not None:
+            if (
+                not isinstance(self.order_key, tuple)
+                or len(self.order_key) != 9
+                or any(
+                    isinstance(value, bool) or not isinstance(value, int)
+                    for value in self.order_key[:8]
+                )
+                or not isinstance(self.order_key[8], str)
+            ):
+                raise SchedulingContractError(
+                    "starvation order key has invalid field types"
+                )
+            _require_token(self.order_key[8], field="starvation_tie_break")
+        expected = _urgency_deadline_values(policy=self.policy, item=self.item)
+        actual = {
+            "effective_deadline": self.effective_deadline,
+            "deadline_source": self.deadline_source,
+            "queue_age_seconds": self.queue_age_seconds,
+            "deadline_overdue": self.deadline_overdue,
+            "starvation_state": self.starvation_state,
+            "starvation_overrun_seconds": self.starvation_overrun_seconds,
+            "revalidation_required": self.revalidation_required,
+            "schedulable": self.schedulable,
+            "order_key": self.order_key,
+        }
+        if actual != expected:
+            raise SchedulingContractError(
+                "starvation observation differs from deterministic policy"
+            )
+        if (
+            self.authority != "NONE"
+            or self.effect != "NONE"
+            or self.production_activation_authorised is not False
+        ):
+            raise SchedulingContractError(
+                "starvation observation cannot claim authority, effect or activation"
+            )
+
+    @property
+    def schema_version(self) -> str:
+        return SCHEDULING_POLICY_SCHEMA_VERSION
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "record_type": "starvation_observation",
+            "policy": self.policy.canonical_value(),
+            "policy_digest": self.policy.policy_digest,
+            "input": self.item.canonical_value(),
+            "input_digest": self.item.input_digest,
+            "effective_deadline": self.effective_deadline,
+            "deadline_source": self.deadline_source,
+            "queue_age_seconds": self.queue_age_seconds,
+            "deadline_overdue": self.deadline_overdue,
+            "starvation_state": self.starvation_state.value,
+            "starvation_overrun_seconds": self.starvation_overrun_seconds,
+            "revalidation_required": self.revalidation_required,
+            "schedulable": self.schedulable,
+            "order_key": None if self.order_key is None else list(self.order_key),
+            "authority": self.authority,
+            "effect": self.effect,
+            "production_activation_authorised": (
+                self.production_activation_authorised
+            ),
+        }
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return canonical_json_bytes(self.canonical_value())
+
+    @property
+    def decision_digest(self) -> str:
+        return digest_bytes(self.canonical_bytes)
+
+    @classmethod
+    def from_canonical_bytes(cls, raw: bytes) -> "StarvationObservation":
+        value = _decode_canonical_object(raw, field="starvation_observation")
+        _strict_keys(
+            value,
+            required={
+                "schema_version",
+                "record_type",
+                "policy",
+                "policy_digest",
+                "input",
+                "input_digest",
+                "effective_deadline",
+                "deadline_source",
+                "queue_age_seconds",
+                "deadline_overdue",
+                "starvation_state",
+                "starvation_overrun_seconds",
+                "revalidation_required",
+                "schedulable",
+                "order_key",
+                "authority",
+                "effect",
+                "production_activation_authorised",
+            },
+            field="starvation_observation",
+        )
+        if (
+            value["schema_version"] != SCHEDULING_POLICY_SCHEMA_VERSION
+            or value["record_type"] != "starvation_observation"
+        ):
+            raise SchedulingContractError("starvation observation schema differs")
+        raw_policy = value["policy"]
+        raw_input = value["input"]
+        if not isinstance(raw_policy, dict) or not isinstance(raw_input, dict):
+            raise SchedulingContractError(
+                "starvation observation policy and input must be objects"
+            )
+        policy = UrgencyDeadlinePolicy.from_mapping(raw_policy)
+        item = UrgencyDeadlineInput.from_mapping(raw_input)
+        if value["policy_digest"] != policy.policy_digest:
+            raise SchedulingContractError("starvation policy digest differs")
+        if value["input_digest"] != item.input_digest:
+            raise SchedulingContractError("starvation input digest differs")
+        raw_order = value["order_key"]
+        if raw_order is not None and not isinstance(raw_order, list):
+            raise SchedulingContractError("starvation order key must be a list or null")
+        try:
+            result = cls(
+                policy=policy,
+                item=item,
+                effective_deadline=value["effective_deadline"],  # type: ignore[arg-type]
+                deadline_source=value["deadline_source"],  # type: ignore[arg-type]
+                queue_age_seconds=value["queue_age_seconds"],  # type: ignore[arg-type]
+                deadline_overdue=value["deadline_overdue"],  # type: ignore[arg-type]
+                starvation_state=StarvationState(value["starvation_state"]),
+                starvation_overrun_seconds=value["starvation_overrun_seconds"],  # type: ignore[arg-type]
+                revalidation_required=value["revalidation_required"],  # type: ignore[arg-type]
+                schedulable=value["schedulable"],  # type: ignore[arg-type]
+                order_key=None if raw_order is None else tuple(raw_order),
+                authority=value["authority"],  # type: ignore[arg-type]
+                effect=value["effect"],  # type: ignore[arg-type]
+                production_activation_authorised=value[
+                    "production_activation_authorised"
+                ],  # type: ignore[arg-type]
+            )
+        except (TypeError, ValueError) as exc:
+            raise SchedulingContractError(
+                "starvation observation is malformed"
+            ) from exc
+        if result.canonical_bytes != raw:
+            raise SchedulingContractError("starvation observation is not canonical")
+        return result
+
+
+UrgencyDeadlineDecision = StarvationObservation
+
+
+def calculate_urgency_deadline(
+    *, policy: UrgencyDeadlinePolicy, item: UrgencyDeadlineInput
+) -> UrgencyDeadlineDecision:
+    """Calculate one pure observation using no ambient clock or queue state."""
+
+    if not isinstance(policy, UrgencyDeadlinePolicy):
+        raise TypeError("urgency deadline policy must be typed")
+    if not isinstance(item, UrgencyDeadlineInput):
+        raise TypeError("urgency deadline input must be typed")
+    values = _urgency_deadline_values(policy=policy, item=item)
+    return StarvationObservation(policy=policy, item=item, **values)  # type: ignore[arg-type]
+
+
+class CapacityPathState(StrEnum):
+    AVAILABLE = "AVAILABLE"
+    DEGRADED = "DEGRADED"
+    UNAVAILABLE = "UNAVAILABLE"
+
+
+class CapacityClass(StrEnum):
+    URGENT_RESERVED = "URGENT_RESERVED"
+    ORDINARY = "ORDINARY"
+
+
+def capacity_class_for_lane(lane: PriorityLane) -> CapacityClass:
+    """Map only canonical lanes; this classification grants no admission."""
+
+    if not isinstance(lane, PriorityLane):
+        raise SchedulingContractError("capacity classification lane must be typed")
+    if lane in {PriorityLane.CONTAINMENT, PriorityLane.URGENT}:
+        return CapacityClass.URGENT_RESERVED
+    return CapacityClass.ORDINARY
+
+
+class ReservedCapacityDisposition(StrEnum):
+    ADMITTED = "ADMITTED"
+    NO_PENDING_WORK = "NO_PENDING_WORK"
+    CAPACITY_DEFERRED = "CAPACITY_DEFERRED"
+    URGENT_VISIBLE_OPERATIONAL_HOLD = "URGENT_VISIBLE_OPERATIONAL_HOLD"
+
+
+@dataclass(frozen=True, slots=True)
+class ReservedCapacityPolicy:
+    policy_id: str
+    policy_version: str
+    total_slots: int
+    urgent_reserved_slots: int
+    minimum_ordinary_slots: int
+    degraded_urgent_disposition: ReservedCapacityDisposition
+    schema_version: str = SCHEDULING_POLICY_SCHEMA_VERSION
+    authority: str = "NONE"
+    effect: str = "NONE"
+    production_activation_authorised: bool = False
+
+    def __post_init__(self) -> None:
+        _require_token(self.policy_id, field="capacity_policy_id")
+        _require_token(self.policy_version, field="capacity_policy_version")
+        total = _require_positive_int(self.total_slots, field="capacity_total_slots")
+        urgent = _require_positive_int(
+            self.urgent_reserved_slots,
+            field="urgent_reserved_slots",
+        )
+        ordinary = _require_positive_int(
+            self.minimum_ordinary_slots,
+            field="minimum_ordinary_slots",
+        )
+        if urgent + ordinary > total:
+            raise SchedulingContractError(
+                "urgent and ordinary reservations exceed total capacity"
+            )
+        if (
+            self.degraded_urgent_disposition
+            is not ReservedCapacityDisposition.URGENT_VISIBLE_OPERATIONAL_HOLD
+        ):
+            raise SchedulingContractError(
+                "degraded Urgent work must remain a visible operational hold"
+            )
+        if self.schema_version != SCHEDULING_POLICY_SCHEMA_VERSION:
+            raise SchedulingContractError("reserved capacity schema differs")
+        if (
+            self.authority != "NONE"
+            or self.effect != "NONE"
+            or self.production_activation_authorised is not False
+        ):
+            raise SchedulingContractError(
+                "reserved capacity policy cannot claim authority or effect"
+            )
+
+    @property
+    def max_urgent_slots(self) -> int:
+        return self.total_slots - self.minimum_ordinary_slots
+
+    @property
+    def ordinary_capacity_ceiling(self) -> int:
+        return self.total_slots - self.urgent_reserved_slots
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "record_type": "reserved_capacity_policy",
+            "policy_id": self.policy_id,
+            "policy_version": self.policy_version,
+            "total_slots": self.total_slots,
+            "urgent_reserved_slots": self.urgent_reserved_slots,
+            "minimum_ordinary_slots": self.minimum_ordinary_slots,
+            "max_urgent_slots": self.max_urgent_slots,
+            "ordinary_capacity_ceiling": self.ordinary_capacity_ceiling,
+            "degraded_urgent_disposition": self.degraded_urgent_disposition.value,
+            "authority": self.authority,
+            "effect": self.effect,
+            "production_activation_authorised": (
+                self.production_activation_authorised
+            ),
+        }
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return canonical_json_bytes(self.canonical_value())
+
+    @property
+    def policy_digest(self) -> str:
+        return digest_bytes(self.canonical_bytes)
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> "ReservedCapacityPolicy":
+        _strict_keys(
+            value,
+            required={
+                "schema_version",
+                "record_type",
+                "policy_id",
+                "policy_version",
+                "total_slots",
+                "urgent_reserved_slots",
+                "minimum_ordinary_slots",
+                "max_urgent_slots",
+                "ordinary_capacity_ceiling",
+                "degraded_urgent_disposition",
+                "authority",
+                "effect",
+                "production_activation_authorised",
+            },
+            field="reserved_capacity_policy",
+        )
+        if value["record_type"] != "reserved_capacity_policy":
+            raise SchedulingContractError("reserved capacity record type differs")
+        try:
+            result = cls(
+                policy_id=value["policy_id"],  # type: ignore[arg-type]
+                policy_version=value["policy_version"],  # type: ignore[arg-type]
+                total_slots=value["total_slots"],  # type: ignore[arg-type]
+                urgent_reserved_slots=value["urgent_reserved_slots"],  # type: ignore[arg-type]
+                minimum_ordinary_slots=value["minimum_ordinary_slots"],  # type: ignore[arg-type]
+                degraded_urgent_disposition=ReservedCapacityDisposition(
+                    value["degraded_urgent_disposition"]
+                ),
+                schema_version=value["schema_version"],  # type: ignore[arg-type]
+                authority=value["authority"],  # type: ignore[arg-type]
+                effect=value["effect"],  # type: ignore[arg-type]
+                production_activation_authorised=value[
+                    "production_activation_authorised"
+                ],  # type: ignore[arg-type]
+            )
+        except (TypeError, ValueError) as exc:
+            raise SchedulingContractError("reserved capacity policy is malformed") from exc
+        if (
+            value["max_urgent_slots"] != result.max_urgent_slots
+            or value["ordinary_capacity_ceiling"]
+            != result.ordinary_capacity_ceiling
+        ):
+            raise SchedulingContractError("reserved capacity derived bounds differ")
+        return result
+
+
+@dataclass(frozen=True, slots=True)
+class CapacitySnapshot:
+    observed_at: str
+    active_urgent_slots: int
+    active_ordinary_slots: int
+    pending_urgent: int
+    pending_ordinary: int
+    urgent_path_state: CapacityPathState
+
+    def __post_init__(self) -> None:
+        _parse_utc(self.observed_at, field="capacity_observed_at")
+        for field in (
+            "active_urgent_slots",
+            "active_ordinary_slots",
+            "pending_urgent",
+            "pending_ordinary",
+        ):
+            _require_non_negative_int(getattr(self, field), field=field)
+        if not isinstance(self.urgent_path_state, CapacityPathState):
+            raise SchedulingContractError("Urgent capacity path state must be typed")
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "observed_at": self.observed_at,
+            "active_urgent_slots": self.active_urgent_slots,
+            "active_ordinary_slots": self.active_ordinary_slots,
+            "pending_urgent": self.pending_urgent,
+            "pending_ordinary": self.pending_ordinary,
+            "urgent_path_state": self.urgent_path_state.value,
+        }
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> "CapacitySnapshot":
+        _strict_keys(
+            value,
+            required={
+                "observed_at",
+                "active_urgent_slots",
+                "active_ordinary_slots",
+                "pending_urgent",
+                "pending_ordinary",
+                "urgent_path_state",
+            },
+            field="capacity_snapshot",
+        )
+        try:
+            return cls(
+                observed_at=value["observed_at"],  # type: ignore[arg-type]
+                active_urgent_slots=value["active_urgent_slots"],  # type: ignore[arg-type]
+                active_ordinary_slots=value["active_ordinary_slots"],  # type: ignore[arg-type]
+                pending_urgent=value["pending_urgent"],  # type: ignore[arg-type]
+                pending_ordinary=value["pending_ordinary"],  # type: ignore[arg-type]
+                urgent_path_state=CapacityPathState(value["urgent_path_state"]),
+            )
+        except (TypeError, ValueError) as exc:
+            raise SchedulingContractError("capacity snapshot is malformed") from exc
+
+
+def _capacity_values(
+    *, policy: ReservedCapacityPolicy, snapshot: CapacitySnapshot
+) -> dict[str, object]:
+    active_total = snapshot.active_urgent_slots + snapshot.active_ordinary_slots
+    if active_total > policy.total_slots:
+        raise SchedulingContractError("active work exceeds total capacity")
+    if snapshot.active_urgent_slots > policy.max_urgent_slots:
+        raise SchedulingContractError("active Urgent work consumed ordinary reserve")
+    if snapshot.active_ordinary_slots > policy.ordinary_capacity_ceiling:
+        raise SchedulingContractError("active ordinary work consumed Urgent reserve")
+    available = policy.total_slots - active_total
+    if snapshot.pending_urgent == 0:
+        urgent_grants = 0
+        urgent_disposition = ReservedCapacityDisposition.NO_PENDING_WORK
+    elif snapshot.urgent_path_state is not CapacityPathState.AVAILABLE:
+        urgent_grants = 0
+        urgent_disposition = policy.degraded_urgent_disposition
+    else:
+        urgent_grants = min(
+            snapshot.pending_urgent,
+            available,
+            policy.max_urgent_slots - snapshot.active_urgent_slots,
+        )
+        urgent_disposition = (
+            ReservedCapacityDisposition.ADMITTED
+            if urgent_grants
+            else ReservedCapacityDisposition.CAPACITY_DEFERRED
+        )
+    remaining = available - urgent_grants
+    ordinary_grants = min(
+        snapshot.pending_ordinary,
+        remaining,
+        policy.ordinary_capacity_ceiling - snapshot.active_ordinary_slots,
+    )
+    if snapshot.pending_ordinary == 0:
+        ordinary_disposition = ReservedCapacityDisposition.NO_PENDING_WORK
+    elif ordinary_grants:
+        ordinary_disposition = ReservedCapacityDisposition.ADMITTED
+    else:
+        ordinary_disposition = ReservedCapacityDisposition.CAPACITY_DEFERRED
+    return {
+        "urgent_grants": urgent_grants,
+        "ordinary_grants": ordinary_grants,
+        "unallocated_slots": remaining - ordinary_grants,
+        "urgent_disposition": urgent_disposition,
+        "ordinary_disposition": ordinary_disposition,
+        "downgraded_urgent_to_ordinary": False,
+    }
+
+
+@dataclass(frozen=True, slots=True)
+class ReservedCapacityDecision:
+    policy: ReservedCapacityPolicy
+    snapshot: CapacitySnapshot
+    urgent_grants: int
+    ordinary_grants: int
+    unallocated_slots: int
+    urgent_disposition: ReservedCapacityDisposition
+    ordinary_disposition: ReservedCapacityDisposition
+    downgraded_urgent_to_ordinary: bool
+    authority: str = "NONE"
+    effect: str = "NONE"
+    production_activation_authorised: bool = False
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.policy, ReservedCapacityPolicy):
+            raise SchedulingContractError("capacity decision policy must be typed")
+        if not isinstance(self.snapshot, CapacitySnapshot):
+            raise SchedulingContractError("capacity decision snapshot must be typed")
+        for field in (
+            "urgent_grants",
+            "ordinary_grants",
+            "unallocated_slots",
+        ):
+            _require_non_negative_int(getattr(self, field), field=field)
+        if not isinstance(
+            self.urgent_disposition, ReservedCapacityDisposition
+        ) or not isinstance(
+            self.ordinary_disposition, ReservedCapacityDisposition
+        ):
+            raise SchedulingContractError("capacity dispositions must be typed")
+        if type(self.downgraded_urgent_to_ordinary) is not bool:
+            raise SchedulingContractError(
+                "Urgent downgrade indicator must be boolean"
+            )
+        expected = _capacity_values(policy=self.policy, snapshot=self.snapshot)
+        actual = {
+            "urgent_grants": self.urgent_grants,
+            "ordinary_grants": self.ordinary_grants,
+            "unallocated_slots": self.unallocated_slots,
+            "urgent_disposition": self.urgent_disposition,
+            "ordinary_disposition": self.ordinary_disposition,
+            "downgraded_urgent_to_ordinary": self.downgraded_urgent_to_ordinary,
+        }
+        if actual != expected:
+            raise SchedulingContractError(
+                "capacity decision differs from deterministic policy"
+            )
+        if (
+            self.authority != "NONE"
+            or self.effect != "NONE"
+            or self.production_activation_authorised is not False
+        ):
+            raise SchedulingContractError(
+                "capacity decision cannot claim authority, effect or activation"
+            )
+
+    @property
+    def active_after_urgent(self) -> int:
+        return self.snapshot.active_urgent_slots + self.urgent_grants
+
+    @property
+    def active_after_ordinary(self) -> int:
+        return self.snapshot.active_ordinary_slots + self.ordinary_grants
+
+    @property
+    def schema_version(self) -> str:
+        return SCHEDULING_POLICY_SCHEMA_VERSION
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "record_type": "reserved_capacity_decision",
+            "policy": self.policy.canonical_value(),
+            "policy_digest": self.policy.policy_digest,
+            "snapshot": self.snapshot.canonical_value(),
+            "urgent_grants": self.urgent_grants,
+            "ordinary_grants": self.ordinary_grants,
+            "unallocated_slots": self.unallocated_slots,
+            "active_after_urgent": self.active_after_urgent,
+            "active_after_ordinary": self.active_after_ordinary,
+            "urgent_disposition": self.urgent_disposition.value,
+            "ordinary_disposition": self.ordinary_disposition.value,
+            "downgraded_urgent_to_ordinary": self.downgraded_urgent_to_ordinary,
+            "authority": self.authority,
+            "effect": self.effect,
+            "production_activation_authorised": (
+                self.production_activation_authorised
+            ),
+        }
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return canonical_json_bytes(self.canonical_value())
+
+    @property
+    def decision_digest(self) -> str:
+        return digest_bytes(self.canonical_bytes)
+
+    @classmethod
+    def from_canonical_bytes(cls, raw: bytes) -> "ReservedCapacityDecision":
+        value = _decode_canonical_object(raw, field="reserved_capacity_decision")
+        _strict_keys(
+            value,
+            required={
+                "schema_version",
+                "record_type",
+                "policy",
+                "policy_digest",
+                "snapshot",
+                "urgent_grants",
+                "ordinary_grants",
+                "unallocated_slots",
+                "active_after_urgent",
+                "active_after_ordinary",
+                "urgent_disposition",
+                "ordinary_disposition",
+                "downgraded_urgent_to_ordinary",
+                "authority",
+                "effect",
+                "production_activation_authorised",
+            },
+            field="reserved_capacity_decision",
+        )
+        if (
+            value["schema_version"] != SCHEDULING_POLICY_SCHEMA_VERSION
+            or value["record_type"] != "reserved_capacity_decision"
+        ):
+            raise SchedulingContractError("reserved capacity decision schema differs")
+        raw_policy = value["policy"]
+        raw_snapshot = value["snapshot"]
+        if not isinstance(raw_policy, dict) or not isinstance(raw_snapshot, dict):
+            raise SchedulingContractError(
+                "capacity decision policy and snapshot must be objects"
+            )
+        policy = ReservedCapacityPolicy.from_mapping(raw_policy)
+        snapshot = CapacitySnapshot.from_mapping(raw_snapshot)
+        if value["policy_digest"] != policy.policy_digest:
+            raise SchedulingContractError("capacity policy digest differs")
+        try:
+            result = cls(
+                policy=policy,
+                snapshot=snapshot,
+                urgent_grants=value["urgent_grants"],  # type: ignore[arg-type]
+                ordinary_grants=value["ordinary_grants"],  # type: ignore[arg-type]
+                unallocated_slots=value["unallocated_slots"],  # type: ignore[arg-type]
+                urgent_disposition=ReservedCapacityDisposition(
+                    value["urgent_disposition"]
+                ),
+                ordinary_disposition=ReservedCapacityDisposition(
+                    value["ordinary_disposition"]
+                ),
+                downgraded_urgent_to_ordinary=value[
+                    "downgraded_urgent_to_ordinary"
+                ],  # type: ignore[arg-type]
+                authority=value["authority"],  # type: ignore[arg-type]
+                effect=value["effect"],  # type: ignore[arg-type]
+                production_activation_authorised=value[
+                    "production_activation_authorised"
+                ],  # type: ignore[arg-type]
+            )
+        except (TypeError, ValueError) as exc:
+            raise SchedulingContractError(
+                "reserved capacity decision is malformed"
+            ) from exc
+        if (
+            value["active_after_urgent"] != result.active_after_urgent
+            or value["active_after_ordinary"] != result.active_after_ordinary
+        ):
+            raise SchedulingContractError("capacity active totals differ")
+        if result.canonical_bytes != raw:
+            raise SchedulingContractError(
+                "reserved capacity decision is not canonical"
+            )
+        return result
+
+
+def allocate_reserved_capacity(
+    *, policy: ReservedCapacityPolicy, snapshot: CapacitySnapshot
+) -> ReservedCapacityDecision:
+    """Return grants only; this pure function owns no queue admission effect."""
+
+    if not isinstance(policy, ReservedCapacityPolicy):
+        raise TypeError("reserved capacity policy must be typed")
+    if not isinstance(snapshot, CapacitySnapshot):
+        raise TypeError("capacity snapshot must be typed")
+    values = _capacity_values(policy=policy, snapshot=snapshot)
+    return ReservedCapacityDecision(policy=policy, snapshot=snapshot, **values)  # type: ignore[arg-type]
+
+
+URGENCY_DEADLINE_POLICY = UrgencyDeadlinePolicy
+RESERVED_CAPACITY_POLICY = ReservedCapacityPolicy
+STARVATION_OBSERVATION = StarvationObservation
+
+
+__all__ = [
+    "RESERVED_CAPACITY_POLICY",
+    "SCHEDULING_POLICY_SCHEMA_VERSION",
+    "STARVATION_OBSERVATION",
+    "URGENCY_DEADLINE_POLICY",
+    "CapacityPathState",
+    "CapacityClass",
+    "CapacitySnapshot",
+    "DeadlineBoundary",
+    "DeadlineKind",
+    "LaneTimingRule",
+    "ReservedCapacityDecision",
+    "ReservedCapacityDisposition",
+    "ReservedCapacityPolicy",
+    "SchedulingContractError",
+    "SchedulingEligibility",
+    "StarvationObservation",
+    "StarvationState",
+    "UrgencyDeadlineDecision",
+    "UrgencyDeadlineInput",
+    "UrgencyDeadlinePolicy",
+    "allocate_reserved_capacity",
+    "capacity_class_for_lane",
+    "calculate_urgency_deadline",
+]

--- a/newsroom/increment6/scheduling.py
+++ b/newsroom/increment6/scheduling.py
@@ -195,7 +195,7 @@ class DeadlineBoundary:
             )
         try:
             zone = ZoneInfo(self.source_time_zone)
-        except ZoneInfoNotFoundError as exc:
+        except (ValueError, ZoneInfoNotFoundError) as exc:
             raise SchedulingContractError(
                 "deadline source time zone is not available"
             ) from exc

--- a/newsroom/tests/test_increment6b2_scheduling.py
+++ b/newsroom/tests/test_increment6b2_scheduling.py
@@ -1,0 +1,461 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from datetime import UTC, datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from newsroom.increment6.outcomes import PriorityLane, PrioritySelection, ReasonReference
+from newsroom.increment6.scheduling import (
+    RESERVED_CAPACITY_POLICY,
+    STARVATION_OBSERVATION,
+    URGENCY_DEADLINE_POLICY,
+    CapacityPathState,
+    CapacityClass,
+    CapacitySnapshot,
+    DeadlineBoundary,
+    DeadlineKind,
+    LaneTimingRule,
+    ReservedCapacityDecision,
+    ReservedCapacityDisposition,
+    SchedulingContractError,
+    SchedulingEligibility,
+    StarvationState,
+    UrgencyDeadlineInput,
+    UrgencyDeadlineDecision,
+    allocate_reserved_capacity,
+    capacity_class_for_lane,
+    calculate_urgency_deadline,
+)
+
+
+SHA_A = "sha256:" + "a" * 64
+SHA_B = "sha256:" + "b" * 64
+SHA_C = "sha256:" + "c" * 64
+
+
+def _deadline(
+    due_at: str = "2026-08-09T15:30:00Z",
+) -> DeadlineBoundary:
+    due = datetime.strptime(due_at, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
+    local = due.astimezone(ZoneInfo("Europe/London"))
+    offset = local.utcoffset()
+    assert offset is not None
+    return DeadlineBoundary(
+        kind=DeadlineKind.HARD_ACTION,
+        due_at=due_at,
+        source_time_zone="Europe/London",
+        source_local_time=local.strftime("%Y-%m-%dT%H:%M:%S"),
+        source_utc_offset_minutes=int(offset.total_seconds() // 60),
+        source_fold=local.fold,
+    )
+
+
+def _rules() -> tuple[LaneTimingRule, ...]:
+    values = {
+        PriorityLane.CONTAINMENT: (60, 120, True),
+        PriorityLane.URGENT: (120, 300, True),
+        PriorityLane.TIME_SENSITIVE: (900, 1_800, True),
+        PriorityLane.PLANNED_WINDOW: (1_800, 3_600, True),
+        PriorityLane.ROUTINE: (3_600, 7_200, False),
+        PriorityLane.OPTIONAL_EVALUATION: (7_200, 14_400, False),
+    }
+    return tuple(
+        LaneTimingRule(
+            lane=lane,
+            starvation_warning_seconds=values[lane][0],
+            starvation_limit_seconds=values[lane][1],
+            explicit_deadline_required=values[lane][2],
+        )
+        for lane in PriorityLane
+    )
+
+
+def _policy() -> URGENCY_DEADLINE_POLICY:
+    return URGENCY_DEADLINE_POLICY(
+        policy_id="fixture-scheduling-policy",
+        policy_version="v1",
+        clock_time_zone="UTC",
+        tie_break="WORK_ITEM_VERSION_ID_ASC",
+        lane_rules=_rules(),
+    )
+
+
+def _input(
+    *,
+    version_id: str = "work-item-version-a",
+    lane: PriorityLane = PriorityLane.TIME_SENSITIVE,
+    enqueued_at: str = "2026-08-09T15:00:00Z",
+    observed_at: str = "2026-08-09T15:10:00Z",
+    deadline: DeadlineBoundary | None = None,
+    eligibility: SchedulingEligibility = SchedulingEligibility.CURRENT_ELIGIBLE,
+    delay_consequence_ordinal: int = 2,
+    staleness_risk_ordinal: int = 1,
+    dependency_ready: bool = True,
+) -> UrgencyDeadlineInput:
+    if deadline is None and lane in {
+        PriorityLane.CONTAINMENT,
+        PriorityLane.URGENT,
+        PriorityLane.TIME_SENSITIVE,
+        PriorityLane.PLANNED_WINDOW,
+    }:
+        deadline = _deadline()
+    return UrgencyDeadlineInput(
+        work_item_id="work-item-a",
+        work_item_version_id=version_id,
+        work_item_version_digest=SHA_A,
+        priority_selection=PrioritySelection(
+            work_identity="work-item-a",
+            work_version=version_id,
+            lane=lane,
+            basis_references=(
+                ReasonReference(
+                    reference_type="lead-disposition",
+                    identifier="decision-a",
+                    digest=SHA_B,
+                ),
+            ),
+        ),
+        lane=lane,
+        enqueued_at=enqueued_at,
+        observed_at=observed_at,
+        deadline=deadline,
+        eligibility=eligibility,
+        delay_consequence_ordinal=delay_consequence_ordinal,
+        staleness_risk_ordinal=staleness_risk_ordinal,
+        dependency_ready=dependency_ready,
+    )
+
+
+def test_identical_inputs_produce_byte_identical_deadline_and_order() -> None:
+    policy = _policy()
+    item = _input()
+
+    first = calculate_urgency_deadline(policy=policy, item=item)
+    second = calculate_urgency_deadline(policy=policy, item=item)
+
+    assert first.canonical_bytes == second.canonical_bytes
+    assert first.decision_digest == second.decision_digest
+    assert first.order_key == second.order_key
+    assert first.effective_deadline == "2026-08-09T15:30:00Z"
+    assert first.queue_age_seconds == 600
+    assert first.deadline_overdue is False
+    assert first.schedulable is True
+    assert first.authority == "NONE"
+    assert first.effect == "NONE"
+    assert first.production_activation_authorised is False
+    assert UrgencyDeadlineDecision.from_canonical_bytes(first.canonical_bytes) == first
+
+
+def test_deadline_boundary_resolves_exact_time_zone_and_dst_fold() -> None:
+    first_fold = DeadlineBoundary(
+        kind=DeadlineKind.PLANNED_WINDOW_END,
+        due_at="2026-10-25T00:30:00Z",
+        source_time_zone="Europe/London",
+        source_local_time="2026-10-25T01:30:00",
+        source_utc_offset_minutes=60,
+        source_fold=0,
+    )
+    second_fold = replace(
+        first_fold,
+        due_at="2026-10-25T01:30:00Z",
+        source_utc_offset_minutes=0,
+        source_fold=1,
+    )
+
+    assert first_fold.due_at != second_fold.due_at
+    with pytest.raises(SchedulingContractError):
+        replace(first_fold, source_fold=1)
+    with pytest.raises(SchedulingContractError):
+        DeadlineBoundary(
+            kind=DeadlineKind.HARD_ACTION,
+            due_at="2026-03-29T01:30:00Z",
+            source_time_zone="Europe/London",
+            source_local_time="2026-03-29T01:30:00",
+            source_utc_offset_minutes=0,
+            source_fold=0,
+        )
+
+
+def test_required_lane_cannot_drop_its_deadline() -> None:
+    tampered = replace(_input(), deadline=None)
+
+    with pytest.raises(SchedulingContractError):
+        calculate_urgency_deadline(policy=_policy(), item=tampered)
+
+
+def test_lane_cannot_be_rebound_away_from_exact_priority_selection() -> None:
+    item = _input(lane=PriorityLane.ROUTINE, deadline=None)
+    with pytest.raises(SchedulingContractError):
+        replace(item, lane=PriorityLane.URGENT, deadline=_deadline())
+
+
+def test_stale_or_blocked_work_never_becomes_schedulable_by_priority() -> None:
+    for state in (
+        SchedulingEligibility.STALE,
+        SchedulingEligibility.CLOSED,
+        SchedulingEligibility.POLICY_BLOCKED,
+        SchedulingEligibility.CURRENT_DEPENDENCY_BLOCKED,
+    ):
+        decision = calculate_urgency_deadline(
+            policy=_policy(),
+            item=_input(eligibility=state),
+        )
+        assert decision.schedulable is False
+        assert decision.order_key is None
+        assert decision.revalidation_required is (
+            state is SchedulingEligibility.STALE
+        )
+
+
+def test_starvation_is_measurable_and_requires_current_revalidation() -> None:
+    warning = calculate_urgency_deadline(
+        policy=_policy(),
+        item=_input(
+            lane=PriorityLane.ROUTINE,
+            enqueued_at="2026-08-09T13:30:00Z",
+            observed_at="2026-08-09T15:00:00Z",
+            deadline=None,
+        ),
+    )
+    starved = calculate_urgency_deadline(
+        policy=_policy(),
+        item=_input(
+            lane=PriorityLane.ROUTINE,
+            enqueued_at="2026-08-09T12:00:00Z",
+            observed_at="2026-08-09T15:00:00Z",
+            deadline=None,
+        ),
+    )
+
+    assert warning.starvation_state is StarvationState.AT_RISK
+    assert warning.revalidation_required is False
+    assert starved.starvation_state is StarvationState.STARVED
+    assert starved.revalidation_required is True
+    assert starved.starvation_overrun_seconds == 3_600
+    assert STARVATION_OBSERVATION.from_canonical_bytes(
+        starved.canonical_bytes
+    ) == starved
+
+
+def test_overdue_exact_deadline_is_visible_and_requires_revalidation() -> None:
+    decision = calculate_urgency_deadline(
+        policy=_policy(),
+        item=_input(
+            observed_at="2026-08-09T15:40:00Z",
+            deadline=_deadline("2026-08-09T15:30:00Z"),
+        ),
+    )
+
+    assert decision.deadline_overdue is True
+    assert decision.revalidation_required is True
+
+
+def test_within_lane_order_is_deadline_then_consequence_risk_age_and_tie_break() -> None:
+    policy = _policy()
+    early = calculate_urgency_deadline(
+        policy=policy,
+        item=_input(
+            version_id="work-item-version-z",
+            deadline=_deadline("2026-08-09T15:20:00Z"),
+            delay_consequence_ordinal=0,
+            staleness_risk_ordinal=0,
+        ),
+    )
+    later_high_risk = calculate_urgency_deadline(
+        policy=policy,
+        item=_input(
+            version_id="work-item-version-a",
+            deadline=_deadline("2026-08-09T15:30:00Z"),
+            delay_consequence_ordinal=3,
+            staleness_risk_ordinal=3,
+        ),
+    )
+    same_a = calculate_urgency_deadline(
+        policy=policy,
+        item=_input(version_id="work-item-version-a"),
+    )
+    same_b = calculate_urgency_deadline(
+        policy=policy,
+        item=_input(version_id="work-item-version-b"),
+    )
+
+    assert early.order_key < later_high_risk.order_key
+    assert same_a.order_key < same_b.order_key
+
+
+def _capacity_policy() -> RESERVED_CAPACITY_POLICY:
+    return RESERVED_CAPACITY_POLICY(
+        policy_id="fixture-capacity-policy",
+        policy_version="v1",
+        total_slots=6,
+        urgent_reserved_slots=2,
+        minimum_ordinary_slots=2,
+        degraded_urgent_disposition=(
+            ReservedCapacityDisposition.URGENT_VISIBLE_OPERATIONAL_HOLD
+        ),
+    )
+
+
+def _snapshot(
+    *,
+    active_urgent_slots: int = 0,
+    active_ordinary_slots: int = 0,
+    pending_urgent: int = 10,
+    pending_ordinary: int = 10,
+    urgent_path_state: CapacityPathState = CapacityPathState.AVAILABLE,
+) -> CapacitySnapshot:
+    return CapacitySnapshot(
+        observed_at="2026-08-09T15:10:00Z",
+        active_urgent_slots=active_urgent_slots,
+        active_ordinary_slots=active_ordinary_slots,
+        pending_urgent=pending_urgent,
+        pending_ordinary=pending_ordinary,
+        urgent_path_state=urgent_path_state,
+    )
+
+
+def test_reserved_capacity_admits_urgent_without_consuming_all_capacity() -> None:
+    decision = allocate_reserved_capacity(
+        policy=_capacity_policy(),
+        snapshot=_snapshot(),
+    )
+
+    assert decision.urgent_grants == 4
+    assert decision.ordinary_grants == 2
+    assert decision.urgent_grants <= decision.policy.max_urgent_slots
+    assert decision.ordinary_grants >= decision.policy.minimum_ordinary_slots
+    assert decision.urgent_disposition is ReservedCapacityDisposition.ADMITTED
+    assert decision.ordinary_disposition is ReservedCapacityDisposition.ADMITTED
+    assert ReservedCapacityDecision.from_canonical_bytes(
+        decision.canonical_bytes
+    ) == decision
+
+
+def test_capacity_classes_are_closed_over_canonical_lanes() -> None:
+    assert capacity_class_for_lane(PriorityLane.CONTAINMENT) is (
+        CapacityClass.URGENT_RESERVED
+    )
+    assert capacity_class_for_lane(PriorityLane.URGENT) is (
+        CapacityClass.URGENT_RESERVED
+    )
+    for lane in (
+        PriorityLane.TIME_SENSITIVE,
+        PriorityLane.PLANNED_WINDOW,
+        PriorityLane.ROUTINE,
+        PriorityLane.OPTIONAL_EVALUATION,
+    ):
+        assert capacity_class_for_lane(lane) is CapacityClass.ORDINARY
+
+
+def test_ordinary_work_cannot_consume_the_urgent_reserve() -> None:
+    decision = allocate_reserved_capacity(
+        policy=_capacity_policy(),
+        snapshot=_snapshot(pending_urgent=0, pending_ordinary=99),
+    )
+
+    assert decision.urgent_grants == 0
+    assert decision.ordinary_grants == 4
+    assert decision.unallocated_slots == 2
+
+
+def test_degraded_urgent_path_is_visible_and_never_downgrades_to_ordinary() -> None:
+    decision = allocate_reserved_capacity(
+        policy=_capacity_policy(),
+        snapshot=_snapshot(urgent_path_state=CapacityPathState.DEGRADED),
+    )
+
+    assert decision.urgent_grants == 0
+    assert decision.urgent_disposition is (
+        ReservedCapacityDisposition.URGENT_VISIBLE_OPERATIONAL_HOLD
+    )
+    assert decision.ordinary_grants == 4
+    assert decision.unallocated_slots == 2
+    assert decision.downgraded_urgent_to_ordinary is False
+    assert decision.effect == "NONE"
+
+
+def test_active_urgent_work_still_preserves_ordinary_headroom() -> None:
+    decision = allocate_reserved_capacity(
+        policy=_capacity_policy(),
+        snapshot=_snapshot(
+            active_urgent_slots=3,
+            active_ordinary_slots=0,
+            pending_urgent=10,
+            pending_ordinary=10,
+        ),
+    )
+
+    assert decision.urgent_grants == 1
+    assert decision.ordinary_grants == 2
+    assert decision.active_after_urgent == 4
+    assert decision.active_after_ordinary == 2
+
+
+def test_capacity_policy_rejects_configuration_that_lets_urgent_take_every_slot() -> None:
+    with pytest.raises(SchedulingContractError):
+        replace(_capacity_policy(), minimum_ordinary_slots=0)
+    with pytest.raises(SchedulingContractError):
+        replace(_capacity_policy(), urgent_reserved_slots=6)
+
+
+def test_decision_parsers_reject_unknown_duplicate_and_noncanonical_json() -> None:
+    decision = calculate_urgency_deadline(policy=_policy(), item=_input())
+    value = json.loads(decision.canonical_bytes)
+    value["unexpected"] = True
+    with pytest.raises(SchedulingContractError):
+        UrgencyDeadlineDecision.from_canonical_bytes(
+            json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+        )
+
+    duplicate = decision.canonical_bytes.replace(
+        b'{"authority":', b'{"authority":"NONE","authority":', 1
+    )
+    with pytest.raises(SchedulingContractError):
+        UrgencyDeadlineDecision.from_canonical_bytes(duplicate)
+
+    with pytest.raises(SchedulingContractError):
+        UrgencyDeadlineDecision.from_canonical_bytes(
+            json.dumps(json.loads(decision.canonical_bytes), indent=2).encode()
+        )
+
+    wrong_boolean_type = json.loads(decision.canonical_bytes)
+    wrong_boolean_type["deadline_overdue"] = 0
+    with pytest.raises(SchedulingContractError):
+        UrgencyDeadlineDecision.from_canonical_bytes(
+            json.dumps(
+                wrong_boolean_type,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode()
+        )
+
+    capacity = allocate_reserved_capacity(
+        policy=_capacity_policy(),
+        snapshot=_snapshot(),
+    )
+    wrong_integer_type = json.loads(capacity.canonical_bytes)
+    wrong_integer_type["urgent_grants"] = True
+    with pytest.raises(SchedulingContractError):
+        ReservedCapacityDecision.from_canonical_bytes(
+            json.dumps(
+                wrong_integer_type,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode()
+        )
+
+
+def test_interface_aliases_and_schema_boundary_are_exact() -> None:
+    assert URGENCY_DEADLINE_POLICY.__name__ == "UrgencyDeadlinePolicy"
+    assert RESERVED_CAPACITY_POLICY.__name__ == "ReservedCapacityPolicy"
+    assert STARVATION_OBSERVATION.__name__ == "StarvationObservation"
+    assert _policy().schema_version == (
+        "newsroom.increment6.triage-scheduling-policy.v1"
+    )
+    assert _capacity_policy().schema_version == (
+        "newsroom.increment6.triage-scheduling-policy.v1"
+    )
+    assert SHA_C != _policy().policy_digest

--- a/newsroom/tests/test_increment6b2_scheduling.py
+++ b/newsroom/tests/test_increment6b2_scheduling.py
@@ -20,7 +20,8 @@ from newsroom.increment6.scheduling import (
     CapacityClass,
     CapacityPathState,
     CapacityPopulationItem,
-    CapacityRevalidationDisposition,
+    CapacityRevalidationEvidence,
+    CapacityRevalidationResult,
     CapacitySnapshot,
     CapacityWorkState,
     DeadlineBoundary,
@@ -315,6 +316,7 @@ def _capacity_item(
     state: CapacityWorkState = CapacityWorkState.PENDING,
     starved: bool = False,
     revalidated: bool = False,
+    revalidation_result: CapacityRevalidationResult | None = None,
     identity: str | None = None,
 ) -> CapacityPopulationItem:
     digest = (
@@ -341,20 +343,33 @@ def _capacity_item(
             else _deadline(),
         ),
     )
+    evidence = None
+    if observation.revalidation_required:
+        result = (
+            revalidation_result or CapacityRevalidationResult.REVALIDATED
+            if revalidated
+            else revalidation_result or CapacityRevalidationResult.EXPIRED
+        )
+        evidence = CapacityRevalidationEvidence(
+            work_item_id=observation.item.work_item_id,
+            work_item_version_id=observation.item.work_item_version_id,
+            work_item_version_digest=observation.item.work_item_version_digest,
+            starvation_observation_digest=observation.decision_digest,
+            governing_policy_digest=observation.policy.policy_digest,
+            snapshot_observed_at=observation.item.observed_at,
+            currentness_basis=(
+                ReasonReference(
+                    reference_type=f"revalidation-{result.value.lower()}",
+                    identifier=f"receipt-{name}",
+                    digest=SHA_C,
+                ),
+            ),
+            result=result,
+        )
     return CapacityPopulationItem(
-        work_item_id=observation.item.work_item_id,
-        work_item_version_id=observation.item.work_item_version_id,
-        work_item_version_digest=observation.item.work_item_version_digest,
-        priority_selection=observation.item.priority_selection,
         observation=observation,
         state=state,
-        revalidation=(
-            CapacityRevalidationDisposition.REVALIDATED
-            if revalidated
-            else CapacityRevalidationDisposition.REVALIDATION_REQUIRED
-            if observation.revalidation_required
-            else CapacityRevalidationDisposition.NOT_REQUIRED
-        ),
+        revalidation_evidence=evidence,
     )
 
 
@@ -364,6 +379,7 @@ def _snapshot(
 ) -> CapacitySnapshot:
     return CapacitySnapshot(
         observed_at="2026-08-09T15:10:00Z",
+        urgency_policy=_policy(),
         population=tuple(sorted(items, key=lambda item: item.identity_key)),
         urgent_path_state=urgent_path_state,
     )
@@ -447,6 +463,65 @@ def test_caller_cannot_tamper_with_derived_counts_lane_or_digest() -> None:
         )
 
 
+def test_capacity_snapshot_rejects_mixed_exact_urgency_policy_thresholds() -> None:
+    base = _capacity_item("base-policy", lane=PriorityLane.ROUTINE)
+    changed_rules = list(_rules())
+    changed_rules[PriorityLane.ROUTINE.ordinal - 1] = replace(
+        changed_rules[PriorityLane.ROUTINE.ordinal - 1],
+        starvation_warning_seconds=3_601,
+        starvation_limit_seconds=7_201,
+    )
+    changed_policy = replace(_policy(), lane_rules=tuple(changed_rules))
+    changed_observation = calculate_urgency_deadline(
+        policy=changed_policy,
+        item=_input(
+            work_item_id="work-item-changed-policy",
+            version_id="work-item-version-changed-policy",
+            version_digest=SHA_C,
+            lane=PriorityLane.ROUTINE,
+            enqueued_at="2026-08-09T15:05:00Z",
+            observed_at="2026-08-09T15:10:00Z",
+            deadline=None,
+        ),
+    )
+    changed = CapacityPopulationItem(
+        observation=changed_observation,
+        state=CapacityWorkState.PENDING,
+        revalidation_evidence=None,
+    )
+
+    with pytest.raises(SchedulingContractError):
+        _snapshot(base, changed)
+
+
+def test_revalidation_evidence_rejects_caller_flip_replay_and_binding_drift() -> None:
+    expired = _capacity_item("receipt", lane=PriorityLane.ROUTINE, starved=True)
+    evidence = expired.revalidation_evidence
+    assert evidence is not None
+
+    with pytest.raises(SchedulingContractError):
+        replace(evidence, result=CapacityRevalidationResult.REVALIDATED)
+    for drift in (
+        {"snapshot_observed_at": "2026-08-09T15:11:00Z"},
+        {"governing_policy_digest": SHA_A},
+        {"starvation_observation_digest": SHA_B},
+        {"work_item_version_digest": SHA_C},
+    ):
+        with pytest.raises(SchedulingContractError):
+            replace(expired, revalidation_evidence=replace(evidence, **drift))
+
+    decision = allocate_reserved_capacity(
+        policy=_capacity_policy(), snapshot=_snapshot(expired)
+    )
+    tampered = json.loads(decision.canonical_bytes)
+    raw_evidence = tampered["snapshot"]["population"][0]["revalidation_evidence"]
+    raw_evidence["result"] = CapacityRevalidationResult.REVALIDATED.value
+    with pytest.raises(SchedulingContractError):
+        ReservedCapacityDecision.from_canonical_bytes(
+            json.dumps(tampered, sort_keys=True, separators=(",", ":")).encode()
+        )
+
+
 def test_revalidated_starved_routine_gets_next_ordinary_grant_before_fresh_inflow() -> (
     None
 ):
@@ -486,7 +561,8 @@ def test_starved_routine_requires_visible_revalidation_before_protection() -> No
 
     assert decision.granted_items == (fresh,)
     allocation = next(a for a in decision.allocations if a.item == awaiting)
-    assert allocation.disposition is CapacityAllocationDisposition.REVALIDATION_REQUIRED
+    assert allocation.disposition is CapacityAllocationDisposition.CAPACITY_DEFERRED
+    assert allocation.item.revalidation_result is CapacityRevalidationResult.EXPIRED
     assert allocation.protected_routine_grant is False
 
 
@@ -511,6 +587,38 @@ def test_degraded_urgent_is_exact_visible_hold_and_never_downgraded() -> None:
         is CapacityAllocationDisposition.URGENT_VISIBLE_OPERATIONAL_HOLD
     )
     assert decision.downgraded_urgent_to_ordinary is False
+
+
+def test_degraded_urgent_hold_remains_primary_during_expired_revalidation() -> None:
+    urgent = _capacity_item("urgent-expired", lane=PriorityLane.URGENT, starved=True)
+    decision = allocate_reserved_capacity(
+        policy=_capacity_policy(),
+        snapshot=_snapshot(urgent, urgent_path_state=CapacityPathState.DEGRADED),
+    )
+    allocation = decision.allocations[0]
+
+    assert allocation.disposition is (
+        CapacityAllocationDisposition.URGENT_VISIBLE_OPERATIONAL_HOLD
+    )
+    assert allocation.item.revalidation_result is CapacityRevalidationResult.EXPIRED
+    assert decision.urgent_grants == 0
+    assert decision.downgraded_urgent_to_ordinary is False
+
+
+def test_maximum_valid_population_decision_round_trips_canonically() -> None:
+    items = tuple(
+        _capacity_item(f"maximum-{index:02d}", lane=PriorityLane.TIME_SENSITIVE)
+        for index in range(48)
+    )
+    decision = allocate_reserved_capacity(
+        policy=_capacity_policy(), snapshot=_snapshot(*items)
+    )
+
+    assert len(decision.snapshot.population) == 48
+    assert (
+        ReservedCapacityDecision.from_canonical_bytes(decision.canonical_bytes)
+        == decision
+    )
 
 
 @pytest.mark.parametrize("active_urgent", range(5))
@@ -658,6 +766,27 @@ def test_canonical_parsers_reject_boolean_ordinals_as_type_confusion() -> None:
         UrgencyDeadlineDecision.from_canonical_bytes(
             json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
         )
+
+
+def test_deep_json_and_canonical_recursion_fail_as_contract_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    deeply_nested = b'{"value":' * 1_100 + b"0" + b"}" * 1_100
+    with pytest.raises(SchedulingContractError):
+        ReservedCapacityDecision.from_canonical_bytes(deeply_nested)
+
+    decision = calculate_urgency_deadline(policy=_policy(), item=_input())
+    raw = decision.canonical_bytes
+
+    def recursive_canonical(_: object) -> bytes:
+        raise RecursionError("fixture canonical recursion")
+
+    monkeypatch.setattr(
+        "newsroom.increment6.scheduling.canonical_json_bytes",
+        recursive_canonical,
+    )
+    with pytest.raises(SchedulingContractError):
+        UrgencyDeadlineDecision.from_canonical_bytes(raw)
 
 
 def test_interface_aliases_and_schema_boundary_are_exact() -> None:

--- a/newsroom/tests/test_increment6b2_scheduling.py
+++ b/newsroom/tests/test_increment6b2_scheduling.py
@@ -7,14 +7,22 @@ from zoneinfo import ZoneInfo
 
 import pytest
 
-from newsroom.increment6.outcomes import PriorityLane, PrioritySelection, ReasonReference
+from newsroom.increment6.outcomes import (
+    PriorityLane,
+    PrioritySelection,
+    ReasonReference,
+)
 from newsroom.increment6.scheduling import (
     RESERVED_CAPACITY_POLICY,
     STARVATION_OBSERVATION,
     URGENCY_DEADLINE_POLICY,
-    CapacityPathState,
+    CapacityAllocationDisposition,
     CapacityClass,
+    CapacityPathState,
+    CapacityPopulationItem,
+    CapacityRevalidationDisposition,
     CapacitySnapshot,
+    CapacityWorkState,
     DeadlineBoundary,
     DeadlineKind,
     LaneTimingRule,
@@ -23,13 +31,12 @@ from newsroom.increment6.scheduling import (
     SchedulingContractError,
     SchedulingEligibility,
     StarvationState,
-    UrgencyDeadlineInput,
     UrgencyDeadlineDecision,
+    UrgencyDeadlineInput,
     allocate_reserved_capacity,
-    capacity_class_for_lane,
     calculate_urgency_deadline,
+    capacity_class_for_lane,
 )
-
 
 SHA_A = "sha256:" + "a" * 64
 SHA_B = "sha256:" + "b" * 64
@@ -85,7 +92,9 @@ def _policy() -> URGENCY_DEADLINE_POLICY:
 
 def _input(
     *,
+    work_item_id: str = "work-item-a",
     version_id: str = "work-item-version-a",
+    version_digest: str = SHA_A,
     lane: PriorityLane = PriorityLane.TIME_SENSITIVE,
     enqueued_at: str = "2026-08-09T15:00:00Z",
     observed_at: str = "2026-08-09T15:10:00Z",
@@ -103,11 +112,11 @@ def _input(
     }:
         deadline = _deadline()
     return UrgencyDeadlineInput(
-        work_item_id="work-item-a",
+        work_item_id=work_item_id,
         work_item_version_id=version_id,
-        work_item_version_digest=SHA_A,
+        work_item_version_digest=version_digest,
         priority_selection=PrioritySelection(
-            work_identity="work-item-a",
+            work_identity=work_item_id,
             work_version=version_id,
             lane=lane,
             basis_references=(
@@ -205,9 +214,7 @@ def test_stale_or_blocked_work_never_becomes_schedulable_by_priority() -> None:
         )
         assert decision.schedulable is False
         assert decision.order_key is None
-        assert decision.revalidation_required is (
-            state is SchedulingEligibility.STALE
-        )
+        assert decision.revalidation_required is (state is SchedulingEligibility.STALE)
 
 
 def test_starvation_is_measurable_and_requires_current_revalidation() -> None:
@@ -235,9 +242,9 @@ def test_starvation_is_measurable_and_requires_current_revalidation() -> None:
     assert starved.starvation_state is StarvationState.STARVED
     assert starved.revalidation_required is True
     assert starved.starvation_overrun_seconds == 3_600
-    assert STARVATION_OBSERVATION.from_canonical_bytes(
-        starved.canonical_bytes
-    ) == starved
+    assert (
+        STARVATION_OBSERVATION.from_canonical_bytes(starved.canonical_bytes) == starved
+    )
 
 
 def test_overdue_exact_deadline_is_visible_and_requires_revalidation() -> None:
@@ -253,7 +260,9 @@ def test_overdue_exact_deadline_is_visible_and_requires_revalidation() -> None:
     assert decision.revalidation_required is True
 
 
-def test_within_lane_order_is_deadline_then_consequence_risk_age_and_tie_break() -> None:
+def test_within_lane_order_is_deadline_then_consequence_risk_age_and_tie_break() -> (
+    None
+):
     policy = _policy()
     early = calculate_urgency_deadline(
         policy=policy,
@@ -299,48 +308,106 @@ def _capacity_policy() -> RESERVED_CAPACITY_POLICY:
     )
 
 
-def _snapshot(
+def _capacity_item(
+    name: str,
     *,
-    active_urgent_slots: int = 0,
-    active_ordinary_slots: int = 0,
-    pending_urgent: int = 10,
-    pending_ordinary: int = 10,
+    lane: PriorityLane,
+    state: CapacityWorkState = CapacityWorkState.PENDING,
+    starved: bool = False,
+    revalidated: bool = False,
+    identity: str | None = None,
+) -> CapacityPopulationItem:
+    digest = (
+        "sha256:" + (name[-1].encode().hex()[0] if name[-1].isalnum() else "d") * 64
+    )
+    enqueued_at = (
+        "2026-08-09T12:00:00Z"
+        if starved
+        else "2026-08-09T15:09:30Z"
+        if lane in {PriorityLane.CONTAINMENT, PriorityLane.URGENT}
+        else "2026-08-09T15:05:00Z"
+    )
+    observation = calculate_urgency_deadline(
+        policy=_policy(),
+        item=_input(
+            work_item_id=identity or f"work-item-{name}",
+            version_id=f"work-item-version-{name}",
+            version_digest=digest,
+            lane=lane,
+            enqueued_at=enqueued_at,
+            observed_at="2026-08-09T15:10:00Z",
+            deadline=None
+            if lane in {PriorityLane.ROUTINE, PriorityLane.OPTIONAL_EVALUATION}
+            else _deadline(),
+        ),
+    )
+    return CapacityPopulationItem(
+        work_item_id=observation.item.work_item_id,
+        work_item_version_id=observation.item.work_item_version_id,
+        work_item_version_digest=observation.item.work_item_version_digest,
+        priority_selection=observation.item.priority_selection,
+        observation=observation,
+        state=state,
+        revalidation=(
+            CapacityRevalidationDisposition.REVALIDATED
+            if revalidated
+            else CapacityRevalidationDisposition.REVALIDATION_REQUIRED
+            if observation.revalidation_required
+            else CapacityRevalidationDisposition.NOT_REQUIRED
+        ),
+    )
+
+
+def _snapshot(
+    *items: CapacityPopulationItem,
     urgent_path_state: CapacityPathState = CapacityPathState.AVAILABLE,
 ) -> CapacitySnapshot:
     return CapacitySnapshot(
         observed_at="2026-08-09T15:10:00Z",
-        active_urgent_slots=active_urgent_slots,
-        active_ordinary_slots=active_ordinary_slots,
-        pending_urgent=pending_urgent,
-        pending_ordinary=pending_ordinary,
+        population=tuple(sorted(items, key=lambda item: item.identity_key)),
         urgent_path_state=urgent_path_state,
     )
 
 
-def test_reserved_capacity_admits_urgent_without_consuming_all_capacity() -> None:
-    decision = allocate_reserved_capacity(
-        policy=_capacity_policy(),
-        snapshot=_snapshot(),
+def test_capacity_population_derives_counts_and_exact_grants_from_canonical_lanes() -> (
+    None
+):
+    items = tuple(
+        _capacity_item(str(index), lane=lane, state=state)
+        for index, (lane, state) in enumerate(
+            (
+                (PriorityLane.URGENT, CapacityWorkState.ACTIVE),
+                (PriorityLane.TIME_SENSITIVE, CapacityWorkState.ACTIVE),
+                (PriorityLane.CONTAINMENT, CapacityWorkState.PENDING),
+                (PriorityLane.URGENT, CapacityWorkState.PENDING),
+                (PriorityLane.PLANNED_WINDOW, CapacityWorkState.PENDING),
+                (PriorityLane.ROUTINE, CapacityWorkState.PENDING),
+            )
+        )
     )
+    snapshot = _snapshot(*items)
+    decision = allocate_reserved_capacity(policy=_capacity_policy(), snapshot=snapshot)
 
-    assert decision.urgent_grants == 4
+    assert (snapshot.active_urgent_slots, snapshot.active_ordinary_slots) == (1, 1)
+    assert (snapshot.pending_urgent, snapshot.pending_ordinary) == (2, 2)
+    assert decision.urgent_grants == 2
     assert decision.ordinary_grants == 2
-    assert decision.urgent_grants <= decision.policy.max_urgent_slots
-    assert decision.ordinary_grants >= decision.policy.minimum_ordinary_slots
-    assert decision.urgent_disposition is ReservedCapacityDisposition.ADMITTED
-    assert decision.ordinary_disposition is ReservedCapacityDisposition.ADMITTED
-    assert ReservedCapacityDecision.from_canonical_bytes(
-        decision.canonical_bytes
-    ) == decision
+    assert {
+        (item.work_item_id, item.work_item_version_digest)
+        for item in decision.granted_items
+    } == {(item.work_item_id, item.work_item_version_digest) for item in items[2:]}
+    assert (
+        ReservedCapacityDecision.from_canonical_bytes(decision.canonical_bytes)
+        == decision
+    )
 
 
 def test_capacity_classes_are_closed_over_canonical_lanes() -> None:
-    assert capacity_class_for_lane(PriorityLane.CONTAINMENT) is (
-        CapacityClass.URGENT_RESERVED
+    assert (
+        capacity_class_for_lane(PriorityLane.CONTAINMENT)
+        is CapacityClass.URGENT_RESERVED
     )
-    assert capacity_class_for_lane(PriorityLane.URGENT) is (
-        CapacityClass.URGENT_RESERVED
-    )
+    assert capacity_class_for_lane(PriorityLane.URGENT) is CapacityClass.URGENT_RESERVED
     for lane in (
         PriorityLane.TIME_SENSITIVE,
         PriorityLane.PLANNED_WINDOW,
@@ -350,51 +417,154 @@ def test_capacity_classes_are_closed_over_canonical_lanes() -> None:
         assert capacity_class_for_lane(lane) is CapacityClass.ORDINARY
 
 
-def test_ordinary_work_cannot_consume_the_urgent_reserve() -> None:
+def test_duplicate_identity_version_or_conflicting_version_fails_closed() -> None:
+    item = _capacity_item("duplicate", lane=PriorityLane.ROUTINE)
+    with pytest.raises(SchedulingContractError):
+        _snapshot(item, item)
+    conflicting = _capacity_item(
+        "other", lane=PriorityLane.ROUTINE, identity=item.work_item_id
+    )
+    with pytest.raises(SchedulingContractError):
+        _snapshot(item, conflicting)
+
+
+def test_caller_cannot_tamper_with_derived_counts_lane_or_digest() -> None:
+    item = _capacity_item("tamper", lane=PriorityLane.URGENT)
     decision = allocate_reserved_capacity(
-        policy=_capacity_policy(),
-        snapshot=_snapshot(pending_urgent=0, pending_ordinary=99),
+        policy=_capacity_policy(), snapshot=_snapshot(item)
     )
+    value = json.loads(decision.canonical_bytes)
+    value["snapshot"]["pending_urgent"] = 99
+    with pytest.raises(SchedulingContractError):
+        ReservedCapacityDecision.from_canonical_bytes(
+            json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+        )
+    value = json.loads(decision.canonical_bytes)
+    value["snapshot"]["population"][0]["lane"] = PriorityLane.ROUTINE.value
+    with pytest.raises(SchedulingContractError):
+        ReservedCapacityDecision.from_canonical_bytes(
+            json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+        )
 
-    assert decision.urgent_grants == 0
-    assert decision.ordinary_grants == 4
-    assert decision.unallocated_slots == 2
 
-
-def test_degraded_urgent_path_is_visible_and_never_downgrades_to_ordinary() -> None:
+def test_revalidated_starved_routine_gets_next_ordinary_grant_before_fresh_inflow() -> (
+    None
+):
+    active = tuple(
+        _capacity_item(
+            f"active-{index}",
+            lane=PriorityLane.TIME_SENSITIVE,
+            state=CapacityWorkState.ACTIVE,
+        )
+        for index in range(3)
+    )
+    fresh = _capacity_item("fresh", lane=PriorityLane.TIME_SENSITIVE)
+    protected = _capacity_item(
+        "protected", lane=PriorityLane.ROUTINE, starved=True, revalidated=True
+    )
     decision = allocate_reserved_capacity(
-        policy=_capacity_policy(),
-        snapshot=_snapshot(urgent_path_state=CapacityPathState.DEGRADED),
+        policy=_capacity_policy(), snapshot=_snapshot(*active, fresh, protected)
     )
 
-    assert decision.urgent_grants == 0
-    assert decision.urgent_disposition is (
-        ReservedCapacityDisposition.URGENT_VISIBLE_OPERATIONAL_HOLD
+    assert decision.ordinary_grants == 1
+    assert decision.granted_items == (protected,)
+    protected_allocation = next(a for a in decision.allocations if a.item == protected)
+    fresh_allocation = next(a for a in decision.allocations if a.item == fresh)
+    assert protected_allocation.protected_routine_grant is True
+    assert protected_allocation.disposition is CapacityAllocationDisposition.GRANTED
+    assert (
+        fresh_allocation.disposition is CapacityAllocationDisposition.CAPACITY_DEFERRED
     )
-    assert decision.ordinary_grants == 4
-    assert decision.unallocated_slots == 2
-    assert decision.downgraded_urgent_to_ordinary is False
-    assert decision.effect == "NONE"
 
 
-def test_active_urgent_work_still_preserves_ordinary_headroom() -> None:
+def test_starved_routine_requires_visible_revalidation_before_protection() -> None:
+    fresh = _capacity_item("fresh2", lane=PriorityLane.TIME_SENSITIVE)
+    awaiting = _capacity_item("awaiting", lane=PriorityLane.ROUTINE, starved=True)
+    decision = allocate_reserved_capacity(
+        policy=_capacity_policy(), snapshot=_snapshot(fresh, awaiting)
+    )
+
+    assert decision.granted_items == (fresh,)
+    allocation = next(a for a in decision.allocations if a.item == awaiting)
+    assert allocation.disposition is CapacityAllocationDisposition.REVALIDATION_REQUIRED
+    assert allocation.protected_routine_grant is False
+
+
+def test_degraded_urgent_is_exact_visible_hold_and_never_downgraded() -> None:
+    urgent = _capacity_item("urgent", lane=PriorityLane.URGENT)
+    ordinary = _capacity_item("ordinary", lane=PriorityLane.ROUTINE)
     decision = allocate_reserved_capacity(
         policy=_capacity_policy(),
         snapshot=_snapshot(
-            active_urgent_slots=3,
-            active_ordinary_slots=0,
-            pending_urgent=10,
-            pending_ordinary=10,
+            urgent, ordinary, urgent_path_state=CapacityPathState.DEGRADED
         ),
     )
 
-    assert decision.urgent_grants == 1
-    assert decision.ordinary_grants == 2
-    assert decision.active_after_urgent == 4
-    assert decision.active_after_ordinary == 2
+    assert decision.urgent_grants == 0
+    assert decision.ordinary_grants == 1
+    assert (
+        decision.urgent_disposition
+        is ReservedCapacityDisposition.URGENT_VISIBLE_OPERATIONAL_HOLD
+    )
+    assert (
+        next(a for a in decision.allocations if a.item == urgent).disposition
+        is CapacityAllocationDisposition.URGENT_VISIBLE_OPERATIONAL_HOLD
+    )
+    assert decision.downgraded_urgent_to_ordinary is False
 
 
-def test_capacity_policy_rejects_configuration_that_lets_urgent_take_every_slot() -> None:
+@pytest.mark.parametrize("active_urgent", range(5))
+@pytest.mark.parametrize("active_ordinary", range(5))
+def test_capacity_invariants_hold_across_bounded_population_grid(
+    active_urgent: int, active_ordinary: int
+) -> None:
+    if active_urgent > 4 or active_ordinary > 4 or active_urgent + active_ordinary > 6:
+        return
+    items = [
+        *(
+            _capacity_item(
+                f"au-{index}", lane=PriorityLane.URGENT, state=CapacityWorkState.ACTIVE
+            )
+            for index in range(active_urgent)
+        ),
+        *(
+            _capacity_item(
+                f"ao-{index}", lane=PriorityLane.ROUTINE, state=CapacityWorkState.ACTIVE
+            )
+            for index in range(active_ordinary)
+        ),
+        *(
+            _capacity_item(f"pu-{index}", lane=PriorityLane.URGENT)
+            for index in range(8)
+        ),
+        *(
+            _capacity_item(f"po-{index}", lane=PriorityLane.TIME_SENSITIVE)
+            for index in range(8)
+        ),
+    ]
+    if active_urgent > 4 or active_ordinary > 4:
+        with pytest.raises(SchedulingContractError):
+            allocate_reserved_capacity(
+                policy=_capacity_policy(), snapshot=_snapshot(*items)
+            )
+        return
+    decision = allocate_reserved_capacity(
+        policy=_capacity_policy(), snapshot=_snapshot(*items)
+    )
+    assert decision.active_after_urgent <= decision.policy.max_urgent_slots
+    assert decision.active_after_ordinary <= decision.policy.ordinary_capacity_ceiling
+    assert (
+        len(decision.granted_items) + active_urgent + active_ordinary
+        <= decision.policy.total_slots
+    )
+    assert len({item.identity_key for item in decision.granted_items}) == len(
+        decision.granted_items
+    )
+
+
+def test_capacity_policy_rejects_configuration_that_lets_urgent_take_every_slot() -> (
+    None
+):
     with pytest.raises(SchedulingContractError):
         replace(_capacity_policy(), minimum_ordinary_slots=0)
     with pytest.raises(SchedulingContractError):
@@ -445,6 +615,48 @@ def test_decision_parsers_reject_unknown_duplicate_and_noncanonical_json() -> No
                 sort_keys=True,
                 separators=(",", ":"),
             ).encode()
+        )
+
+
+def test_total_contract_boundaries_never_leak_raw_numeric_or_datetime_errors() -> None:
+    with pytest.raises(SchedulingContractError):
+        calculate_urgency_deadline(
+            policy=_policy(),
+            item=_input(
+                lane=PriorityLane.ROUTINE,
+                enqueued_at="9999-12-31T23:59:00Z",
+                observed_at="9999-12-31T23:59:30Z",
+                deadline=None,
+            ),
+        )
+    with pytest.raises(SchedulingContractError):
+        replace(_rules()[-1], starvation_limit_seconds=315_576_001)
+
+    decision = calculate_urgency_deadline(policy=_policy(), item=_input())
+    huge_integer = decision.canonical_bytes.replace(
+        b'"queue_age_seconds":600',
+        b'"queue_age_seconds":' + b"9" * 5_000,
+    )
+    with pytest.raises(SchedulingContractError):
+        UrgencyDeadlineDecision.from_canonical_bytes(huge_integer)
+    with pytest.raises(SchedulingContractError):
+        UrgencyDeadlineDecision.from_canonical_bytes(b"{" + b" " * 1_000_000)
+
+
+def test_canonical_parsers_reject_boolean_ordinals_as_type_confusion() -> None:
+    decision = calculate_urgency_deadline(policy=_policy(), item=_input())
+    value = json.loads(decision.canonical_bytes)
+    value["input"]["lane_ordinal"] = True
+    with pytest.raises(SchedulingContractError):
+        UrgencyDeadlineDecision.from_canonical_bytes(
+            json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+        )
+
+    value = json.loads(decision.canonical_bytes)
+    value["policy"]["lane_rules"][0]["lane_ordinal"] = True
+    with pytest.raises(SchedulingContractError):
+        UrgencyDeadlineDecision.from_canonical_bytes(
+            json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
         )
 
 

--- a/newsroom/tests/test_increment6b2_scheduling.py
+++ b/newsroom/tests/test_increment6b2_scheduling.py
@@ -159,6 +159,43 @@ def test_identical_inputs_produce_byte_identical_deadline_and_order() -> None:
     assert UrgencyDeadlineDecision.from_canonical_bytes(first.canonical_bytes) == first
 
 
+def _input_with_basis_reference_count(count: int) -> UrgencyDeadlineInput:
+    item = _input()
+    references = tuple(
+        ReasonReference(
+            reference_type="boundary-basis",
+            identifier=f"{index:03d}-" + "x" * 3_996,
+            digest=SHA_B,
+        )
+        for index in range(count)
+    )
+    return replace(
+        item,
+        priority_selection=replace(
+            item.priority_selection,
+            basis_references=references,
+        ),
+    )
+
+
+def test_standalone_observation_size_boundary_matches_canonical_parser() -> None:
+    accepted = calculate_urgency_deadline(
+        policy=_policy(),
+        item=_input_with_basis_reference_count(220),
+    )
+
+    assert len(accepted.canonical_bytes) < 917_504
+    assert (
+        UrgencyDeadlineDecision.from_canonical_bytes(accepted.canonical_bytes)
+        == accepted
+    )
+    with pytest.raises(SchedulingContractError):
+        calculate_urgency_deadline(
+            policy=_policy(),
+            item=_input_with_basis_reference_count(230),
+        )
+
+
 def test_deadline_boundary_resolves_exact_time_zone_and_dst_fold() -> None:
     first_fold = DeadlineBoundary(
         kind=DeadlineKind.PLANNED_WINDOW_END,

--- a/newsroom/tests/test_increment6b2_scheduling.py
+++ b/newsroom/tests/test_increment6b2_scheduling.py
@@ -226,6 +226,29 @@ def test_deadline_boundary_resolves_exact_time_zone_and_dst_fold() -> None:
         )
 
 
+@pytest.mark.parametrize(
+    "source_time_zone",
+    ("Etc/../../etc/passwd", "UTC/", "A//B"),
+)
+def test_non_normalised_time_zone_fails_closed_at_constructor_and_parser(
+    source_time_zone: str,
+) -> None:
+    with pytest.raises(SchedulingContractError):
+        replace(_deadline(), source_time_zone=source_time_zone)
+
+    observation = calculate_urgency_deadline(policy=_policy(), item=_input())
+    value = observation.canonical_value()
+    value["input"]["deadline"]["source_time_zone"] = source_time_zone  # type: ignore[index]
+    raw = json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    with pytest.raises(SchedulingContractError):
+        UrgencyDeadlineDecision.from_canonical_bytes(raw)
+
+
 def test_required_lane_cannot_drop_its_deadline() -> None:
     tampered = replace(_input(), deadline=None)
 


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-6b2
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

## Accepted allocation

- Issue: #359 / Increment 6B2
- Accepted 6R contract digest: `sha256:13b43c927e4222c143b8691eaf179eb956096c19a72f4cc29cae13008d6e0590`
- Accepted 6R merge: `main@a44a073e3d798521a373115aa2c54f104b58a4cd`
- Rebased integration base: `main@8645ea0db0a8c99cf76d9acc294dcf52b9efd520`
- Implementation head: `5d2b601d7cde2fea399e5e9a9d1babd6bf7a732c`
- Effective wave: 2
- Dependencies: #354, #355
- Gate: Tier L
- Sole public module: `newsroom.increment6.scheduling`
- Schema identity: `newsroom.increment6.triage-scheduling-policy.v1`
- Sole interface ownership: `URGENCY_DEADLINE_POLICY`, `RESERVED_CAPACITY_POLICY`, `STARVATION_OBSERVATION`
- Migration allocation: none
- Source digest: `newsroom/increment6/scheduling.py` = `sha256:3e019289b5bc52552a7aaec9e1aa0acd691db00863569bf4367f14c7b74b6feb`

## Summary

- binds each capacity snapshot to one exact typed urgency policy and derived policy digest; every population observation must use that exact policy
- derives Work Item identity/version/digest, Priority Selection, canonical lane and capacity class solely from one replayable starvation observation, eliminating duplicated caller state
- replaces the bare revalidation flag with immutable evidence bound to the exact Work Item version, starvation-observation digest, governing-policy digest, snapshot time and typed currentness basis
- exposes typed `REVALIDATED`, `EXPIRED` and `CLOSED` results as a bounded, no-authority input seam for a downstream authoritative receipt
- protects a starved Routine item only with exact current `REVALIDATED` evidence; caller flips, replayed times, policy drift and digest tampering fail closed
- keeps degraded or unavailable Urgent allocation primarily on the visible Operational Hold while exposing revalidation result separately, with no grant or downgrade
- makes every legal 48-item decision canonical-round-trip safe by deriving the raw-byte ceiling from item/population bounds
- rejects deeply nested JSON and canonical recursion as `SchedulingContractError`, retaining bounded raw bytes, integers, durations and datetime representability
- gives standalone starvation observations an explicit construction/parser-aligned canonical byte cap: the 220-reference boundary round-trips while the 230-reference oversize case fails during construction
- converts non-normalised `ZoneInfo` keys to bounded `SchedulingContractError` failures at direct construction and canonical replay boundaries
- retains pure policy, exact UTC/IANA/DST/tie-break behaviour and explicit `authority: NONE` / `effect: NONE`

## Scope

This PR changes only:

- `newsroom/increment6/scheduling.py`
- `newsroom/tests/test_increment6b2_scheduling.py`

It introduces no migration, persistence, queue ownership, clock read, model/provider call, publication or external effect.

## Verification

- focused 6B2 tests: **54 passed**
- 6A1 + 6C1 + 6E1 + 6R compatibility: **93 passed**
- full local suite on rebased head: **2633 passed, 41 skipped, 20 existing macOS environment-specific failures**
  - 16 trusted-system-Python qualification failures
  - 3 Linux-only no-replace transport failures
  - 1 watchdog timing/environment failure
- cached Ruff 0.16.2 format/check on both owned files — passed
- `python3 -m compileall -q newsroom/increment6/scheduling.py newsroom/tests/test_increment6b2_scheduling.py` — passed
- `git diff --check` — passed
- local and remote branch exact head — `5d2b601d7cde2fea399e5e9a9d1babd6bf7a732c`

Issue: #359





