### PR TITLE
Increment 6D1: persist Event Hypothesis authority

### DIFF
--- a/newsroom/authority/event_hypothesis_migrations.py
+++ b/newsroom/authority/event_hypothesis_migrations.py
@@ -1,0 +1,318 @@
+"""Checked v21 persistence for Event Hypothesis authority."""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+from .canonical import canonical_json_bytes, digest_canonical
+
+EVENT_HYPOTHESIS_SCHEMA_VERSION = 21
+EVENT_HYPOTHESIS_MIGRATION_NAME = "event_hypothesis_authority_v21"
+EVENT_HYPOTHESIS_PREDECESSOR_FINGERPRINT = (
+    "sha256:36a7c9910775ede9c29113a43e08bba261a5a98c4fab5225dd2cae9448689389"
+)
+EVENT_HYPOTHESIS_PREDECESSOR_MIGRATION_CHECKSUM = (
+    "sha256:6eb04f981f650bbb4956f148d11f1656bcd2b7c510117db96602dd9d83ab9bd3"
+)
+
+
+class EventHypothesisBackupError(sqlite3.DatabaseError):
+    """The exact retained v20 backup boundary is absent or differs."""
+
+
+@dataclass(frozen=True, slots=True)
+class EventHypothesisBackupReceipt:
+    backup_path: Path
+    digest_path: Path
+    backup_digest: str
+    logical_digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class EventHypothesisMigrationRecord:
+    version: int
+    name: str
+    checksum: str
+
+
+def event_hypothesis_backup_paths(database: str | Path) -> tuple[Path, Path]:
+    source = Path(database)
+    backup = source.with_name(source.name + ".pre-v21.sqlite3")
+    return backup, backup.with_name(backup.name + ".sha256")
+
+
+def _logical_database_digest(connection: sqlite3.Connection) -> str:
+    digest = hashlib.sha256()
+    digest.update(b"[")
+    first = True
+    for statement in connection.iterdump():
+        if not first:
+            digest.update(b",")
+        digest.update(canonical_json_bytes(statement))
+        first = False
+    digest.update(b"]")
+    return "sha256:" + digest.hexdigest()
+
+
+def _file_digest(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        while chunk := source.read(1024 * 1024):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def _schema_fingerprint(connection: sqlite3.Connection) -> str:
+    rows = connection.execute(
+        "SELECT type,name,tbl_name,sql FROM sqlite_master "
+        "WHERE name NOT LIKE 'sqlite_%' ORDER BY type,name"
+    ).fetchall()
+    return digest_canonical(
+        [
+            [str(r[0]), str(r[1]), str(r[2]), " ".join(str(r[3] or "").split())]
+            for r in rows
+        ]
+    )
+
+
+def prepare_event_hypothesis_backup(
+    connection: sqlite3.Connection, backup_path: Path
+) -> EventHypothesisBackupReceipt:
+    if connection.in_transaction:
+        raise EventHypothesisBackupError("backup requires no active transaction")
+    if connection.execute("PRAGMA user_version").fetchone()[0] != 20:
+        raise EventHypothesisBackupError("backup requires exact schema v20")
+    if _schema_fingerprint(connection) != EVENT_HYPOTHESIS_PREDECESSOR_FINGERPRINT:
+        raise EventHypothesisBackupError("backup requires checked v20 schema")
+    if not isinstance(backup_path, Path) or not backup_path.is_absolute():
+        raise EventHypothesisBackupError("backup path must be absolute")
+    source_path = Path(
+        next(r[2] for r in connection.execute("PRAGMA database_list") if r[1] == "main")
+    )
+    if not source_path or source_path.resolve() == backup_path.resolve():
+        raise EventHypothesisBackupError("backup path must differ from source")
+    digest_path = backup_path.with_name(backup_path.name + ".sha256")
+    logical_digest = _logical_database_digest(connection)
+    if backup_path.exists() != digest_path.exists():
+        raise EventHypothesisBackupError("backup receipt is incomplete")
+    if not backup_path.exists():
+        backup_path.open("xb").close()
+        target = sqlite3.connect(backup_path, isolation_level=None)
+        try:
+            connection.backup(target)
+        finally:
+            target.close()
+        backup_digest = _file_digest(backup_path)
+        with digest_path.open("x", encoding="ascii") as receipt:
+            receipt.write(backup_digest + "\n")
+    else:
+        backup_digest = _file_digest(backup_path)
+    if digest_path.read_text(encoding="ascii") != backup_digest + "\n":
+        raise EventHypothesisBackupError("retained backup digest differs")
+    target = sqlite3.connect(
+        f"file:{backup_path}?mode=ro", uri=True, isolation_level=None
+    )
+    try:
+        if (
+            target.execute("PRAGMA user_version").fetchone()[0] != 20
+            or _schema_fingerprint(target) != EVENT_HYPOTHESIS_PREDECESSOR_FINGERPRINT
+            or _logical_database_digest(target) != logical_digest
+        ):
+            raise EventHypothesisBackupError("retained backup differs from source")
+    finally:
+        target.close()
+    connection.execute(
+        "CREATE TEMP TABLE IF NOT EXISTS event_hypothesis_backup_gate("
+        "backup_path TEXT PRIMARY KEY,backup_digest TEXT NOT NULL,logical_digest TEXT NOT NULL) STRICT"
+    )
+    connection.execute("DELETE FROM event_hypothesis_backup_gate")
+    connection.execute(
+        "INSERT INTO event_hypothesis_backup_gate VALUES(?,?,?)",
+        (str(backup_path), backup_digest, logical_digest),
+    )
+    if connection.in_transaction:
+        connection.commit()
+    return EventHypothesisBackupReceipt(
+        backup_path, digest_path, backup_digest, logical_digest
+    )
+
+
+def require_event_hypothesis_backup(
+    connection: sqlite3.Connection,
+    *,
+    expected_history: tuple[tuple[int, str, str], ...],
+) -> EventHypothesisBackupReceipt:
+    try:
+        row = connection.execute(
+            "SELECT backup_path,backup_digest,logical_digest FROM temp.event_hypothesis_backup_gate"
+        ).fetchone()
+    except sqlite3.OperationalError as exc:
+        raise EventHypothesisBackupError(
+            "v20 to v21 upgrade requires a prepared backup"
+        ) from exc
+    if row is None:
+        raise EventHypothesisBackupError(
+            "v20 to v21 upgrade requires a prepared backup"
+        )
+    backup_path, backup_digest, logical_digest = (
+        Path(str(row[0])),
+        str(row[1]),
+        str(row[2]),
+    )
+    digest_path = backup_path.with_name(backup_path.name + ".sha256")
+    if (
+        not backup_path.is_file()
+        or not digest_path.is_file()
+        or _file_digest(backup_path) != backup_digest
+        or digest_path.read_text(encoding="ascii") != backup_digest + "\n"
+        or _logical_database_digest(connection) != logical_digest
+    ):
+        raise EventHypothesisBackupError("prepared backup identity differs")
+    target = sqlite3.connect(
+        f"file:{backup_path}?mode=ro", uri=True, isolation_level=None
+    )
+    try:
+        history = target.execute(
+            "SELECT version,name,checksum FROM authority_migrations ORDER BY version"
+        ).fetchall()
+        if (
+            target.execute("PRAGMA user_version").fetchone()[0] != 20
+            or _schema_fingerprint(target) != EVENT_HYPOTHESIS_PREDECESSOR_FINGERPRINT
+            or _logical_database_digest(target) != logical_digest
+            or history != list(expected_history)
+        ):
+            raise EventHypothesisBackupError("prepared backup is not exact v20")
+    finally:
+        target.close()
+    return EventHypothesisBackupReceipt(
+        backup_path, digest_path, backup_digest, logical_digest
+    )
+
+
+_DIGEST_CHECK = "substr({0},1,7)='sha256:' AND length({0})=71 AND substr({0},8) NOT GLOB '*[^0-9a-f]*'"
+
+EVENT_HYPOTHESIS_MIGRATION_STATEMENTS: tuple[str, ...] = (
+    f"""CREATE TABLE event_hypotheses_v2(
+        hypothesis_id TEXT PRIMARY KEY,
+        canonical_bytes BLOB NOT NULL CHECK(length(canonical_bytes) BETWEEN 1 AND 4096),
+        canonical_digest TEXT NOT NULL UNIQUE CHECK({_DIGEST_CHECK.format("canonical_digest")}),
+        actor_identity_digest TEXT NOT NULL CHECK({_DIGEST_CHECK.format("actor_identity_digest")}),
+        authority_event_id TEXT NOT NULL UNIQUE,
+        recorded_at TEXT NOT NULL
+    ) STRICT""",
+    f"""CREATE TABLE event_hypothesis_versions_v2(
+        version_id TEXT PRIMARY KEY,
+        hypothesis_id TEXT NOT NULL REFERENCES event_hypotheses_v2(hypothesis_id),
+        ordinal INTEGER NOT NULL CHECK(ordinal BETWEEN 1 AND 9007199254740991),
+        previous_version_id TEXT REFERENCES event_hypothesis_versions_v2(version_id),
+        previous_version_digest TEXT CHECK(previous_version_digest IS NULL OR {_DIGEST_CHECK.format("previous_version_digest")}),
+        proposal_id TEXT NOT NULL, proposal_local_id TEXT NOT NULL,
+        proposal_content_identity TEXT NOT NULL CHECK({_DIGEST_CHECK.format("proposal_content_identity")}),
+        proposal_canonical_digest TEXT NOT NULL CHECK({_DIGEST_CHECK.format("proposal_canonical_digest")}),
+        proposal_canonical_bytes BLOB NOT NULL CHECK(length(proposal_canonical_bytes) BETWEEN 1 AND 67108864),
+        proposed_relationship TEXT NOT NULL CHECK(proposed_relationship IN ('SAME_STATE','DEVELOPMENT_OF','CORRECTION_REVERSAL_OF','RELATED_DISTINCT','NO_ADEQUATE_PRIOR_MATCH','UNCERTAIN')),
+        proposed_target_hypothesis_id TEXT,
+        target_version_id TEXT REFERENCES event_hypothesis_versions_v2(version_id),
+        target_version_digest TEXT CHECK(target_version_digest IS NULL OR {_DIGEST_CHECK.format("target_version_digest")}),
+        work_item_id TEXT NOT NULL, work_item_version_id TEXT NOT NULL,
+        work_item_version_digest TEXT NOT NULL CHECK({_DIGEST_CHECK.format("work_item_version_digest")}),
+        retrieval_context_id TEXT NOT NULL,
+        retrieval_context_digest TEXT NOT NULL CHECK({_DIGEST_CHECK.format("retrieval_context_digest")}),
+        actor_identity_digest TEXT NOT NULL CHECK({_DIGEST_CHECK.format("actor_identity_digest")}),
+        authority_event_id TEXT NOT NULL UNIQUE,
+        canonical_bytes BLOB NOT NULL CHECK(length(canonical_bytes) BETWEEN 1 AND 1048576),
+        canonical_digest TEXT NOT NULL UNIQUE CHECK({_DIGEST_CHECK.format("canonical_digest")}),
+        recorded_at TEXT NOT NULL,
+        UNIQUE(hypothesis_id,ordinal), UNIQUE(previous_version_id), UNIQUE(proposal_id,proposal_local_id),
+        FOREIGN KEY(work_item_version_id,work_item_id) REFERENCES triage_work_item_versions(version_id,work_item_id),
+        CHECK((ordinal=1 AND previous_version_id IS NULL AND previous_version_digest IS NULL)
+           OR (ordinal>1 AND previous_version_id IS NOT NULL AND previous_version_digest IS NOT NULL)),
+        CHECK((proposed_target_hypothesis_id IS NULL AND target_version_id IS NULL AND target_version_digest IS NULL)
+           OR (proposed_target_hypothesis_id IS NOT NULL AND target_version_id IS NOT NULL AND target_version_digest IS NOT NULL))
+    ) STRICT""",
+    f"""CREATE TABLE event_hypothesis_heads_v2(
+        hypothesis_id TEXT PRIMARY KEY REFERENCES event_hypotheses_v2(hypothesis_id),
+        version_id TEXT NOT NULL UNIQUE REFERENCES event_hypothesis_versions_v2(version_id),
+        ordinal INTEGER NOT NULL CHECK(ordinal BETWEEN 1 AND 9007199254740991),
+        version_digest TEXT NOT NULL CHECK({_DIGEST_CHECK.format("version_digest")}), updated_at TEXT NOT NULL
+    ) STRICT""",
+    """CREATE TRIGGER event_hypothesis_identity_coherence BEFORE INSERT ON event_hypotheses_v2
+      WHEN NOT json_valid(CAST(NEW.canonical_bytes AS TEXT))
+        OR json_extract(CAST(NEW.canonical_bytes AS TEXT),'$.schema_version') IS NOT 'newsroom.increment6.event-hypothesis.v1'
+        OR json_extract(CAST(NEW.canonical_bytes AS TEXT),'$.hypothesis_id') IS NOT NEW.hypothesis_id
+      BEGIN SELECT RAISE(ABORT,'Hypothesis scalars differ from canonical bytes'); END""",
+    """CREATE TRIGGER event_hypothesis_version_coherence BEFORE INSERT ON event_hypothesis_versions_v2
+      WHEN NOT json_valid(CAST(NEW.canonical_bytes AS TEXT))
+        OR json_extract(CAST(NEW.canonical_bytes AS TEXT),'$.schema_version') IS NOT 'newsroom.increment6.event-hypothesis-version.v1'
+        OR json_extract(CAST(NEW.canonical_bytes AS TEXT),'$.version.version_id') IS NOT NEW.version_id
+        OR json_extract(CAST(NEW.canonical_bytes AS TEXT),'$.version.hypothesis_id') IS NOT NEW.hypothesis_id
+        OR json_extract(CAST(NEW.canonical_bytes AS TEXT),'$.version.ordinal') IS NOT NEW.ordinal
+        OR json_extract(CAST(NEW.canonical_bytes AS TEXT),'$.version.previous_version_id') IS NOT NEW.previous_version_id
+        OR json_extract(CAST(NEW.canonical_bytes AS TEXT),'$.version.previous_version_digest') IS NOT NEW.previous_version_digest
+        OR json_extract(CAST(NEW.canonical_bytes AS TEXT),'$.version.proposal_id') IS NOT NEW.proposal_id
+        OR json_extract(CAST(NEW.canonical_bytes AS TEXT),'$.version.proposal_local_id') IS NOT NEW.proposal_local_id
+        OR json_extract(CAST(NEW.canonical_bytes AS TEXT),'$.version.proposal_content_identity') IS NOT NEW.proposal_content_identity
+        OR json_extract(CAST(NEW.canonical_bytes AS TEXT),'$.version.proposal_canonical_digest') IS NOT NEW.proposal_canonical_digest
+        OR json_extract(CAST(NEW.canonical_bytes AS TEXT),'$.version.proposed_relationship') IS NOT NEW.proposed_relationship
+        OR json_extract(CAST(NEW.canonical_bytes AS TEXT),'$.version.proposed_target_hypothesis_id') IS NOT NEW.proposed_target_hypothesis_id
+        OR json_extract(CAST(NEW.canonical_bytes AS TEXT),'$.version.target_version_id') IS NOT NEW.target_version_id
+        OR json_extract(CAST(NEW.canonical_bytes AS TEXT),'$.version.target_version_digest') IS NOT NEW.target_version_digest
+        OR json_extract(CAST(NEW.canonical_bytes AS TEXT),'$.version.work_item_id') IS NOT NEW.work_item_id
+        OR json_extract(CAST(NEW.canonical_bytes AS TEXT),'$.version.work_item_version_id') IS NOT NEW.work_item_version_id
+        OR json_extract(CAST(NEW.canonical_bytes AS TEXT),'$.version.work_item_version_digest') IS NOT NEW.work_item_version_digest
+        OR json_extract(CAST(NEW.canonical_bytes AS TEXT),'$.version.retrieval_context_id') IS NOT NEW.retrieval_context_id
+        OR json_extract(CAST(NEW.canonical_bytes AS TEXT),'$.version.retrieval_context_digest') IS NOT NEW.retrieval_context_digest
+        OR json_extract(CAST(NEW.canonical_bytes AS TEXT),'$.version.actor_identity_digest') IS NOT NEW.actor_identity_digest
+        OR json_extract(CAST(NEW.canonical_bytes AS TEXT),'$.version.authority_event_id') IS NOT NEW.authority_event_id
+        OR json_extract(CAST(NEW.canonical_bytes AS TEXT),'$.version.recorded_at') IS NOT NEW.recorded_at
+        OR (NEW.ordinal>1 AND NOT EXISTS(SELECT 1 FROM event_hypothesis_versions_v2 p
+            WHERE p.version_id=NEW.previous_version_id AND p.hypothesis_id=NEW.hypothesis_id
+              AND p.ordinal=NEW.ordinal-1 AND p.canonical_digest=NEW.previous_version_digest))
+      BEGIN SELECT RAISE(ABORT,'Hypothesis Version scalars or predecessor differ'); END""",
+    """CREATE TRIGGER event_hypothesis_head_insert_guard BEFORE INSERT ON event_hypothesis_heads_v2
+      WHEN NOT EXISTS(SELECT 1 FROM event_hypothesis_versions_v2 v WHERE v.version_id=NEW.version_id
+        AND v.hypothesis_id=NEW.hypothesis_id AND v.ordinal=NEW.ordinal
+        AND v.canonical_digest=NEW.version_digest AND v.recorded_at=NEW.updated_at)
+      BEGIN SELECT RAISE(ABORT,'Hypothesis head differs from Version'); END""",
+    """CREATE TRIGGER event_hypothesis_head_update_guard BEFORE UPDATE ON event_hypothesis_heads_v2
+      WHEN NEW.hypothesis_id IS NOT OLD.hypothesis_id OR NEW.ordinal!=OLD.ordinal+1
+        OR NOT EXISTS(SELECT 1 FROM event_hypothesis_versions_v2 v WHERE v.version_id=NEW.version_id
+          AND v.hypothesis_id=NEW.hypothesis_id AND v.ordinal=NEW.ordinal
+          AND v.previous_version_id=OLD.version_id AND v.previous_version_digest=OLD.version_digest
+          AND v.canonical_digest=NEW.version_digest AND v.recorded_at=NEW.updated_at)
+      BEGIN SELECT RAISE(ABORT,'illegal Hypothesis head CAS update'); END""",
+    """CREATE TRIGGER immutable_event_hypothesis_update BEFORE UPDATE ON event_hypotheses_v2 BEGIN SELECT RAISE(ABORT,'immutable Hypothesis'); END""",
+    """CREATE TRIGGER retained_event_hypothesis_delete BEFORE DELETE ON event_hypotheses_v2 BEGIN SELECT RAISE(ABORT,'retained Hypothesis'); END""",
+    """CREATE TRIGGER immutable_event_hypothesis_version_update BEFORE UPDATE ON event_hypothesis_versions_v2 BEGIN SELECT RAISE(ABORT,'immutable Hypothesis Version'); END""",
+    """CREATE TRIGGER retained_event_hypothesis_version_delete BEFORE DELETE ON event_hypothesis_versions_v2 BEGIN SELECT RAISE(ABORT,'retained Hypothesis Version'); END""",
+    """CREATE TRIGGER retained_event_hypothesis_head_delete BEFORE DELETE ON event_hypothesis_heads_v2 BEGIN SELECT RAISE(ABORT,'retained Hypothesis head'); END""",
+)
+EVENT_HYPOTHESIS_MIGRATION_CHECKSUM = digest_canonical(
+    {
+        "version": EVENT_HYPOTHESIS_SCHEMA_VERSION,
+        "name": EVENT_HYPOTHESIS_MIGRATION_NAME,
+        "statements": list(EVENT_HYPOTHESIS_MIGRATION_STATEMENTS),
+    }
+)
+EVENT_HYPOTHESIS_MIGRATION = EventHypothesisMigrationRecord(
+    EVENT_HYPOTHESIS_SCHEMA_VERSION,
+    EVENT_HYPOTHESIS_MIGRATION_NAME,
+    EVENT_HYPOTHESIS_MIGRATION_CHECKSUM,
+)
+__all__ = [
+    "EVENT_HYPOTHESIS_MIGRATION",
+    "EVENT_HYPOTHESIS_MIGRATION_CHECKSUM",
+    "EVENT_HYPOTHESIS_MIGRATION_NAME",
+    "EVENT_HYPOTHESIS_MIGRATION_STATEMENTS",
+    "EVENT_HYPOTHESIS_PREDECESSOR_FINGERPRINT",
+    "EVENT_HYPOTHESIS_PREDECESSOR_MIGRATION_CHECKSUM",
+    "EVENT_HYPOTHESIS_SCHEMA_VERSION",
+    "EventHypothesisBackupError",
+    "EventHypothesisBackupReceipt",
+    "event_hypothesis_backup_paths",
+    "prepare_event_hypothesis_backup",
+    "require_event_hypothesis_backup",
+]

--- a/newsroom/authority/migrations.py
+++ b/newsroom/authority/migrations.py
@@ -58,6 +58,17 @@ from .evaluation_handoff_migrations import (
     prepare_evaluation_handoff_backup,
     require_evaluation_handoff_backup,
 )
+from .event_hypothesis_migrations import (
+    EVENT_HYPOTHESIS_MIGRATION,
+    EVENT_HYPOTHESIS_MIGRATION_CHECKSUM,
+    EVENT_HYPOTHESIS_MIGRATION_NAME,
+    EVENT_HYPOTHESIS_MIGRATION_STATEMENTS,
+    EVENT_HYPOTHESIS_SCHEMA_VERSION,
+    EventHypothesisBackupReceipt,
+    event_hypothesis_backup_paths,
+    prepare_event_hypothesis_backup,
+    require_event_hypothesis_backup,
+)
 from .extraction_migrations import (
     EXTRACTION_AUTHORITY_MIGRATION,
     EXTRACTION_AUTHORITY_MIGRATION_CHECKSUM,
@@ -121,17 +132,6 @@ from .source_registry_migrations import (
     SOURCE_REGISTRY_MIGRATION_STATEMENTS,
     SOURCE_REGISTRY_SCHEMA_VERSION,
 )
-from .triage_work_item_migrations import (
-    TRIAGE_WORK_ITEM_MIGRATION,
-    TRIAGE_WORK_ITEM_MIGRATION_CHECKSUM,
-    TRIAGE_WORK_ITEM_MIGRATION_NAME,
-    TRIAGE_WORK_ITEM_MIGRATION_STATEMENTS,
-    TRIAGE_WORK_ITEM_SCHEMA_VERSION,
-    TriageWorkItemBackupReceipt,
-    prepare_triage_work_item_backup,
-    require_triage_work_item_backup,
-    triage_work_item_backup_paths,
-)
 from .triage_disposition_migrations import (
     TRIAGE_DISPOSITION_MIGRATION,
     TRIAGE_DISPOSITION_MIGRATION_CHECKSUM,
@@ -154,9 +154,20 @@ from .triage_execution_migrations import (
     require_triage_execution_backup,
     triage_execution_backup_paths,
 )
+from .triage_work_item_migrations import (
+    TRIAGE_WORK_ITEM_MIGRATION,
+    TRIAGE_WORK_ITEM_MIGRATION_CHECKSUM,
+    TRIAGE_WORK_ITEM_MIGRATION_NAME,
+    TRIAGE_WORK_ITEM_MIGRATION_STATEMENTS,
+    TRIAGE_WORK_ITEM_SCHEMA_VERSION,
+    TriageWorkItemBackupReceipt,
+    prepare_triage_work_item_backup,
+    require_triage_work_item_backup,
+    triage_work_item_backup_paths,
+)
 
 BASE_SCHEMA_VERSION = 1
-SCHEMA_VERSION = TRIAGE_EXECUTION_SCHEMA_VERSION
+SCHEMA_VERSION = EVENT_HYPOTHESIS_SCHEMA_VERSION
 MIGRATION_NAME = "authority_event_foundation_v1"
 
 
@@ -600,11 +611,12 @@ def prepare_pending_migration_backup(
     | TriageWorkItemBackupReceipt
     | TriageDispositionBackupReceipt
     | TriageExecutionBackupReceipt
+    | EventHypothesisBackupReceipt
     | None
 ):
     """Prepare the exact retained backup required by a checked predecessor."""
     version = int(conn.execute("PRAGMA user_version").fetchone()[0])
-    if version not in {16, 17, 18, 19}:
+    if version not in {16, 17, 18, 19, 20}:
         return None
     database_path = next(
         str(row[2])
@@ -624,8 +636,11 @@ def prepare_pending_migration_backup(
     if version == 18:
         backup_path, _ = triage_disposition_backup_paths(database_path)
         return prepare_triage_disposition_backup(conn, backup_path)
-    backup_path, _ = triage_execution_backup_paths(database_path)
-    return prepare_triage_execution_backup(conn, backup_path)
+    if version == 19:
+        backup_path, _ = triage_execution_backup_paths(database_path)
+        return prepare_triage_execution_backup(conn, backup_path)
+    backup_path, _ = event_hypothesis_backup_paths(database_path)
+    return prepare_event_hypothesis_backup(conn, backup_path)
 
 
 def apply_migration(
@@ -921,7 +936,7 @@ def apply_pending_migrations(conn: sqlite3.Connection, *, applied_at: str) -> No
             if starting_version != 0:
                 require_evaluation_handoff_backup(
                     conn,
-                    expected_history=EXPECTED_MIGRATION_HISTORY[:-4],
+                    expected_history=EXPECTED_MIGRATION_HISTORY[:-5],
                 )
             for statement in EVALUATION_HANDOFF_MIGRATION_STATEMENTS:
                 conn.execute(statement)
@@ -956,7 +971,7 @@ def apply_pending_migrations(conn: sqlite3.Connection, *, applied_at: str) -> No
             if starting_version != 0:
                 require_triage_work_item_backup(
                     conn,
-                    expected_history=EXPECTED_MIGRATION_HISTORY[:-3],
+                    expected_history=EXPECTED_MIGRATION_HISTORY[:-4],
                 )
             for statement in TRIAGE_WORK_ITEM_MIGRATION_STATEMENTS:
                 conn.execute(statement)
@@ -990,7 +1005,7 @@ def apply_pending_migrations(conn: sqlite3.Connection, *, applied_at: str) -> No
             if starting_version != 0:
                 require_triage_disposition_backup(
                     conn,
-                    expected_history=EXPECTED_MIGRATION_HISTORY[:-2],
+                    expected_history=EXPECTED_MIGRATION_HISTORY[:-3],
                 )
             for statement in TRIAGE_DISPOSITION_MIGRATION_STATEMENTS:
                 conn.execute(statement)
@@ -1024,7 +1039,7 @@ def apply_pending_migrations(conn: sqlite3.Connection, *, applied_at: str) -> No
             if starting_version != 0:
                 require_triage_execution_backup(
                     conn,
-                    expected_history=EXPECTED_MIGRATION_HISTORY[:-1],
+                    expected_history=EXPECTED_MIGRATION_HISTORY[:-2],
                 )
             for statement in TRIAGE_EXECUTION_MIGRATION_STATEMENTS:
                 conn.execute(statement)
@@ -1039,6 +1054,39 @@ def apply_pending_migrations(conn: sqlite3.Connection, *, applied_at: str) -> No
                 ),
             )
             current = TRIAGE_EXECUTION_SCHEMA_VERSION
+        if current == TRIAGE_EXECUTION_SCHEMA_VERSION:
+            if 0 < starting_version < TRIAGE_EXECUTION_SCHEMA_VERSION:
+                conn.execute(f"PRAGMA user_version={TRIAGE_EXECUTION_SCHEMA_VERSION}")
+                conn.execute("COMMIT")
+                database_path = next(
+                    str(row[2])
+                    for row in conn.execute("PRAGMA database_list")
+                    if row[1] == "main"
+                )
+                if not database_path:
+                    raise sqlite3.DatabaseError(
+                        "existing multihop upgrade requires a file-backed database"
+                    )
+                backup_path, _ = event_hypothesis_backup_paths(database_path)
+                prepare_event_hypothesis_backup(conn, backup_path)
+                conn.execute("BEGIN EXCLUSIVE")
+            if starting_version != 0:
+                require_event_hypothesis_backup(
+                    conn, expected_history=EXPECTED_MIGRATION_HISTORY[:-1]
+                )
+            for statement in EVENT_HYPOTHESIS_MIGRATION_STATEMENTS:
+                conn.execute(statement)
+            conn.execute(
+                "INSERT INTO authority_migrations(version,name,checksum,applied_at) "
+                "VALUES(?,?,?,?)",
+                (
+                    EVENT_HYPOTHESIS_SCHEMA_VERSION,
+                    EVENT_HYPOTHESIS_MIGRATION_NAME,
+                    EVENT_HYPOTHESIS_MIGRATION_CHECKSUM,
+                    applied_at,
+                ),
+            )
+            current = EVENT_HYPOTHESIS_SCHEMA_VERSION
         conn.execute(f"PRAGMA user_version={current}")
         conn.execute("COMMIT")
     except Exception:
@@ -1068,6 +1116,7 @@ MIGRATIONS: tuple[MigrationRecord | object, ...] = (
     TRIAGE_WORK_ITEM_MIGRATION,
     TRIAGE_DISPOSITION_MIGRATION,
     TRIAGE_EXECUTION_MIGRATION,
+    EVENT_HYPOTHESIS_MIGRATION,
 )
 
 
@@ -1174,5 +1223,10 @@ EXPECTED_MIGRATION_HISTORY: tuple[tuple[int, str, str], ...] = (
         TRIAGE_EXECUTION_SCHEMA_VERSION,
         TRIAGE_EXECUTION_MIGRATION_NAME,
         TRIAGE_EXECUTION_MIGRATION_CHECKSUM,
+    ),
+    (
+        EVENT_HYPOTHESIS_SCHEMA_VERSION,
+        EVENT_HYPOTHESIS_MIGRATION_NAME,
+        EVENT_HYPOTHESIS_MIGRATION_CHECKSUM,
     ),
 )

--- a/newsroom/increment6/_hypothesis_store.py
+++ b/newsroom/increment6/_hypothesis_store.py
@@ -303,6 +303,20 @@ class _HypothesisStore:
                 _, replay_actor = _AUTHENTICATE_DISPOSITION(self._dispositions, proof)
                 if replay_actor != retained.actor_identity_digest:
                     raise HypothesisContractError("semantic replay actor differs")
+                if retained.proposed_target_hypothesis_id is None:
+                    if expected_target_version is not None:
+                        raise HypothesisContractError(
+                            "semantic replay comparator diverges"
+                        )
+                elif (
+                    type(expected_target_version) is not EventHypothesisVersion
+                    or expected_target_version.hypothesis_id
+                    != retained.proposed_target_hypothesis_id
+                    or expected_target_version.version_id != retained.target_version_id
+                    or expected_target_version.canonical_digest
+                    != retained.target_version_digest
+                ):
+                    raise HypothesisContractError("semantic replay comparator diverges")
                 self._commit()
                 return retained
             retained_values = tuple(

--- a/newsroom/increment6/_hypothesis_store.py
+++ b/newsroom/increment6/_hypothesis_store.py
@@ -38,13 +38,15 @@ from newsroom.increment6.proposals import (
     HypothesisRelationship,
     LeadRecommendation,
     ProposalRoute,
-    ProposedHypothesis,
     TriageProposal,
 )
 from newsroom.increment6.work_items import RetrievalContextAuthority
 
 _REQUIRE_DISPOSITION = ProposalDispositionStore.require_current_in_transaction
 _AUTHENTICATE_DISPOSITION = ProposalDispositionStore._authenticate
+_VERIFY_DISPOSITION_INTEGRITY = (
+    ProposalDispositionStore.verify_retained_integrity_in_transaction
+)
 _CREATE_ROUTES = {
     HypothesisRelationship.NO_ADEQUATE_PRIOR_MATCH,
     HypothesisRelationship.RELATED_DISTINCT,
@@ -66,7 +68,6 @@ _ALLOWED_ROUTES = {
 def _require_exact_proposal_authorisation(
     disposition: ProposalDisposition,
     recommendation: LeadRecommendation,
-    proposed: ProposedHypothesis,
     proposal: TriageProposal,
     proposal_digest: str,
 ) -> None:
@@ -76,11 +77,28 @@ def _require_exact_proposal_authorisation(
         or disposition.proposal_id != proposal.proposal_id
         or disposition.proposal_content_identity != proposal.content_identity
         or disposition.proposal_canonical_digest != proposal_digest
-        or disposition.route_binding.hypothesis != proposed
+        or disposition.route_binding != recommendation
         or disposition.decision_lead_id != recommendation.decision_lead_id
     ):
         raise HypothesisContractError(
             "disposition does not authorise the exact Proposal group"
+        )
+
+
+def _require_exact_proposal_provenance(
+    version: EventHypothesisVersion,
+    proposal: TriageProposal,
+) -> None:
+    if (
+        version.work_item_id != proposal.work_item.work_item_id
+        or version.work_item_version_id != proposal.work_item.work_item_version_id
+        or version.work_item_version_digest
+        != proposal.work_item.work_item_version_digest
+        or version.retrieval_context_id != proposal.retrieval_context.context_id
+        or version.retrieval_context_digest != proposal.retrieval_context.context_digest
+    ):
+        raise HypothesisContractError(
+            "Hypothesis Version provenance differs from the exact Proposal"
         )
 
 
@@ -360,7 +378,6 @@ class _HypothesisStore:
                 _require_exact_proposal_authorisation(
                     value,
                     recommendation,
-                    proposed,
                     proposal,
                     digest_bytes(proposal_bytes),
                 )
@@ -451,6 +468,7 @@ class _HypothesisStore:
                 authority_event_id,
                 now,
             )
+            _require_exact_proposal_provenance(version, proposal)
             self._connection.execute(
                 "INSERT OR IGNORE INTO event_hypotheses_v2 VALUES(?,?,?,?,?,?)",
                 (
@@ -552,6 +570,7 @@ class _HypothesisStore:
     def load_version(self, version_id: str) -> EventHypothesisVersion:
         try:
             self._begin()
+            self._verify()
             row = self._connection.execute(
                 "SELECT canonical_bytes FROM event_hypothesis_versions_v2 WHERE version_id=?",
                 (version_id,),
@@ -572,6 +591,7 @@ class _HypothesisStore:
     def load_hypothesis(self, hypothesis_id: str) -> EventHypothesis:
         try:
             self._begin()
+            self._verify()
             row = self._connection.execute(
                 "SELECT canonical_bytes FROM event_hypotheses_v2 WHERE hypothesis_id=?",
                 (hypothesis_id,),
@@ -632,6 +652,7 @@ class _HypothesisStore:
     def versions(self, hypothesis_id: str) -> tuple[EventHypothesisVersion, ...]:
         try:
             self._begin()
+            self._verify()
             rows = self._connection.execute(
                 "SELECT canonical_bytes FROM event_hypothesis_versions_v2 WHERE hypothesis_id=? ORDER BY ordinal",
                 (hypothesis_id,),
@@ -658,6 +679,7 @@ class _HypothesisStore:
             self._lock.release()
 
     def _verify(self) -> None:
+        _VERIFY_DISPOSITION_INTEGRITY(self._dispositions)
         tables = {
             str(row[0])
             for row in self._connection.execute(
@@ -757,6 +779,7 @@ class _HypothesisStore:
                 or proposal.content_identity != value.proposal_content_identity
             ):
                 raise HypothesisContractError("retained Proposal differs")
+            _require_exact_proposal_provenance(value, proposal)
             recs = [
                 r
                 for r in proposal.recommendations
@@ -771,8 +794,6 @@ class _HypothesisStore:
                 for r in recs
             ):
                 raise HypothesisContractError("retained Proposal retargeted")
-            proposed = recs[0].hypothesis
-            assert proposed is not None
             if tuple(r.decision_lead_id for r in recs) != tuple(
                 binding.decision_lead_id for binding in value.source_bindings
             ):
@@ -797,7 +818,6 @@ class _HypothesisStore:
                 _require_exact_proposal_authorisation(
                     disposition,
                     recommendation,
-                    proposed,
                     proposal,
                     value.proposal_canonical_digest,
                 )

--- a/newsroom/increment6/_hypothesis_store.py
+++ b/newsroom/increment6/_hypothesis_store.py
@@ -36,7 +36,9 @@ from newsroom.increment6.hypotheses import (
 )
 from newsroom.increment6.proposals import (
     HypothesisRelationship,
+    LeadRecommendation,
     ProposalRoute,
+    ProposedHypothesis,
     TriageProposal,
 )
 from newsroom.increment6.work_items import RetrievalContextAuthority
@@ -59,6 +61,27 @@ _ALLOWED_ROUTES = {
     ProposalRoute.DEVELOPMENT_CANDIDATE,
     ProposalRoute.CORRECTION_CANDIDATE,
 }
+
+
+def _require_exact_proposal_authorisation(
+    disposition: ProposalDisposition,
+    recommendation: LeadRecommendation,
+    proposed: ProposedHypothesis,
+    proposal: TriageProposal,
+    proposal_digest: str,
+) -> None:
+    if (
+        disposition.judgement is not DispositionJudgement.ACCEPT
+        or disposition.route not in _ALLOWED_ROUTES
+        or disposition.proposal_id != proposal.proposal_id
+        or disposition.proposal_content_identity != proposal.content_identity
+        or disposition.proposal_canonical_digest != proposal_digest
+        or disposition.route_binding.hypothesis != proposed
+        or disposition.decision_lead_id != recommendation.decision_lead_id
+    ):
+        raise HypothesisContractError(
+            "disposition does not authorise the exact Proposal group"
+        )
 
 
 def _secure_directory(path: Path) -> None:
@@ -334,19 +357,13 @@ class _HypothesisStore:
             for value, recommendation in zip(
                 retained_values, recommendations, strict=True
             ):
-                hypothesis = value.route_binding.hypothesis
-                if (
-                    value.judgement is not DispositionJudgement.ACCEPT
-                    or value.route not in _ALLOWED_ROUTES
-                    or value.proposal_id != proposal.proposal_id
-                    or value.proposal_content_identity != proposal.content_identity
-                    or value.proposal_canonical_digest != digest_bytes(proposal_bytes)
-                    or hypothesis != proposed
-                    or value.decision_lead_id != recommendation.decision_lead_id
-                ):
-                    raise HypothesisContractError(
-                        "disposition does not authorise the exact Proposal group"
-                    )
+                _require_exact_proposal_authorisation(
+                    value,
+                    recommendation,
+                    proposed,
+                    proposal,
+                    digest_bytes(proposal_bytes),
+                )
             actors = {
                 value.validator_input.authenticated_context_identity
                 for value in retained_values
@@ -754,6 +771,8 @@ class _HypothesisStore:
                 for r in recs
             ):
                 raise HypothesisContractError("retained Proposal retargeted")
+            proposed = recs[0].hypothesis
+            assert proposed is not None
             if tuple(r.decision_lead_id for r in recs) != tuple(
                 binding.decision_lead_id for binding in value.source_bindings
             ):
@@ -761,7 +780,9 @@ class _HypothesisStore:
                     "retained Proposal group coverage differs"
                 )
             retained_bindings: list[HypothesisSourceBinding] = []
-            for binding in value.source_bindings:
+            for binding, recommendation in zip(
+                value.source_bindings, recs, strict=True
+            ):
                 disposition_row = self._connection.execute(
                     "SELECT canonical_bytes FROM triage_proposal_dispositions WHERE disposition_id=?",
                     (binding.disposition_id,),
@@ -772,6 +793,13 @@ class _HypothesisStore:
                     )
                 disposition = ProposalDisposition.from_canonical_bytes(
                     bytes(disposition_row[0])
+                )
+                _require_exact_proposal_authorisation(
+                    disposition,
+                    recommendation,
+                    proposed,
+                    proposal,
+                    value.proposal_canonical_digest,
                 )
                 retained_bindings.extend(self._bindings((disposition,)))
                 if (

--- a/newsroom/increment6/_hypothesis_store.py
+++ b/newsroom/increment6/_hypothesis_store.py
@@ -1,0 +1,1013 @@
+"""Private checked v21 Event Hypothesis authority composition."""
+
+from __future__ import annotations
+
+import fcntl
+import os
+import sqlite3
+import stat
+import uuid
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from threading import Lock, get_ident
+from typing import Self
+
+from newsroom.authority.auth import AuthenticationProof, StaticAuthenticator
+from newsroom.authority.canonical import canonical_json_bytes, digest_bytes
+from newsroom.authority.migrations import (
+    EXPECTED_MIGRATION_HISTORY,
+    EXPECTED_SCHEMA_FINGERPRINT,
+    SCHEMA_VERSION,
+    apply_pending_migrations,
+    prepare_pending_migration_backup,
+    schema_fingerprint,
+)
+from newsroom.authority.types import UtcTimestamp
+from newsroom.increment6.dispositions import (
+    DispositionJudgement,
+    ProposalDisposition,
+    ProposalDispositionStore,
+)
+from newsroom.increment6.hypotheses import (
+    EventHypothesis,
+    EventHypothesisVersion,
+    HypothesisContractError,
+    HypothesisSourceBinding,
+)
+from newsroom.increment6.proposals import (
+    HypothesisRelationship,
+    ProposalRoute,
+    TriageProposal,
+)
+from newsroom.increment6.work_items import RetrievalContextAuthority
+
+_REQUIRE_DISPOSITION = ProposalDispositionStore.require_current_in_transaction
+_AUTHENTICATE_DISPOSITION = ProposalDispositionStore._authenticate
+_CREATE_ROUTES = {
+    HypothesisRelationship.NO_ADEQUATE_PRIOR_MATCH,
+    HypothesisRelationship.RELATED_DISTINCT,
+    HypothesisRelationship.UNCERTAIN,
+}
+_APPEND_ROUTES = {
+    HypothesisRelationship.SAME_STATE,
+    HypothesisRelationship.DEVELOPMENT_OF,
+    HypothesisRelationship.CORRECTION_REVERSAL_OF,
+}
+_ALLOWED_ROUTES = {
+    ProposalRoute.ASSOCIATE_WITHOUT_CANDIDATE,
+    ProposalRoute.NEW_EVENT_CANDIDATE,
+    ProposalRoute.DEVELOPMENT_CANDIDATE,
+    ProposalRoute.CORRECTION_CANDIDATE,
+}
+
+
+def _secure_directory(path: Path) -> None:
+    if path.exists():
+        if path.is_symlink() or not path.is_dir():
+            raise HypothesisContractError(
+                "authority database parent must be a real directory"
+            )
+    else:
+        path.mkdir(parents=True, mode=0o700)
+        os.chmod(path, 0o700)
+    info = path.stat()
+    if (hasattr(os, "getuid") and info.st_uid != os.getuid()) or stat.S_IMODE(
+        info.st_mode
+    ) != 0o700:
+        raise HypothesisContractError("authority database parent ownership differs")
+
+
+def _validate_owned_file(path: Path) -> None:
+    if path.is_symlink() or not path.is_file():
+        raise HypothesisContractError("authority database must be a regular file")
+    info = path.stat()
+    if (hasattr(os, "getuid") and info.st_uid != os.getuid()) or stat.S_IMODE(
+        info.st_mode
+    ) != 0o600:
+        raise HypothesisContractError("authority database file ownership differs")
+
+
+def _time(clock: Callable[[], UtcTimestamp]) -> str:
+    return clock().to_text()
+
+
+def _version_event_id(
+    hypothesis_id: str,
+    ordinal: int,
+    previous_version_digest: str | None,
+    proposal_digest: str,
+    local_id: str,
+    target_version_digest: str | None,
+    bindings: tuple[HypothesisSourceBinding, ...],
+    actor: str,
+    recorded_at: str,
+) -> str:
+    identity = digest_bytes(
+        canonical_json_bytes(
+            {
+                "ordinal": ordinal,
+                "previous_version_digest": previous_version_digest,
+                "proposal_digest": proposal_digest,
+                "proposal_local_id": local_id,
+                "target_version_digest": target_version_digest,
+                "source_disposition_ids": [item.disposition_id for item in bindings],
+                "actor_identity_digest": actor,
+                "recorded_at": recorded_at,
+            }
+        )
+    )
+    return str(uuid.uuid5(uuid.UUID(hypothesis_id), f"authority-event:{identity}"))
+
+
+def _creation_event_id(hypothesis_id: str, actor: str, recorded_at: str) -> str:
+    identity = digest_bytes(
+        canonical_json_bytes(
+            {
+                "hypothesis_id": hypothesis_id,
+                "actor_identity_digest": actor,
+                "recorded_at": recorded_at,
+            }
+        )
+    )
+    return str(uuid.uuid5(uuid.UUID(hypothesis_id), f"authority-create:{identity}"))
+
+
+class _HypothesisStore:
+    def __init__(
+        self,
+        connection: sqlite3.Connection,
+        retrieval_authority: RetrievalContextAuthority,
+        authenticator: StaticAuthenticator,
+        clock: Callable[[], UtcTimestamp],
+    ) -> None:
+        if (
+            type(connection) is not sqlite3.Connection
+            or connection.in_transaction
+            or type(retrieval_authority) is not RetrievalContextAuthority
+            or type(authenticator) is not StaticAuthenticator
+        ):
+            raise HypothesisContractError("Hypothesis authority collaborators differ")
+        self._connection = connection
+        self._retrieval = retrieval_authority
+        self._authenticator = authenticator
+        self._clock = clock
+        self._lock = Lock()
+        self._owner: int | None = None
+        try:
+            connection.execute("PRAGMA foreign_keys=ON")
+            retrieval_authority.attach(connection)
+            self._dispositions = ProposalDispositionStore(
+                connection, retrieval_authority, authenticator
+            )
+            self._begin()
+            self._verify()
+            self._commit()
+        except BaseException as exc:
+            self._rollback()
+            if not isinstance(exc, Exception):
+                raise
+            if isinstance(exc, HypothesisContractError):
+                raise
+            raise HypothesisContractError(
+                "Hypothesis authority initialisation failed"
+            ) from exc
+
+    def _begin(self) -> None:
+        self._lock.acquire()
+        try:
+            if self._connection.in_transaction:
+                raise HypothesisContractError("connection has an active transaction")
+            self._connection.execute("BEGIN IMMEDIATE")
+            self._owner = get_ident()
+        except BaseException:
+            self._lock.release()
+            raise
+
+    def _commit(self) -> None:
+        if self._owner != get_ident() or not self._connection.in_transaction:
+            raise HypothesisContractError("transaction ownership differs")
+        self._connection.execute("COMMIT")
+        self._owner = None
+        self._lock.release()
+
+    def _rollback(self) -> None:
+        if self._owner != get_ident():
+            return
+        try:
+            if self._connection.in_transaction:
+                self._connection.execute("ROLLBACK")
+        finally:
+            self._owner = None
+            self._lock.release()
+
+    @staticmethod
+    def _exact_dispositions(
+        values: Sequence[ProposalDisposition],
+    ) -> tuple[ProposalDisposition, ...]:
+        if type(values) is not tuple or not values or len(values) > 32:
+            raise HypothesisContractError(
+                "dispositions must be a non-empty bounded exact sequence"
+            )
+        result = tuple(values)
+        if any(type(value) is not ProposalDisposition for value in result):
+            raise HypothesisContractError("dispositions must be exact retained values")
+        if tuple(value.decision_lead_id for value in result) != tuple(
+            sorted({value.decision_lead_id for value in result})
+        ):
+            raise HypothesisContractError(
+                "dispositions must be sorted and unique by decision Lead"
+            )
+        return result
+
+    @staticmethod
+    def _bindings(
+        values: tuple[ProposalDisposition, ...],
+    ) -> tuple[HypothesisSourceBinding, ...]:
+        return tuple(
+            HypothesisSourceBinding(
+                value.disposition_id,
+                digest_bytes(value.canonical_bytes),
+                value.finding_set_digest,
+                value.route_binding_digest,
+                value.decision_lead_id,
+                value.lead_head.decision_lead_digest,
+                value.lead_head.current_disposition_head_id,
+                value.lead_head.current_disposition_head_digest,
+            )
+            for value in values
+        )
+
+    def retain(
+        self,
+        proposal_bytes: bytes,
+        dispositions: Sequence[ProposalDisposition],
+        *,
+        proof: AuthenticationProof,
+        expected_target_version: EventHypothesisVersion | None = None,
+        proposal_local_id: str | None = None,
+    ) -> EventHypothesisVersion:
+        """Create or append exactly one complete proposal-local Hypothesis group."""
+        try:
+            proposal = TriageProposal.from_canonical_bytes(proposal_bytes)
+            supplied = self._exact_dispositions(dispositions)
+            local_ids = {
+                value.route_binding.hypothesis.proposal_local_id
+                for value in supplied
+                if value.route_binding.hypothesis is not None
+            }
+            if proposal_local_id is not None:
+                local_ids &= {proposal_local_id}
+            if len(local_ids) != 1:
+                raise HypothesisContractError(
+                    "one exact proposal-local Hypothesis group is required"
+                )
+            local_id = next(iter(local_ids))
+            recommendations = tuple(
+                r
+                for r in proposal.recommendations
+                if r.hypothesis is not None
+                and r.hypothesis.proposal_local_id == local_id
+            )
+            if not recommendations:
+                raise HypothesisContractError("Proposal Hypothesis group is absent")
+            required_leads = tuple(r.decision_lead_id for r in recommendations)
+            if tuple(value.decision_lead_id for value in supplied) != required_leads:
+                raise HypothesisContractError(
+                    "Proposal Hypothesis group is partial or extra"
+                )
+            proposed = recommendations[0].hypothesis
+            assert proposed is not None
+            if any(r.hypothesis != proposed for r in recommendations):
+                raise HypothesisContractError("Proposal Hypothesis group diverges")
+            bindings = self._bindings(supplied)
+
+            # Lost-response lookup is deliberately before currentness checks.
+            # BEGIN IMMEDIATE also serialises a competing connection and the
+            # local ownership lock prevents a thread observing uncommitted work.
+            self._begin()
+            self._verify()
+            row = self._connection.execute(
+                "SELECT canonical_bytes,proposal_canonical_bytes FROM event_hypothesis_versions_v2 "
+                "WHERE proposal_id=? AND proposal_local_id=?",
+                (proposal.proposal_id, local_id),
+            ).fetchone()
+            if row is not None:
+                retained = EventHypothesisVersion.from_canonical_bytes(bytes(row[0]))
+                if (
+                    bytes(row[1]) != proposal_bytes
+                    or retained.proposal_canonical_digest
+                    != digest_bytes(proposal_bytes)
+                    or retained.source_bindings != bindings
+                ):
+                    raise HypothesisContractError("semantic replay diverges")
+                _, replay_actor = _AUTHENTICATE_DISPOSITION(self._dispositions, proof)
+                if replay_actor != retained.actor_identity_digest:
+                    raise HypothesisContractError("semantic replay actor differs")
+                self._commit()
+                return retained
+            retained_values = tuple(
+                _REQUIRE_DISPOSITION(
+                    self._dispositions, value.disposition_id, proof=proof
+                )
+                for value in supplied
+            )
+            if tuple(value.canonical_bytes for value in retained_values) != tuple(
+                value.canonical_bytes for value in supplied
+            ):
+                raise HypothesisContractError(
+                    "caller disposition differs from retained authority"
+                )
+            for value, recommendation in zip(
+                retained_values, recommendations, strict=True
+            ):
+                hypothesis = value.route_binding.hypothesis
+                if (
+                    value.judgement is not DispositionJudgement.ACCEPT
+                    or value.route not in _ALLOWED_ROUTES
+                    or value.proposal_id != proposal.proposal_id
+                    or value.proposal_content_identity != proposal.content_identity
+                    or value.proposal_canonical_digest != digest_bytes(proposal_bytes)
+                    or hypothesis != proposed
+                    or value.decision_lead_id != recommendation.decision_lead_id
+                ):
+                    raise HypothesisContractError(
+                        "disposition does not authorise the exact Proposal group"
+                    )
+            actors = {
+                value.validator_input.authenticated_context_identity
+                for value in retained_values
+            }
+            if len(actors) != 1:
+                raise HypothesisContractError(
+                    "Hypothesis group requires one authenticated actor"
+                )
+            actor_identity_digest = next(iter(actors))
+
+            target = proposed.target_hypothesis_id
+            target_version: EventHypothesisVersion | None = None
+            if target is not None:
+                if type(expected_target_version) is not EventHypothesisVersion:
+                    raise HypothesisContractError(
+                        "target-bearing relationship requires the exact current target Version"
+                    )
+                if expected_target_version.hypothesis_id != target:
+                    raise HypothesisContractError(
+                        "relationship target differs from expected head"
+                    )
+                current_target = self._head(target)
+                if (
+                    current_target.version_id != expected_target_version.version_id
+                    or current_target.canonical_digest
+                    != expected_target_version.canonical_digest
+                ):
+                    raise HypothesisContractError("target Hypothesis head CAS differs")
+                target_version = current_target
+            if proposed.relationship_kind in _CREATE_ROUTES:
+                hypothesis = EventHypothesis.allocate(proposal.proposal_id, local_id)
+                ordinal, predecessor = 1, None
+                if target is None and expected_target_version is not None:
+                    raise HypothesisContractError(
+                        "new Hypothesis does not accept a head token"
+                    )
+            elif proposed.relationship_kind in _APPEND_ROUTES:
+                if target is None or target_version is None:
+                    raise HypothesisContractError(
+                        "append requires the exact expected current Version"
+                    )
+                hypothesis = EventHypothesis(target)
+                ordinal, predecessor = target_version.ordinal + 1, target_version
+            else:
+                raise HypothesisContractError("Hypothesis relationship is unsupported")
+
+            now = _time(self._clock)
+            authority_event_id = _version_event_id(
+                hypothesis.hypothesis_id,
+                ordinal,
+                None if predecessor is None else predecessor.canonical_digest,
+                digest_bytes(proposal_bytes),
+                local_id,
+                None if target_version is None else target_version.canonical_digest,
+                bindings,
+                actor_identity_digest,
+                now,
+            )
+            version = EventHypothesisVersion(
+                str(
+                    uuid.uuid5(
+                        uuid.UUID(hypothesis.hypothesis_id), f"version:{ordinal}"
+                    )
+                ),
+                hypothesis.hypothesis_id,
+                ordinal,
+                None if predecessor is None else predecessor.version_id,
+                None if predecessor is None else predecessor.canonical_digest,
+                proposed.summary,
+                proposed.relationship_kind,
+                proposed.target_hypothesis_id,
+                None if target_version is None else target_version.version_id,
+                None if target_version is None else target_version.canonical_digest,
+                proposal.proposal_id,
+                proposal.content_identity,
+                digest_bytes(proposal_bytes),
+                local_id,
+                proposal.work_item.work_item_id,
+                proposal.work_item.work_item_version_id,
+                proposal.work_item.work_item_version_digest,
+                proposal.retrieval_context.context_id,
+                proposal.retrieval_context.context_digest,
+                bindings,
+                actor_identity_digest,
+                authority_event_id,
+                now,
+            )
+            self._connection.execute(
+                "INSERT OR IGNORE INTO event_hypotheses_v2 VALUES(?,?,?,?,?,?)",
+                (
+                    hypothesis.hypothesis_id,
+                    hypothesis.canonical_bytes,
+                    hypothesis.canonical_digest,
+                    actor_identity_digest,
+                    _creation_event_id(
+                        hypothesis.hypothesis_id, actor_identity_digest, now
+                    ),
+                    now,
+                ),
+            )
+            existing_identity = self._connection.execute(
+                "SELECT canonical_bytes FROM event_hypotheses_v2 WHERE hypothesis_id=?",
+                (hypothesis.hypothesis_id,),
+            ).fetchone()
+            if (
+                existing_identity is None
+                or bytes(existing_identity[0]) != hypothesis.canonical_bytes
+            ):
+                raise HypothesisContractError("Hypothesis identity collision diverges")
+            self._connection.execute(
+                "INSERT INTO event_hypothesis_versions_v2("
+                "version_id,hypothesis_id,ordinal,previous_version_id,previous_version_digest,"
+                "proposal_id,proposal_local_id,proposal_content_identity,proposal_canonical_digest,"
+                "proposal_canonical_bytes,proposed_relationship,proposed_target_hypothesis_id,"
+                "target_version_id,target_version_digest,work_item_id,work_item_version_id,"
+                "work_item_version_digest,retrieval_context_id,retrieval_context_digest,"
+                "actor_identity_digest,authority_event_id,canonical_bytes,canonical_digest,recorded_at) "
+                "VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                (
+                    version.version_id,
+                    version.hypothesis_id,
+                    version.ordinal,
+                    version.previous_version_id,
+                    version.previous_version_digest,
+                    version.proposal_id,
+                    version.proposal_local_id,
+                    version.proposal_content_identity,
+                    version.proposal_canonical_digest,
+                    proposal_bytes,
+                    version.proposed_relationship.value,
+                    version.proposed_target_hypothesis_id,
+                    version.target_version_id,
+                    version.target_version_digest,
+                    version.work_item_id,
+                    version.work_item_version_id,
+                    version.work_item_version_digest,
+                    version.retrieval_context_id,
+                    version.retrieval_context_digest,
+                    version.actor_identity_digest,
+                    version.authority_event_id,
+                    version.canonical_bytes,
+                    version.canonical_digest,
+                    version.recorded_at,
+                ),
+            )
+            if predecessor is None:
+                self._connection.execute(
+                    "INSERT INTO event_hypothesis_heads_v2 VALUES(?,?,?,?,?)",
+                    (
+                        version.hypothesis_id,
+                        version.version_id,
+                        version.ordinal,
+                        version.canonical_digest,
+                        now,
+                    ),
+                )
+            else:
+                changed = self._connection.execute(
+                    "UPDATE event_hypothesis_heads_v2 SET version_id=?,ordinal=?,version_digest=?,updated_at=? "
+                    "WHERE hypothesis_id=? AND version_id=? AND version_digest=?",
+                    (
+                        version.version_id,
+                        version.ordinal,
+                        version.canonical_digest,
+                        now,
+                        version.hypothesis_id,
+                        predecessor.version_id,
+                        predecessor.canonical_digest,
+                    ),
+                ).rowcount
+                if changed != 1:
+                    raise HypothesisContractError("Hypothesis head CAS lost")
+            self._verify()
+            self._commit()
+            return version
+        except BaseException as exc:
+            self._rollback()
+            if not isinstance(exc, Exception):
+                raise
+            if isinstance(exc, HypothesisContractError):
+                raise
+            raise HypothesisContractError("Hypothesis retention failed") from exc
+
+    create_or_append = retain
+
+    def load_version(self, version_id: str) -> EventHypothesisVersion:
+        try:
+            self._begin()
+            row = self._connection.execute(
+                "SELECT canonical_bytes FROM event_hypothesis_versions_v2 WHERE version_id=?",
+                (version_id,),
+            ).fetchone()
+            if row is None:
+                raise HypothesisContractError("unknown Hypothesis Version")
+            value = EventHypothesisVersion.from_canonical_bytes(bytes(row[0]))
+            self._commit()
+            return value
+        except BaseException as exc:
+            self._rollback()
+            if not isinstance(exc, Exception):
+                raise
+            if isinstance(exc, HypothesisContractError):
+                raise
+            raise HypothesisContractError("Hypothesis Version load failed") from exc
+
+    def load_hypothesis(self, hypothesis_id: str) -> EventHypothesis:
+        try:
+            self._begin()
+            row = self._connection.execute(
+                "SELECT canonical_bytes FROM event_hypotheses_v2 WHERE hypothesis_id=?",
+                (hypothesis_id,),
+            ).fetchone()
+            if row is None:
+                raise HypothesisContractError("unknown Hypothesis")
+            value = EventHypothesis.from_canonical_bytes(bytes(row[0]))
+            self._commit()
+            return value
+        except BaseException as exc:
+            self._rollback()
+            if not isinstance(exc, Exception):
+                raise
+            if isinstance(exc, HypothesisContractError):
+                raise
+            raise HypothesisContractError("Hypothesis load failed") from exc
+
+    def _head(self, hypothesis_id: str) -> EventHypothesisVersion:
+        row = self._connection.execute(
+            "SELECT version_id FROM event_hypothesis_heads_v2 WHERE hypothesis_id=?",
+            (hypothesis_id,),
+        ).fetchone()
+        if row is None:
+            raise HypothesisContractError("unknown current Hypothesis")
+        version = self._connection.execute(
+            "SELECT canonical_bytes FROM event_hypothesis_versions_v2 WHERE version_id=?",
+            (str(row[0]),),
+        ).fetchone()
+        if version is None:
+            raise HypothesisContractError("current Hypothesis Version is absent")
+        return EventHypothesisVersion.from_canonical_bytes(bytes(version[0]))
+
+    def current(
+        self, hypothesis_id: str, *, proof: AuthenticationProof
+    ) -> EventHypothesisVersion:
+        try:
+            self._begin()
+            self._verify()
+            version = self._head(hypothesis_id)
+            for binding in version.source_bindings:
+                disposition = _REQUIRE_DISPOSITION(
+                    self._dispositions, binding.disposition_id, proof=proof
+                )
+                if self._bindings((disposition,)) != (binding,):
+                    raise HypothesisContractError("current source binding differs")
+            self._commit()
+            return version
+        except BaseException as exc:
+            self._rollback()
+            if not isinstance(exc, Exception):
+                raise
+            if isinstance(exc, HypothesisContractError):
+                raise
+            raise HypothesisContractError("Hypothesis currentness failed") from exc
+
+    require_current = current
+
+    def versions(self, hypothesis_id: str) -> tuple[EventHypothesisVersion, ...]:
+        try:
+            self._begin()
+            rows = self._connection.execute(
+                "SELECT canonical_bytes FROM event_hypothesis_versions_v2 WHERE hypothesis_id=? ORDER BY ordinal",
+                (hypothesis_id,),
+            ).fetchall()
+            values = tuple(
+                EventHypothesisVersion.from_canonical_bytes(bytes(row[0]))
+                for row in rows
+            )
+            self._commit()
+            return values
+        except BaseException as exc:
+            self._rollback()
+            if not isinstance(exc, Exception):
+                raise
+            if isinstance(exc, HypothesisContractError):
+                raise
+            raise HypothesisContractError("Hypothesis history load failed") from exc
+
+    def close(self, operation: Callable[[], None]) -> None:
+        self._lock.acquire()
+        try:
+            operation()
+        finally:
+            self._lock.release()
+
+    def _verify(self) -> None:
+        tables = {
+            str(row[0])
+            for row in self._connection.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+        required = {
+            "event_hypotheses_v2",
+            "event_hypothesis_versions_v2",
+            "event_hypothesis_heads_v2",
+        }
+        if not required <= tables:
+            raise HypothesisContractError("v21 Hypothesis schema is absent")
+        identities: dict[str, EventHypothesis] = {}
+        for row in self._connection.execute(
+            "SELECT hypothesis_id,canonical_bytes,canonical_digest,actor_identity_digest,authority_event_id,recorded_at FROM event_hypotheses_v2"
+        ):
+            value = EventHypothesis.from_canonical_bytes(bytes(row[1]))
+            if (
+                value.hypothesis_id != row[0]
+                or value.canonical_digest != row[2]
+                or row[4]
+                != _creation_event_id(value.hypothesis_id, str(row[3]), str(row[5]))
+            ):
+                raise HypothesisContractError("retained Hypothesis identity differs")
+            identities[value.hypothesis_id] = value
+        chains: dict[str, list[EventHypothesisVersion]] = {}
+        semantic: set[tuple[str, str]] = set()
+        for row in self._connection.execute(
+            "SELECT version_id,hypothesis_id,ordinal,previous_version_id,previous_version_digest,proposal_id,proposal_local_id,proposal_content_identity,proposal_canonical_digest,proposal_canonical_bytes,proposed_relationship,proposed_target_hypothesis_id,target_version_id,target_version_digest,work_item_id,work_item_version_id,work_item_version_digest,retrieval_context_id,retrieval_context_digest,actor_identity_digest,authority_event_id,canonical_bytes,canonical_digest,recorded_at FROM event_hypothesis_versions_v2 ORDER BY hypothesis_id,ordinal"
+        ):
+            value = EventHypothesisVersion.from_canonical_bytes(bytes(row[21]))
+            scalars = (
+                value.version_id,
+                value.hypothesis_id,
+                value.ordinal,
+                value.previous_version_id,
+                value.previous_version_digest,
+                value.proposal_id,
+                value.proposal_local_id,
+                value.proposal_content_identity,
+                value.proposal_canonical_digest,
+                value.proposed_relationship.value,
+                value.proposed_target_hypothesis_id,
+                value.target_version_id,
+                value.target_version_digest,
+                value.work_item_id,
+                value.work_item_version_id,
+                value.work_item_version_digest,
+                value.retrieval_context_id,
+                value.retrieval_context_digest,
+                value.actor_identity_digest,
+                value.authority_event_id,
+                value.canonical_digest,
+                value.recorded_at,
+            )
+            if scalars != tuple(
+                row[i]
+                for i in (
+                    *range(9),
+                    10,
+                    11,
+                    12,
+                    13,
+                    14,
+                    15,
+                    16,
+                    17,
+                    18,
+                    19,
+                    20,
+                    22,
+                    23,
+                )
+            ):
+                raise HypothesisContractError(
+                    "retained Hypothesis Version scalars differ"
+                )
+            if value.authority_event_id != _version_event_id(
+                value.hypothesis_id,
+                value.ordinal,
+                value.previous_version_digest,
+                value.proposal_canonical_digest,
+                value.proposal_local_id,
+                value.target_version_digest,
+                value.source_bindings,
+                value.actor_identity_digest,
+                value.recorded_at,
+            ):
+                raise HypothesisContractError(
+                    "retained authority event identity differs"
+                )
+            proposal = TriageProposal.from_canonical_bytes(bytes(row[9]))
+            if (
+                digest_bytes(bytes(row[9])) != value.proposal_canonical_digest
+                or proposal.proposal_id != value.proposal_id
+                or proposal.content_identity != value.proposal_content_identity
+            ):
+                raise HypothesisContractError("retained Proposal differs")
+            recs = [
+                r
+                for r in proposal.recommendations
+                if r.hypothesis is not None
+                and r.hypothesis.proposal_local_id == value.proposal_local_id
+            ]
+            if not recs or any(
+                r.hypothesis.summary != value.proposed_summary
+                or r.hypothesis.relationship_kind is not value.proposed_relationship
+                or r.hypothesis.target_hypothesis_id
+                != value.proposed_target_hypothesis_id
+                for r in recs
+            ):
+                raise HypothesisContractError("retained Proposal retargeted")
+            if tuple(r.decision_lead_id for r in recs) != tuple(
+                binding.decision_lead_id for binding in value.source_bindings
+            ):
+                raise HypothesisContractError(
+                    "retained Proposal group coverage differs"
+                )
+            retained_bindings: list[HypothesisSourceBinding] = []
+            for binding in value.source_bindings:
+                disposition_row = self._connection.execute(
+                    "SELECT canonical_bytes FROM triage_proposal_dispositions WHERE disposition_id=?",
+                    (binding.disposition_id,),
+                ).fetchone()
+                if disposition_row is None:
+                    raise HypothesisContractError(
+                        "retained source disposition is absent"
+                    )
+                disposition = ProposalDisposition.from_canonical_bytes(
+                    bytes(disposition_row[0])
+                )
+                retained_bindings.extend(self._bindings((disposition,)))
+                if (
+                    disposition.proposal_id != value.proposal_id
+                    or disposition.proposal_content_identity
+                    != value.proposal_content_identity
+                    or disposition.proposal_canonical_digest
+                    != value.proposal_canonical_digest
+                    or disposition.work_item_id != value.work_item_id
+                    or disposition.work_item_version_id != value.work_item_version_id
+                    or disposition.work_item_version_digest
+                    != value.work_item_version_digest
+                    or disposition.retrieval_context_id != value.retrieval_context_id
+                    or disposition.retrieval_context_digest
+                    != value.retrieval_context_digest
+                ):
+                    raise HypothesisContractError(
+                        "retained source disposition retargeted"
+                    )
+                if (
+                    disposition.validator_input.authenticated_context_identity
+                    != value.actor_identity_digest
+                ):
+                    raise HypothesisContractError("retained source actor differs")
+            if tuple(retained_bindings) != value.source_bindings:
+                raise HypothesisContractError("retained source bindings differ")
+            if value.proposed_target_hypothesis_id is not None:
+                target_row = self._connection.execute(
+                    "SELECT hypothesis_id,canonical_digest FROM event_hypothesis_versions_v2 WHERE version_id=?",
+                    (value.target_version_id,),
+                ).fetchone()
+                if target_row is None or target_row != (
+                    value.proposed_target_hypothesis_id,
+                    value.target_version_digest,
+                ):
+                    raise HypothesisContractError("retained target Version pin differs")
+                if value.proposed_relationship in _APPEND_ROUTES and (
+                    value.previous_version_id != value.target_version_id
+                    or value.previous_version_digest != value.target_version_digest
+                ):
+                    raise HypothesisContractError(
+                        "append comparator differs from predecessor"
+                    )
+            if (value.proposal_id, value.proposal_local_id) in semantic:
+                raise HypothesisContractError("duplicate semantic source")
+            semantic.add((value.proposal_id, value.proposal_local_id))
+            chains.setdefault(value.hypothesis_id, []).append(value)
+        if set(chains) != set(identities):
+            raise HypothesisContractError(
+                "Hypothesis identity/version coverage differs"
+            )
+        heads = {
+            str(row[0]): (
+                str(row[1]),
+                int(row[2]),
+                str(row[3]),
+                str(row[4]),
+            )
+            for row in self._connection.execute(
+                "SELECT hypothesis_id,version_id,ordinal,version_digest,updated_at "
+                "FROM event_hypothesis_heads_v2"
+            )
+        }
+        if set(heads) != set(chains):
+            raise HypothesisContractError("Hypothesis head coverage differs")
+        for hypothesis_id, versions in chains.items():
+            identity_row = self._connection.execute(
+                "SELECT actor_identity_digest,recorded_at FROM event_hypotheses_v2 WHERE hypothesis_id=?",
+                (hypothesis_id,),
+            ).fetchone()
+            if identity_row != (
+                versions[0].actor_identity_digest,
+                versions[0].recorded_at,
+            ):
+                raise HypothesisContractError("Hypothesis creation provenance differs")
+            for index, version in enumerate(versions, 1):
+                predecessor = None if index == 1 else versions[index - 2]
+                if (
+                    version.ordinal != index
+                    or version.previous_version_id
+                    != (None if predecessor is None else predecessor.version_id)
+                    or version.previous_version_digest
+                    != (None if predecessor is None else predecessor.canonical_digest)
+                ):
+                    raise HypothesisContractError("Hypothesis chain is not contiguous")
+            last = versions[-1]
+            if heads[hypothesis_id] != (
+                last.version_id,
+                last.ordinal,
+                last.canonical_digest,
+                last.recorded_at,
+            ):
+                raise HypothesisContractError("Hypothesis head is not max Version")
+        if self._connection.execute("PRAGMA foreign_key_check").fetchone() is not None:
+            raise HypothesisContractError("Hypothesis foreign keys differ")
+
+
+class EventHypothesisAuthority:
+    __slots__ = ("__close", "__closed", "__store")
+
+    def __init__(self, store: _HypothesisStore, close: Callable[[], None]):
+        self.__store = store
+        self.__close = close
+        self.__closed = False
+
+    @classmethod
+    def open(
+        cls,
+        database: str | Path,
+        *,
+        retrieval_authority: RetrievalContextAuthority,
+        authenticator: StaticAuthenticator,
+        clock: Callable[[], UtcTimestamp] = UtcTimestamp.now,
+        busy_timeout_ms: int = 5000,
+    ) -> Self:
+        if (
+            isinstance(busy_timeout_ms, bool)
+            or type(busy_timeout_ms) is not int
+            or busy_timeout_ms <= 0
+        ):
+            raise HypothesisContractError("busy timeout must be positive")
+        path = Path(database).expanduser().absolute()
+        if path.is_symlink():
+            raise HypothesisContractError("authority database path cannot be a symlink")
+        _secure_directory(path.parent)
+        existed = path.exists()
+        if existed:
+            _validate_owned_file(path)
+        lock_path = path.with_name(path.name + ".writer.lock")
+        if lock_path.is_symlink():
+            raise HypothesisContractError("writer lock path cannot be a symlink")
+        if lock_path.exists():
+            _validate_owned_file(lock_path)
+        descriptor = os.open(
+            lock_path, os.O_CREAT | os.O_RDWR | getattr(os, "O_CLOEXEC", 0), 0o600
+        )
+        os.fchmod(descriptor, 0o600)
+        lock_info = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(lock_info.st_mode)
+            or (hasattr(os, "getuid") and lock_info.st_uid != os.getuid())
+            or stat.S_IMODE(lock_info.st_mode) != 0o600
+        ):
+            os.close(descriptor)
+            raise HypothesisContractError("writer lock ownership differs")
+        connection: sqlite3.Connection | None = None
+        try:
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError as exc:
+                raise HypothesisContractError(
+                    "another authority writer is active"
+                ) from exc
+            connection = sqlite3.connect(
+                path,
+                isolation_level=None,
+                timeout=busy_timeout_ms / 1000,
+                check_same_thread=False,
+            )
+            if not existed:
+                os.chmod(path, 0o600)
+            _validate_owned_file(path)
+            connection.execute("PRAGMA foreign_keys=ON")
+            if (
+                str(connection.execute("PRAGMA journal_mode=WAL").fetchone()[0]).lower()
+                != "wal"
+            ):
+                raise HypothesisContractError("SQLite WAL mode is unavailable")
+            connection.execute("PRAGMA synchronous=FULL")
+            connection.execute(f"PRAGMA busy_timeout={busy_timeout_ms}")
+            current = int(connection.execute("PRAGMA user_version").fetchone()[0])
+            tables = connection.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' LIMIT 1"
+            ).fetchone()
+            if current == 0 and tables is not None:
+                raise HypothesisContractError(
+                    "refusing a non-empty unversioned authority database"
+                )
+            if current < SCHEMA_VERSION:
+                prepare_pending_migration_backup(connection)
+            apply_pending_migrations(connection, applied_at=_time(clock))
+            history = connection.execute(
+                "SELECT version,name,checksum FROM authority_migrations ORDER BY version"
+            ).fetchall()
+            if (
+                int(connection.execute("PRAGMA user_version").fetchone()[0])
+                != SCHEMA_VERSION
+                or history != list(EXPECTED_MIGRATION_HISTORY)
+                or schema_fingerprint(connection) != EXPECTED_SCHEMA_FINGERPRINT
+                or connection.execute("PRAGMA quick_check").fetchone()[0] != "ok"
+                or connection.execute("PRAGMA foreign_key_check").fetchone() is not None
+                or connection.execute("PRAGMA foreign_keys").fetchone()[0] != 1
+                or connection.execute("PRAGMA synchronous").fetchone()[0] != 2
+                or connection.execute("PRAGMA busy_timeout").fetchone()[0]
+                != busy_timeout_ms
+                or str(connection.execute("PRAGMA journal_mode").fetchone()[0]).lower()
+                != "wal"
+            ):
+                raise HypothesisContractError("checked authority lifecycle differs")
+            store = _HypothesisStore(
+                connection, retrieval_authority, authenticator, clock
+            )
+
+            def close() -> None:
+                assert connection is not None
+                connection.close()
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+                os.close(descriptor)
+
+            return cls(store, close)
+        except Exception:
+            if connection is not None:
+                connection.close()
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+            finally:
+                os.close(descriptor)
+            raise
+
+    def retain(self, *args: object, **kwargs: object) -> EventHypothesisVersion:
+        return self.__store.retain(*args, **kwargs)  # type: ignore[arg-type]
+
+    create_or_append = retain
+
+    def current(
+        self, hypothesis_id: str, *, proof: AuthenticationProof
+    ) -> EventHypothesisVersion:
+        return self.__store.current(hypothesis_id, proof=proof)
+
+    require_current = current
+
+    def load_version(self, version_id: str) -> EventHypothesisVersion:
+        return self.__store.load_version(version_id)
+
+    def load_hypothesis(self, hypothesis_id: str) -> EventHypothesis:
+        return self.__store.load_hypothesis(hypothesis_id)
+
+    def versions(self, hypothesis_id: str) -> tuple[EventHypothesisVersion, ...]:
+        return self.__store.versions(hypothesis_id)
+
+    def close(self) -> None:
+        if not self.__closed:
+            self.__closed = True
+            self.__store.close(self.__close)
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
+
+
+__all__: list[str] = []

--- a/newsroom/increment6/hypotheses.py
+++ b/newsroom/increment6/hypotheses.py
@@ -1,0 +1,552 @@
+"""Stable Event Hypothesis identities and immutable version snapshots.
+
+This is the sole public Increment 6D1 surface.  A Hypothesis records an
+editorially unverified proposal association; it grants no Candidate,
+relationship, evidence, publication, model, provider, egress, or external
+effect authority.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from dataclasses import dataclass
+from typing import Self
+
+from newsroom.authority.canonical import (
+    MAX_SAFE_INTEGER,
+    canonical_json_bytes,
+    digest_bytes,
+)
+from newsroom.authority.types import UtcTimestamp
+from newsroom.increment6.proposals import HypothesisRelationship
+
+EVENT_HYPOTHESIS = "newsroom.increment6.event-hypothesis.v1"
+EVENT_HYPOTHESIS_VERSION = "newsroom.increment6.event-hypothesis-version.v1"
+HYPOTHESIS_CURRENT_VERSION = "EXACT_RETAINED_MAX_ORDINAL_HEAD"
+MAX_HYPOTHESIS_VERSION_BYTES = 1_048_576
+_NAMESPACE = uuid.UUID("435812df-489e-5e4c-9b3d-838148b1918a")
+_DIGEST = re.compile(r"sha256:[0-9a-f]{64}\Z")
+_TOKEN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:\-]{0,255}\Z")
+
+
+class HypothesisContractError(ValueError):
+    """A Hypothesis value, replay, or authority claim failed closed."""
+
+
+class _NoEffect:
+    authorises_persistence = False
+    authorises_external_effect = False
+    authorises_publication = False
+    authorises_evidence = False
+    authorises_egress = False
+    creates_candidate = False
+    creates_relationship = False
+    model_authority = False
+    provider_authority = False
+
+
+def _normalise[T](operation: object, message: str) -> T:
+    try:
+        return operation()  # type: ignore[operator,no-any-return]
+    except HypothesisContractError:
+        raise
+    except Exception as exc:
+        raise HypothesisContractError(message) from exc
+
+
+def _uuid(value: object, field: str) -> str:
+    if type(value) is not str:
+        raise HypothesisContractError(f"{field} must be a canonical UUID")
+    parsed = _normalise(lambda: uuid.UUID(value), f"{field} must be a canonical UUID")
+    if str(parsed) != value:
+        raise HypothesisContractError(f"{field} must be a canonical UUID")
+    return value
+
+
+def _digest(value: object, field: str) -> str:
+    if type(value) is not str or _DIGEST.fullmatch(value) is None:
+        raise HypothesisContractError(f"{field} must be a canonical SHA-256 digest")
+    return value
+
+
+def _token(value: object, field: str) -> str:
+    if type(value) is not str or _TOKEN.fullmatch(value) is None:
+        raise HypothesisContractError(f"{field} must be bounded canonical text")
+    return value
+
+
+def _text(value: object, field: str) -> str:
+    try:
+        valid = (
+            type(value) is str
+            and bool(value)
+            and value == value.strip()
+            and len(value.encode("utf-8")) <= 4096
+        )
+    except Exception as exc:
+        raise HypothesisContractError(
+            f"{field} must be bounded canonical text"
+        ) from exc
+    if not valid:
+        raise HypothesisContractError(f"{field} must be bounded canonical text")
+    return value
+
+
+def _integer(value: object, field: str) -> int:
+    if type(value) is not int or not 1 <= value <= MAX_SAFE_INTEGER:
+        raise HypothesisContractError(
+            f"{field} must be an exact bounded positive integer"
+        )
+    return value
+
+
+def _timestamp(value: object, field: str) -> str:
+    if type(value) is not str:
+        raise HypothesisContractError(f"{field} must be an exact UTC timestamp")
+    parsed = _normalise(
+        lambda: UtcTimestamp.parse(value), f"{field} must be an exact UTC timestamp"
+    )
+    if parsed.to_text() != value:
+        raise HypothesisContractError(f"{field} must be an exact UTC timestamp")
+    return value
+
+
+def _exact(value: object, fields: set[str], field: str) -> dict[str, object]:
+    if type(value) is not dict:
+        raise HypothesisContractError(f"{field} fields are not exact")
+    try:
+        if set(value) != fields:
+            raise HypothesisContractError(f"{field} fields are not exact")
+    except HypothesisContractError:
+        raise
+    except Exception as exc:
+        raise HypothesisContractError(f"{field} fields are not exact") from exc
+    return value
+
+
+def _decode(raw: bytes) -> dict[str, object]:
+    if type(raw) is not bytes or not raw or len(raw) > MAX_HYPOTHESIS_VERSION_BYTES:
+        raise HypothesisContractError("canonical input is not bounded immutable bytes")
+
+    def unique(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        result: dict[str, object] = {}
+        for key, value in pairs:
+            if key in result:
+                raise HypothesisContractError(f"duplicate object name: {key}")
+            result[key] = value
+        return result
+
+    def integer(text: str) -> int:
+        if len(text.lstrip("-")) > 16:
+            raise HypothesisContractError("integer exceeds the producer envelope")
+        value = int(text)
+        if not -MAX_SAFE_INTEGER <= value <= MAX_SAFE_INTEGER:
+            raise HypothesisContractError("integer exceeds the producer envelope")
+        return value
+
+    def no_float(_: str) -> float:
+        raise HypothesisContractError("floating-point values are unsupported")
+
+    try:
+        value = json.loads(
+            raw.decode("utf-8"),
+            object_pairs_hook=unique,
+            parse_int=integer,
+            parse_float=no_float,
+            parse_constant=no_float,
+        )
+    except HypothesisContractError:
+        raise
+    except Exception as exc:
+        raise HypothesisContractError("canonical input is invalid UTF-8 JSON") from exc
+    pending: list[tuple[object, int]] = [(value, 1)]
+    nodes = 0
+    while pending:
+        item, depth = pending.pop()
+        nodes += 1
+        if depth > 24 or nodes > 32768:
+            raise HypothesisContractError("canonical input exceeds structural bounds")
+        if type(item) is dict:
+            pending.extend((child, depth + 1) for child in item.values())
+        elif type(item) is list:
+            pending.extend((child, depth + 1) for child in item)
+        elif type(item) not in (str, int, bool, type(None)):
+            raise HypothesisContractError(
+                "canonical input contains an unsupported value"
+            )
+    if type(value) is not dict:
+        raise HypothesisContractError("canonical input must be an object")
+    try:
+        if canonical_json_bytes(value) != raw:
+            raise HypothesisContractError("canonical input bytes differ")
+    except HypothesisContractError:
+        raise
+    except Exception as exc:
+        raise HypothesisContractError("canonical input cannot be normalised") from exc
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class EventHypothesis(_NoEffect):
+    hypothesis_id: str
+
+    def __post_init__(self) -> None:
+        if type(self) is not EventHypothesis:
+            raise HypothesisContractError("Hypothesis requires the exact contract type")
+        _uuid(self.hypothesis_id, "hypothesis_id")
+
+    @classmethod
+    def allocate(cls, proposal_id: str, proposal_local_id: str) -> Self:
+        _token(proposal_id, "proposal_id")
+        _token(proposal_local_id, "proposal_local_id")
+        return cls(str(uuid.uuid5(_NAMESPACE, f"{proposal_id}\0{proposal_local_id}")))
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return _normalise(
+            lambda: canonical_json_bytes(
+                {
+                    "schema_version": EVENT_HYPOTHESIS,
+                    "hypothesis_id": self.hypothesis_id,
+                }
+            ),
+            "Hypothesis cannot be canonicalised",
+        )
+
+    @property
+    def canonical_digest(self) -> str:
+        return digest_bytes(self.canonical_bytes)
+
+    @classmethod
+    def from_canonical_bytes(cls, raw: bytes) -> Self:
+        root = _exact(_decode(raw), {"schema_version", "hypothesis_id"}, "Hypothesis")
+        if root["schema_version"] != EVENT_HYPOTHESIS:
+            raise HypothesisContractError("Hypothesis schema is unsupported")
+        return _normalise(
+            lambda: cls(_uuid(root["hypothesis_id"], "hypothesis_id")),
+            "Hypothesis replay failed",
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class HypothesisSourceBinding:
+    disposition_id: str
+    disposition_digest: str
+    finding_set_digest: str
+    route_binding_digest: str
+    decision_lead_id: str
+    decision_lead_digest: str
+    decision_lead_head_id: str
+    decision_lead_head_digest: str
+
+    def __post_init__(self) -> None:
+        if type(self) is not HypothesisSourceBinding:
+            raise HypothesisContractError(
+                "source binding requires the exact contract type"
+            )
+        _digest(self.disposition_id, "disposition_id")
+        for name in (
+            "disposition_digest",
+            "finding_set_digest",
+            "route_binding_digest",
+            "decision_lead_digest",
+            "decision_lead_head_digest",
+        ):
+            _digest(getattr(self, name), name)
+        _uuid(self.decision_lead_id, "decision_lead_id")
+        _uuid(self.decision_lead_head_id, "decision_lead_head_id")
+
+    def canonical_value(self) -> dict[str, object]:
+        return _normalise(
+            lambda: {name: getattr(self, name) for name in self.__dataclass_fields__},
+            "source binding cannot be canonicalised",
+        )
+
+    @classmethod
+    def from_value(cls, value: object) -> Self:
+        fields = set(cls.__dataclass_fields__)
+        item = _exact(value, fields, "source binding")
+        return cls(**{name: item[name] for name in fields})  # type: ignore[arg-type]
+
+
+@dataclass(frozen=True, slots=True)
+class EventHypothesisVersion(_NoEffect):
+    version_id: str
+    hypothesis_id: str
+    ordinal: int
+    previous_version_id: str | None
+    previous_version_digest: str | None
+    proposed_summary: str
+    proposed_relationship: HypothesisRelationship
+    proposed_target_hypothesis_id: str | None
+    target_version_id: str | None
+    target_version_digest: str | None
+    proposal_id: str
+    proposal_content_identity: str
+    proposal_canonical_digest: str
+    proposal_local_id: str
+    work_item_id: str
+    work_item_version_id: str
+    work_item_version_digest: str
+    retrieval_context_id: str
+    retrieval_context_digest: str
+    source_bindings: tuple[HypothesisSourceBinding, ...]
+    actor_identity_digest: str
+    authority_event_id: str
+    recorded_at: str
+
+    def __post_init__(self) -> None:
+        if type(self) is not EventHypothesisVersion:
+            raise HypothesisContractError(
+                "Hypothesis Version requires the exact contract type"
+            )
+        _uuid(self.hypothesis_id, "hypothesis_id")
+        _uuid(self.version_id, "version_id")
+        ordinal = _integer(self.ordinal, "ordinal")
+        expected = str(uuid.uuid5(uuid.UUID(self.hypothesis_id), f"version:{ordinal}"))
+        if self.version_id != expected:
+            raise HypothesisContractError(
+                "version_id differs from stable identity and ordinal"
+            )
+        if (ordinal == 1) != (
+            self.previous_version_id is None and self.previous_version_digest is None
+        ):
+            raise HypothesisContractError("predecessor binding differs from ordinal")
+        if self.previous_version_id is not None:
+            _uuid(self.previous_version_id, "previous_version_id")
+        if self.previous_version_digest is not None:
+            _digest(self.previous_version_digest, "previous_version_digest")
+        _text(self.proposed_summary, "proposed_summary")
+        if type(self.proposed_relationship) is not HypothesisRelationship:
+            raise HypothesisContractError("proposed_relationship must be exact")
+        target_required = (
+            self.proposed_relationship
+            is not HypothesisRelationship.NO_ADEQUATE_PRIOR_MATCH
+        )
+        if target_required != (
+            self.proposed_target_hypothesis_id is not None
+            and self.target_version_id is not None
+            and self.target_version_digest is not None
+        ):
+            raise HypothesisContractError("proposed target differs from relationship")
+        if not target_required and (
+            self.target_version_id is not None or self.target_version_digest is not None
+        ):
+            raise HypothesisContractError(
+                "target Version must be absent without a target"
+            )
+        if self.proposed_target_hypothesis_id is not None:
+            _uuid(self.proposed_target_hypothesis_id, "proposed_target_hypothesis_id")
+        if self.target_version_id is not None:
+            _uuid(self.target_version_id, "target_version_id")
+        if self.target_version_digest is not None:
+            _digest(self.target_version_digest, "target_version_digest")
+        for name in (
+            "proposal_id",
+            "proposal_local_id",
+            "work_item_id",
+            "work_item_version_id",
+            "retrieval_context_id",
+        ):
+            _token(getattr(self, name), name)
+        for name in (
+            "proposal_content_identity",
+            "proposal_canonical_digest",
+            "work_item_version_digest",
+            "retrieval_context_digest",
+        ):
+            _digest(getattr(self, name), name)
+        _digest(self.actor_identity_digest, "actor_identity_digest")
+        _uuid(self.authority_event_id, "authority_event_id")
+        _timestamp(self.recorded_at, "recorded_at")
+        if (
+            type(self.source_bindings) is not tuple
+            or not self.source_bindings
+            or len(self.source_bindings) > 32
+            or any(
+                type(item) is not HypothesisSourceBinding
+                for item in self.source_bindings
+            )
+        ):
+            raise HypothesisContractError(
+                "source_bindings must be a non-empty bounded exact tuple"
+            )
+        keys = tuple(
+            (item.decision_lead_id, item.disposition_id)
+            for item in self.source_bindings
+        )
+        if keys != tuple(sorted(set(keys))):
+            raise HypothesisContractError("source_bindings must be sorted and unique")
+        _normalise(
+            lambda: self.canonical_bytes, "Hypothesis Version cannot be canonicalised"
+        )
+
+    @property
+    def canonical_value(self) -> dict[str, object]:
+        return _normalise(
+            lambda: {
+                "version_id": self.version_id,
+                "hypothesis_id": self.hypothesis_id,
+                "ordinal": self.ordinal,
+                "previous_version_id": self.previous_version_id,
+                "previous_version_digest": self.previous_version_digest,
+                "proposed_summary": self.proposed_summary,
+                "proposed_relationship": self.proposed_relationship.value,
+                "proposed_target_hypothesis_id": self.proposed_target_hypothesis_id,
+                "target_version_id": self.target_version_id,
+                "target_version_digest": self.target_version_digest,
+                "proposal_id": self.proposal_id,
+                "proposal_content_identity": self.proposal_content_identity,
+                "proposal_canonical_digest": self.proposal_canonical_digest,
+                "proposal_local_id": self.proposal_local_id,
+                "work_item_id": self.work_item_id,
+                "work_item_version_id": self.work_item_version_id,
+                "work_item_version_digest": self.work_item_version_digest,
+                "retrieval_context_id": self.retrieval_context_id,
+                "retrieval_context_digest": self.retrieval_context_digest,
+                "source_bindings": [
+                    item.canonical_value() for item in self.source_bindings
+                ],
+                "actor_identity_digest": self.actor_identity_digest,
+                "authority_event_id": self.authority_event_id,
+                "recorded_at": self.recorded_at,
+            },
+            "Hypothesis Version cannot be canonicalised",
+        )
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return _normalise(
+            lambda: canonical_json_bytes(
+                {
+                    "schema_version": EVENT_HYPOTHESIS_VERSION,
+                    "version": self.canonical_value,
+                }
+            ),
+            "Hypothesis Version cannot be canonicalised",
+        )
+
+    @property
+    def canonical_digest(self) -> str:
+        return digest_bytes(self.canonical_bytes)
+
+    @classmethod
+    def from_canonical_bytes(cls, raw: bytes) -> Self:
+        root = _exact(
+            _decode(raw), {"schema_version", "version"}, "Hypothesis Version document"
+        )
+        if root["schema_version"] != EVENT_HYPOTHESIS_VERSION:
+            raise HypothesisContractError("Hypothesis Version schema is unsupported")
+        fields = set(cls.__dataclass_fields__)
+        item = _exact(root["version"], fields, "Hypothesis Version")
+        relationship = _normalise(
+            lambda: HypothesisRelationship(item["proposed_relationship"]),
+            "proposed_relationship is unsupported",
+        )
+        raw_bindings = item["source_bindings"]
+        if type(raw_bindings) is not list:
+            raise HypothesisContractError("source_bindings must be an array")
+        values = dict(item)
+        values["proposed_relationship"] = relationship
+        values["source_bindings"] = tuple(
+            HypothesisSourceBinding.from_value(value) for value in raw_bindings
+        )
+        return _normalise(
+            lambda: cls(**values),  # type: ignore[arg-type]
+            "Hypothesis Version replay failed",
+        )
+
+
+class EventHypothesisAuthority:
+    """Narrow public facade over the private checked v21 store."""
+
+    __slots__ = ("__authority",)
+
+    def __init__(self, authority: object) -> None:
+        from newsroom.increment6._hypothesis_store import (
+            EventHypothesisAuthority as PrivateAuthority,
+        )
+
+        if type(authority) is not PrivateAuthority:
+            raise HypothesisContractError(
+                "Hypothesis authority facade requires the exact private authority"
+            )
+        self.__authority = authority
+
+    def retain(self, *args: object, **kwargs: object) -> EventHypothesisVersion:
+        return _normalise(
+            lambda: self.__authority.retain(*args, **kwargs),
+            "Hypothesis retention failed",
+        )  # type: ignore[attr-defined,no-any-return]
+
+    create_or_append = retain
+
+    def current(self, hypothesis_id: str, *, proof: object) -> EventHypothesisVersion:
+        return _normalise(
+            lambda: self.__authority.current(hypothesis_id, proof=proof),
+            "Hypothesis currentness failed",
+        )  # type: ignore[attr-defined,no-any-return]
+
+    require_current = current
+
+    def load_version(self, version_id: str) -> EventHypothesisVersion:
+        return _normalise(
+            lambda: self.__authority.load_version(version_id),
+            "Hypothesis Version load failed",
+        )  # type: ignore[attr-defined,no-any-return]
+
+    def load_hypothesis(self, hypothesis_id: str) -> EventHypothesis:
+        return _normalise(
+            lambda: self.__authority.load_hypothesis(hypothesis_id),
+            "Hypothesis load failed",
+        )  # type: ignore[attr-defined,no-any-return]
+
+    def versions(self, hypothesis_id: str) -> tuple[EventHypothesisVersion, ...]:
+        return _normalise(
+            lambda: self.__authority.versions(hypothesis_id),
+            "Hypothesis history load failed",
+        )  # type: ignore[attr-defined,no-any-return]
+
+    def close(self) -> None:
+        _normalise(
+            lambda: self.__authority.close(), "Hypothesis authority close failed"
+        )  # type: ignore[attr-defined]
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
+
+
+def open_event_hypothesis_authority(
+    *args: object, **kwargs: object
+) -> EventHypothesisAuthority:
+    """Open the checked v21 authority without exposing SQLite mutation."""
+    from newsroom.increment6._hypothesis_store import (
+        EventHypothesisAuthority as PrivateAuthority,
+    )
+
+    return _normalise(
+        lambda: EventHypothesisAuthority(PrivateAuthority.open(*args, **kwargs)),
+        "Hypothesis authority open failed",
+    )
+
+
+open_hypothesis_authority = open_event_hypothesis_authority
+
+
+__all__ = [
+    "EVENT_HYPOTHESIS",
+    "EVENT_HYPOTHESIS_VERSION",
+    "HYPOTHESIS_CURRENT_VERSION",
+    "EventHypothesis",
+    "EventHypothesisAuthority",
+    "EventHypothesisVersion",
+    "HypothesisContractError",
+    "HypothesisSourceBinding",
+    "open_event_hypothesis_authority",
+    "open_hypothesis_authority",
+]

--- a/newsroom/increment6/hypotheses.py
+++ b/newsroom/increment6/hypotheses.py
@@ -29,6 +29,16 @@ MAX_HYPOTHESIS_VERSION_BYTES = 1_048_576
 _NAMESPACE = uuid.UUID("435812df-489e-5e4c-9b3d-838148b1918a")
 _DIGEST = re.compile(r"sha256:[0-9a-f]{64}\Z")
 _TOKEN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:\-]{0,255}\Z")
+_CREATE_RELATIONSHIPS = {
+    HypothesisRelationship.NO_ADEQUATE_PRIOR_MATCH,
+    HypothesisRelationship.RELATED_DISTINCT,
+    HypothesisRelationship.UNCERTAIN,
+}
+_APPEND_RELATIONSHIPS = {
+    HypothesisRelationship.SAME_STATE,
+    HypothesisRelationship.DEVELOPMENT_OF,
+    HypothesisRelationship.CORRECTION_REVERSAL_OF,
+}
 
 
 class HypothesisContractError(ValueError):
@@ -351,6 +361,31 @@ class EventHypothesisVersion(_NoEffect):
             "retrieval_context_id",
         ):
             _token(getattr(self, name), name)
+        if ordinal == 1:
+            if self.proposed_relationship not in _CREATE_RELATIONSHIPS:
+                raise HypothesisContractError(
+                    "first Version requires a create relationship"
+                )
+            stable_identity = EventHypothesis.allocate(
+                self.proposal_id, self.proposal_local_id
+            )
+            if self.hypothesis_id != stable_identity.hypothesis_id:
+                raise HypothesisContractError(
+                    "Hypothesis differs from stable identity allocation"
+                )
+        else:
+            if self.proposed_relationship not in _APPEND_RELATIONSHIPS:
+                raise HypothesisContractError(
+                    "later Version requires an append relationship"
+                )
+            if (
+                self.proposed_target_hypothesis_id != self.hypothesis_id
+                or self.target_version_id != self.previous_version_id
+                or self.target_version_digest != self.previous_version_digest
+            ):
+                raise HypothesisContractError(
+                    "append target differs from the exact predecessor"
+                )
         for name in (
             "proposal_content_identity",
             "proposal_canonical_digest",

--- a/newsroom/tests/graphiti_adapter_4d_migration_helpers.py
+++ b/newsroom/tests/graphiti_adapter_4d_migration_helpers.py
@@ -6,17 +6,20 @@ from pathlib import Path
 from newsroom.authority.evaluation_handoff_migrations import (
     EVALUATION_HANDOFF_SCHEMA_VERSION,
 )
+from newsroom.authority.event_hypothesis_migrations import (
+    EVENT_HYPOTHESIS_SCHEMA_VERSION,
+)
 from newsroom.authority.graphiti_adapter_migrations import (
     GRAPHITI_ADAPTER_SCHEMA_VERSION,
-)
-from newsroom.authority.triage_work_item_migrations import (
-    TRIAGE_WORK_ITEM_SCHEMA_VERSION,
 )
 from newsroom.authority.triage_disposition_migrations import (
     TRIAGE_DISPOSITION_SCHEMA_VERSION,
 )
 from newsroom.authority.triage_execution_migrations import (
     TRIAGE_EXECUTION_SCHEMA_VERSION,
+)
+from newsroom.authority.triage_work_item_migrations import (
+    TRIAGE_WORK_ITEM_SCHEMA_VERSION,
 )
 
 
@@ -40,6 +43,14 @@ def downgrade_empty_graphiti_adapter_schema_to_v15(database: Path) -> None:
         ).fetchone()
         assert delete_trigger is not None and delete_trigger[0]
         conn.execute("DROP TRIGGER immutable_authority_migrations_delete")
+
+        if current >= EVENT_HYPOTHESIS_SCHEMA_VERSION:
+            for table in (
+                "event_hypothesis_heads_v2",
+                "event_hypothesis_versions_v2",
+                "event_hypotheses_v2",
+            ):
+                conn.execute(f'DROP TABLE "{table}"')
 
         if current >= TRIAGE_EXECUTION_SCHEMA_VERSION:
             for table in (

--- a/newsroom/tests/test_editorial_relation_4c_migrations.py
+++ b/newsroom/tests/test_editorial_relation_4c_migrations.py
@@ -77,7 +77,7 @@ def test_fresh_schema_v15_history_registry_tables_and_view_are_exact(
     conn = sqlite3.connect(state.extraction.database)
     try:
         assert EDITORIAL_RELATION_SCHEMA_VERSION == 15
-        assert SCHEMA_VERSION == 20
+        assert SCHEMA_VERSION == 21
         assert conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
         assert schema_fingerprint(conn) == EXPECTED_SCHEMA_FINGERPRINT
         assert conn.execute(

--- a/newsroom/tests/test_entity_4b_migrations.py
+++ b/newsroom/tests/test_entity_4b_migrations.py
@@ -118,7 +118,7 @@ def test_current_schema_retains_exact_v14_history_tables_and_view(
     conn = sqlite3.connect(state.database)
     try:
         assert ENTITY_AUTHORITY_SCHEMA_VERSION == 14
-        assert SCHEMA_VERSION == 20
+        assert SCHEMA_VERSION == 21
         assert conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
         assert schema_fingerprint(conn) == EXPECTED_SCHEMA_FINGERPRINT
         assert conn.execute(

--- a/newsroom/tests/test_graphiti_adapter_4d_migrations.py
+++ b/newsroom/tests/test_graphiti_adapter_4d_migrations.py
@@ -76,7 +76,7 @@ def test_fresh_schema_v16_history_policies_tables_and_triggers_are_exact(
     conn = sqlite3.connect(state.database)
     try:
         assert GRAPHITI_ADAPTER_SCHEMA_VERSION == 16
-        assert SCHEMA_VERSION == 20
+        assert SCHEMA_VERSION == 21
         assert conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
         assert schema_fingerprint(conn) == EXPECTED_SCHEMA_FINGERPRINT
         assert conn.execute(

--- a/newsroom/tests/test_increment6a2_work_item_migrations.py
+++ b/newsroom/tests/test_increment6a2_work_item_migrations.py
@@ -31,12 +31,12 @@ def _open(path: str | Path) -> sqlite3.Connection:
 def test_current_schema_retains_exact_v18_and_is_integral() -> None:
     connection = _open(":memory:")
     apply_pending_migrations(connection, applied_at="2042-03-12T10:00:00Z")
-    assert SCHEMA_VERSION == 20 and TRIAGE_WORK_ITEM_SCHEMA_VERSION == 18
+    assert SCHEMA_VERSION == 21 and TRIAGE_WORK_ITEM_SCHEMA_VERSION == 18
     assert schema_fingerprint(connection) == EXPECTED_SCHEMA_FINGERPRINT
     assert connection.execute(
         "SELECT version,name,checksum FROM authority_migrations ORDER BY version"
     ).fetchall() == list(EXPECTED_MIGRATION_HISTORY)
-    assert EXPECTED_MIGRATION_HISTORY[-3] == (
+    assert EXPECTED_MIGRATION_HISTORY[-4] == (
         18,
         TRIAGE_WORK_ITEM_MIGRATION_NAME,
         TRIAGE_WORK_ITEM_MIGRATION_CHECKSUM,
@@ -99,6 +99,9 @@ def test_exact_v17_upgrade_retains_pre_v18_backup(tmp_path: Path) -> None:
     ).fetchone()[0]
     connection.execute("DROP TRIGGER immutable_authority_migrations_delete")
     for table in (
+        "event_hypothesis_heads_v2",
+        "event_hypothesis_versions_v2",
+        "event_hypotheses_v2",
         "triage_work_item_leases",
         "triage_worker_attempts",
         "triage_execution_batches",
@@ -120,12 +123,12 @@ def test_exact_v17_upgrade_retains_pre_v18_backup(tmp_path: Path) -> None:
     apply_pending_migrations(connection, applied_at="2042-03-12T10:00:01Z")
     backup, digest = triage_work_item_backup_paths(database)
     assert backup.is_file() and digest.is_file()
-    assert connection.execute("PRAGMA user_version").fetchone()[0] == 20
+    assert connection.execute("PRAGMA user_version").fetchone()[0] == 21
 
 
 def test_newer_schema_and_injected_v18_failure_fail_closed() -> None:
     newer = _open(":memory:")
-    newer.execute("PRAGMA user_version=21")
+    newer.execute("PRAGMA user_version=22")
     with pytest.raises(sqlite3.DatabaseError, match="newer"):
         apply_pending_migrations(newer, applied_at="2042-03-12T10:00:00Z")
 

--- a/newsroom/tests/test_increment6b1_execution_migrations.py
+++ b/newsroom/tests/test_increment6b1_execution_migrations.py
@@ -46,6 +46,9 @@ def _downgrade_to_v19(connection: sqlite3.Connection) -> None:
         "WHERE name='immutable_authority_migrations_delete'"
     ).fetchone()[0]
     connection.execute("DROP TRIGGER immutable_authority_migrations_delete")
+    connection.execute("DROP TABLE event_hypothesis_heads_v2")
+    connection.execute("DROP TABLE event_hypothesis_versions_v2")
+    connection.execute("DROP TABLE event_hypotheses_v2")
     for trigger in (
         "triage_execution_batch_coherence",
         "triage_worker_attempt_coherence",
@@ -62,7 +65,7 @@ def _downgrade_to_v19(connection: sqlite3.Connection) -> None:
     connection.execute("DROP TABLE triage_work_item_leases")
     connection.execute("DROP TABLE triage_worker_attempts")
     connection.execute("DROP TABLE triage_execution_batches")
-    connection.execute("DELETE FROM authority_migrations WHERE version=20")
+    connection.execute("DELETE FROM authority_migrations WHERE version>=20")
     connection.execute(guard)
     connection.execute("PRAGMA user_version=19")
     connection.execute("PRAGMA foreign_keys=ON")
@@ -70,8 +73,8 @@ def _downgrade_to_v19(connection: sqlite3.Connection) -> None:
 
 def test_fresh_v20_history_fingerprint_and_exact_three_table_allocation() -> None:
     connection = _fresh()
-    assert SCHEMA_VERSION == TRIAGE_EXECUTION_SCHEMA_VERSION == 20
-    assert EXPECTED_MIGRATION_HISTORY[-1] == (
+    assert SCHEMA_VERSION == 21 and TRIAGE_EXECUTION_SCHEMA_VERSION == 20
+    assert EXPECTED_MIGRATION_HISTORY[-2] == (
         20,
         TRIAGE_EXECUTION_MIGRATION_NAME,
         TRIAGE_EXECUTION_MIGRATION_CHECKSUM,
@@ -107,9 +110,9 @@ def test_v20_literal_predecessor_pins_are_exact() -> None:
         "sha256:6eb04f981f650bbb4956f148d11f1656bcd2b7c510117db96602dd9d83ab9bd3"
     )
     assert EXPECTED_SCHEMA_FINGERPRINT == (
-        "sha256:36a7c9910775ede9c29113a43e08bba261a5a98c4fab5225dd2cae9448689389"
+        "sha256:d314d06118a25f8a32a0f9d8acb1af5383abd6b30be682cb5f65943ae15c213f"
     )
-    assert EXPECTED_MIGRATION_HISTORY[-1] == (
+    assert EXPECTED_MIGRATION_HISTORY[-2] == (
         20,
         "triage_execution_authority_v20",
         "sha256:6eb04f981f650bbb4956f148d11f1656bcd2b7c510117db96602dd9d83ab9bd3",
@@ -127,7 +130,7 @@ def test_exact_v19_backup_upgrade_reuse_and_tamper_fail_closed(
     receipt = prepare_triage_execution_backup(connection, backup)
     assert prepare_triage_execution_backup(connection, backup) == receipt
     apply_pending_migrations(connection, applied_at="2042-03-12T10:00:01Z")
-    assert connection.execute("PRAGMA user_version").fetchone() == (20,)
+    assert connection.execute("PRAGMA user_version").fetchone() == (21,)
     assert backup.is_file() and digest.is_file()
 
     digest.write_text("sha256:" + "0" * 64 + "\n", encoding="ascii")
@@ -161,6 +164,6 @@ def test_injected_v20_failure_rolls_back_exact_v19_and_v21_rejects(
     ).fetchall() == []
 
     newer = _open(":memory:")
-    newer.execute("PRAGMA user_version=21")
+    newer.execute("PRAGMA user_version=22")
     with pytest.raises(sqlite3.DatabaseError, match="newer"):
         apply_pending_migrations(newer, applied_at="2042-03-12T10:00:00Z")

--- a/newsroom/tests/test_increment6c2_disposition_migrations.py
+++ b/newsroom/tests/test_increment6c2_disposition_migrations.py
@@ -44,6 +44,9 @@ def _downgrade_to_v18(connection: sqlite3.Connection) -> None:
         "SELECT sql FROM sqlite_master WHERE name='immutable_authority_migrations_delete'"
     ).fetchone()[0]
     connection.execute("DROP TRIGGER immutable_authority_migrations_delete")
+    connection.execute("DROP TABLE event_hypothesis_heads_v2")
+    connection.execute("DROP TABLE event_hypothesis_versions_v2")
+    connection.execute("DROP TABLE event_hypotheses_v2")
     connection.execute("DROP TABLE triage_work_item_leases")
     connection.execute("DROP TABLE triage_worker_attempts")
     connection.execute("DROP TABLE triage_execution_batches")
@@ -57,8 +60,8 @@ def _downgrade_to_v18(connection: sqlite3.Connection) -> None:
 
 def test_fresh_v19_history_fingerprint_guards_and_integrity_are_exact() -> None:
     connection = _fresh()
-    assert SCHEMA_VERSION == 20 and TRIAGE_DISPOSITION_SCHEMA_VERSION == 19
-    assert EXPECTED_MIGRATION_HISTORY[-2] == (
+    assert SCHEMA_VERSION == 21 and TRIAGE_DISPOSITION_SCHEMA_VERSION == 19
+    assert EXPECTED_MIGRATION_HISTORY[-3] == (
         19,
         TRIAGE_DISPOSITION_MIGRATION_NAME,
         TRIAGE_DISPOSITION_MIGRATION_CHECKSUM,
@@ -106,7 +109,7 @@ def test_exact_v18_backup_upgrade_reuse_and_tamper_fail_closed(tmp_path: Path) -
         connection, triage_disposition_backup_paths(database)[0]
     ) == receipt
     apply_pending_migrations(connection, applied_at="2042-03-12T10:00:01Z")
-    assert connection.execute("PRAGMA user_version").fetchone()[0] == 20
+    assert connection.execute("PRAGMA user_version").fetchone()[0] == 21
     backup, digest = triage_disposition_backup_paths(database)
     assert backup.is_file() and digest.is_file()
     connection.close()
@@ -144,7 +147,7 @@ def test_v19_injected_failure_restores_exact_v18_and_v20_is_rejected(
     ).fetchall() == []
 
     newer = _open(":memory:")
-    newer.execute("PRAGMA user_version=21")
+    newer.execute("PRAGMA user_version=22")
     with pytest.raises(sqlite3.DatabaseError, match="newer"):
         apply_pending_migrations(newer, applied_at="2042-03-12T10:00:00Z")
 
@@ -218,7 +221,7 @@ def test_v19_checksum_and_schema_fingerprint_are_literal_release_pins() -> None:
     assert TRIAGE_DISPOSITION_MIGRATION_CHECKSUM == (
         "sha256:d5f9702d359836e3b564ba1cadbad27e5fc17ba79e5155e2b34382ec30681177"
     )
-    assert EXPECTED_MIGRATION_HISTORY[-2][2] == TRIAGE_DISPOSITION_MIGRATION_CHECKSUM
+    assert EXPECTED_MIGRATION_HISTORY[-3][2] == TRIAGE_DISPOSITION_MIGRATION_CHECKSUM
 
 
 def test_exact_v18_apply_without_prepared_backup_preserves_history_and_schema(

--- a/newsroom/tests/test_increment6d1_hypotheses.py
+++ b/newsroom/tests/test_increment6d1_hypotheses.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import replace
+
+import pytest
+
+from newsroom.increment6.hypotheses import (
+    EVENT_HYPOTHESIS,
+    EVENT_HYPOTHESIS_VERSION,
+    EventHypothesis,
+    EventHypothesisAuthority,
+    EventHypothesisVersion,
+    HypothesisContractError,
+    HypothesisSourceBinding,
+)
+from newsroom.increment6.proposals import HypothesisRelationship
+
+D = "sha256:" + "1" * 64
+
+
+def _version() -> EventHypothesisVersion:
+    hypothesis = EventHypothesis.allocate(str(uuid.UUID(int=1)), "local-1")
+    source = HypothesisSourceBinding(
+        D, D, D, D, str(uuid.UUID(int=2)), D, str(uuid.UUID(int=3)), D
+    )
+    return EventHypothesisVersion(
+        str(uuid.uuid5(uuid.UUID(hypothesis.hypothesis_id), "version:1")),
+        hypothesis.hypothesis_id,
+        1,
+        None,
+        None,
+        "Unverified summary",
+        HypothesisRelationship.NO_ADEQUATE_PRIOR_MATCH,
+        None,
+        None,
+        None,
+        str(uuid.UUID(int=4)),
+        D,
+        D,
+        "local-1",
+        str(uuid.UUID(int=5)),
+        str(uuid.UUID(int=6)),
+        D,
+        str(uuid.UUID(int=7)),
+        D,
+        (source,),
+        D,
+        str(uuid.UUID(int=8)),
+        "2042-01-01T00:00:00.000000Z",
+    )
+
+
+def test_exact_contract_round_trip_and_non_effects() -> None:
+    value = _version()
+    assert EventHypothesisVersion.from_canonical_bytes(value.canonical_bytes) == value
+    assert EVENT_HYPOTHESIS.endswith("event-hypothesis.v1")
+    assert EVENT_HYPOTHESIS_VERSION.endswith("event-hypothesis-version.v1")
+    assert value.creates_candidate is value.creates_relationship is False
+    assert value.authorises_publication is value.authorises_external_effect is False
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        b'{"hypothesis_id":true,"schema_version":"newsroom.increment6.event-hypothesis.v1"}',
+        b'{"hypothesis_id":1.0,"schema_version":"newsroom.increment6.event-hypothesis.v1"}',
+        b'{"schema_version":"x","schema_version":"x"}',
+    ],
+)
+def test_contract_errors_are_total(raw: bytes) -> None:
+    with pytest.raises(HypothesisContractError):
+        EventHypothesis.from_canonical_bytes(raw)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        b"[]",
+        b"true",
+        b"1",
+        b"1.0",
+        b'{"x":9223372036854775808}',
+        b'{"hypothesis_id":"\\ud800","schema_version":"newsroom.increment6.event-hypothesis.v1"}',
+        b'{"hypothesis_id":"00000000-0000-0000-0000-000000000001","schema_version":"newsroom.increment6.event-hypothesis.v1","unknown":1}',
+        b'{ "hypothesis_id":"00000000-0000-0000-0000-000000000001","schema_version":"newsroom.increment6.event-hypothesis.v1"}',
+    ],
+)
+def test_parser_rejects_noncanonical_or_unsupported_json_as_contract_error(
+    raw: bytes,
+) -> None:
+    with pytest.raises(HypothesisContractError):
+        EventHypothesis.from_canonical_bytes(raw)
+
+
+def test_exact_types_uninitialised_values_and_corrupted_nested_sources_are_total() -> (
+    None
+):
+    class Raw(bytes):
+        def __len__(self):
+            raise RuntimeError("should not dispatch")
+
+    class Sources(tuple):
+        def __iter__(self):
+            raise RuntimeError("should not dispatch")
+
+    with pytest.raises(HypothesisContractError):
+        EventHypothesis.from_canonical_bytes(Raw(b"{}"))
+    with pytest.raises(HypothesisContractError):
+        replace(_version(), source_bindings=Sources(_version().source_bindings))
+    for value in (
+        object.__new__(EventHypothesis),
+        object.__new__(EventHypothesisVersion),
+        object.__new__(HypothesisSourceBinding),
+    ):
+        with pytest.raises(HypothesisContractError):
+            _ = (
+                value.canonical_bytes
+                if not isinstance(value, HypothesisSourceBinding)
+                else value.canonical_value()
+            )
+    version = _version()
+    corrupt = version.source_bindings[0]
+    object.__setattr__(corrupt, "disposition_id", object())
+    with pytest.raises(HypothesisContractError):
+        _ = version.canonical_bytes
+
+
+def test_public_facade_requires_exact_private_authority() -> None:
+    with pytest.raises(HypothesisContractError):
+        EventHypothesisAuthority(object())
+
+
+def test_structural_depth_node_caps_and_constructed_self_cycles_are_total() -> None:
+    deep = b'{"a":' * 25 + b"null" + b"}" * 25
+    wide = (
+        b'{"hypothesis_id":"00000000-0000-0000-0000-000000000001","schema_version":"newsroom.increment6.event-hypothesis.v1","x":['
+        + b"null," * 32768
+        + b"null]}"
+    )
+    for raw in (deep, wide):
+        with pytest.raises(HypothesisContractError):
+            EventHypothesis.from_canonical_bytes(raw)
+    version = _version()
+    cyclic = list(version.source_bindings)
+    cyclic.append(cyclic)  # type: ignore[arg-type]
+    object.__setattr__(version, "source_bindings", cyclic)
+    with pytest.raises(HypothesisContractError):
+        _ = version.canonical_bytes
+
+
+def test_explosive_builtin_subclasses_are_rejected_without_dispatch() -> None:
+    class ExplosiveStr(str):
+        def encode(self, *_: object, **__: object) -> bytes:
+            raise AssertionError("subclass dispatch")
+
+    class ExplosiveInt(int):
+        def __index__(self) -> int:
+            raise AssertionError("subclass dispatch")
+
+    class ExplosiveDict(dict):
+        def __iter__(self):
+            raise AssertionError("subclass dispatch")
+
+    class ExplosiveList(list):
+        def __iter__(self):
+            raise AssertionError("subclass dispatch")
+
+    with pytest.raises(HypothesisContractError):
+        EventHypothesis(ExplosiveStr(str(uuid.UUID(int=1))))
+    with pytest.raises(HypothesisContractError):
+        replace(_version(), ordinal=ExplosiveInt(1))
+    with pytest.raises(HypothesisContractError):
+        HypothesisSourceBinding.from_value(ExplosiveDict())
+    with pytest.raises(HypothesisContractError):
+        replace(_version(), source_bindings=ExplosiveList())
+
+
+def test_uninitialised_facade_normalises_ordinary_failures_and_preserves_base_exceptions() -> (
+    None
+):
+    facade = object.__new__(EventHypothesisAuthority)
+    operations = (
+        lambda: facade.retain(b"", (), proof=object()),
+        lambda: facade.current(str(uuid.UUID(int=1)), proof=object()),
+        lambda: facade.load_version(str(uuid.UUID(int=1))),
+        lambda: facade.load_hypothesis(str(uuid.UUID(int=1))),
+        lambda: facade.versions(str(uuid.UUID(int=1))),
+        facade.close,
+    )
+    for operation in operations:
+        with pytest.raises(HypothesisContractError):
+            operation()
+
+    from newsroom.increment6 import hypotheses as module
+
+    for exc in (
+        RuntimeError("runtime"),
+        KeyError("key"),
+        IndexError("index"),
+        AttributeError("attribute"),
+    ):
+        with pytest.raises(HypothesisContractError):
+            module._normalise(lambda exc=exc: (_ for _ in ()).throw(exc), "normalised")
+    for exc_type in (KeyboardInterrupt, SystemExit):
+        with pytest.raises(exc_type):
+            module._normalise(
+                lambda exc_type=exc_type: (_ for _ in ()).throw(exc_type()), "propagate"
+            )

--- a/newsroom/tests/test_increment6d1_hypotheses.py
+++ b/newsroom/tests/test_increment6d1_hypotheses.py
@@ -5,6 +5,7 @@ from dataclasses import replace
 
 import pytest
 
+from newsroom.authority.canonical import canonical_json_bytes
 from newsroom.increment6.hypotheses import (
     EVENT_HYPOTHESIS,
     EVENT_HYPOTHESIS_VERSION,
@@ -20,7 +21,8 @@ D = "sha256:" + "1" * 64
 
 
 def _version() -> EventHypothesisVersion:
-    hypothesis = EventHypothesis.allocate(str(uuid.UUID(int=1)), "local-1")
+    proposal_id = str(uuid.UUID(int=1))
+    hypothesis = EventHypothesis.allocate(proposal_id, "local-1")
     source = HypothesisSourceBinding(
         D, D, D, D, str(uuid.UUID(int=2)), D, str(uuid.UUID(int=3)), D
     )
@@ -35,7 +37,7 @@ def _version() -> EventHypothesisVersion:
         None,
         None,
         None,
-        str(uuid.UUID(int=4)),
+        proposal_id,
         D,
         D,
         "local-1",
@@ -58,6 +60,43 @@ def test_exact_contract_round_trip_and_non_effects() -> None:
     assert EVENT_HYPOTHESIS_VERSION.endswith("event-hypothesis-version.v1")
     assert value.creates_candidate is value.creates_relationship is False
     assert value.authorises_publication is value.authorises_external_effect is False
+
+
+def test_version_identity_and_create_append_topology_fail_closed() -> None:
+    value = _version()
+    wrong_hypothesis_id = str(uuid.UUID(int=999))
+    wrong_version_id = str(uuid.uuid5(uuid.UUID(wrong_hypothesis_id), "version:1"))
+    with pytest.raises(HypothesisContractError, match="stable identity"):
+        replace(
+            value,
+            hypothesis_id=wrong_hypothesis_id,
+            version_id=wrong_version_id,
+        )
+    with pytest.raises(HypothesisContractError, match="create relationship"):
+        replace(
+            value,
+            proposed_relationship=HypothesisRelationship.SAME_STATE,
+            proposed_target_hypothesis_id=value.hypothesis_id,
+            target_version_id=value.version_id,
+            target_version_digest=value.canonical_digest,
+        )
+    with pytest.raises(HypothesisContractError, match="append relationship"):
+        replace(
+            value,
+            ordinal=2,
+            version_id=str(uuid.uuid5(uuid.UUID(value.hypothesis_id), "version:2")),
+            previous_version_id=value.version_id,
+            previous_version_digest=value.canonical_digest,
+        )
+
+    forged = value.canonical_value
+    forged["hypothesis_id"] = wrong_hypothesis_id
+    forged["version_id"] = wrong_version_id
+    raw = canonical_json_bytes(
+        {"schema_version": EVENT_HYPOTHESIS_VERSION, "version": forged}
+    )
+    with pytest.raises(HypothesisContractError, match="stable identity"):
+        EventHypothesisVersion.from_canonical_bytes(raw)
 
 
 @pytest.mark.parametrize(

--- a/newsroom/tests/test_increment6d1_hypothesis_migrations.py
+++ b/newsroom/tests/test_increment6d1_hypothesis_migrations.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from newsroom.authority import migrations
+from newsroom.authority.event_hypothesis_migrations import (
+    EVENT_HYPOTHESIS_MIGRATION_CHECKSUM,
+    EVENT_HYPOTHESIS_MIGRATION_NAME,
+    EVENT_HYPOTHESIS_PREDECESSOR_FINGERPRINT,
+    EVENT_HYPOTHESIS_PREDECESSOR_MIGRATION_CHECKSUM,
+    EventHypothesisBackupError,
+    event_hypothesis_backup_paths,
+    prepare_event_hypothesis_backup,
+)
+from newsroom.authority.migrations import (
+    EXPECTED_MIGRATION_HISTORY,
+    EXPECTED_SCHEMA_FINGERPRINT,
+    SCHEMA_VERSION,
+    apply_pending_migrations,
+    schema_fingerprint,
+)
+
+
+def _open(path: str | Path = ":memory:") -> sqlite3.Connection:
+    connection = sqlite3.connect(path, isolation_level=None)
+    connection.execute("PRAGMA foreign_keys=ON")
+    return connection
+
+
+def _fresh(path: str | Path = ":memory:") -> sqlite3.Connection:
+    connection = _open(path)
+    apply_pending_migrations(connection, applied_at="2042-01-01T00:00:00.000000Z")
+    return connection
+
+
+def _downgrade_to_v20(connection: sqlite3.Connection) -> None:
+    connection.execute("PRAGMA foreign_keys=OFF")
+    immutable = connection.execute(
+        "SELECT sql FROM sqlite_master WHERE name='immutable_authority_migrations_delete'"
+    ).fetchone()[0]
+    connection.execute("DROP TRIGGER immutable_authority_migrations_delete")
+    for trigger in (
+        "event_hypothesis_identity_coherence",
+        "event_hypothesis_version_coherence",
+        "event_hypothesis_head_insert_guard",
+        "event_hypothesis_head_update_guard",
+        "immutable_event_hypothesis_update",
+        "retained_event_hypothesis_delete",
+        "immutable_event_hypothesis_version_update",
+        "retained_event_hypothesis_version_delete",
+        "retained_event_hypothesis_head_delete",
+    ):
+        connection.execute(f"DROP TRIGGER {trigger}")
+    connection.execute("DROP TABLE event_hypothesis_heads_v2")
+    connection.execute("DROP TABLE event_hypothesis_versions_v2")
+    connection.execute("DROP TABLE event_hypotheses_v2")
+    connection.execute("DELETE FROM authority_migrations WHERE version=21")
+    connection.execute(immutable)
+    connection.execute("PRAGMA user_version=20")
+    connection.execute("PRAGMA foreign_keys=ON")
+
+
+def _history(connection: sqlite3.Connection) -> list[tuple[int, str, str]]:
+    return connection.execute(
+        "SELECT version,name,checksum FROM authority_migrations ORDER BY version"
+    ).fetchall()
+
+
+def test_fresh_v21_has_exact_allocation_history_and_integrity() -> None:
+    connection = _fresh()
+    assert SCHEMA_VERSION == 21
+    assert EXPECTED_MIGRATION_HISTORY[-1] == (
+        21,
+        EVENT_HYPOTHESIS_MIGRATION_NAME,
+        EVENT_HYPOTHESIS_MIGRATION_CHECKSUM,
+    )
+    assert _history(connection) == list(EXPECTED_MIGRATION_HISTORY)
+    assert {
+        r[0]
+        for r in connection.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'event_hypoth%_v2'"
+        )
+    } == {
+        "event_hypotheses_v2",
+        "event_hypothesis_versions_v2",
+        "event_hypothesis_heads_v2",
+    }
+    assert connection.execute("PRAGMA foreign_key_check").fetchall() == []
+    assert connection.execute("PRAGMA quick_check").fetchall() == [("ok",)]
+    assert schema_fingerprint(connection) == EXPECTED_SCHEMA_FINGERPRINT
+
+
+def test_literal_v21_and_predecessor_pins() -> None:
+    assert (
+        EVENT_HYPOTHESIS_PREDECESSOR_MIGRATION_CHECKSUM
+        == "sha256:6eb04f981f650bbb4956f148d11f1656bcd2b7c510117db96602dd9d83ab9bd3"
+    )
+    assert (
+        EVENT_HYPOTHESIS_PREDECESSOR_FINGERPRINT
+        == "sha256:36a7c9910775ede9c29113a43e08bba261a5a98c4fab5225dd2cae9448689389"
+    )
+    assert (
+        EVENT_HYPOTHESIS_MIGRATION_CHECKSUM
+        == "sha256:42009475669a475af8e3e24bbcd02e6fcd9fbb71a800e18d83624e34e79e5e21"
+    )
+    assert (
+        EXPECTED_SCHEMA_FINGERPRINT
+        == "sha256:d314d06118a25f8a32a0f9d8acb1af5383abd6b30be682cb5f65943ae15c213f"
+    )
+
+
+def test_exact_v20_predecessor_backup_receipt_reuse_and_upgrade(tmp_path: Path) -> None:
+    database = tmp_path / "authority.sqlite3"
+    connection = _fresh(database)
+    _downgrade_to_v20(connection)
+    assert _history(connection) == list(EXPECTED_MIGRATION_HISTORY[:-1])
+    assert schema_fingerprint(connection) == EVENT_HYPOTHESIS_PREDECESSOR_FINGERPRINT
+    backup, digest = event_hypothesis_backup_paths(database)
+    receipt = prepare_event_hypothesis_backup(connection, backup)
+    assert prepare_event_hypothesis_backup(connection, backup) == receipt
+    assert receipt.backup_path == backup and receipt.digest_path == digest
+    apply_pending_migrations(connection, applied_at="2042-01-01T00:00:01.000000Z")
+    assert connection.execute("PRAGMA user_version").fetchone() == (21,)
+    assert _history(connection) == list(EXPECTED_MIGRATION_HISTORY)
+    assert schema_fingerprint(connection) == EXPECTED_SCHEMA_FINGERPRINT
+
+
+@pytest.mark.parametrize(
+    "damage",
+    ("missing-backup", "missing-sidecar", "tampered-backup", "tampered-sidecar"),
+)
+def test_incomplete_or_tampered_v20_backup_is_rejected(
+    tmp_path: Path, damage: str
+) -> None:
+    database = tmp_path / f"{damage}.sqlite3"
+    connection = _fresh(database)
+    _downgrade_to_v20(connection)
+    backup, digest = event_hypothesis_backup_paths(database)
+    prepare_event_hypothesis_backup(connection, backup)
+    if damage == "missing-backup":
+        backup.unlink()
+    elif damage == "missing-sidecar":
+        digest.unlink()
+    elif damage == "tampered-backup":
+        with backup.open("ab") as target:
+            target.write(b"tamper")
+    else:
+        digest.write_text("sha256:" + "0" * 64 + "\n", encoding="ascii")
+    with pytest.raises(EventHypothesisBackupError):
+        apply_pending_migrations(connection, applied_at="2042-01-01T00:00:01.000000Z")
+    assert connection.execute("PRAGMA user_version").fetchone() == (20,)
+    assert _history(connection) == list(EXPECTED_MIGRATION_HISTORY[:-1])
+    assert schema_fingerprint(connection) == EVENT_HYPOTHESIS_PREDECESSOR_FINGERPRINT
+
+
+def test_direct_v20_apply_requires_prepared_backup_and_v22_rejects(
+    tmp_path: Path,
+) -> None:
+    connection = _fresh(tmp_path / "direct.sqlite3")
+    _downgrade_to_v20(connection)
+    with pytest.raises(EventHypothesisBackupError, match="prepared backup"):
+        apply_pending_migrations(connection, applied_at="2042-01-01T00:00:01.000000Z")
+    assert connection.execute("PRAGMA user_version").fetchone() == (20,)
+    assert schema_fingerprint(connection) == EVENT_HYPOTHESIS_PREDECESSOR_FINGERPRINT
+    newer = _open()
+    newer.execute("PRAGMA user_version=22")
+    with pytest.raises(sqlite3.DatabaseError, match="newer"):
+        apply_pending_migrations(newer, applied_at="2042-01-01T00:00:00.000000Z")
+
+
+def test_injected_v21_failure_rolls_back_exact_v20(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    database = tmp_path / "rollback.sqlite3"
+    connection = _fresh(database)
+    _downgrade_to_v20(connection)
+    prepare_event_hypothesis_backup(
+        connection, event_hypothesis_backup_paths(database)[0]
+    )
+    before = schema_fingerprint(connection)
+    monkeypatch.setattr(
+        migrations,
+        "EVENT_HYPOTHESIS_MIGRATION_STATEMENTS",
+        migrations.EVENT_HYPOTHESIS_MIGRATION_STATEMENTS
+        + ("CREATE TABLE injected_failure(",),
+    )
+    with pytest.raises(sqlite3.OperationalError):
+        apply_pending_migrations(connection, applied_at="2042-01-01T00:00:01.000000Z")
+    assert connection.execute("PRAGMA user_version").fetchone() == (20,)
+    assert _history(connection) == list(EXPECTED_MIGRATION_HISTORY[:-1])
+    assert schema_fingerprint(connection) == before
+    assert (
+        connection.execute(
+            "SELECT name FROM sqlite_master WHERE name LIKE 'event_hypothesis%'"
+        ).fetchall()
+        == []
+    )
+
+
+def test_older_file_backed_multihop_retains_each_stage_backup(tmp_path: Path) -> None:
+    # A v19 predecessor must cross the separately retained v20 and v21 backup gates.
+    from newsroom.tests.test_increment6b1_execution_migrations import _downgrade_to_v19
+
+    database = tmp_path / "multihop.sqlite3"
+    connection = _fresh(database)
+    _downgrade_to_v19(connection)
+    migrations.prepare_pending_migration_backup(connection)
+    apply_pending_migrations(connection, applied_at="2042-01-01T00:00:01.000000Z")
+    assert connection.execute("PRAGMA user_version").fetchone() == (21,)
+    assert (tmp_path / "multihop.sqlite3.pre-v20.sqlite3").is_file()
+    assert (tmp_path / "multihop.sqlite3.pre-v20.sqlite3.sha256").is_file()
+    assert (tmp_path / "multihop.sqlite3.pre-v21.sqlite3").is_file()
+    assert (tmp_path / "multihop.sqlite3.pre-v21.sqlite3.sha256").is_file()
+
+
+def test_v21_sql_guards_are_sensitive() -> None:
+    connection = _fresh()
+    # Checks are executable, not merely present in the migration text.
+    with pytest.raises(sqlite3.IntegrityError):
+        connection.execute(
+            "INSERT INTO event_hypotheses_v2 VALUES(?,?,?,?,?,?)",
+            ("id", b"{}", "sha256:" + "0" * 64, "sha256:" + "1" * 64, "event", "time"),
+        )

--- a/newsroom/tests/test_increment6d1_hypothesis_store.py
+++ b/newsroom/tests/test_increment6d1_hypothesis_store.py
@@ -31,6 +31,8 @@ from newsroom.increment6._hypothesis_store import (
 from newsroom.increment6._hypothesis_store import (
     _creation_event_id,
     _HypothesisStore,
+    _require_exact_proposal_authorisation,
+    _require_exact_proposal_provenance,
     _version_event_id,
 )
 from newsroom.increment6.dispositions import (
@@ -51,6 +53,7 @@ from newsroom.increment6.outcomes import (
     CanonicalOutcome,
     ReasonCode,
 )
+from newsroom.increment6.proposals import TriageProposal
 from newsroom.increment6.work_items import (
     RetrievalContextAuthority,
     RetrievalInputBinding,
@@ -519,7 +522,9 @@ def test_self_consistent_direct_tamper_fails_current_and_reopen(tmp_path) -> Non
     _assert_wrong_stable_identity_fails(wrong_identity_fixture, fixture[0], valid)
 
 
-def _assert_self_consistent_disposition_retarget_fails(fixture, valid) -> None:
+def _assert_self_consistent_disposition_retarget_fails(
+    fixture, valid, *, complete_route: bool = False
+) -> None:
     connection = fixture[0]
     old_disposition = ProposalDisposition.from_canonical_bytes(
         bytes(
@@ -536,15 +541,25 @@ def _assert_self_consistent_disposition_retarget_fails(fixture, valid) -> None:
         )
     )
 
-    assert old_disposition.route_binding.hypothesis is not None
-    forged_hypothesis = replace(
-        old_disposition.route_binding.hypothesis,
-        summary="Self-consistent forged summary",
-    )
-    forged_route = replace(
-        old_disposition.route_binding,
-        hypothesis=forged_hypothesis,
-    )
+    if complete_route:
+        assert old_disposition.route_binding.candidate_manifest is not None
+        forged_route = replace(
+            old_disposition.route_binding,
+            candidate_manifest=replace(
+                old_disposition.route_binding.candidate_manifest,
+                likely_new_information="Self-consistent forged Candidate coverage.",
+            ),
+        )
+    else:
+        assert old_disposition.route_binding.hypothesis is not None
+        forged_hypothesis = replace(
+            old_disposition.route_binding.hypothesis,
+            summary="Self-consistent forged summary",
+        )
+        forged_route = replace(
+            old_disposition.route_binding,
+            hypothesis=forged_hypothesis,
+        )
     forged_route_digest = digest_bytes(
         canonical_json_bytes(forged_route.canonical_value())
     )
@@ -661,6 +676,214 @@ def _assert_self_consistent_disposition_retarget_fails(fixture, valid) -> None:
     with pytest.raises(HypothesisContractError, match="exact Proposal group"):
         _open(fixture)
     connection.close()
+
+
+def test_self_consistent_complete_route_rewrite_fails_reopen(tmp_path) -> None:
+    fixture = _authority_fixture(tmp_path)
+    authority = _open(fixture)
+    valid = authority.retain(fixture[4], fixture[5], proof=fixture[3])
+    authority.close()
+    _assert_self_consistent_disposition_retarget_fails(
+        fixture, valid, complete_route=True
+    )
+
+
+def test_exact_proposal_authorisation_compares_complete_recommendation(
+    tmp_path,
+) -> None:
+    fixture = _authority_fixture(tmp_path)
+    proposal = TriageProposal.from_canonical_bytes(fixture[4])
+    disposition = fixture[5][0]
+    recommendation = next(
+        item
+        for item in proposal.recommendations
+        if item.decision_lead_id == disposition.decision_lead_id
+    )
+    forged_route = replace(
+        disposition.route_binding,
+        materiality_basis="A different but self-consistent retained route binding.",
+    )
+    forged_route_digest = digest_bytes(
+        canonical_json_bytes(forged_route.canonical_value())
+    )
+    identity = disposition._identity_value()
+    identity.update(
+        route_binding=forged_route.canonical_value(),
+        route_binding_digest=forged_route_digest,
+    )
+    forged = replace(
+        disposition,
+        disposition_id=digest_bytes(canonical_json_bytes(identity)),
+        route_binding=forged_route,
+        route_binding_digest=forged_route_digest,
+    )
+    assert recommendation.hypothesis is not None
+    with pytest.raises(HypothesisContractError, match="exact Proposal group"):
+        _require_exact_proposal_authorisation(
+            forged,
+            recommendation,
+            proposal,
+            digest_bytes(fixture[4]),
+        )
+
+
+def test_version_provenance_must_equal_retained_proposal_binding(tmp_path) -> None:
+    fixture = _authority_fixture(tmp_path)
+    authority = _open(fixture)
+    value = authority.retain(fixture[4], fixture[5], proof=fixture[3])
+    authority.close()
+    connection, _, _, _, _, _, work_store, item, first_work, *_ = fixture
+    second_work = replace(
+        work_item_helpers._version(item, 2), retrieval=first_work.retrieval
+    )
+    work_store.append_version(
+        first_work.version_id, first_work.canonical_digest, second_work
+    )
+    old_disposition = ProposalDisposition.from_canonical_bytes(
+        bytes(
+            connection.execute(
+                "SELECT canonical_bytes FROM triage_proposal_dispositions"
+            ).fetchone()[0]
+        )
+    )
+    disposition_identity = old_disposition._identity_value()
+    disposition_identity.update(
+        work_item_version_id=second_work.version_id,
+        work_item_version_digest=second_work.canonical_digest,
+    )
+    forged_disposition = replace(
+        old_disposition,
+        disposition_id=digest_bytes(canonical_json_bytes(disposition_identity)),
+        work_item_version_id=second_work.version_id,
+        work_item_version_digest=second_work.canonical_digest,
+    )
+    forged_bindings = _HypothesisStore._bindings((forged_disposition,))
+    forged_event_id = _version_event_id(
+        value.hypothesis_id,
+        value.ordinal,
+        value.previous_version_digest,
+        value.proposal_canonical_digest,
+        value.proposal_local_id,
+        value.target_version_digest,
+        forged_bindings,
+        value.actor_identity_digest,
+        value.recorded_at,
+    )
+    forged_version = replace(
+        value,
+        work_item_version_id=second_work.version_id,
+        work_item_version_digest=second_work.canonical_digest,
+        source_bindings=forged_bindings,
+        authority_event_id=forged_event_id,
+    )
+    affected_tables = (
+        "'triage_proposal_validation_findings',"
+        "'triage_proposal_dispositions',"
+        "'event_hypothesis_versions_v2',"
+        "'event_hypothesis_heads_v2'"
+    )
+    triggers = connection.execute(
+        "SELECT name,sql FROM sqlite_master WHERE type='trigger' "
+        f"AND tbl_name IN ({affected_tables}) ORDER BY name"
+    ).fetchall()
+    connection.execute("PRAGMA foreign_keys=OFF")
+    connection.execute("BEGIN")
+    for name, _ in triggers:
+        connection.execute(f'DROP TRIGGER "{name}"')
+    connection.execute(
+        "UPDATE triage_proposal_validation_findings SET "
+        "work_item_version_id=?,work_item_version_digest=?",
+        (second_work.version_id, second_work.canonical_digest),
+    )
+    connection.execute(
+        "UPDATE triage_proposal_dispositions SET disposition_id=?,"
+        "work_item_version_id=?,work_item_version_digest=?,"
+        "canonical_bytes=?,canonical_digest=? WHERE disposition_id=?",
+        (
+            forged_disposition.disposition_id,
+            second_work.version_id,
+            second_work.canonical_digest,
+            forged_disposition.canonical_bytes,
+            digest_bytes(forged_disposition.canonical_bytes),
+            old_disposition.disposition_id,
+        ),
+    )
+    connection.execute(
+        "UPDATE event_hypothesis_versions_v2 SET work_item_version_id=?,"
+        "work_item_version_digest=?,authority_event_id=?,canonical_bytes=?,"
+        "canonical_digest=? WHERE version_id=?",
+        (
+            second_work.version_id,
+            second_work.canonical_digest,
+            forged_version.authority_event_id,
+            forged_version.canonical_bytes,
+            forged_version.canonical_digest,
+            forged_version.version_id,
+        ),
+    )
+    connection.execute(
+        "UPDATE event_hypothesis_heads_v2 SET version_digest=? WHERE version_id=?",
+        (forged_version.canonical_digest, forged_version.version_id),
+    )
+    for _, statement in triggers:
+        connection.execute(statement)
+    connection.execute("COMMIT")
+    connection.execute("PRAGMA foreign_keys=ON")
+    assert connection.execute("PRAGMA foreign_key_check").fetchall() == []
+    proposal = TriageProposal.from_canonical_bytes(fixture[4])
+    with pytest.raises(HypothesisContractError, match="exact Proposal"):
+        _require_exact_proposal_provenance(forged_version, proposal)
+    with pytest.raises(HypothesisContractError, match="exact Proposal"):
+        _open(fixture)
+
+
+@pytest.mark.parametrize("operation", ("load_version", "load_hypothesis", "versions"))
+def test_historical_reads_revalidate_post_open_integrity(
+    tmp_path, operation: str
+) -> None:
+    fixture = _authority_fixture(tmp_path)
+    authority = _open(fixture)
+    value = authority.retain(fixture[4], fixture[5], proof=fixture[3])
+    connection = fixture[0]
+    if operation == "load_hypothesis":
+        trigger_name = "immutable_event_hypothesis_update"
+        statement = "UPDATE event_hypotheses_v2 SET canonical_digest=?"
+    else:
+        trigger_name = "immutable_event_hypothesis_version_update"
+        statement = "UPDATE event_hypothesis_versions_v2 SET canonical_digest=?"
+    trigger = connection.execute(
+        "SELECT sql FROM sqlite_master WHERE name=?", (trigger_name,)
+    ).fetchone()[0]
+    connection.execute(f"DROP TRIGGER {trigger_name}")
+    connection.execute(statement, (_D2,))
+    connection.execute(trigger)
+    with pytest.raises(HypothesisContractError):
+        if operation == "load_version":
+            authority.load_version(value.version_id)
+        elif operation == "load_hypothesis":
+            authority.load_hypothesis(value.hypothesis_id)
+        else:
+            authority.versions(value.hypothesis_id)
+
+
+def test_replay_revalidates_retained_disposition_without_upstream_currentness(
+    tmp_path,
+) -> None:
+    fixture = _authority_fixture(tmp_path)
+    authority = _open(fixture)
+    authority.retain(fixture[4], fixture[5], proof=fixture[3])
+    connection = fixture[0]
+    trigger = connection.execute(
+        "SELECT sql FROM sqlite_master "
+        "WHERE name='immutable_triage_proposal_dispositions_update'"
+    ).fetchone()[0]
+    connection.execute("DROP TRIGGER immutable_triage_proposal_dispositions_update")
+    connection.execute(
+        "UPDATE triage_proposal_dispositions SET work_item_version_digest=?", (_D2,)
+    )
+    connection.execute(trigger)
+    with pytest.raises(HypothesisContractError):
+        authority.retain(fixture[4], fixture[5], proof=fixture[3])
 
 
 def _assert_wrong_stable_identity_fails(fixture, source, valid) -> None:

--- a/newsroom/tests/test_increment6d1_hypothesis_store.py
+++ b/newsroom/tests/test_increment6d1_hypothesis_store.py
@@ -33,7 +33,13 @@ from newsroom.increment6._hypothesis_store import (
     _HypothesisStore,
     _version_event_id,
 )
-from newsroom.increment6.dispositions import ProposalDispositionStore
+from newsroom.increment6.dispositions import (
+    _FINDING_SET_SCHEMA_VERSION,
+    DispositionAuthority,
+    ProposalDisposition,
+    ProposalDispositionStore,
+    ProposalValidationFinding,
+)
 from newsroom.increment6.hypotheses import (
     EVENT_HYPOTHESIS,
     EventHypothesisAuthority,
@@ -462,6 +468,153 @@ def test_direct_scalar_tamper_is_detected_by_current_and_reopen(tmp_path) -> Non
         ("sha256:" + "f" * 64,),
     )
     with pytest.raises(HypothesisContractError):
+        _open(fixture)
+
+
+def test_self_consistent_disposition_retarget_fails_reopen(tmp_path) -> None:
+    fixture = _authority_fixture(tmp_path)
+    connection = fixture[0]
+    authority = _open(fixture)
+    valid = authority.retain(fixture[4], fixture[5], proof=fixture[3])
+    authority.close()
+    old_disposition = ProposalDisposition.from_canonical_bytes(
+        bytes(
+            connection.execute(
+                "SELECT canonical_bytes FROM triage_proposal_dispositions"
+            ).fetchone()[0]
+        )
+    )
+    old_finding = ProposalValidationFinding.from_canonical_bytes(
+        bytes(
+            connection.execute(
+                "SELECT canonical_bytes FROM triage_proposal_validation_findings"
+            ).fetchone()[0]
+        )
+    )
+
+    assert old_disposition.route_binding.hypothesis is not None
+    forged_hypothesis = replace(
+        old_disposition.route_binding.hypothesis,
+        summary="Self-consistent forged summary",
+    )
+    forged_route = replace(
+        old_disposition.route_binding,
+        hypothesis=forged_hypothesis,
+    )
+    forged_route_digest = digest_bytes(
+        canonical_json_bytes(forged_route.canonical_value())
+    )
+    finding_identity = old_finding._identity_value()
+    finding_identity["evidence_reference_digest"] = forged_route_digest
+    forged_finding_id = digest_bytes(canonical_json_bytes(finding_identity))
+    forged_finding = replace(
+        old_finding,
+        finding_id=forged_finding_id,
+        evidence_reference_digest=forged_route_digest,
+    )
+    forged_finding_set_digest = digest_bytes(
+        canonical_json_bytes(
+            {
+                "schema_version": _FINDING_SET_SCHEMA_VERSION,
+                "proposal_content_identity": forged_finding.proposal_content_identity,
+                "validator_input_binding": forged_finding.validator_input.canonical_value(),
+                "finding_ids": [forged_finding.finding_id],
+                "authority": DispositionAuthority.NONE.value,
+            }
+        )
+    )
+    disposition_identity = old_disposition._identity_value()
+    disposition_identity.update(
+        finding_set_digest=forged_finding_set_digest,
+        route_binding=forged_route.canonical_value(),
+        route_binding_digest=forged_route_digest,
+    )
+    forged_disposition_id = digest_bytes(canonical_json_bytes(disposition_identity))
+    forged_disposition = replace(
+        old_disposition,
+        disposition_id=forged_disposition_id,
+        finding_set_digest=forged_finding_set_digest,
+        route_binding=forged_route,
+        route_binding_digest=forged_route_digest,
+    )
+    forged_bindings = _HypothesisStore._bindings((forged_disposition,))
+    forged_event_id = _version_event_id(
+        valid.hypothesis_id,
+        valid.ordinal,
+        valid.previous_version_digest,
+        valid.proposal_canonical_digest,
+        valid.proposal_local_id,
+        valid.target_version_digest,
+        forged_bindings,
+        valid.actor_identity_digest,
+        valid.recorded_at,
+    )
+    forged_version = replace(
+        valid,
+        source_bindings=forged_bindings,
+        authority_event_id=forged_event_id,
+    )
+
+    affected_tables = (
+        "'triage_proposal_validation_findings',"
+        "'triage_proposal_dispositions',"
+        "'event_hypothesis_versions_v2',"
+        "'event_hypothesis_heads_v2'"
+    )
+    triggers = connection.execute(
+        "SELECT name,sql FROM sqlite_master WHERE type='trigger' "
+        f"AND tbl_name IN ({affected_tables}) ORDER BY name"
+    ).fetchall()
+    connection.execute("PRAGMA foreign_keys=OFF")
+    connection.execute("BEGIN")
+    for name, _ in triggers:
+        connection.execute(f'DROP TRIGGER "{name}"')
+    connection.execute(
+        "UPDATE triage_proposal_validation_findings SET "
+        "finding_id=?,finding_set_digest=?,canonical_bytes=?,canonical_digest=? "
+        "WHERE finding_id=?",
+        (
+            forged_finding.finding_id,
+            forged_finding_set_digest,
+            forged_finding.canonical_bytes,
+            digest_bytes(forged_finding.canonical_bytes),
+            old_finding.finding_id,
+        ),
+    )
+    connection.execute(
+        "UPDATE triage_proposal_dispositions SET "
+        "disposition_id=?,finding_set_digest=?,finding_id=?,canonical_bytes=?,canonical_digest=? "
+        "WHERE disposition_id=?",
+        (
+            forged_disposition.disposition_id,
+            forged_finding_set_digest,
+            forged_finding.finding_id,
+            forged_disposition.canonical_bytes,
+            digest_bytes(forged_disposition.canonical_bytes),
+            old_disposition.disposition_id,
+        ),
+    )
+    connection.execute(
+        "UPDATE event_hypothesis_versions_v2 SET "
+        "authority_event_id=?,canonical_bytes=?,canonical_digest=? WHERE version_id=?",
+        (
+            forged_version.authority_event_id,
+            forged_version.canonical_bytes,
+            forged_version.canonical_digest,
+            forged_version.version_id,
+        ),
+    )
+    connection.execute(
+        "UPDATE event_hypothesis_heads_v2 SET version_digest=? WHERE version_id=?",
+        (forged_version.canonical_digest, forged_version.version_id),
+    )
+    for _, statement in triggers:
+        connection.execute(statement)
+    connection.execute("COMMIT")
+    connection.execute("PRAGMA foreign_keys=ON")
+    assert connection.execute("PRAGMA foreign_key_check").fetchall() == []
+
+    with pytest.raises(HypothesisContractError, match="exact Proposal group"):
         _open(fixture)
 
 
@@ -1113,8 +1266,9 @@ _SINGLE_INTEGRITY_MUTATIONS = (
 )
 
 
+@pytest.mark.parametrize("shard", range(4))
 def test_retained_single_version_integrity_mutations_fail_current_and_reopen(
-    tmp_path,
+    tmp_path, shard: int
 ) -> None:
     fixture = _authority_fixture(tmp_path)
     seed = _open(fixture)
@@ -1123,6 +1277,8 @@ def test_retained_single_version_integrity_mutations_fail_current_and_reopen(
     for index, (trigger, statement, parameters) in enumerate(
         _SINGLE_INTEGRITY_MUTATIONS
     ):
+        if index % 4 != shard:
+            continue
         database = tmp_path / f"retained-{index}.sqlite3"
         copied = sqlite3.connect(database, isolation_level=None)
         fixture[0].backup(copied)
@@ -1196,8 +1352,9 @@ _CHAIN_INTEGRITY_MUTATIONS = (
 )
 
 
+@pytest.mark.parametrize("shard", range(2))
 def test_retained_chain_gaps_and_noncontiguous_links_fail_closed(
-    tmp_path,
+    tmp_path, shard: int
 ) -> None:
     fixture = _authority_fixture(tmp_path)
     seed = _open(fixture)
@@ -1212,6 +1369,8 @@ def test_retained_chain_gaps_and_noncontiguous_links_fail_closed(
     last = seed.retain(raw, source, proof=fixture[3], expected_target_version=first)
     seed.close()
     for index, (trigger, statement) in enumerate(_CHAIN_INTEGRITY_MUTATIONS):
+        if index % 2 != shard:
+            continue
         database = tmp_path / f"chain-{index}.sqlite3"
         copied = sqlite3.connect(database, isolation_level=None)
         fixture[0].backup(copied)

--- a/newsroom/tests/test_increment6d1_hypothesis_store.py
+++ b/newsroom/tests/test_increment6d1_hypothesis_store.py
@@ -55,6 +55,7 @@ from newsroom.increment6.work_items import (
     RetrievalContextAuthority,
     RetrievalInputBinding,
     TriageWorkItem,
+    TriageWorkItemStore,
 )
 from newsroom.tests import test_increment5d1_hybrid_composer as composer_helpers
 from newsroom.tests import test_increment5d2_retrieval_context as retrieval_helpers
@@ -62,7 +63,7 @@ from newsroom.tests import test_increment6a2_work_items as work_item_helpers
 from newsroom.tests import test_increment6c2_dispositions as disposition_helpers
 
 
-def _authority_fixture(tmp_path, *, persist_sources: bool = True):
+def _build_authority_fixture(tmp_path, *, persist_sources: bool = True):
     inputs = composer_helpers.branch_inputs.__wrapped__(tmp_path)
     builder, _, _, _, _, request, receipt, _ = (
         retrieval_helpers._retained_complete_context(
@@ -134,6 +135,39 @@ def _authority_fixture(tmp_path, *, persist_sources: bool = True):
         receipt,
         proposal_sources,
     )
+
+
+_AUTHORITY_SEED = None
+
+
+def _clone_authority_fixture(seed):
+    connection = sqlite3.connect(":memory:", isolation_level=None)
+    seed[0].backup(connection)
+    retrieval = seed[1]
+    work_store = TriageWorkItemStore(connection, retrieval)
+    return (
+        connection,
+        retrieval,
+        seed[2],
+        seed[3],
+        seed[4],
+        seed[5],
+        work_store,
+        seed[7],
+        seed[8],
+        seed[9],
+        seed[10],
+        list(seed[11]),
+    )
+
+
+def _authority_fixture(tmp_path, *, persist_sources: bool = True):
+    if not persist_sources:
+        return _build_authority_fixture(tmp_path, persist_sources=False)
+    global _AUTHORITY_SEED
+    if _AUTHORITY_SEED is None:
+        _AUTHORITY_SEED = _build_authority_fixture(tmp_path)
+    return _clone_authority_fixture(_AUTHORITY_SEED)
 
 
 def _open(fixture):

--- a/newsroom/tests/test_increment6d1_hypothesis_store.py
+++ b/newsroom/tests/test_increment6d1_hypothesis_store.py
@@ -1,0 +1,1147 @@
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from copy import deepcopy
+from dataclasses import replace
+
+import pytest
+
+from newsroom.authority.auth import (
+    AuthenticationProof,
+    StaticAuthenticator,
+    StaticPrincipal,
+)
+from newsroom.authority.event_hypothesis_migrations import (
+    EVENT_HYPOTHESIS_MIGRATION_STATEMENTS,
+)
+from newsroom.authority.migrations import apply_pending_migrations
+from newsroom.authority.triage_disposition_migrations import (
+    TRIAGE_DISPOSITION_MIGRATION_STATEMENTS,
+)
+from newsroom.authority.types import UtcTimestamp
+from newsroom.increment6._hypothesis_store import (
+    EventHypothesisAuthority as PrivateAuthority,
+)
+from newsroom.increment6._hypothesis_store import (
+    _HypothesisStore,
+)
+from newsroom.increment6.dispositions import ProposalDispositionStore
+from newsroom.increment6.hypotheses import (
+    EventHypothesisAuthority,
+    HypothesisContractError,
+    open_event_hypothesis_authority,
+)
+from newsroom.increment6.outcomes import (
+    CanonicalNextAction,
+    CanonicalOutcome,
+    ReasonCode,
+)
+from newsroom.increment6.work_items import (
+    RetrievalContextAuthority,
+    RetrievalInputBinding,
+    TriageWorkItem,
+)
+from newsroom.tests import test_increment5d1_hybrid_composer as composer_helpers
+from newsroom.tests import test_increment5d2_retrieval_context as retrieval_helpers
+from newsroom.tests import test_increment6a2_work_items as work_item_helpers
+from newsroom.tests import test_increment6c2_dispositions as disposition_helpers
+
+
+def _authority_fixture(tmp_path, *, persist_sources: bool = True):
+    inputs = composer_helpers.branch_inputs.__wrapped__(tmp_path)
+    builder, _, _, _, _, request, receipt, _ = (
+        retrieval_helpers._retained_complete_context(
+            tmp_path, inputs, name="hypothesis-authority"
+        )
+    )
+    retrieval = RetrievalContextAuthority(
+        builder.journal.path, {request.request_digest: (request, receipt)}
+    )
+    decisions = tuple(work_item_helpers._decision(index) for index in range(1, 17))
+    decision = decisions[0]
+    connection, work_store = work_item_helpers._store(
+        decisions, retrieval_authority=retrieval
+    )
+    item = TriageWorkItem.create((decision,))
+    version = replace(
+        work_item_helpers._version(item),
+        retrieval=RetrievalInputBinding.from_receipt(request, receipt),
+    )
+    work_store.create_or_replay(item, version)
+    proposal_sources = []
+    for candidate in decisions[1:]:
+        candidate_item = TriageWorkItem.create((candidate,))
+        candidate_version = replace(
+            work_item_helpers._version(candidate_item),
+            retrieval=RetrievalInputBinding.from_receipt(request, receipt),
+        )
+        if persist_sources:
+            work_store.create_or_replay(candidate_item, candidate_version)
+        proposal_sources.append((candidate_version, candidate))
+    for statement in (
+        *TRIAGE_DISPOSITION_MIGRATION_STATEMENTS,
+        *EVENT_HYPOTHESIS_MIGRATION_STATEMENTS,
+    ):
+        connection.execute(statement)
+    authenticator = StaticAuthenticator(
+        credentials={
+            "credential": StaticPrincipal("editor"),
+            "other": StaticPrincipal("other"),
+        },
+        authority_domain="newsroom.dispositions",
+    )
+    proof = AuthenticationProof(method="STATIC_TOKEN", credential="credential")
+    proposal = disposition_helpers._persistable_proposal(version, decision, receipt)
+    dispositions = ProposalDispositionStore(
+        connection, retrieval, authenticator
+    ).persist(
+        proposal,
+        {
+            decision.lead_id: disposition_helpers._selection(
+                CanonicalOutcome.LEAD_ADMIT_NEW_CANDIDATE,
+                CanonicalNextAction.HANDOFF_FOR_EVALUATION,
+                ReasonCode.NOVELTY_LIKELY_NEW_EVENT,
+            )
+        },
+        proof=proof,
+    )
+    return (
+        connection,
+        retrieval,
+        authenticator,
+        proof,
+        proposal,
+        dispositions,
+        work_store,
+        item,
+        version,
+        decision,
+        receipt,
+        proposal_sources,
+    )
+
+
+def _open(fixture):
+    connection, retrieval, authenticator, *_ = fixture
+    store = _HypothesisStore(
+        connection,
+        retrieval,
+        authenticator,
+        lambda: UtcTimestamp.parse("2042-01-01T00:00:00.000000Z"),
+    )
+    return EventHypothesisAuthority(PrivateAuthority(store, lambda: None))
+
+
+def _selection_for(relationship: str):
+    return {
+        "RELATED_DISTINCT": disposition_helpers._selection(
+            CanonicalOutcome.LEAD_ASSOCIATE_WITHOUT_CANDIDATE,
+            CanonicalNextAction.CLOSE_DECISION,
+            ReasonCode.REL_RELATED_DISTINCT,
+        ),
+        "UNCERTAIN": disposition_helpers._selection(
+            CanonicalOutcome.LEAD_ASSOCIATE_WITHOUT_CANDIDATE,
+            CanonicalNextAction.CLOSE_DECISION,
+            ReasonCode.REL_UNCERTAIN,
+        ),
+        "SAME_STATE": disposition_helpers._selection(
+            CanonicalOutcome.LEAD_ASSOCIATE_WITHOUT_CANDIDATE,
+            CanonicalNextAction.CLOSE_DECISION,
+            ReasonCode.REL_SAME_STATE,
+        ),
+        "DEVELOPMENT_OF": disposition_helpers._selection(
+            CanonicalOutcome.LEAD_ADMIT_DEVELOPMENT_CANDIDATE,
+            CanonicalNextAction.HANDOFF_FOR_EVALUATION,
+            ReasonCode.REL_DEVELOPMENT,
+        ),
+    }[relationship]
+
+
+def _targeted_proposal(
+    fixture, *, proposal_id: str, local_id: str, relationship: str, target: str
+) -> tuple[bytes, tuple]:
+    connection, retrieval, authenticator, proof, _, _, _, _, _, _, receipt, sources = (
+        fixture
+    )
+    version, decision = sources.pop(0)
+    base = disposition_helpers._persistable_proposal(version, decision, receipt)
+    document = json.loads(base)
+    proposal = document["proposal"]
+    proposal["proposal_id"] = proposal_id
+    recommendation = proposal["recommendations"][0]
+    route = (
+        "DEVELOPMENT_CANDIDATE"
+        if relationship == "DEVELOPMENT_OF"
+        else "ASSOCIATE_WITHOUT_CANDIDATE"
+    )
+    recommendation["route"] = route
+    recommendation["hypothesis"] = {
+        "proposal_local_id": local_id,
+        "summary": f"A retained {relationship.lower()} relationship.",
+        "relationship_kind": relationship,
+        "target_hypothesis_id": target,
+    }
+    for citation in recommendation["input_citations"]:
+        citation["target_hypothesis_id"] = (
+            target if citation["source_kind"] == "RETRIEVAL_MATCH" else None
+        )
+    if route == "ASSOCIATE_WITHOUT_CANDIDATE":
+        recommendation["candidate_manifest"] = None
+    else:
+        recommendation["candidate_manifest"]["manifest_kind"] = "DEVELOPMENT"
+    raw = disposition_helpers._resign(document)
+    dispositions = ProposalDispositionStore(
+        connection, retrieval, authenticator
+    ).persist(raw, {decision.lead_id: _selection_for(relationship)}, proof=proof)
+    return raw, dispositions
+
+
+def _reopen_copy(fixture, authority):
+    connection, retrieval, authenticator, *rest = fixture
+    authority.close()
+    reopened = sqlite3.connect(":memory:", isolation_level=None)
+    connection.backup(reopened)
+    return _open((reopened, retrieval, authenticator, *rest)), reopened
+
+
+def test_real_store_create_replay_current_history_and_reopen(tmp_path) -> None:
+    fixture = _authority_fixture(tmp_path)
+    _, _, _, proof, proposal, dispositions, *_ = fixture
+    authority = _open(fixture)
+    try:
+        first = authority.retain(proposal, dispositions, proof=proof)
+        assert authority.retain(proposal, dispositions, proof=proof) == first
+        assert authority.current(first.hypothesis_id, proof=proof) == first
+        assert authority.load_version(first.version_id) == first
+        assert (
+            authority.load_hypothesis(first.hypothesis_id).hypothesis_id
+            == first.hypothesis_id
+        )
+        assert authority.versions(first.hypothesis_id) == (first,)
+        assert (
+            first.actor_identity_digest
+            == dispositions[0].validator_input.authenticated_context_identity
+        )
+        assert first.recorded_at == "2042-01-01T00:00:00.000000Z"
+    finally:
+        authority.close()
+    connection, retrieval, authenticator, *_ = fixture
+    reopened_connection = sqlite3.connect(":memory:", isolation_level=None)
+    connection.backup(reopened_connection)
+    reopened_fixture = (reopened_connection, retrieval, authenticator, *fixture[3:])
+    assert _open(reopened_fixture).current(first.hypothesis_id, proof=proof) == first
+
+
+def test_wrong_proof_partial_or_unretained_inputs_write_nothing(tmp_path) -> None:
+    fixture = _authority_fixture(tmp_path)
+    connection, _, _, proof, proposal, dispositions, *_ = fixture
+    other = AuthenticationProof(method="STATIC_TOKEN", credential="other")
+    authority = _open(fixture)
+    try:
+        with pytest.raises(HypothesisContractError):
+            authority.retain(proposal, dispositions, proof=other)
+        with pytest.raises(HypothesisContractError):
+            authority.retain(proposal, (), proof=proof)
+    finally:
+        authority.close()
+    assert connection.execute(
+        "SELECT count(*) FROM event_hypothesis_versions_v2"
+    ).fetchone() == (0,)
+
+
+def test_complete_two_lead_proposal_group_retains_once_and_partial_writes_zero(
+    tmp_path,
+) -> None:
+    fixture = _authority_fixture(tmp_path, persist_sources=False)
+    connection, retrieval, authenticator, proof, _, _, _, _, _, _, receipt, sources = (
+        fixture
+    )
+    first_version, first_decision = sources.pop(0)
+    _second_version, second_decision = sources.pop(0)
+    # Re-persist both Leads in one real Work Item/Version authority boundary.
+    item = TriageWorkItem.create((first_decision, second_decision))
+    version = replace(
+        work_item_helpers._version(item),
+        retrieval=first_version.retrieval,
+    )
+    fixture[6].create_or_replay(item, version)
+    document = json.loads(
+        disposition_helpers._persistable_proposal(version, first_decision, receipt)
+    )
+    proposal = document["proposal"]
+    first = proposal["recommendations"][0]
+    second = deepcopy(first)
+    second["decision_lead_id"] = second_decision.lead_id
+    second["input_citations"][0]["source_id"] = second_decision.lead_id
+    second["input_citations"][0]["source_digest"] = second_decision.lead_digest
+    second["candidate_manifest"]["contributing_lead_ids"] = [second_decision.lead_id]
+    proposal["decision_lead_ids"] = sorted(
+        (first_decision.lead_id, second_decision.lead_id)
+    )
+    proposal["recommendations"] = sorted(
+        (first, second), key=lambda recommendation: recommendation["decision_lead_id"]
+    )
+    raw = disposition_helpers._resign(document)
+    selection = disposition_helpers._selection(
+        CanonicalOutcome.LEAD_ADMIT_NEW_CANDIDATE,
+        CanonicalNextAction.HANDOFF_FOR_EVALUATION,
+        ReasonCode.NOVELTY_LIKELY_NEW_EVENT,
+    )
+    retained = ProposalDispositionStore(connection, retrieval, authenticator).persist(
+        raw,
+        {first_decision.lead_id: selection, second_decision.lead_id: selection},
+        proof=proof,
+    )
+    authority = _open(fixture)
+    with pytest.raises(HypothesisContractError):
+        authority.retain(raw, retained[:1], proof=proof)
+    assert connection.execute(
+        "SELECT count(*) FROM event_hypothesis_versions_v2"
+    ).fetchone() == (0,)
+    value = authority.retain(raw, retained, proof=proof)
+    assert tuple(
+        binding.decision_lead_id for binding in value.source_bindings
+    ) == tuple(sorted((first_decision.lead_id, second_decision.lead_id)))
+    assert authority.retain(raw, retained, proof=proof) == value
+    assert connection.execute(
+        "SELECT count(*) FROM event_hypothesis_versions_v2"
+    ).fetchone() == (1,)
+
+
+def test_legal_large_producer_envelope_round_trips_without_inflating_public_version(
+    tmp_path,
+) -> None:
+    fixture = _authority_fixture(tmp_path, persist_sources=False)
+    connection, retrieval, authenticator, proof, _, _, _, _, _, _, receipt, sources = (
+        fixture
+    )
+    selected = sources[:8]
+    decisions = tuple(decision for _, decision in selected)
+    item = TriageWorkItem.create(decisions)
+    version = replace(
+        work_item_helpers._version(item), retrieval=selected[0][0].retrieval
+    )
+    fixture[6].create_or_replay(item, version)
+    legal_proposal = json.loads(
+        disposition_helpers._persistable_proposal(version, decisions[0], receipt)
+    )["proposal"]
+    legal = legal_proposal["recommendations"][0]
+    document = json.loads(disposition_helpers._reviewed_large_producer_payload())
+    proposal = document["proposal"]
+    proposal["work_item_binding"] = {
+        "work_item_id": version.work_item_id,
+        "work_item_version_id": version.version_id,
+        "work_item_version_digest": version.canonical_digest,
+    }
+    proposal["retrieval_context_binding"] = {
+        "context_id": receipt.context_id,
+        "context_digest": receipt.receipt_digest,
+        "contract_digest": legal_proposal["retrieval_context_binding"][
+            "contract_digest"
+        ],
+    }
+    proposal["worker_attempt_binding"]["work_item_version_digest"] = (
+        version.canonical_digest
+    )
+    proposal["worker_attempt_binding"]["retrieval_context_digest"] = (
+        receipt.receipt_digest
+    )
+    ordered = tuple(sorted(decisions, key=lambda decision: decision.lead_id))
+    proposal["decision_lead_ids"] = [decision.lead_id for decision in ordered]
+    manifest = deepcopy(legal["candidate_manifest"])
+    manifest["contributing_lead_ids"] = [decision.lead_id for decision in ordered]
+    manifest["likely_new_information"] = "n" * 1_024
+    manifest["reader_utility_basis"] = "u" * 1_024
+    manifest["uncertainties"] = [f"{index:02d}:" + "x" * 1_021 for index in range(32)]
+    manifest["evidence_objectives"] = [
+        f"{index:02d}:" + "y" * 1_021 for index in range(32)
+    ]
+    passage = receipt.items[0].passage
+    text = receipt.items[0].text.encode("utf-8")
+    for recommendation, decision in zip(
+        proposal["recommendations"], ordered, strict=True
+    ):
+        recommendation["decision_lead_id"] = decision.lead_id
+        recommendation["route"] = "NEW_EVENT_CANDIDATE"
+        recommendation["hypothesis"] = deepcopy(legal["hypothesis"])
+        recommendation["candidate_manifest"] = deepcopy(manifest)
+        for index, citation in enumerate(recommendation["input_citations"]):
+            if index == 0:
+                citation.update(
+                    source_kind="DECISION_LEAD",
+                    source_id=decision.lead_id,
+                    source_digest=decision.lead_digest,
+                    byte_start=0,
+                    byte_end=18,
+                )
+            else:
+                citation.update(
+                    source_kind="RETRIEVAL_MATCH",
+                    source_id=passage.passage_id,
+                    source_digest=passage.text_digest,
+                    byte_start=0,
+                    byte_end=len(text),
+                    quote_digest=disposition_helpers.digest_bytes(text),
+                    field_path="passage.text",
+                )
+            citation["target_hypothesis_id"] = None
+    raw = disposition_helpers._resign(document)
+    assert len(raw) > 1_100_000
+    selection = disposition_helpers._selection(
+        CanonicalOutcome.LEAD_ADMIT_NEW_CANDIDATE,
+        CanonicalNextAction.HANDOFF_FOR_EVALUATION,
+        ReasonCode.NOVELTY_LIKELY_NEW_EVENT,
+    )
+    retained = ProposalDispositionStore(connection, retrieval, authenticator).persist(
+        raw, {decision.lead_id: selection for decision in ordered}, proof=proof
+    )
+    value = _open(fixture).retain(raw, retained, proof=proof)
+    stored = connection.execute(
+        "SELECT proposal_canonical_bytes FROM event_hypothesis_versions_v2"
+    ).fetchone()[0]
+    assert bytes(stored) == raw
+    assert len(value.canonical_bytes) <= 1_048_576
+
+
+def test_second_opener_and_unsafe_modes_fail_closed(tmp_path) -> None:
+    fixture = _authority_fixture(tmp_path)
+    _, retrieval, authenticator, *_ = fixture
+    database = tmp_path / "secure" / "authority.sqlite3"
+    database.parent.mkdir(mode=0o700)
+    seed = sqlite3.connect(database, isolation_level=None)
+    seed.execute("PRAGMA foreign_keys=ON")
+    apply_pending_migrations(seed, applied_at="2042-01-01T00:00:00.000000Z")
+    seed.close()
+    os.chmod(database, 0o600)
+
+    def opened():
+        return open_event_hypothesis_authority(
+            database, retrieval_authority=retrieval, authenticator=authenticator
+        )
+
+    first = opened()
+    try:
+        with pytest.raises(HypothesisContractError, match="writer"):
+            opened()
+    finally:
+        first.close()
+    os.chmod(database, 0o640)
+    with pytest.raises(HypothesisContractError):
+        open_event_hypothesis_authority(
+            database, retrieval_authority=retrieval, authenticator=authenticator
+        )
+
+
+def test_direct_scalar_tamper_is_detected_by_current_and_reopen(tmp_path) -> None:
+    fixture = _authority_fixture(tmp_path)
+    connection, _, _, proof, proposal, dispositions, *_ = fixture
+    authority = _open(fixture)
+    try:
+        authority.retain(proposal, dispositions, proof=proof)
+    finally:
+        authority.close()
+    connection.execute("DROP TRIGGER immutable_event_hypothesis_version_update")
+    connection.execute(
+        "UPDATE event_hypothesis_versions_v2 SET actor_identity_digest=?",
+        ("sha256:" + "f" * 64,),
+    )
+    with pytest.raises(HypothesisContractError):
+        _open(fixture)
+
+
+@pytest.mark.parametrize("relationship", ("RELATED_DISTINCT", "UNCERTAIN"))
+def test_target_bearing_create_pins_current_target_and_reopens(
+    tmp_path, relationship: str
+) -> None:
+    fixture = _authority_fixture(tmp_path)
+    _, _, _, proof, proposal, dispositions, *_ = fixture
+    authority = _open(fixture)
+    target = authority.retain(proposal, dispositions, proof=proof)
+    raw, source = _targeted_proposal(
+        fixture,
+        proposal_id=f"00000000-0000-4000-8000-000000000{101 if relationship == 'RELATED_DISTINCT' else 102}",
+        local_id=f"hypothesis:{relationship.lower()}",
+        relationship=relationship,
+        target=target.hypothesis_id,
+    )
+    created = authority.retain(raw, source, proof=proof, expected_target_version=target)
+    assert created.ordinal == 1
+    assert created.hypothesis_id != target.hypothesis_id
+    assert created.proposed_target_hypothesis_id == target.hypothesis_id
+    assert (created.target_version_id, created.target_version_digest) == (
+        target.version_id,
+        target.canonical_digest,
+    )
+    reopened, connection = _reopen_copy(fixture, authority)
+    try:
+        assert reopened.versions(created.hypothesis_id) == (created,)
+        assert reopened.current(created.hypothesis_id, proof=proof) == created
+    finally:
+        reopened.close()
+        connection.close()
+
+
+def test_target_comparators_reject_arbitrary_wrong_and_stale_heads_without_rows(
+    tmp_path,
+) -> None:
+    fixture = _authority_fixture(tmp_path)
+    connection, _, _, proof, proposal, dispositions, *_ = fixture
+    authority = _open(fixture)
+    target = authority.retain(proposal, dispositions, proof=proof)
+    second_raw, second_source = _targeted_proposal(
+        fixture,
+        proposal_id="00000000-0000-4000-8000-000000000111",
+        local_id="hypothesis:second-target",
+        relationship="RELATED_DISTINCT",
+        target=target.hypothesis_id,
+    )
+    second = authority.retain(
+        second_raw, second_source, proof=proof, expected_target_version=target
+    )
+    before = connection.execute(
+        "SELECT count(*) FROM event_hypothesis_versions_v2"
+    ).fetchone()
+
+    arbitrary_raw, arbitrary_source = _targeted_proposal(
+        fixture,
+        proposal_id="00000000-0000-4000-8000-000000000112",
+        local_id="hypothesis:arbitrary",
+        relationship="RELATED_DISTINCT",
+        target="44444444-4444-4444-8444-444444444444",
+    )
+    with pytest.raises(HypothesisContractError):
+        authority.retain(
+            arbitrary_raw,
+            arbitrary_source,
+            proof=proof,
+            expected_target_version=target,
+        )
+    wrong_raw, wrong_source = _targeted_proposal(
+        fixture,
+        proposal_id="00000000-0000-4000-8000-000000000113",
+        local_id="hypothesis:wrong-version",
+        relationship="RELATED_DISTINCT",
+        target=target.hypothesis_id,
+    )
+    with pytest.raises(HypothesisContractError):
+        authority.retain(
+            wrong_raw,
+            wrong_source,
+            proof=proof,
+            expected_target_version=second,
+        )
+    append_raw, append_source = _targeted_proposal(
+        fixture,
+        proposal_id="00000000-0000-4000-8000-000000000114",
+        local_id="hypothesis:advance",
+        relationship="SAME_STATE",
+        target=target.hypothesis_id,
+    )
+    advanced = authority.retain(
+        append_raw, append_source, proof=proof, expected_target_version=target
+    )
+    stale_raw, stale_source = _targeted_proposal(
+        fixture,
+        proposal_id="00000000-0000-4000-8000-000000000115",
+        local_id="hypothesis:stale",
+        relationship="UNCERTAIN",
+        target=target.hypothesis_id,
+    )
+    with pytest.raises(HypothesisContractError):
+        authority.retain(
+            stale_raw,
+            stale_source,
+            proof=proof,
+            expected_target_version=target,
+        )
+    assert connection.execute(
+        "SELECT count(*) FROM event_hypothesis_versions_v2"
+    ).fetchone() == (before[0] + 1,)
+    reopened, reopened_connection = _reopen_copy(fixture, authority)
+    try:
+        assert reopened.versions(target.hypothesis_id) == (target, advanced)
+        assert reopened.current(target.hypothesis_id, proof=proof) == advanced
+    finally:
+        reopened.close()
+        reopened_connection.close()
+
+
+@pytest.mark.parametrize("relationship", ("SAME_STATE", "DEVELOPMENT_OF"))
+def test_append_replay_stale_cas_and_reopen_exact_chain(
+    tmp_path, relationship: str
+) -> None:
+    fixture = _authority_fixture(tmp_path)
+    connection, _, _, proof, proposal, dispositions, *_ = fixture
+    authority = _open(fixture)
+    first = authority.retain(proposal, dispositions, proof=proof)
+    raw, source = _targeted_proposal(
+        fixture,
+        proposal_id=f"00000000-0000-4000-8000-000000000{121 if relationship == 'SAME_STATE' else 122}",
+        local_id=f"hypothesis:append-{relationship.lower()}",
+        relationship=relationship,
+        target=first.hypothesis_id,
+    )
+    second = authority.retain(raw, source, proof=proof, expected_target_version=first)
+    assert second.hypothesis_id == first.hypothesis_id
+    assert second.ordinal == 2
+    assert (second.previous_version_id, second.previous_version_digest) == (
+        first.version_id,
+        first.canonical_digest,
+    )
+    assert (second.target_version_id, second.target_version_digest) == (
+        first.version_id,
+        first.canonical_digest,
+    )
+    assert (
+        authority.load_version(first.version_id).canonical_bytes
+        == first.canonical_bytes
+    )
+    assert authority.current(first.hypothesis_id, proof=proof) == second
+    assert (
+        authority.retain(raw, source, proof=proof, expected_target_version=first)
+        == second
+    )
+    assert connection.execute(
+        "SELECT count(*) FROM event_hypothesis_versions_v2 WHERE hypothesis_id=?",
+        (first.hypothesis_id,),
+    ).fetchone() == (2,)
+    divergent_raw, divergent_source = _targeted_proposal(
+        fixture,
+        proposal_id="00000000-0000-4000-8000-000000000123",
+        local_id="hypothesis:stale-append",
+        relationship=relationship,
+        target=first.hypothesis_id,
+    )
+    with pytest.raises(HypothesisContractError):
+        authority.retain(
+            divergent_raw,
+            divergent_source,
+            proof=proof,
+            expected_target_version=first,
+        )
+    reopened, reopened_connection = _reopen_copy(fixture, authority)
+    try:
+        assert reopened.versions(first.hypothesis_id) == (first, second)
+        assert reopened.current(first.hypothesis_id, proof=proof) == second
+    finally:
+        reopened.close()
+        reopened_connection.close()
+
+
+def test_upstream_advance_invalidates_current_but_not_history_or_replay(
+    tmp_path,
+) -> None:
+    fixture = _authority_fixture(tmp_path)
+    (
+        connection,
+        _,
+        _,
+        proof,
+        proposal,
+        dispositions,
+        work_store,
+        item,
+        first_work,
+        *_,
+    ) = fixture
+    authority = _open(fixture)
+    first = authority.retain(proposal, dispositions, proof=proof)
+    second_work = replace(
+        work_item_helpers._version(item, 2), retrieval=first_work.retrieval
+    )
+    work_store.append_version(
+        first_work.version_id, first_work.canonical_digest, second_work
+    )
+    for operation in (authority.current, authority.require_current):
+        with pytest.raises(HypothesisContractError):
+            operation(first.hypothesis_id, proof=proof)
+    assert authority.load_version(first.version_id) == first
+    assert authority.retain(proposal, dispositions, proof=proof) == first
+    assert connection.execute(
+        "SELECT count(*) FROM event_hypothesis_versions_v2"
+    ).fetchone() == (1,)
+    reopened, reopened_connection = _reopen_copy(fixture, authority)
+    try:
+        assert reopened.load_version(first.version_id) == first
+        assert reopened.versions(first.hypothesis_id) == (first,)
+        with pytest.raises(HypothesisContractError):
+            reopened.current(first.hypothesis_id, proof=proof)
+    finally:
+        reopened.close()
+        reopened_connection.close()
+
+
+def _copied_race_stores(tmp_path, fixture, name: str):
+    database = tmp_path / f"{name}.sqlite3"
+    target = sqlite3.connect(database, isolation_level=None)
+    fixture[0].backup(target)
+    target.close()
+    connections = tuple(
+        sqlite3.connect(
+            database, isolation_level=None, timeout=10, check_same_thread=False
+        )
+        for _ in range(2)
+    )
+    stores = tuple(
+        _HypothesisStore(
+            connection,
+            fixture[1],
+            fixture[2],
+            lambda: UtcTimestamp.parse("2042-01-01T00:00:00.000000Z"),
+        )
+        for connection in connections
+    )
+    return database, connections, stores
+
+
+def test_two_connection_equivalent_create_converges_and_reopens(tmp_path) -> None:
+    fixture = _authority_fixture(tmp_path)
+    _, _, _, proof, proposal, dispositions, *_ = fixture
+    database, connections, stores = _copied_race_stores(
+        tmp_path, fixture, "equivalent-create-race"
+    )
+    barrier = threading.Barrier(2)
+
+    def retain(store):
+        barrier.wait()
+        return store.retain(proposal, dispositions, proof=proof)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = tuple(executor.submit(retain, store) for store in stores)
+        results = tuple(future.result() for future in futures)
+    assert results[0] == results[1]
+    assert connections[0].execute(
+        "SELECT count(*) FROM event_hypothesis_versions_v2"
+    ).fetchone() == (1,)
+    for connection in connections:
+        connection.close()
+    reopened_connection = sqlite3.connect(database, isolation_level=None)
+    reopened = _HypothesisStore(
+        reopened_connection,
+        fixture[1],
+        fixture[2],
+        lambda: UtcTimestamp.parse("2042-01-01T00:00:00.000000Z"),
+    )
+    assert reopened.versions(results[0].hypothesis_id) == (results[0],)
+    assert reopened.current(results[0].hypothesis_id, proof=proof) == results[0]
+    reopened_connection.close()
+
+
+def test_two_connection_stale_appends_have_one_winner_and_exact_reopen(
+    tmp_path,
+) -> None:
+    fixture = _authority_fixture(tmp_path)
+    _, _, _, proof, proposal, dispositions, *_ = fixture
+    seed_authority = _open(fixture)
+    first = seed_authority.retain(proposal, dispositions, proof=proof)
+    proposals = tuple(
+        _targeted_proposal(
+            fixture,
+            proposal_id=f"00000000-0000-4000-8000-00000000013{index}",
+            local_id=f"hypothesis:race-append-{index}",
+            relationship="SAME_STATE",
+            target=first.hypothesis_id,
+        )
+        for index in (1, 2)
+    )
+    seed_authority.close()
+    database, connections, stores = _copied_race_stores(
+        tmp_path, fixture, "stale-append-race"
+    )
+    barrier = threading.Barrier(2)
+
+    def append(store, values):
+        barrier.wait()
+        try:
+            return store.retain(
+                values[0], values[1], proof=proof, expected_target_version=first
+            )
+        except HypothesisContractError as exc:
+            return exc
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = tuple(
+            executor.submit(append, stores[index], proposals[index])
+            for index in range(2)
+        )
+        results = tuple(future.result() for future in futures)
+    winners = tuple(value for value in results if not isinstance(value, Exception))
+    losers = tuple(
+        value for value in results if isinstance(value, HypothesisContractError)
+    )
+    assert len(winners) == len(losers) == 1
+    assert connections[0].execute(
+        "SELECT count(*) FROM event_hypothesis_versions_v2 WHERE hypothesis_id=?",
+        (first.hypothesis_id,),
+    ).fetchone() == (2,)
+    for connection in connections:
+        connection.close()
+    reopened_connection = sqlite3.connect(database, isolation_level=None)
+    reopened = _HypothesisStore(
+        reopened_connection,
+        fixture[1],
+        fixture[2],
+        lambda: UtcTimestamp.parse("2042-01-01T00:00:00.000000Z"),
+    )
+    assert reopened.versions(first.hypothesis_id) == (first, winners[0])
+    assert reopened.current(first.hypothesis_id, proof=proof) == winners[0]
+    reopened_connection.close()
+
+
+def test_transaction_owner_lock_isolates_failure_from_replay_and_current(
+    tmp_path, monkeypatch
+) -> None:
+    fixture = _authority_fixture(tmp_path)
+    _, _, _, proof, proposal, dispositions, *_ = fixture
+    database = tmp_path / "shared-connection.sqlite3"
+    copied = sqlite3.connect(database, isolation_level=None)
+    fixture[0].backup(copied)
+    copied.close()
+    connection = sqlite3.connect(
+        database, isolation_level=None, check_same_thread=False
+    )
+    store = _HypothesisStore(
+        connection,
+        fixture[1],
+        fixture[2],
+        lambda: UtcTimestamp.parse("2042-01-01T00:00:00.000000Z"),
+    )
+    first = store.retain(proposal, dispositions, proof=proof)
+    original_verify = _HypothesisStore._verify
+    failure_started = threading.Event()
+    release_failure = threading.Event()
+    reader_started = threading.Event()
+    injected = False
+
+    def verify(candidate):
+        nonlocal injected
+        if not injected:
+            injected = True
+            failure_started.set()
+            assert release_failure.wait(5)
+            raise RuntimeError("ordinary injected failure")
+        return original_verify(candidate)
+
+    monkeypatch.setattr(_HypothesisStore, "_verify", verify)
+
+    def fail():
+        with pytest.raises(HypothesisContractError):
+            store.retain(proposal, dispositions, proof=proof)
+
+    def read():
+        reader_started.set()
+        return store.current(first.hypothesis_id, proof=proof)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        failing = executor.submit(fail)
+        assert failure_started.wait(5)
+        reading = executor.submit(read)
+        assert reader_started.wait(5)
+        assert reading.done() is False
+        release_failure.set()
+        failing.result()
+        assert reading.result() == first
+    assert store.retain(proposal, dispositions, proof=proof) == first
+    assert connection.in_transaction is False
+    assert store.versions(first.hypothesis_id) == (first,)
+
+
+def _retained_file_fixture(tmp_path, fixture, *, append: bool = False):
+    """Copy a genuinely persisted authority so corruption is externally observable."""
+    _, _, _, proof, proposal, dispositions, *_ = fixture
+    seed = _open(fixture)
+    first = seed.retain(proposal, dispositions, proof=proof)
+    last = first
+    if append:
+        raw, source = _targeted_proposal(
+            fixture,
+            proposal_id="00000000-0000-4000-8000-000000000991",
+            local_id="hypothesis:integrity-append",
+            relationship="SAME_STATE",
+            target=first.hypothesis_id,
+        )
+        last = seed.retain(raw, source, proof=proof, expected_target_version=first)
+    seed.close()
+    database = tmp_path / ("retained-chain.sqlite3" if append else "retained.sqlite3")
+    copied = sqlite3.connect(database, isolation_level=None)
+    fixture[0].backup(copied)
+    copied.close()
+    reader_connection = sqlite3.connect(database, isolation_level=None)
+    reader = _HypothesisStore(
+        reader_connection,
+        fixture[1],
+        fixture[2],
+        lambda: UtcTimestamp.parse("2042-01-01T00:00:00.000000Z"),
+    )
+    mutator = sqlite3.connect(database, isolation_level=None)
+    mutator.execute("PRAGMA foreign_keys=OFF")
+    return database, reader, reader_connection, mutator, first, last
+
+
+_D2 = "sha256:" + "e" * 64
+
+
+_SINGLE_INTEGRITY_MUTATIONS = (
+    (
+        "immutable_event_hypothesis_update",
+        "UPDATE event_hypotheses_v2 SET canonical_bytes=?",
+        (b"{}",),
+    ),
+    (
+        "immutable_event_hypothesis_update",
+        "UPDATE event_hypotheses_v2 SET canonical_digest=?",
+        (_D2,),
+    ),
+    (
+        "immutable_event_hypothesis_update",
+        "UPDATE event_hypotheses_v2 SET actor_identity_digest=?",
+        (_D2,),
+    ),
+    (
+        "immutable_event_hypothesis_update",
+        "UPDATE event_hypotheses_v2 SET authority_event_id=?",
+        ("retargeted:event",),
+    ),
+    (
+        "immutable_event_hypothesis_update",
+        "UPDATE event_hypotheses_v2 SET recorded_at=?",
+        ("2043-01-01T00:00:00.000000Z",),
+    ),
+    (
+        "immutable_event_hypothesis_version_update",
+        "UPDATE event_hypothesis_versions_v2 SET proposal_id=?",
+        ("00000000-0000-4000-8000-000000000998",),
+    ),
+    (
+        "immutable_event_hypothesis_version_update",
+        "UPDATE event_hypothesis_versions_v2 SET version_id=?",
+        ("00000000-0000-4000-8000-000000000998",),
+    ),
+    (
+        "immutable_event_hypothesis_version_update",
+        "UPDATE event_hypothesis_versions_v2 SET hypothesis_id=?",
+        ("00000000-0000-4000-8000-000000000998",),
+    ),
+    (
+        "immutable_event_hypothesis_version_update",
+        "UPDATE event_hypothesis_versions_v2 SET proposal_local_id=?",
+        ("hypothesis:retargeted",),
+    ),
+    (
+        "immutable_event_hypothesis_version_update",
+        "UPDATE event_hypothesis_versions_v2 SET proposal_content_identity=?",
+        (_D2,),
+    ),
+    (
+        "immutable_event_hypothesis_version_update",
+        "UPDATE event_hypothesis_versions_v2 SET proposal_canonical_digest=?",
+        (_D2,),
+    ),
+    (
+        "immutable_event_hypothesis_version_update",
+        "UPDATE event_hypothesis_versions_v2 SET proposal_canonical_bytes=?",
+        (b"{}",),
+    ),
+    (
+        "immutable_event_hypothesis_version_update",
+        "UPDATE event_hypothesis_versions_v2 SET work_item_id=?",
+        ("00000000-0000-4000-8000-000000000998",),
+    ),
+    (
+        "immutable_event_hypothesis_version_update",
+        "UPDATE event_hypothesis_versions_v2 SET work_item_version_digest=?",
+        (_D2,),
+    ),
+    (
+        "immutable_event_hypothesis_version_update",
+        "UPDATE event_hypothesis_versions_v2 SET work_item_version_id=?",
+        ("00000000-0000-4000-8000-000000000998",),
+    ),
+    (
+        "immutable_event_hypothesis_version_update",
+        "UPDATE event_hypothesis_versions_v2 SET retrieval_context_digest=?",
+        (_D2,),
+    ),
+    (
+        "immutable_event_hypothesis_version_update",
+        "UPDATE event_hypothesis_versions_v2 SET retrieval_context_id=?",
+        ("00000000-0000-4000-8000-000000000998",),
+    ),
+    (
+        "immutable_event_hypothesis_version_update",
+        "UPDATE event_hypothesis_versions_v2 SET actor_identity_digest=?",
+        (_D2,),
+    ),
+    (
+        "immutable_event_hypothesis_version_update",
+        "UPDATE event_hypothesis_versions_v2 SET authority_event_id=?",
+        ("retargeted:event",),
+    ),
+    (
+        "immutable_event_hypothesis_version_update",
+        "UPDATE event_hypothesis_versions_v2 SET recorded_at=?",
+        ("2043-01-01T00:00:00.000000Z",),
+    ),
+    (
+        "immutable_event_hypothesis_version_update",
+        "UPDATE event_hypothesis_versions_v2 SET canonical_bytes=?",
+        (b"{}",),
+    ),
+    (
+        "immutable_event_hypothesis_version_update",
+        "UPDATE event_hypothesis_versions_v2 SET canonical_digest=?",
+        (_D2,),
+    ),
+    (
+        "immutable_triage_proposal_dispositions_update",
+        "UPDATE triage_proposal_dispositions SET work_item_version_digest=?",
+        (_D2,),
+    ),
+    ("retained_event_hypothesis_delete", "DELETE FROM event_hypotheses_v2", ()),
+    (
+        "retained_event_hypothesis_version_delete",
+        "DELETE FROM event_hypothesis_versions_v2",
+        (),
+    ),
+    (
+        "retained_event_hypothesis_head_delete",
+        "DELETE FROM event_hypothesis_heads_v2",
+        (),
+    ),
+    (
+        "event_hypothesis_head_update_guard",
+        "UPDATE event_hypothesis_heads_v2 SET updated_at=?",
+        ("2043-01-01T00:00:00.000000Z",),
+    ),
+)
+
+
+def test_retained_single_version_integrity_mutations_fail_current_and_reopen(
+    tmp_path,
+) -> None:
+    fixture = _authority_fixture(tmp_path)
+    seed = _open(fixture)
+    first = seed.retain(fixture[4], fixture[5], proof=fixture[3])
+    seed.close()
+    for index, (trigger, statement, parameters) in enumerate(
+        _SINGLE_INTEGRITY_MUTATIONS
+    ):
+        database = tmp_path / f"retained-{index}.sqlite3"
+        copied = sqlite3.connect(database, isolation_level=None)
+        fixture[0].backup(copied)
+        copied.close()
+        reader_connection = sqlite3.connect(database, isolation_level=None)
+        reader = _HypothesisStore(
+            reader_connection, fixture[1], fixture[2], UtcTimestamp.now
+        )
+        mutator = sqlite3.connect(database, isolation_level=None)
+        mutator.execute("PRAGMA foreign_keys=OFF")
+        try:
+            mutator.execute(f"DROP TRIGGER {trigger}")
+            mutator.execute(statement, parameters)
+            with pytest.raises(HypothesisContractError):
+                reader.current(first.hypothesis_id, proof=fixture[3])
+            reopen_connection = sqlite3.connect(database, isolation_level=None)
+            try:
+                with pytest.raises(HypothesisContractError):
+                    _HypothesisStore(
+                        reopen_connection, fixture[1], fixture[2], UtcTimestamp.now
+                    )
+            finally:
+                reopen_connection.close()
+        finally:
+            mutator.close()
+            reader_connection.close()
+
+
+_CHAIN_INTEGRITY_MUTATIONS = (
+    (
+        "immutable_event_hypothesis_version_update",
+        "UPDATE event_hypothesis_versions_v2 SET previous_version_digest='sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' WHERE ordinal=2",
+    ),
+    (
+        "immutable_event_hypothesis_version_update",
+        "UPDATE event_hypothesis_versions_v2 SET previous_version_id=version_id WHERE ordinal=2",
+    ),
+    (
+        "immutable_event_hypothesis_version_update",
+        "UPDATE event_hypothesis_versions_v2 SET ordinal=3 WHERE ordinal=2",
+    ),
+    (
+        "immutable_event_hypothesis_version_update",
+        "UPDATE event_hypothesis_versions_v2 SET proposed_target_hypothesis_id='00000000-0000-4000-8000-000000000998' WHERE ordinal=2",
+    ),
+    (
+        "immutable_event_hypothesis_version_update",
+        "UPDATE event_hypothesis_versions_v2 SET target_version_id=version_id WHERE ordinal=2",
+    ),
+    (
+        "immutable_event_hypothesis_version_update",
+        "UPDATE event_hypothesis_versions_v2 SET target_version_digest='sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee' WHERE ordinal=2",
+    ),
+    (
+        "retained_event_hypothesis_version_delete",
+        "DELETE FROM event_hypothesis_versions_v2 WHERE ordinal=1",
+    ),
+    (
+        "retained_event_hypothesis_version_delete",
+        "DELETE FROM event_hypothesis_versions_v2 WHERE ordinal=2",
+    ),
+    ("retained_event_hypothesis_head_delete", "DELETE FROM event_hypothesis_heads_v2"),
+    (
+        "event_hypothesis_head_update_guard",
+        "UPDATE event_hypothesis_heads_v2 SET version_id=(SELECT version_id FROM event_hypothesis_versions_v2 WHERE ordinal=1),ordinal=1,version_digest=(SELECT canonical_digest FROM event_hypothesis_versions_v2 WHERE ordinal=1)",
+    ),
+    (
+        "event_hypothesis_head_insert_guard",
+        "INSERT INTO event_hypothesis_heads_v2 VALUES('00000000-0000-4000-8000-000000000997','00000000-0000-4000-8000-000000000996',1,'sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee','2042-01-01T00:00:00.000000Z')",
+    ),
+)
+
+
+def test_retained_chain_gaps_and_noncontiguous_links_fail_closed(
+    tmp_path,
+) -> None:
+    fixture = _authority_fixture(tmp_path)
+    seed = _open(fixture)
+    first = seed.retain(fixture[4], fixture[5], proof=fixture[3])
+    raw, source = _targeted_proposal(
+        fixture,
+        proposal_id="00000000-0000-4000-8000-000000000991",
+        local_id="hypothesis:integrity-append",
+        relationship="SAME_STATE",
+        target=first.hypothesis_id,
+    )
+    last = seed.retain(raw, source, proof=fixture[3], expected_target_version=first)
+    seed.close()
+    for index, (trigger, statement) in enumerate(_CHAIN_INTEGRITY_MUTATIONS):
+        database = tmp_path / f"chain-{index}.sqlite3"
+        copied = sqlite3.connect(database, isolation_level=None)
+        fixture[0].backup(copied)
+        copied.close()
+        reader_connection = sqlite3.connect(database, isolation_level=None)
+        reader = _HypothesisStore(
+            reader_connection, fixture[1], fixture[2], UtcTimestamp.now
+        )
+        mutator = sqlite3.connect(database, isolation_level=None)
+        mutator.execute("PRAGMA foreign_keys=OFF")
+        try:
+            mutator.execute(f"DROP TRIGGER {trigger}")
+            mutator.execute(statement)
+            with pytest.raises(HypothesisContractError):
+                reader.current(last.hypothesis_id, proof=fixture[3])
+            reopen_connection = sqlite3.connect(database, isolation_level=None)
+            try:
+                with pytest.raises(HypothesisContractError):
+                    _HypothesisStore(
+                        reopen_connection, fixture[1], fixture[2], UtcTimestamp.now
+                    )
+            finally:
+                reopen_connection.close()
+        finally:
+            mutator.close()
+            reader_connection.close()

--- a/newsroom/tests/test_increment6d1_hypothesis_store.py
+++ b/newsroom/tests/test_increment6d1_hypothesis_store.py
@@ -4,6 +4,7 @@ import json
 import os
 import sqlite3
 import threading
+import uuid
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from dataclasses import replace
@@ -15,6 +16,7 @@ from newsroom.authority.auth import (
     StaticAuthenticator,
     StaticPrincipal,
 )
+from newsroom.authority.canonical import canonical_json_bytes, digest_bytes
 from newsroom.authority.event_hypothesis_migrations import (
     EVENT_HYPOTHESIS_MIGRATION_STATEMENTS,
 )
@@ -27,10 +29,13 @@ from newsroom.increment6._hypothesis_store import (
     EventHypothesisAuthority as PrivateAuthority,
 )
 from newsroom.increment6._hypothesis_store import (
+    _creation_event_id,
     _HypothesisStore,
+    _version_event_id,
 )
 from newsroom.increment6.dispositions import ProposalDispositionStore
 from newsroom.increment6.hypotheses import (
+    EVENT_HYPOTHESIS,
     EventHypothesisAuthority,
     HypothesisContractError,
     open_event_hypothesis_authority,
@@ -215,6 +220,13 @@ def test_real_store_create_replay_current_history_and_reopen(tmp_path) -> None:
     try:
         first = authority.retain(proposal, dispositions, proof=proof)
         assert authority.retain(proposal, dispositions, proof=proof) == first
+        with pytest.raises(HypothesisContractError, match="comparator"):
+            authority.retain(
+                proposal,
+                dispositions,
+                proof=proof,
+                expected_target_version=first,
+            )
         assert authority.current(first.hypothesis_id, proof=proof) == first
         assert authority.load_version(first.version_id) == first
         assert (
@@ -453,6 +465,77 @@ def test_direct_scalar_tamper_is_detected_by_current_and_reopen(tmp_path) -> Non
         _open(fixture)
 
 
+def test_self_consistent_direct_insert_with_wrong_stable_identity_fails_reopen(
+    tmp_path,
+) -> None:
+    fixture = _authority_fixture(tmp_path)
+    forged_connection = sqlite3.connect(":memory:", isolation_level=None)
+    fixture[0].backup(forged_connection)
+    authority = _open(fixture)
+    valid = authority.retain(fixture[4], fixture[5], proof=fixture[3])
+    authority.close()
+
+    wrong_hypothesis_id = str(uuid.UUID(int=999))
+    wrong_version_id = str(uuid.uuid5(uuid.UUID(wrong_hypothesis_id), "version:1"))
+    identity_row = list(
+        fixture[0].execute("SELECT * FROM event_hypotheses_v2").fetchone()
+    )
+    identity_row[0] = wrong_hypothesis_id
+    identity_row[1] = canonical_json_bytes(
+        {
+            "schema_version": EVENT_HYPOTHESIS,
+            "hypothesis_id": wrong_hypothesis_id,
+        }
+    )
+    identity_row[2] = digest_bytes(identity_row[1])
+    identity_row[4] = _creation_event_id(
+        wrong_hypothesis_id, str(identity_row[3]), str(identity_row[5])
+    )
+
+    version_row = list(
+        fixture[0].execute("SELECT * FROM event_hypothesis_versions_v2").fetchone()
+    )
+    version_document = json.loads(valid.canonical_bytes)
+    version_document["version"]["hypothesis_id"] = wrong_hypothesis_id
+    version_document["version"]["version_id"] = wrong_version_id
+    version_document["version"]["authority_event_id"] = _version_event_id(
+        wrong_hypothesis_id,
+        valid.ordinal,
+        valid.previous_version_digest,
+        valid.proposal_canonical_digest,
+        valid.proposal_local_id,
+        valid.target_version_digest,
+        valid.source_bindings,
+        valid.actor_identity_digest,
+        valid.recorded_at,
+    )
+    version_row[0] = wrong_version_id
+    version_row[1] = wrong_hypothesis_id
+    version_row[20] = version_document["version"]["authority_event_id"]
+    version_row[21] = canonical_json_bytes(version_document)
+    version_row[22] = digest_bytes(version_row[21])
+    head_row = list(
+        fixture[0].execute("SELECT * FROM event_hypothesis_heads_v2").fetchone()
+    )
+    head_row[0] = wrong_hypothesis_id
+    head_row[1] = wrong_version_id
+    head_row[3] = version_row[22]
+
+    forged_connection.execute(
+        "INSERT INTO event_hypotheses_v2 VALUES(?,?,?,?,?,?)", identity_row
+    )
+    forged_connection.execute(
+        "INSERT INTO event_hypothesis_versions_v2 VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        version_row,
+    )
+    forged_connection.execute(
+        "INSERT INTO event_hypothesis_heads_v2 VALUES(?,?,?,?,?)", head_row
+    )
+    with pytest.raises(HypothesisContractError, match="stable identity"):
+        _HypothesisStore(forged_connection, fixture[1], fixture[2], UtcTimestamp.now)
+    forged_connection.close()
+
+
 @pytest.mark.parametrize("relationship", ("RELATED_DISTINCT", "UNCERTAIN"))
 def test_target_bearing_create_pins_current_target_and_reopens(
     tmp_path, relationship: str
@@ -476,6 +559,12 @@ def test_target_bearing_create_pins_current_target_and_reopens(
         target.version_id,
         target.canonical_digest,
     )
+    assert (
+        authority.retain(raw, source, proof=proof, expected_target_version=target)
+        == created
+    )
+    with pytest.raises(HypothesisContractError, match="comparator"):
+        authority.retain(raw, source, proof=proof)
     reopened, connection = _reopen_copy(fixture, authority)
     try:
         assert reopened.versions(created.hypothesis_id) == (created,)
@@ -605,6 +694,10 @@ def test_append_replay_stale_cas_and_reopen_exact_chain(
         authority.retain(raw, source, proof=proof, expected_target_version=first)
         == second
     )
+    for comparator in (None, second, object()):
+        kwargs = {} if comparator is None else {"expected_target_version": comparator}
+        with pytest.raises(HypothesisContractError, match="comparator"):
+            authority.retain(raw, source, proof=proof, **kwargs)
     assert connection.execute(
         "SELECT count(*) FROM event_hypothesis_versions_v2 WHERE hypothesis_id=?",
         (first.hypothesis_id,),

--- a/newsroom/tests/test_increment6d1_hypothesis_store.py
+++ b/newsroom/tests/test_increment6d1_hypothesis_store.py
@@ -454,29 +454,39 @@ def test_second_opener_and_unsafe_modes_fail_closed(tmp_path) -> None:
         )
 
 
-def test_direct_scalar_tamper_is_detected_by_current_and_reopen(tmp_path) -> None:
+def _copy_authority_fixture(fixture):
+    connection = sqlite3.connect(":memory:", isolation_level=None)
+    fixture[0].backup(connection)
+    return (connection, *fixture[1:])
+
+
+def test_self_consistent_direct_tamper_fails_current_and_reopen(tmp_path) -> None:
     fixture = _authority_fixture(tmp_path)
-    connection, _, _, proof, proposal, dispositions, *_ = fixture
+    wrong_identity_fixture = _copy_authority_fixture(fixture)
+    _, _, _, proof, proposal, dispositions, *_ = fixture
     authority = _open(fixture)
     try:
-        authority.retain(proposal, dispositions, proof=proof)
+        valid = authority.retain(proposal, dispositions, proof=proof)
     finally:
         authority.close()
+    scalar_fixture = _copy_authority_fixture(fixture)
+    connection = scalar_fixture[0]
     connection.execute("DROP TRIGGER immutable_event_hypothesis_version_update")
     connection.execute(
         "UPDATE event_hypothesis_versions_v2 SET actor_identity_digest=?",
         ("sha256:" + "f" * 64,),
     )
     with pytest.raises(HypothesisContractError):
-        _open(fixture)
+        _open(scalar_fixture)
+    connection.close()
+    _assert_self_consistent_disposition_retarget_fails(
+        _copy_authority_fixture(fixture), valid
+    )
+    _assert_wrong_stable_identity_fails(wrong_identity_fixture, fixture[0], valid)
 
 
-def test_self_consistent_disposition_retarget_fails_reopen(tmp_path) -> None:
-    fixture = _authority_fixture(tmp_path)
+def _assert_self_consistent_disposition_retarget_fails(fixture, valid) -> None:
     connection = fixture[0]
-    authority = _open(fixture)
-    valid = authority.retain(fixture[4], fixture[5], proof=fixture[3])
-    authority.close()
     old_disposition = ProposalDisposition.from_canonical_bytes(
         bytes(
             connection.execute(
@@ -616,23 +626,14 @@ def test_self_consistent_disposition_retarget_fails_reopen(tmp_path) -> None:
 
     with pytest.raises(HypothesisContractError, match="exact Proposal group"):
         _open(fixture)
+    connection.close()
 
 
-def test_self_consistent_direct_insert_with_wrong_stable_identity_fails_reopen(
-    tmp_path,
-) -> None:
-    fixture = _authority_fixture(tmp_path)
-    forged_connection = sqlite3.connect(":memory:", isolation_level=None)
-    fixture[0].backup(forged_connection)
-    authority = _open(fixture)
-    valid = authority.retain(fixture[4], fixture[5], proof=fixture[3])
-    authority.close()
-
+def _assert_wrong_stable_identity_fails(fixture, source, valid) -> None:
+    forged_connection = fixture[0]
     wrong_hypothesis_id = str(uuid.UUID(int=999))
     wrong_version_id = str(uuid.uuid5(uuid.UUID(wrong_hypothesis_id), "version:1"))
-    identity_row = list(
-        fixture[0].execute("SELECT * FROM event_hypotheses_v2").fetchone()
-    )
+    identity_row = list(source.execute("SELECT * FROM event_hypotheses_v2").fetchone())
     identity_row[0] = wrong_hypothesis_id
     identity_row[1] = canonical_json_bytes(
         {
@@ -646,7 +647,7 @@ def test_self_consistent_direct_insert_with_wrong_stable_identity_fails_reopen(
     )
 
     version_row = list(
-        fixture[0].execute("SELECT * FROM event_hypothesis_versions_v2").fetchone()
+        source.execute("SELECT * FROM event_hypothesis_versions_v2").fetchone()
     )
     version_document = json.loads(valid.canonical_bytes)
     version_document["version"]["hypothesis_id"] = wrong_hypothesis_id
@@ -668,7 +669,7 @@ def test_self_consistent_direct_insert_with_wrong_stable_identity_fails_reopen(
     version_row[21] = canonical_json_bytes(version_document)
     version_row[22] = digest_bytes(version_row[21])
     head_row = list(
-        fixture[0].execute("SELECT * FROM event_hypothesis_heads_v2").fetchone()
+        source.execute("SELECT * FROM event_hypothesis_heads_v2").fetchone()
     )
     head_row[0] = wrong_hypothesis_id
     head_row[1] = wrong_version_id
@@ -1096,38 +1097,6 @@ def test_transaction_owner_lock_isolates_failure_from_replay_and_current(
     assert store.versions(first.hypothesis_id) == (first,)
 
 
-def _retained_file_fixture(tmp_path, fixture, *, append: bool = False):
-    """Copy a genuinely persisted authority so corruption is externally observable."""
-    _, _, _, proof, proposal, dispositions, *_ = fixture
-    seed = _open(fixture)
-    first = seed.retain(proposal, dispositions, proof=proof)
-    last = first
-    if append:
-        raw, source = _targeted_proposal(
-            fixture,
-            proposal_id="00000000-0000-4000-8000-000000000991",
-            local_id="hypothesis:integrity-append",
-            relationship="SAME_STATE",
-            target=first.hypothesis_id,
-        )
-        last = seed.retain(raw, source, proof=proof, expected_target_version=first)
-    seed.close()
-    database = tmp_path / ("retained-chain.sqlite3" if append else "retained.sqlite3")
-    copied = sqlite3.connect(database, isolation_level=None)
-    fixture[0].backup(copied)
-    copied.close()
-    reader_connection = sqlite3.connect(database, isolation_level=None)
-    reader = _HypothesisStore(
-        reader_connection,
-        fixture[1],
-        fixture[2],
-        lambda: UtcTimestamp.parse("2042-01-01T00:00:00.000000Z"),
-    )
-    mutator = sqlite3.connect(database, isolation_level=None)
-    mutator.execute("PRAGMA foreign_keys=OFF")
-    return database, reader, reader_connection, mutator, first, last
-
-
 _D2 = "sha256:" + "e" * 64
 
 
@@ -1266,35 +1235,33 @@ _SINGLE_INTEGRITY_MUTATIONS = (
 )
 
 
-@pytest.mark.parametrize("shard", range(4))
 def test_retained_single_version_integrity_mutations_fail_current_and_reopen(
-    tmp_path, shard: int
+    tmp_path,
 ) -> None:
     fixture = _authority_fixture(tmp_path)
     seed = _open(fixture)
     first = seed.retain(fixture[4], fixture[5], proof=fixture[3])
     seed.close()
-    for index, (trigger, statement, parameters) in enumerate(
-        _SINGLE_INTEGRITY_MUTATIONS
-    ):
-        if index % 4 != shard:
-            continue
-        database = tmp_path / f"retained-{index}.sqlite3"
-        copied = sqlite3.connect(database, isolation_level=None)
-        fixture[0].backup(copied)
-        copied.close()
-        reader_connection = sqlite3.connect(database, isolation_level=None)
+    for trigger, statement, parameters in _SINGLE_INTEGRITY_MUTATIONS:
+        reader_connection = sqlite3.connect(":memory:", isolation_level=None)
+        fixture[0].backup(reader_connection)
         reader = _HypothesisStore(
             reader_connection, fixture[1], fixture[2], UtcTimestamp.now
         )
-        mutator = sqlite3.connect(database, isolation_level=None)
-        mutator.execute("PRAGMA foreign_keys=OFF")
         try:
-            mutator.execute(f"DROP TRIGGER {trigger}")
-            mutator.execute(statement, parameters)
+            trigger_sql = reader_connection.execute(
+                "SELECT sql FROM sqlite_master WHERE type='trigger' AND name=?",
+                (trigger,),
+            ).fetchone()[0]
+            reader_connection.execute("PRAGMA foreign_keys=OFF")
+            reader_connection.execute(f"DROP TRIGGER {trigger}")
+            reader_connection.execute(statement, parameters)
+            reader_connection.execute(trigger_sql)
+            reader_connection.execute("PRAGMA foreign_keys=ON")
             with pytest.raises(HypothesisContractError):
                 reader.current(first.hypothesis_id, proof=fixture[3])
-            reopen_connection = sqlite3.connect(database, isolation_level=None)
+            reopen_connection = sqlite3.connect(":memory:", isolation_level=None)
+            reader_connection.backup(reopen_connection)
             try:
                 with pytest.raises(HypothesisContractError):
                     _HypothesisStore(
@@ -1303,7 +1270,6 @@ def test_retained_single_version_integrity_mutations_fail_current_and_reopen(
             finally:
                 reopen_connection.close()
         finally:
-            mutator.close()
             reader_connection.close()
 
 
@@ -1352,9 +1318,8 @@ _CHAIN_INTEGRITY_MUTATIONS = (
 )
 
 
-@pytest.mark.parametrize("shard", range(2))
 def test_retained_chain_gaps_and_noncontiguous_links_fail_closed(
-    tmp_path, shard: int
+    tmp_path,
 ) -> None:
     fixture = _authority_fixture(tmp_path)
     seed = _open(fixture)
@@ -1368,25 +1333,26 @@ def test_retained_chain_gaps_and_noncontiguous_links_fail_closed(
     )
     last = seed.retain(raw, source, proof=fixture[3], expected_target_version=first)
     seed.close()
-    for index, (trigger, statement) in enumerate(_CHAIN_INTEGRITY_MUTATIONS):
-        if index % 2 != shard:
-            continue
-        database = tmp_path / f"chain-{index}.sqlite3"
-        copied = sqlite3.connect(database, isolation_level=None)
-        fixture[0].backup(copied)
-        copied.close()
-        reader_connection = sqlite3.connect(database, isolation_level=None)
+    for trigger, statement in _CHAIN_INTEGRITY_MUTATIONS:
+        reader_connection = sqlite3.connect(":memory:", isolation_level=None)
+        fixture[0].backup(reader_connection)
         reader = _HypothesisStore(
             reader_connection, fixture[1], fixture[2], UtcTimestamp.now
         )
-        mutator = sqlite3.connect(database, isolation_level=None)
-        mutator.execute("PRAGMA foreign_keys=OFF")
         try:
-            mutator.execute(f"DROP TRIGGER {trigger}")
-            mutator.execute(statement)
+            trigger_sql = reader_connection.execute(
+                "SELECT sql FROM sqlite_master WHERE type='trigger' AND name=?",
+                (trigger,),
+            ).fetchone()[0]
+            reader_connection.execute("PRAGMA foreign_keys=OFF")
+            reader_connection.execute(f"DROP TRIGGER {trigger}")
+            reader_connection.execute(statement)
+            reader_connection.execute(trigger_sql)
+            reader_connection.execute("PRAGMA foreign_keys=ON")
             with pytest.raises(HypothesisContractError):
                 reader.current(last.hypothesis_id, proof=fixture[3])
-            reopen_connection = sqlite3.connect(database, isolation_level=None)
+            reopen_connection = sqlite3.connect(":memory:", isolation_level=None)
+            reader_connection.backup(reopen_connection)
             try:
                 with pytest.raises(HypothesisContractError):
                     _HypothesisStore(
@@ -1395,5 +1361,4 @@ def test_retained_chain_gaps_and_noncontiguous_links_fail_closed(
             finally:
                 reopen_connection.close()
         finally:
-            mutator.close()
             reader_connection.close()

--- a/newsroom/tests/test_increment6f1_handoff_migrations.py
+++ b/newsroom/tests/test_increment6f1_handoff_migrations.py
@@ -77,6 +77,9 @@ def _downgrade_empty_v17_to_v16(connection: sqlite3.Connection) -> None:
     ).fetchone()[0]
     connection.execute("DROP TRIGGER immutable_authority_migrations_delete")
     for table in (
+        "event_hypothesis_heads_v2",
+        "event_hypothesis_versions_v2",
+        "event_hypotheses_v2",
         "triage_work_item_leases",
         "triage_worker_attempts",
         "triage_execution_batches",
@@ -108,8 +111,8 @@ def _downgrade_empty_v17_to_v16(connection: sqlite3.Connection) -> None:
 def test_fresh_v17_schema_history_fingerprint_and_integrity_are_exact() -> None:
     connection = _fresh()
     try:
-        assert SCHEMA_VERSION == 20 and EVALUATION_HANDOFF_SCHEMA_VERSION == 17
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 20
+        assert SCHEMA_VERSION == 21 and EVALUATION_HANDOFF_SCHEMA_VERSION == 17
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 21
         assert connection.execute(
             "SELECT version,name,checksum FROM authority_migrations "
             "ORDER BY version"
@@ -174,7 +177,7 @@ def test_exact_v16_upgrade_requires_and_retains_exact_backup_digest(
             ).fetchall() == retained_v16_history
         finally:
             backup_connection.close()
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 20
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 21
         assert connection.execute(
             "SELECT version,name,checksum FROM authority_migrations "
             "WHERE version<=16 ORDER BY version"
@@ -197,7 +200,7 @@ def test_multihop_existing_upgrade_checkpoints_v16_backup_before_v17(
             connection, applied_at="2042-03-12T10:00:01.000000Z"
         )
         backup, digest_path = evaluation_handoff_backup_paths(database)
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 20
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 21
         assert backup.is_file()
         assert digest_path.is_file()
         backup_connection = _open(backup)
@@ -270,7 +273,7 @@ def test_standard_sqlite_connection_backup_preflight_leaves_no_transaction(
         apply_pending_migrations(
             connection, applied_at="2042-03-12T10:00:01.000000Z"
         )
-        assert connection.execute("PRAGMA user_version").fetchone()[0] == 20
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 21
     finally:
         connection.close()
 


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-6d1
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

## Objective

Complete Increment 6D1 as the single canonical contract-and-persistence atom for #363 on the accepted serial v20 predecessor plus the #362-owned transaction seam at `main@4cfa26b6cc6dddcc28f181f2832ee1a72b33717f`. The change implements only stable Event Hypothesis identity and immutable Version authority after an exact authenticated, committed, current Proposal Disposition.

## Accepted allocation

- Contract digest: `sha256:13b43c927e4222c143b8691eaf179eb956096c19a72f4cc29cae13008d6e0590`
- Tier: **Tier S**
- Dependencies: `#354`, `#358`, `#362`
- Sole public module: `newsroom.increment6.hypotheses`
- Interfaces: `EVENT_HYPOTHESIS`, `EVENT_HYPOTHESIS_VERSION`, `HYPOTHESIS_CURRENT_VERSION`
- Schemas: `newsroom.increment6.event-hypothesis.v1`, `newsroom.increment6.event-hypothesis-version.v1`
- Migration: v21 / `newsroom.authority.event_hypothesis_migrations` / `event_hypothesis_authority_v21`
- Exact tables only: `event_hypotheses_v2`, `event_hypothesis_versions_v2`, `event_hypothesis_heads_v2`

## Implementation

- Stable Hypothesis UUIDv5 identity is derived from the exact Proposal and proposal-local Hypothesis identity; Version identity is derived from stable Hypothesis identity and contiguous ordinal.
- Each immutable Version binds the exact Proposal identity/digest, retained Proposal bytes, current v19 Proposal Disposition set, Decision Lead heads, Work Item Version, Retrieval Context, authenticated actor and server-recorded provenance.
- A complete proposal-local multi-Lead group is retained atomically. Partial, extra, divergent, uncommitted, rejected or stale disposition input writes nothing.
- `NO_ADEQUATE_PRIOR_MATCH`, `RELATED_DISTINCT` and `UNCERTAIN` allocate a distinct stable Hypothesis; target-bearing routes pin the exact current target Version. `SAME_STATE`, `DEVELOPMENT_OF` and `CORRECTION_REVERSAL_OF` append only to the exact immediate predecessor under a head CAS.
- Lost-response replay is resolved before upstream reauthorisation, returns the exact retained Version to the same authenticated actor, and rejects divergent bytes or bindings.
- Current use rechecks every retained v19 disposition and its v18 Work Item, Lead/Gate/Source and Retrieval authority inside the same `BEGIN IMMEDIATE` transaction. Historical loads remain non-authoritative and preserve immutable audit lineage.
- The private store uses an owned 0700 directory, 0600 database/writer lock, WAL/FULL/FK/busy-timeout checks, exact migration history/fingerprint validation and a single writer lifetime lock. Reopen rebuilds identity/version/head, Proposal, disposition, target, predecessor and provenance integrity.
- Relationship semantics remain explicitly unverified snapshots for #364. There is no #365 lineage authority, #366 Candidate authority, publication, evidence publication, egress, model/provider call or external effect.

## v21 release pins

- Accepted v20 migration checksum: `sha256:6eb04f981f650bbb4956f148d11f1656bcd2b7c510117db96602dd9d83ab9bd3`
- Accepted v20 schema fingerprint: `sha256:36a7c9910775ede9c29113a43e08bba261a5a98c4fab5225dd2cae9448689389`
- v21 migration checksum: `sha256:42009475669a475af8e3e24bbcd02e6fcd9fbb71a800e18d83624e34e79e5e21`
- v21 schema fingerprint: `sha256:d314d06118a25f8a32a0f9d8acb1af5383abd6b30be682cb5f65943ae15c213f`
- Exact pre-v21 backup boundary: `.pre-v21.sqlite3` + `.sha256` + logical database digest, with complete v1-v20 history validation.

## Exact revision

- Base / merge-base: `4cfa26b6cc6dddcc28f181f2832ee1a72b33717f`
- Head: `da1d5ac0a0163dc02be4c01261c34506c18b0867`
- Tree: `58a8dbd58768cf4ffc3a4b30deb398760d829bea`
- `newsroom/increment6/hypotheses.py`: `sha256:8d726763899e90d4bcc802ebc10ced71a9774a0b51b1f35b43b8276cb0774287`
- `newsroom/increment6/_hypothesis_store.py`: `sha256:e63ab8cd83346bf4f927713248b33f4b0f4ff91091d848e26a62f19e2c102a1e`
- `newsroom/authority/event_hypothesis_migrations.py`: `sha256:ed7a9cab5673e70529b2696fc85b7259cca841fa7c10d0176ca4111aaab07ac7`
- Central migrations: `sha256:58e6b48e287412731616ca4fd5cb2b09b370b337d6a21387a6d8c21f885f1031`
- Transaction-aware v19 disposition seam: `sha256:92a2d4f714c4d88684545dc732dfcea24ff05dfdbb59fa64ff6a089f18318fc0`

## Exact-head local evidence

- Final-head D1 contracts/store/migration inventory: **46 passed** within the exact-head affected selection. The initial pre-review head also passed the combined D1 plus every migration selection (**130 passed**); migration bytes and release pins are unchanged by the bounded correction.
- Final-head affected compatibility selection covering 6A2/6B1/6C2/6D1: **165 passed**. The canonical exact-head SDLC receipt and risk-selected Tier-S lanes remain the admission evidence.
- `uv lock --check`, `compileall`, `git diff --check`, new-file Ruff format/check and 6R readiness (**12 passed**): passed.
- Focused evidence includes create/append/replay/restart/currentness, complete multi-Lead groups, >1.1 MiB legal Proposal input, target CAS, two-connection races, same-store thread isolation, direct-SQL/reopen tamper, fresh/exact-predecessor/multihop/rollback/newer migration gates and literal release pins.

## Explicit boundary

The retained relationship kind and target are an editorially unverified snapshot only. This atom does not decide relationship authority, consolidate or split lineage, create Candidates, publish evidence, activate publication/egress, call a model/provider, dispatch work or perform an external effect.

Issue: #363

## Bounded substantive-review correction

The single substantive review found 0 P1 / 2 material P2 on the initial head. Commit `66d033cc7568d2dc348345de28f1b337c1bb6549` changes only the two owned D1 source files and their focused tests:

- first Version identity now re-derives the stable Proposal/proposal-local UUID and enforces create-only relationship topology; later Versions enforce append-only topology with target exactly equal to the immediate predecessor;
- lost-response replay still precedes currentness reauthorisation, but now requires the exact original target/predecessor comparator (or exact absence for a targetless create);
- malformed canonical and self-consistent direct-SQL/reopen identities, omitted/wrong-type/wrong-Version comparators and targetless extra comparators are covered by RED-to-GREEN regressions.

Corrected-head focused result before the final retained-authorisation delta: **47 passed**. Ruff check, compileall and diff-check passed. No unrelated hardening or duplicated manual full-suite cycle was added.

## Retained-authorisation review correction

The corrected-head automated review identified one genuine material P2: a self-consistent offline rewrite could make a retained v19 disposition differ from its exact Proposal recommendation while v21 reopen still accepted the recomputed bindings. Commit `5a33e77c09eab33aaf90f2927d215b71b939017d` closes only that surface:

- fresh retain and reopen now share one exact Proposal-authorisation predicate covering ACCEPT judgement, the allowed route set, Proposal identity/digest, exact Hypothesis route binding and exact Decision Lead;
- a RED-to-GREEN regression rewrites the v19 finding/disposition and v21 binding/version/event/head identities self-consistently, restores every trigger, proves `foreign_key_check` clean and requires reopen to reject it;
- the three direct-rewrite regressions share one immutable seed while retaining each scalar, stable-identity and disposition-retarget assertion; unused setup was removed without dropping a mutation or authority check, reducing canonical evidence work under the accepted hard timeout.

Final-head results: affected 6A2/6B1/6C2/6D1 **165 passed**, including all **46** D1 contract/store/migration tests; Ruff, compileall and diff-check passed. Commits `856a3220cdaadc9a685c2f97211ff4141c741c8d` and `fe8d796d86d74e4986d5a3f04c0656586fd6d953` change tests only: they consolidate the same direct-rewrite assertions and clone one immutable authority seed per xdist worker, preserving isolation while avoiding repeated producer setup after three correctly classified infrastructure-budget attempts on superseded heads. Fresh exact-head canonical SDLC evidence and the same reviewer bounded delta verdict are pending.

## Five-finding authority correction — exact head

Rebased commit `da1d5ac0a0163dc02be4c01261c34506c18b0867` retains the single batch closing the five live authority findings without migration, schema, table, allocation or downstream semantics changes:

- fresh retain and reopen now share the complete exact Proposal-Disposition predicate: ACCEPT, allowed route, Proposal identity/digest, exact Decision Lead and complete `LeadRecommendation` equality, including citations, coverage and Candidate manifest;
- fresh Version construction and reopen share exact Proposal Work Item/Retrieval provenance equality;
- `load_hypothesis`, `load_version` and `versions` revalidate complete retained v21 row/chain/provenance plus v19 disposition/finding integrity inside their read transaction;
- lost-response replay revalidates retained v19 integrity through an integrity-only transaction seam, while the existing stale-upstream replay regression proves no unrelated use-time currentness was added;
- realistic self-consistent SQL regressions cover complete route rewrites and Work Item v1-to-v2 provenance rewrites with restored triggers and a clean `foreign_key_check`.

Exact-head evidence: D1 contract/store/full allocated v21 migration matrix **53 passed**; deterministic 6A2+6C2+6D1 dependency closure **138 passed** (6B1 excluded because this delta does not import it); 6R readiness **12 passed**. `uv lock --check`, compileall and diff-check passed; Ruff check/format passed on the fully formatted D1 store and test files. The narrow pre-existing v19 source has the same **9** Ruff findings at base and head; this delta adds none and does not reformat unrelated v19 code.

PR remains draft. Live unresolved review-thread count at this exact head: **5**; threads are intentionally neither resolved nor re-requested in this correction step.

## #362 owner-boundary rebase

Final delta review confirmed all five authority findings functionally closed but identified one material allocation defect: the downstream branch still owned two transaction-aware methods in `newsroom.increment6.dispositions`. PR #386 moved those methods to their accepted #362 owner, passed a 0 P1 / 0 material-P2 substantive review, and squash-merged as `main@4cfa26b6cc6dddcc28f181f2832ee1a72b33717f`.

This branch was rebased once onto that exact main. The PR now has **no diff in `newsroom/increment6/dispositions.py`** and consumes the owner-provided public seams only. Rebased exact-head affected selection covering 6A2/6C2/6D1 plus 6R: **155 passed**; lock, Ruff on changed D1 files, compileall and diff-check passed. The five threads remain unresolved pending the same reviewer’s final exact-head scope confirmation.


