### PR TITLE
Increment 6C2: own retained integrity transaction seams

### DIFF
--- a/newsroom/increment6/dispositions.py
+++ b/newsroom/increment6/dispositions.py
@@ -1666,56 +1666,9 @@ class ProposalDispositionStore:
         _digest(disposition_id, "disposition_id")
         try:
             self._begin()
-            _, authenticated_identity = self._authenticate(proof)
-            self._verify_integrity()
-            row = self._connection.execute(
-                "SELECT canonical_bytes FROM triage_proposal_dispositions WHERE disposition_id=?",
-                (disposition_id,),
-            ).fetchone()
-            if row is None:
-                raise DispositionContractError("unknown disposition")
-            disposition = ProposalDisposition.from_canonical_bytes(bytes(row[0]))
-            version = _WORK_ITEM_REQUIRE_CURRENT(
-                self._work_items, disposition.work_item_id
+            disposition = self.require_current_in_transaction(
+                disposition_id, proof=proof
             )
-            _RETRIEVAL_VERIFY(
-                self._retrieval_authority, self._connection, version.retrieval
-            )
-            lead = next(
-                (item for item in version.decision_leads
-                 if item.lead_id == disposition.decision_lead_id),
-                None,
-            )
-            if (
-                version.version_id != disposition.work_item_version_id
-                or version.canonical_digest != disposition.work_item_version_digest
-                or version.retrieval.context_id != disposition.retrieval_context_id
-                or version.retrieval.context_digest != disposition.retrieval_context_digest
-                or disposition.validator_input.authenticated_context_identity
-                != authenticated_identity
-                or disposition.validator_input.validator_id != _VALIDATOR_ID
-                or disposition.validator_input.validator_version
-                != _VALIDATOR_VERSION
-                or disposition.validator_input.ruleset_id != _RULESET_ID
-                or disposition.validator_input.ruleset_version
-                != _RULESET_VERSION
-                or disposition.validator_input.ruleset_digest != _RULESET_DIGEST
-                or disposition.validator_input.retrieval_request_id
-                != version.retrieval.request_id
-                or disposition.validator_input.retrieval_request_digest
-                != version.retrieval.request_digest
-                or disposition.validator_input.retrieval_receipt_id
-                != version.retrieval.context_id
-                or disposition.validator_input.retrieval_receipt_digest
-                != version.retrieval.context_digest
-                or lead is None
-                or lead.lead_digest != disposition.lead_head.decision_lead_digest
-                or lead.disposition_id
-                != disposition.lead_head.current_disposition_head_id
-                or lead.disposition_digest
-                != disposition.lead_head.current_disposition_head_digest
-            ):
-                raise DispositionContractError("disposition is no longer current")
             self._connection.execute("COMMIT")
             return disposition
         except BaseException as exc:
@@ -1726,9 +1679,77 @@ class ProposalDispositionStore:
                 raise
             raise DispositionContractError("disposition currentness failed") from exc
 
+    def require_current_in_transaction(
+        self, disposition_id: str, *, proof: AuthenticationProof
+    ) -> ProposalDisposition:
+        """Recheck a retained disposition inside the caller's write transaction."""
+        _digest(disposition_id, "disposition_id")
+        if not self._connection.in_transaction:
+            raise DispositionContractError(
+                "transaction-aware disposition use requires an active transaction"
+            )
+        _, authenticated_identity = self._authenticate(proof)
+        self._verify_integrity()
+        row = self._connection.execute(
+            "SELECT canonical_bytes FROM triage_proposal_dispositions WHERE disposition_id=?",
+            (disposition_id,),
+        ).fetchone()
+        if row is None:
+            raise DispositionContractError("unknown disposition")
+        disposition = ProposalDisposition.from_canonical_bytes(bytes(row[0]))
+        version = _WORK_ITEM_REQUIRE_CURRENT(self._work_items, disposition.work_item_id)
+        _RETRIEVAL_VERIFY(
+            self._retrieval_authority, self._connection, version.retrieval
+        )
+        lead = next(
+            (
+                item
+                for item in version.decision_leads
+                if item.lead_id == disposition.decision_lead_id
+            ),
+            None,
+        )
+        if (
+            version.version_id != disposition.work_item_version_id
+            or version.canonical_digest != disposition.work_item_version_digest
+            or version.retrieval.context_id != disposition.retrieval_context_id
+            or version.retrieval.context_digest != disposition.retrieval_context_digest
+            or disposition.validator_input.authenticated_context_identity
+            != authenticated_identity
+            or disposition.validator_input.validator_id != _VALIDATOR_ID
+            or disposition.validator_input.validator_version != _VALIDATOR_VERSION
+            or disposition.validator_input.ruleset_id != _RULESET_ID
+            or disposition.validator_input.ruleset_version != _RULESET_VERSION
+            or disposition.validator_input.ruleset_digest != _RULESET_DIGEST
+            or disposition.validator_input.retrieval_request_id
+            != version.retrieval.request_id
+            or disposition.validator_input.retrieval_request_digest
+            != version.retrieval.request_digest
+            or disposition.validator_input.retrieval_receipt_id
+            != version.retrieval.context_id
+            or disposition.validator_input.retrieval_receipt_digest
+            != version.retrieval.context_digest
+            or lead is None
+            or lead.lead_digest != disposition.lead_head.decision_lead_digest
+            or lead.disposition_id != disposition.lead_head.current_disposition_head_id
+            or lead.disposition_digest
+            != disposition.lead_head.current_disposition_head_digest
+        ):
+            raise DispositionContractError("disposition is no longer current")
+        return disposition
+
+    def verify_retained_integrity_in_transaction(self) -> None:
+        """Revalidate retained disposition/finding authority without currentness."""
+        if not self._connection.in_transaction:
+            raise DispositionContractError(
+                "transaction-aware disposition integrity requires an active transaction"
+            )
+        self._verify_integrity()
+
     def _verify_integrity(self) -> None:
         tables = {
-            str(row[0]) for row in self._connection.execute(
+            str(row[0])
+            for row in self._connection.execute(
                 "SELECT name FROM sqlite_master WHERE type='table'"
             )
         }

--- a/newsroom/tests/test_increment6c2_dispositions.py
+++ b/newsroom/tests/test_increment6c2_dispositions.py
@@ -41,6 +41,8 @@ from newsroom.increment6.work_items import (
     RetrievalContextAuthority,
     RetrievalInputBinding,
     TriageWorkItem,
+    TriageWorkItemStore,
+    TriageWorkItemVersion,
 )
 from newsroom.tests import test_increment5d1_hybrid_composer as composer_helpers
 from newsroom.tests import test_increment5d2_retrieval_context as retrieval_helpers
@@ -276,6 +278,125 @@ def _persistable_proposal(version: object, decision: object, receipt: object) ->
         decision.lead_id
     ]
     return _resign(document)
+
+
+def _persisted_disposition_store(
+    tmp_path: object, *, name: str
+) -> tuple[
+    sqlite3.Connection,
+    TriageWorkItemStore,
+    TriageWorkItem,
+    TriageWorkItemVersion,
+    ProposalDispositionStore,
+    AuthenticationProof,
+    ProposalDisposition,
+]:
+    inputs = composer_helpers.branch_inputs.__wrapped__(tmp_path)
+    builder, _, _, _, _, request, receipt, _ = (
+        retrieval_helpers._retained_complete_context(tmp_path, inputs, name=name)
+    )
+    authority = RetrievalContextAuthority(
+        builder.journal.path, {request.request_digest: (request, receipt)}
+    )
+    decision = work_item_helpers._decision(1)
+    connection, work_store = work_item_helpers._store(
+        (decision,), retrieval_authority=authority
+    )
+    item = TriageWorkItem.create((decision,))
+    version = replace(
+        work_item_helpers._version(item),
+        retrieval=RetrievalInputBinding.from_receipt(request, receipt),
+    )
+    work_store.create_or_replay(item, version)
+    for statement in TRIAGE_DISPOSITION_MIGRATION_STATEMENTS:
+        connection.execute(statement)
+    authenticator = StaticAuthenticator(
+        credentials={"credential": StaticPrincipal("editor")},
+        authority_domain="newsroom.dispositions",
+    )
+    proof = AuthenticationProof(method="STATIC_TOKEN", credential="credential")
+    store = ProposalDispositionStore(connection, authority, authenticator)
+    disposition = store.persist(
+        _persistable_proposal(version, decision, receipt),
+        {
+            decision.lead_id: _selection(
+                CanonicalOutcome.LEAD_ADMIT_NEW_CANDIDATE,
+                CanonicalNextAction.HANDOFF_FOR_EVALUATION,
+                ReasonCode.NOVELTY_LIKELY_NEW_EVENT,
+            )
+        },
+        proof=proof,
+    )[0]
+    return connection, work_store, item, version, store, proof, disposition
+
+
+def test_transaction_aware_retained_integrity_requires_a_transaction_and_passes(
+    tmp_path,
+) -> None:
+    connection, _, _, _, store, _, _ = _persisted_disposition_store(
+        tmp_path, name="retained-integrity-transaction"
+    )
+
+    with pytest.raises(DispositionContractError, match="active transaction"):
+        store.verify_retained_integrity_in_transaction()
+
+    connection.execute("BEGIN IMMEDIATE")
+    assert store.verify_retained_integrity_in_transaction() is None
+    connection.execute("ROLLBACK")
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    ("disposition_scalar", "disposition_digest", "linked_finding"),
+)
+def test_transaction_aware_retained_integrity_rejects_retained_tamper(
+    tmp_path, mutation: str
+) -> None:
+    connection, _, _, _, store, _, _ = _persisted_disposition_store(
+        tmp_path, name=f"retained-integrity-{mutation}"
+    )
+    if mutation == "disposition_scalar":
+        connection.execute("DROP TRIGGER immutable_triage_proposal_dispositions_update")
+        connection.execute("PRAGMA foreign_keys=OFF")
+        connection.execute(
+            "UPDATE triage_proposal_dispositions SET proposal_id=?",
+            ("00000000-0000-4000-8000-000000009999",),
+        )
+        connection.execute("PRAGMA foreign_keys=ON")
+    elif mutation == "disposition_digest":
+        connection.execute("DROP TRIGGER immutable_triage_proposal_dispositions_update")
+        connection.execute(
+            "UPDATE triage_proposal_dispositions SET canonical_digest=?", (DIGEST_A,)
+        )
+    else:
+        connection.execute("DROP TRIGGER immutable_triage_proposal_findings_update")
+        connection.execute(
+            "UPDATE triage_proposal_validation_findings SET canonical_digest=?",
+            (DIGEST_A,),
+        )
+
+    connection.execute("BEGIN IMMEDIATE")
+    with pytest.raises(DispositionContractError, match="retained"):
+        store.verify_retained_integrity_in_transaction()
+    connection.execute("ROLLBACK")
+
+
+def test_retained_integrity_ignores_upstream_currentness_but_current_use_does_not(
+    tmp_path,
+) -> None:
+    connection, work_store, item, version, store, proof, disposition = (
+        _persisted_disposition_store(tmp_path, name="retained-integrity-stale")
+    )
+    successor = replace(
+        work_item_helpers._version(item, 2), retrieval=version.retrieval
+    )
+    work_store.append_version(version.version_id, version.canonical_digest, successor)
+
+    connection.execute("BEGIN IMMEDIATE")
+    assert store.verify_retained_integrity_in_transaction() is None
+    with pytest.raises(DispositionContractError, match="no longer current"):
+        store.require_current_in_transaction(disposition.disposition_id, proof=proof)
+    connection.execute("ROLLBACK")
 
 
 def test_v19_store_exact_success_replay_restart_and_use_time_currentness(tmp_path) -> None:


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-6c2-retained-integrity-seam
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

## Objective

Extract the transaction-aware Proposal Disposition dependency seams into the #362 owner boundary so downstream #363 can validate retained v19 disposition/finding authority during lost-response replay without silently imposing use-time currentness. This applies the authority-store replay requirement in #382 at the owning layer.

## Owner-bound implementation

- `require_current_in_transaction` preserves the complete existing authenticated current-use predicate inside a caller-owned active transaction; `require_current` delegates to it without changing its transaction or rollback contract.
- `verify_retained_integrity_in_transaction` requires an active transaction and invokes the existing complete `_verify_integrity()` only.
- The retained-integrity seam performs no authentication, current Work Item head check, Retrieval Context currentness check or upstream use-time currentness check.
- Focused regressions prove the active-transaction boundary, healthy retained state, disposition scalar/digest and linked-finding tamper rejection, stale-but-intact upstream acceptance by the integrity-only seam, and rejection of that same stale state by the current-use seam.

## Exact revision

- Base / merge-base: `464548e899a3ce84ba389efc2542f5faed67c830`
- Head: `735fd7ecfa57a28550c2b23f7af769cddf4020c0`
- Tree: `70f5b91597711f438aefd503d2e1fe78d56c27dc`
- One commit; two owned files only.

## Exact-head evidence

- Focused 6C2 contract/store and complete allocated v19 migration tests: **53 passed**.
- Minimal imported 6A2 retrieval/current-transaction compatibility: **1 passed**.
- `compileall`: passed for both changed files.
- Ruff format: changed production and test ranges passed.
- Ruff check: unchanged baseline at head (`dispositions.py`: 9 existing findings at base and head; 6C2 test: 1 existing import-order finding at base and head); this bounded seam adds no Ruff finding and does not reformat the pre-existing files wholesale.
- `git diff --check`: passed.

## Allocation boundary

No migration, schema, table, canonical bytes, disposition/finding semantics, public constants or #363-owned hypothesis semantics change. The only public ownership addition is the two #362 transaction-aware store methods extracted from the downstream dependency surface. There is no authentication weakening: the retained-only method is an integrity predicate, while authoritative current use remains authenticated and current through `require_current_in_transaction`.

References #362 and #382. Unblocks the bounded downstream correction in #363 / PR #380; this PR does not merge or otherwise alter that branch.
