### PR TITLE
SDLC v2.5: shard deterministic core evidence

### DIFF
--- a/.github/workflows/evidence.yml
+++ b/.github/workflows/evidence.yml
@@ -85,8 +85,8 @@ jobs:
           include-hidden-files: false
           archive: true
 
-  core:
-    name: core
+  source:
+    name: source
     needs:
       - route
     if: needs.route.result == 'success'
@@ -100,12 +100,153 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
           show-progress: false
-
       - name: Set up Python 3.12
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
+      - name: Set up exact uv with shared cache
+        id: setup_uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: '0.8.0'
+          github-token: ''
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+          restore-cache: true
+          save-cache: false
+          cache-suffix: newsroom-py312
+          prune-cache: false
+          cache-python: false
+      - name: Download exact route evidence
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: newsroom-sdlc-route-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
+          path: .sdlc-run/route
+          merge-multiple: false
+          digest-mismatch: error
+      - name: Sync locked environment
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv lock --check
+          uv sync --dev --locked
+      - name: Execute source integrity
+        shell: bash
+        env:
+          NEWSROOM_SDLC_CACHE_KEY: ${{ steps.setup_uv.outputs.cache-key }}
+          NEWSROOM_SDLC_CACHE_HIT: ${{ steps.setup_uv.outputs.cache-hit }}
+        run: |
+          set -euo pipefail
+          uv run --no-sync python -m scripts.sdlc.workflow_lane execute-source \
+            --route .sdlc-run/route/route.json \
+            --artifact-root .sdlc-run/source-fragment
+      - name: Upload source fragment
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: newsroom-sdlc-source-fragment-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
+          path: .sdlc-run/source-fragment
+          if-no-files-found: error
+          retention-days: 30
+          compression-level: 0
+          overwrite: false
+          include-hidden-files: false
+          archive: true
 
+  core_shard:
+    name: core-shard-${{ matrix.shard }}
+    needs:
+      - route
+    if: needs.route.result == 'success'
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout evaluated head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+          show-progress: false
+      - name: Set up Python 3.12
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.12'
+      - name: Set up exact uv with shared cache
+        id: setup_uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: '0.8.0'
+          github-token: ''
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+          restore-cache: true
+          save-cache: false
+          cache-suffix: newsroom-py312
+          prune-cache: false
+          cache-python: false
+      - name: Download exact route evidence
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: newsroom-sdlc-route-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
+          path: .sdlc-run/route
+          merge-multiple: false
+          digest-mismatch: error
+      - name: Sync locked environment
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv lock --check
+          uv sync --dev --locked
+      - name: Execute bounded core shard
+        shell: bash
+        env:
+          NEWSROOM_SDLC_CACHE_KEY: ${{ steps.setup_uv.outputs.cache-key }}
+          NEWSROOM_SDLC_CACHE_HIT: ${{ steps.setup_uv.outputs.cache-hit }}
+        run: |
+          set -euo pipefail
+          uv run --no-sync python -m scripts.sdlc.workflow_lane execute-core-shard \
+            --route .sdlc-run/route/route.json \
+            --shard-index ${{ matrix.shard }} \
+            --artifact-root .sdlc-run/core-fragment
+      - name: Upload canonical core fragment
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: newsroom-sdlc-core-fragment-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}-${{ matrix.shard }}
+          path: .sdlc-run/core-fragment
+          if-no-files-found: error
+          retention-days: 30
+          compression-level: 0
+          overwrite: false
+          include-hidden-files: false
+          archive: true
+
+  core:
+    name: core
+    needs:
+      - route
+      - source
+      - core_shard
+    if: always() && needs.route.result == 'success'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout evaluated head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+          show-progress: false
+      - name: Set up Python 3.12
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.12'
       - name: Set up exact uv with shared cache
         id: setup_uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
@@ -119,7 +260,6 @@ jobs:
           cache-suffix: newsroom-py312
           prune-cache: false
           cache-python: false
-
       - name: Download exact route evidence
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -127,35 +267,39 @@ jobs:
           path: .sdlc-run/route
           merge-multiple: false
           digest-mismatch: error
-
+      - name: Download exact source fragment
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: newsroom-sdlc-source-fragment-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
+          path: .sdlc-run/source-fragments/source
+          merge-multiple: false
+          digest-mismatch: error
+      - name: Download exact core fragments
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: newsroom-sdlc-core-fragment-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}-*
+          path: .sdlc-run/core-fragments
+          merge-multiple: false
+          digest-mismatch: error
       - name: Sync locked environment
         shell: bash
         run: |
           set -euo pipefail
           uv lock --check
           uv sync --dev --locked
-          uv run --no-sync python - <<'PY'
-          import platform
-          import sys
-
-          assert sys.version_info[:2] == (3, 12), sys.version
-          assert platform.python_implementation() == 'CPython'
-          PY
           uv run --no-sync python -m compileall -q newsroom scripts
-
-      - name: Execute evidence lane
+      - name: Reduce exact core fragments
         shell: bash
         env:
           NEWSROOM_SDLC_CACHE_KEY: ${{ steps.setup_uv.outputs.cache-key }}
           NEWSROOM_SDLC_CACHE_HIT: ${{ steps.setup_uv.outputs.cache-hit }}
         run: |
           set -euo pipefail
-          uv run --no-sync python -m scripts.sdlc.workflow_lane execute \
+          uv run --no-sync python -m scripts.sdlc.workflow_lane reduce-core \
             --route .sdlc-run/route/route.json \
-            --lane core \
-            --artifact-root .sdlc-run/core \
-            --output .sdlc-run/core-execution.json
-
+            --fragment-root .sdlc-run/core-fragments \
+            --source-root .sdlc-run/source-fragments \
+            --artifact-root .sdlc-run/core
       - name: Finalize evidence
         if: always()
         shell: bash
@@ -171,7 +315,6 @@ jobs:
             --output .sdlc-run/core-lane.json \
             > "${RUNNER_TEMP}/core-finalize-gate.json"
           cat "${RUNNER_TEMP}/core-finalize-gate.json"
-
       - name: Upload core lane evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.sdlc/gates.toml
+++ b/.sdlc/gates.toml
@@ -1,10 +1,10 @@
 schema_version = "newsroom.sdlc.gates.v1"
-contract_version = "sdlc-v2.4"
+contract_version = "sdlc-v2.5"
 status = "accepted"
 owner = "fol2"
 canonical_language = "English"
 specification = "docs/specs/sdlc/high-performance-evidence-sdlc.md"
-acceptance_record = "docs/specs/sdlc/2026-08-02-sdlc-v2.4-owner-budget-amendment.md"
+acceptance_record = "docs/specs/sdlc/2026-08-10-sdlc-v2.5-core-sharding-amendment.md"
 issue = 98
 
 [global]
@@ -193,6 +193,13 @@ clustering = [
 
 [lanes.core]
 bootstrap_once = true
+shard_count = 4
+partition = "sha256_node_id_balanced"
+workers_per_shard = 4
+distribution = "worksteal"
+max_worker_restart = 0
+per_shard_hard_timeout_seconds = 220
+reducer_single_canonical_receipt = true
 run_full_suite_when_p95_below_seconds = 35
 hard_timeout_seconds = 220
 required = true

--- a/docs/specs/sdlc/2026-08-10-sdlc-v2.5-core-sharding-amendment.md
+++ b/docs/specs/sdlc/2026-08-10-sdlc-v2.5-core-sharding-amendment.md
@@ -1,0 +1,59 @@
+# SDLC v2.5 core-sharding owner amendment
+
+Status: accepted
+Owner: fol2
+Issue: #381
+Predecessor: `sdlc-v2.4`
+
+## Decision
+
+The deterministic core inventory is executed as four exact-head shards. The
+repository collects the complete sorted recursive `newsroom/tests/**/test_*.py` node-ID
+inventory, orders it by a stable SHA-256 key, and distributes it evenly across
+four shards. Callers cannot provide files, node IDs, exclusions, worker counts,
+or scheduler options.
+
+Each shard retains four persistent pytest-xdist workers, one explicit
+`xdist.plugin`, `worksteal`, `--max-worker-restart=0`, isolated temporary state
+and an independent 220-second hard watchdog. That watchdog starts before node
+collection and covers collection, pytest, report processing and fragment
+finalisation. The producer verifies the tracked checkout immediately after
+collection and again after pytest/report finalisation, before publication; a
+later reducer checkout cannot substitute for either proof.
+
+Each canonical fragment binds the run, attempt, producer job, evaluated commit
+and tree, route, accepted contract, exact lockfile, Python/uv toolchain,
+complete inventory, assignment, command specification and run, JUnit report
+and summary, plus exact shard-lifecycle elapsed time, accepted timeout and typed
+result. The command specification itself binds the complete inventory and
+assigned node-ID digests; the child process recomputes both before pytest.
+
+Source integrity runs concurrently with the four shards. Its producer starts
+the same immutable core-lane deadline before artifact preparation, binds a
+typed full-lifecycle record through durable fragment staging, and proves the
+tracked checkout after source execution and again at publication. A source
+callback or finalisation step cannot publish a stale-tree or over-budget PASS.
+
+The `core` reducer
+rejects missing, extra, duplicate, non-canonical, tampered, wrong-head,
+wrong-tree, wrong-route, wrong-specification, wrong-inventory or wrong-report
+inputs. It proves the assigned and observed JUnit universes, merges the four
+reports, and alone emits the existing canonical core lane artifact consumed by
+the decision. Its bound starts before fragment/source loading and inventory
+re-collection, is checked after every loading or collection boundary, and
+covers validation, merge and durable output staging. It performs final
+deadline and tracked-tree proofs around canonical publication; late work can
+never leave a PASS artifact. Shard fragments are reduction inputs, not
+admission receipts.
+
+`FAIL`, `BUDGET_EXCEEDED`, `EVIDENCE_MISMATCH` and `ENVIRONMENT_ERROR` remain
+distinct. Core admission uses `max(source lifecycle, maximum shard lifecycle) +
+reducer lifecycle`; parallel work is not summed and sequential reducer work is
+not omitted. The resulting core lifecycle fails with typed `BUDGET_EXCEEDED`
+above the unchanged 220-second envelope. Fast CI, service routing, skip policy,
+evidence replay, risk policy and every existing timeout remain unchanged.
+
+## Rollback
+
+One reviewed revert restores `sdlc-v2.4` and its single-runner topology.
+Contract and exact-tree identities prevent evidence crossing that boundary.

--- a/docs/specs/sdlc/high-performance-evidence-sdlc.md
+++ b/docs/specs/sdlc/high-performance-evidence-sdlc.md
@@ -1,15 +1,15 @@
 # High-performance evidence SDLC
 
 - Role: Normative target specification
-- Status: Accepted — amended by the owner on 2026-08-02
+- Status: Accepted — amended by the owner on 2026-08-10
 - Owner: fol2
 - Canonical language: English
 - Date: 2026-07-21
 - Specification ID: `SDLC-V2`
-- Contract version: `sdlc-v2.4`
+- Contract version: `sdlc-v2.5`
 - Related issue: #98
 - Related active product work: #96 / PR #97
-- Current owner amendment: `docs/specs/sdlc/2026-08-02-sdlc-v2.4-owner-budget-amendment.md`
+- Current owner amendment: `docs/specs/sdlc/2026-08-10-sdlc-v2.5-core-sharding-amendment.md`
 
 ## 1. Decision
 
@@ -17,14 +17,14 @@ Newsroom will replace increment-by-increment CI accumulation with an evidence-or
 
 A machine gate is a bounded decision over an exact change, environment and evidence contract. It either produces a reproducible typed decision inside its budget or fails closed. Its timeout does not grow whenever repository scope grows.
 
-The normal pull-request path has one always-reporting decision workflow with two possible parallel lanes:
+The normal pull-request path has one always-reporting decision workflow with parallel source-integrity, four-way deterministic-core and conditional service work:
 
-1. a core lane for routing, source integrity and deterministic repository tests;
+1. a core topology for routing, concurrent source integrity and four deterministic repository-test shards, followed by one canonical reducer;
 2. a Neo4j service lane when the exact change affects the graph adapter, projection-authority integration, graph migrations, service compatibility, credentials, workflow service setup or qualifying GraphRAG behaviour.
 
 One decision-validated exact-head SDLC core receipt is the canonical complete deterministic evidence. Pull-request and merge-queue core/decision receipts are content-addressed, transport-verified evidence-only artifacts, not signed attestations. The isolated signed-closeout job remains limited to exact-main, service-required manual runs and supplies the Tier-M attestation. Fast CI and manually dispatched legacy diagnostics are compatibility signals only; Tier S adds only the affected lanes selected by the route. The change has one feature-complete stop and one review at that stop.
 
-The measured exact-head test selections are currently small: the recorded JUnit suites range from 1.134 to 7.401 seconds. The exact full-repository pytest p95 has not yet been recorded. Full deterministic tests remain the blocking default until measurement proves that their p95 no longer fits the core-lane budget. Test-impact analysis begins in observe mode and cannot replace full evidence until repository-specific shadow controls demonstrate that it preserves defect detection.
+The complete deterministic inventory remains blocking. Its stable node-ID inventory is divided into four complete, duplicate-free balanced shards because a single runner no longer fits the unchanged 220-second envelope. Test-impact analysis remains in observe mode and cannot replace this complete evidence until repository-specific shadow controls demonstrate that it preserves defect detection.
 
 Deep mutation, fuzz, compatibility, flake, performance and recovery work runs as independent scientific shards outside the interactive path. Each shard has its own 220-second hard budget; a large experiment is many content-addressed shards, not one unbounded job.
 
@@ -152,6 +152,10 @@ The 2026-08-02 owner amendment doubles every `sdlc-v2.3` hard command, lane, sha
 Aggregate execution rules:
 
 - core-lane repository-owned execution hard deadline: 220 seconds;
+- core-lane execution is `max(source lifecycle, maximum shard lifecycle) +
+  reducer lifecycle`, with source timed from pre-preparation, each shard timed
+  from pre-collection and the reducer timed from pre-input-loading through
+  durable canonical output staging;
 - service-lane repository-owned execution hard deadline: 220 seconds;
 - merge-lane repository-owned execution hard deadline: 220 seconds;
 - finalisation hard deadline: 20 seconds;
@@ -295,12 +299,17 @@ Shape:
 1. always start;
 2. cancel obsolete heads with a PR-specific concurrency group;
 3. checkout exact head and sufficient base history;
-4. install pinned Python and pinned uv once;
+4. install pinned Python and pinned uv in each isolated exact-head job;
 5. restore an exact lock/toolchain-keyed cache;
 6. run `route`;
-7. run source integrity and deterministic tests in the same environment under one lane deadline;
-8. emit one compact evidence bundle;
-9. report one stable required decision name.
+7. run source integrity and four independently watched deterministic shards concurrently;
+8. prove each shard producer's tracked tree after collection and again before
+   fragment publication, and prove the source producer after execution and at
+   publication;
+9. validate their exact provenance, full lifecycle accounting and JUnit
+   universes in one bounded reducer, which alone emits the compact canonical
+   core evidence bundle;
+10. report one stable required decision name.
 
 Historical increment names do not remain separate required workflows. Requirement IDs live in test/evidence manifests.
 
@@ -381,7 +390,7 @@ Canonical output shape:
 ```json
 {
   "schema_version": "newsroom.sdlc.route.v1",
-  "contract_version": "sdlc-v2.4",
+  "contract_version": "sdlc-v2.5",
   "base_sha": "0000000000000000000000000000000000000000",
   "head_sha": "1111111111111111111111111111111111111111",
   "base_tree_sha": "2222222222222222222222222222222222222222",

--- a/newsroom/tests/test_ci_workflow.py
+++ b/newsroom/tests/test_ci_workflow.py
@@ -134,8 +134,18 @@ def test_legacy_authority_and_projection_workflows_are_manual_only() -> None:
 def test_sdlc_workflow_retains_dynamic_complete_evidence_topology() -> None:
     workflow = _load(EVIDENCE_PATH)
     jobs = workflow["jobs"]
-    assert {"route", "core", "service", "decision"} <= set(jobs)
-    assert jobs["core"]["needs"] == ["route"]
+    assert {"route", "source", "core_shard", "core", "service", "decision"} <= set(
+        jobs
+    )
+    assert jobs["source"]["needs"] == ["route"]
+    assert jobs["core_shard"]["needs"] == ["route"]
+    assert jobs["core_shard"]["strategy"]["matrix"]["shard"] == ["0", "1", "2", "3"]
+    assert jobs["core"]["needs"] == ["route", "source", "core_shard"]
+    assert jobs["core"]["if"] == "always() && needs.route.result == 'success'"
+    assert all(
+        "scripts.sdlc.workflow_lane execute " not in str(step.get("run", ""))
+        for step in _steps(jobs["core"])
+    )
     assert jobs["service"]["needs"] == ["route"]
     assert jobs["service"]["if"] == (
         "needs.route.result == 'success' && "
@@ -145,8 +155,9 @@ def test_sdlc_workflow_retains_dynamic_complete_evidence_topology() -> None:
     assert jobs["decision"]["if"] == "always()"
 
     rendered = EVIDENCE_PATH.read_text(encoding="utf-8")
-    assert "python -m scripts.sdlc.workflow_lane execute" in rendered
-    assert "--lane core" in rendered
+    assert "python -m scripts.sdlc.workflow_lane execute-source" in rendered
+    assert "python -m scripts.sdlc.workflow_lane execute-core-shard" in rendered
+    assert rendered.count("python -m scripts.sdlc.workflow_lane reduce-core") == 1
     assert "--lane service" in rendered
     assert "service_required" in rendered
     assert ".sdlc-run/core" in rendered

--- a/newsroom/tests/test_sdlc_contract.py
+++ b/newsroom/tests/test_sdlc_contract.py
@@ -12,24 +12,25 @@ from scripts.sdlc.contracts import (
 )
 from scripts.sdlc.validate_contract import main as validate_main
 
-
 REPO_ROOT = Path(__file__).parents[2]
 
 
 def test_accepted_contract_loads_and_references_exact_source_files() -> None:
     contract = load_contract(REPO_ROOT)
 
-    assert contract.contract_version == "sdlc-v2.4"
+    assert contract.contract_version == "sdlc-v2.5"
     assert contract.classifier_version == "sdlc-risk-v1"
     assert contract.data["status"] == "accepted"
     assert contract.source_path == REPO_ROOT / ".sdlc" / "gates.toml"
     assert contract.data["acceptance_record"] == (
-        "docs/specs/sdlc/2026-08-02-sdlc-v2.4-owner-budget-amendment.md"
+        "docs/specs/sdlc/2026-08-10-sdlc-v2.5-core-sharding-amendment.md"
     )
     assert contract.unknown_path_risk == "R3_EXTERNAL_SERVICE_SECURITY"
 
 
-def test_every_gate_lane_resolves_and_all_hard_timeouts_are_below_four_minutes() -> None:
+def test_every_gate_lane_resolves_and_all_hard_timeouts_are_below_four_minutes() -> (
+    None
+):
     contract = load_contract(REPO_ROOT)
     lanes = contract.data["lanes"]
 
@@ -66,6 +67,19 @@ def test_every_gate_lane_resolves_and_all_hard_timeouts_are_below_four_minutes()
     }
     assert lanes["decision"] == {"always_reports": True, "hard_timeout_seconds": 20}
     assert lanes["core"]["hard_timeout_seconds"] == 220
+    assert lanes["core"] == {
+        "bootstrap_once": True,
+        "shard_count": 4,
+        "partition": "sha256_node_id_balanced",
+        "workers_per_shard": 4,
+        "distribution": "worksteal",
+        "max_worker_restart": 0,
+        "per_shard_hard_timeout_seconds": 220,
+        "reducer_single_canonical_receipt": True,
+        "run_full_suite_when_p95_below_seconds": 35,
+        "hard_timeout_seconds": 220,
+        "required": True,
+    }
     assert lanes["service"]["hard_timeout_seconds"] == 220
     assert lanes["merge_group"]["hard_timeout_seconds"] == 220
     assert lanes["science"]["per_shard_hard_timeout_seconds"] == 220
@@ -172,5 +186,5 @@ def test_contract_validation_cli_emits_a_small_typed_summary(
     output = capsys.readouterr().out
 
     assert '"status":"PASS"' in output
-    assert '"contract_version":"sdlc-v2.4"' in output
+    assert '"contract_version":"sdlc-v2.5"' in output
     assert "R4_RELEASE_OPERATIONAL" in output

--- a/newsroom/tests/test_sdlc_core_worker_capacity.py
+++ b/newsroom/tests/test_sdlc_core_worker_capacity.py
@@ -1,13 +1,542 @@
 from __future__ import annotations
 
-from pathlib import Path
+import json
 import subprocess
 import sys
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
 
 import scripts.sdlc.workflow_lane as lane_module
-
+from scripts.sdlc.command_spec import CommandRun
+from scripts.sdlc.run_gate import GateRunResult
+from scripts.sdlc.workflow_lane import WorkflowLaneError
 
 REPO_ROOT = Path(__file__).parents[2]
+
+
+def _contract_data() -> dict[str, object]:
+    return {
+        "contract_version": "sdlc-v2.5",
+        "status": "accepted",
+        "lanes": {
+            "core": {
+                "hard_timeout_seconds": 220,
+                "per_shard_hard_timeout_seconds": 220,
+            }
+        },
+    }
+
+
+def _write_fragment_set(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    directory_order: tuple[int, ...] = (0, 1, 2, 3),
+) -> tuple[Path, object, object, dict[str, object]]:
+    fragments = tmp_path / "fragments"
+    fragments.mkdir(parents=True)
+    contract = SimpleNamespace(
+        repo_root=tmp_path,
+        contract_version="sdlc-v2.5",
+        data=_contract_data(),
+    )
+    context = SimpleNamespace(
+        run_id=381,
+        run_attempt=2,
+        job_id="core",
+        evaluated_sha="a" * 40,
+        evaluated_tree_sha="b" * 40,
+    )
+    route: dict[str, object] = {
+        "head_sha": context.evaluated_sha,
+        "head_tree_sha": context.evaluated_tree_sha,
+        "clustering_required": False,
+    }
+    files = tuple(f"newsroom/tests/test_{index}.py" for index in range(4))
+    nodes = tuple(f"{path}::test_{index}" for index, path in enumerate(files))
+    shards = lane_module._core_node_shards(nodes)
+    spec = SimpleNamespace(
+        as_dict=lambda: {"schema_version": "test-command-spec"},
+        digest="sha256:" + "c" * 64,
+    )
+    binding = {
+        "contract_version": "sdlc-v2.5",
+        "contract_digest": "sha256:" + "d" * 64,
+        "lockfile_digest": "sha256:" + "e" * 64,
+        "python_version": "3.12.11",
+        "uv_version": "0.8.0",
+        "toolchain_digest": "sha256:" + "f" * 64,
+    }
+    monkeypatch.setattr(lane_module, "_core_test_files", lambda _root: files)
+    monkeypatch.setattr(
+        lane_module, "_collect_core_node_ids", lambda _root, **_kwargs: nodes
+    )
+    monkeypatch.setattr(lane_module, "_core_shard_spec", lambda **_kwargs: spec)
+    monkeypatch.setattr(lane_module, "_fragment_provenance", lambda **_kwargs: binding)
+    for directory_number, shard_index in enumerate(directory_order):
+        directory = fragments / f"input-{directory_number}"
+        directory.mkdir()
+        run = CommandRun(
+            spec.digest,
+            GateRunResult(
+                "core-deterministic",
+                "tests",
+                "BUDGET_EXCEEDED",
+                "BUDGET_EXCEEDED:core-deterministic:tests",
+                None,
+                200_000 + shard_index,
+                "",
+                "",
+                False,
+                False,
+            ),
+        )
+        body: dict[str, object] = {
+            "schema_version": lane_module._CORE_FRAGMENT_SCHEMA,
+            "run_id": context.run_id,
+            "run_attempt": context.run_attempt,
+            "job_id": "core_shard",
+            "evaluated_sha": context.evaluated_sha,
+            "evaluated_tree_sha": context.evaluated_tree_sha,
+            "route_digest": lane_module.sha256_identity(route),
+            "shard_index": shard_index,
+            "shard_count": 4,
+            "file_inventory": list(files),
+            "file_inventory_digest": lane_module.sha256_identity(list(files)),
+            "node_inventory": list(nodes),
+            "node_inventory_digest": lane_module.sha256_identity(list(nodes)),
+            "selected_node_ids": list(shards[shard_index]),
+            "selected_node_ids_digest": lane_module.sha256_identity(
+                list(shards[shard_index])
+            ),
+            "command_spec": spec.as_dict(),
+            "command_run": run.as_dict(),
+            "shard_lifecycle": {
+                "schema_version": lane_module._CORE_SHARD_LIFECYCLE_SCHEMA,
+                "elapsed_ms": 200_000 + shard_index,
+                "timeout_ms": 220_000,
+                "result": "BUDGET_EXCEEDED",
+            },
+            "junit_summary": None,
+            "report_digest": None,
+            **binding,
+        }
+        fragment = {**body, "fragment_identity": lane_module._fragment_identity(body)}
+        (directory / "fragment.json").write_bytes(
+            lane_module.canonical_json_bytes(fragment) + b"\n"
+        )
+    return fragments, contract, context, route
+
+
+def _rewrite_fragment(
+    path: Path,
+    changes: dict[str, object],
+    *,
+    refresh_identity: bool = True,
+) -> None:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    value.update(changes)
+    if refresh_identity:
+        unsigned = dict(value)
+        unsigned.pop("fragment_identity")
+        value["fragment_identity"] = lane_module._fragment_identity(unsigned)
+    path.write_bytes(lane_module.canonical_json_bytes(value) + b"\n")
+
+
+def _rewrite_fragment_as_pass(path: Path) -> None:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    command_run = value["command_run"]
+    assert isinstance(command_run, dict)
+    gate_run = command_run["gate_run"]
+    assert isinstance(gate_run, dict)
+    gate_run.update(
+        {
+            "result": "PASS",
+            "result_reason": "PASS:core-deterministic:tests",
+            "returncode": 0,
+        }
+    )
+    lifecycle = value["shard_lifecycle"]
+    assert isinstance(lifecycle, dict)
+    lifecycle["result"] = "PASS"
+    _rewrite_fragment(
+        path,
+        {"command_run": command_run, "shard_lifecycle": lifecycle},
+    )
+
+
+def _patch_core_shard_execution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    result: str,
+    report_payload: str | None,
+) -> None:
+    contract = SimpleNamespace(
+        repo_root=tmp_path,
+        contract_version="sdlc-v2.5",
+        data=_contract_data(),
+    )
+    context = SimpleNamespace(
+        run_id=381,
+        run_attempt=2,
+        job_id="core_shard",
+        evaluated_sha="a" * 40,
+        evaluated_tree_sha="b" * 40,
+    )
+    route = {
+        "head_sha": context.evaluated_sha,
+        "head_tree_sha": context.evaluated_tree_sha,
+        "clustering_required": False,
+    }
+    files = tuple(f"newsroom/tests/test_{index}.py" for index in range(4))
+    nodes = tuple(f"{path}::test_{index}" for index, path in enumerate(files))
+    spec = SimpleNamespace(
+        as_dict=lambda: {"schema_version": "test-command-spec"},
+        digest="sha256:" + "c" * 64,
+    )
+    returncode = 0 if result == "PASS" else (None if result != "FAIL" else 1)
+    reason = (
+        "FAIL:core-deterministic:tests:exit=1"
+        if result == "FAIL"
+        else f"{result}:core-deterministic:tests"
+    )
+    run = CommandRun(
+        spec.digest,
+        GateRunResult(
+            "core-deterministic",
+            "tests",
+            result,
+            reason,
+            returncode,
+            219_950,
+            "",
+            "",
+            False,
+            False,
+        ),
+    )
+    monkeypatch.setattr(lane_module, "load_contract", lambda _root: contract)
+    monkeypatch.setattr(lane_module, "context_from_environment", lambda _root: context)
+    monkeypatch.setattr(lane_module, "_load_json", lambda *_args: route)
+    monkeypatch.setattr(lane_module, "_validate_route", lambda *_args: route)
+    monkeypatch.setattr(lane_module, "_validate_test_topology", lambda *_args: None)
+    monkeypatch.setattr(lane_module, "_core_test_files", lambda _root: files)
+    monkeypatch.setattr(
+        lane_module, "_collect_core_node_ids", lambda _root, **_kwargs: nodes
+    )
+    monkeypatch.setattr(lane_module, "_core_shard_spec", lambda **_kwargs: spec)
+    monkeypatch.setattr(
+        lane_module,
+        "start_lane_deadline",
+        lambda *_args: lane_module.LaneDeadline.start(220),
+    )
+    monkeypatch.setattr(lane_module, "verify_tracked_checkout", lambda *_args: None)
+    monkeypatch.setattr(
+        lane_module,
+        "_fragment_provenance",
+        lambda **_kwargs: {
+            "contract_version": "sdlc-v2.5",
+            "contract_digest": "sha256:" + "d" * 64,
+            "lockfile_digest": "sha256:" + "e" * 64,
+            "python_version": "3.12.11",
+            "uv_version": "0.8.0",
+            "toolchain_digest": "sha256:" + "f" * 64,
+        },
+    )
+
+    def execute(**_kwargs: object) -> CommandRun:
+        if report_payload is not None:
+            (tmp_path / "artifacts/core-fragment/pytest.xml").write_text(
+                report_payload,
+                encoding="utf-8",
+            )
+        return run
+
+    monkeypatch.setattr(lane_module, "_execute", execute)
+    (tmp_path / "artifacts").mkdir()
+
+
+def _patch_source_execution(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> tuple[SimpleNamespace, dict[str, object]]:
+    contract = SimpleNamespace(
+        repo_root=tmp_path,
+        contract_version="sdlc-v2.5",
+        data=_contract_data(),
+    )
+    context = SimpleNamespace(
+        run_id=381,
+        run_attempt=2,
+        job_id="source",
+        evaluated_sha="a" * 40,
+        evaluated_tree_sha="b" * 40,
+    )
+    route: dict[str, object] = {
+        "head_sha": context.evaluated_sha,
+        "head_tree_sha": context.evaluated_tree_sha,
+        "clustering_required": False,
+    }
+    spec = SimpleNamespace(
+        as_dict=lambda: {"schema_version": "test-command-spec"},
+        digest="sha256:" + "c" * 64,
+    )
+    run = CommandRun(
+        spec.digest,
+        GateRunResult(
+            "source-integrity",
+            "source",
+            "PASS",
+            "PASS:source-integrity:source",
+            0,
+            1,
+            "",
+            "",
+            False,
+            False,
+        ),
+    )
+    monkeypatch.setattr(lane_module, "load_contract", lambda _root: contract)
+    monkeypatch.setattr(lane_module, "context_from_environment", lambda _root: context)
+    monkeypatch.setattr(lane_module, "_load_json", lambda *_args: route)
+    monkeypatch.setattr(lane_module, "_validate_route", lambda *_args: route)
+    monkeypatch.setattr(lane_module, "_validate_test_topology", lambda *_args: None)
+    monkeypatch.setattr(lane_module, "_source_fragment_spec", lambda **_kwargs: spec)
+    monkeypatch.setattr(lane_module, "_execute", lambda **_kwargs: run)
+    monkeypatch.setattr(
+        lane_module,
+        "start_lane_deadline",
+        lambda *_args: lane_module.LaneDeadline.start(220),
+    )
+    monkeypatch.setattr(lane_module, "verify_tracked_checkout", lambda *_args: None)
+    monkeypatch.setattr(
+        lane_module,
+        "_fragment_provenance",
+        lambda **_kwargs: {
+            "contract_version": "sdlc-v2.5",
+            "contract_digest": "sha256:" + "d" * 64,
+            "lockfile_digest": "sha256:" + "e" * 64,
+            "python_version": "3.12.11",
+            "uv_version": "0.8.0",
+            "toolchain_digest": "sha256:" + "f" * 64,
+        },
+    )
+    (tmp_path / "artifacts").mkdir()
+    return context, route
+
+
+def _write_bound_junit(fragment_path: Path, *, node_id: str | None = None) -> None:
+    value = json.loads(fragment_path.read_text(encoding="utf-8"))
+    selected = value["selected_node_ids"]
+    assert isinstance(selected, list) and len(selected) == 1
+    junit_id = lane_module._junit_id_for_node(node_id or selected[0])
+    classname, name = junit_id.rsplit("::", 1)
+    report = fragment_path.with_name("pytest.xml")
+    report.write_text(
+        (
+            '<testsuites tests="1" failures="0" errors="0" skipped="0">'
+            '<testsuite name="pytest" tests="1" failures="0" errors="0" '
+            'skipped="0">'
+            f'<testcase classname="{classname}" name="{name}" time="0.001" />'
+            "</testsuite></testsuites>"
+        ),
+        encoding="utf-8",
+    )
+    summary = lane_module._report_summary(
+        repo_root=fragment_path.parents[2],
+        artifact_root=fragment_path.parent,
+        report=report,
+        optional_test_ids=(),
+    )
+    assert summary is not None
+    _rewrite_fragment(
+        fragment_path,
+        {
+            "junit_summary": summary.as_dict(),
+            "report_digest": lane_module._file_digest(report),
+        },
+    )
+
+
+def _passing_report() -> str:
+    return (
+        '<testsuite tests="1" failures="0" errors="0" skipped="0">'
+        '<testcase classname="newsroom.tests.test_0" name="test_0" '
+        'time="0.001" />'
+        "</testsuite>"
+    )
+
+
+def _initialise_tracked_file(tmp_path: Path) -> tuple[Path, str]:
+    tracked = tmp_path / "tracked.txt"
+    tracked.write_text("accepted\n", encoding="utf-8")
+    subprocess.run(("git", "init", "-q"), cwd=tmp_path, check=True)
+    subprocess.run(("git", "add", "tracked.txt"), cwd=tmp_path, check=True)
+    subprocess.run(
+        (
+            "git",
+            "-c",
+            "user.name=SDLC Test",
+            "-c",
+            "user.email=sdlc@example.invalid",
+            "commit",
+            "-qm",
+            "fixture",
+        ),
+        cwd=tmp_path,
+        check=True,
+    )
+    head = subprocess.run(
+        ("git", "rev-parse", "HEAD"),
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    return tracked, head
+
+
+def _run_reducer_fixture(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    source_elapsed_ms: int,
+    shard_elapsed_ms: tuple[int, int, int, int],
+    reducer_elapsed_ms: int,
+    load_elapsed_ms: int | None = None,
+    output_elapsed_ms: int | None = None,
+) -> tuple[dict[str, object], list[str]]:
+    fragments_root = tmp_path / "fragments"
+    source_root = tmp_path / "source"
+    output_parent = tmp_path / "output"
+    for directory in (fragments_root, source_root, output_parent):
+        directory.mkdir(parents=True)
+    contract = SimpleNamespace(
+        repo_root=tmp_path,
+        contract_version="sdlc-v2.5",
+        data=_contract_data(),
+    )
+    context = SimpleNamespace(
+        run_id=381,
+        run_attempt=2,
+        job_id="core",
+        evaluated_sha="a" * 40,
+        evaluated_tree_sha="b" * 40,
+    )
+    route: dict[str, object] = {
+        "head_sha": context.evaluated_sha,
+        "head_tree_sha": context.evaluated_tree_sha,
+        "clustering_required": False,
+    }
+
+    def run(gate_id: str, phase: str, elapsed_ms: int) -> CommandRun:
+        return CommandRun(
+            "sha256:" + "9" * 64,
+            GateRunResult(
+                gate_id,
+                phase,
+                "PASS",
+                f"PASS:{gate_id}:{phase}",
+                0,
+                elapsed_ms,
+                "",
+                "",
+                False,
+                False,
+            ),
+        )
+
+    source_run = run("source-integrity", "source", 1)
+    source = {
+        "command_run": source_run.as_dict(),
+        "source_lifecycle": {
+            "schema_version": lane_module._SOURCE_LIFECYCLE_SCHEMA,
+            "elapsed_ms": source_elapsed_ms,
+            "timeout_ms": 220_000,
+            "result": "PASS",
+        },
+        "fragment_identity": "sha256:" + "8" * 64,
+    }
+    fragments = tuple(
+        (
+            {
+                "command_run": run("core-deterministic", "tests", 10).as_dict(),
+                "shard_lifecycle": {
+                    "schema_version": lane_module._CORE_SHARD_LIFECYCLE_SCHEMA,
+                    "elapsed_ms": elapsed,
+                    "timeout_ms": 220_000,
+                    "result": "PASS",
+                },
+                "junit_summary": None,
+                "fragment_identity": "sha256:" + str(index) * 64,
+                "selected_node_ids": [],
+            },
+            fragments_root / f"shard-{index}.xml",
+        )
+        for index, elapsed in enumerate(shard_elapsed_ms)
+    )
+    deadline = lane_module.LaneDeadline.start(220)
+    elapsed = {"value": reducer_elapsed_ms}
+    order: list[str] = []
+
+    def start(*_args: object) -> object:
+        order.append("start")
+        return deadline
+
+    def load_fragments(**_kwargs: object) -> object:
+        order.append("load-fragments")
+        if load_elapsed_ms is not None:
+            elapsed["value"] = load_elapsed_ms
+        return fragments
+
+    def load_source(**_kwargs: object) -> object:
+        order.append("load-source")
+        return source
+
+    monkeypatch.setattr(
+        lane_module,
+        "_context_route",
+        lambda **_kwargs: (contract, context, route),
+    )
+    monkeypatch.setattr(lane_module, "start_lane_deadline", start)
+    monkeypatch.setattr(lane_module, "_load_core_fragments", load_fragments)
+    monkeypatch.setattr(lane_module, "_load_source_fragment", load_source)
+    monkeypatch.setattr(
+        lane_module,
+        "_deadline_elapsed_ms",
+        lambda observed: elapsed["value"] if observed is deadline else 0,
+    )
+    monkeypatch.setattr(
+        lane_module,
+        "_expected_spec",
+        lambda **_kwargs: SimpleNamespace(digest="sha256:" + "9" * 64),
+    )
+    monkeypatch.setattr(lane_module, "artifact_name", lambda _context: "artifact")
+    monkeypatch.setattr(lane_module, "verify_tracked_checkout", lambda *_args: None)
+    if output_elapsed_ms is not None:
+        private_write = lane_module._private_write
+
+        def delayed_output(path: Path, value: object) -> None:
+            private_write(path, value)
+            if "core-deterministic" in path.parts and path.name == "command-run.json":
+                elapsed["value"] = output_elapsed_ms
+
+        monkeypatch.setattr(lane_module, "_private_write", delayed_output)
+
+    lane_module.reduce_core_lane(
+        repo_root=tmp_path,
+        route_path="route.json",
+        fragment_root="fragments",
+        source_root="source",
+        artifact_root="output/core",
+    )
+    aggregate_path = (
+        output_parent / "core/gates/core-deterministic/tests/command-run.json"
+    )
+    return json.loads(aggregate_path.read_text(encoding="utf-8")), order
 
 
 def test_core_lane_uses_four_persistent_worksteal_workers(
@@ -49,3 +578,1369 @@ assert reloaded._CORE_TESTS == ('newsroom/tests',)
     )
 
     assert completed.returncode == 0, completed.stderr
+
+
+def test_core_node_partition_is_deterministic_complete_unique_and_balanced() -> None:
+    nodes = tuple(
+        f"newsroom/tests/test_{index}.py::test_{index}" for index in range(19)
+    )
+
+    first = lane_module._core_node_shards(nodes)
+    second = lane_module._core_node_shards(tuple(reversed(nodes)))
+    flattened = tuple(node for shard in first for node in shard)
+
+    assert first == second
+    assert len(first) == 4
+    assert tuple(sorted(flattened)) == tuple(sorted(nodes))
+    assert len(flattened) == len(set(flattened))
+    assert max(map(len, first)) - min(map(len, first)) == 1
+
+
+def test_core_file_inventory_is_recursive_and_rejects_symlinks(tmp_path: Path) -> None:
+    tests = tmp_path / "newsroom" / "tests"
+    nested = tests / "nested"
+    nested.mkdir(parents=True)
+    for index in range(4):
+        target = nested / f"test_nested_{index}.py"
+        target.write_text(f"def test_{index}(): pass\n", encoding="utf-8")
+
+    assert lane_module._core_test_files(tmp_path) == tuple(
+        f"newsroom/tests/nested/test_nested_{index}.py" for index in range(4)
+    )
+
+    (tests / "test_link.py").symlink_to(nested / "test_nested_0.py")
+    with pytest.raises(WorkflowLaneError, match="core_test_file"):
+        lane_module._core_test_files(tmp_path)
+
+
+def test_core_node_inventory_semantically_matches_recursive_pytest_collection(
+    tmp_path: Path,
+) -> None:
+    nested = tmp_path / "newsroom" / "tests" / "nested"
+    nested.mkdir(parents=True)
+    for index in range(4):
+        (nested / f"test_nested_{index}.py").write_text(
+            f"def test_nested_{index}():\n    assert True\n",
+            encoding="utf-8",
+        )
+
+    assert lane_module._collect_core_node_ids(tmp_path) == tuple(
+        f"newsroom/tests/nested/test_nested_{index}.py::test_nested_{index}"
+        for index in range(4)
+    )
+
+
+def test_core_node_inventory_is_rooted_to_a_nested_workspace() -> None:
+    with tempfile.TemporaryDirectory(
+        prefix=".sdlc-inventory-",
+        dir=REPO_ROOT,
+    ) as raw_root:
+        root = Path(raw_root)
+        nested = root / "newsroom" / "tests" / "nested"
+        nested.mkdir(parents=True)
+        for index in range(4):
+            (nested / f"test_nested_{index}.py").write_text(
+                f"def test_nested_{index}():\n    assert True\n",
+                encoding="utf-8",
+            )
+
+        assert lane_module._collect_core_node_ids(root) == tuple(
+            f"newsroom/tests/nested/test_nested_{index}.py::test_nested_{index}"
+            for index in range(4)
+        )
+
+
+def test_junit_identity_preserves_colons_inside_parameter_ids() -> None:
+    assert (
+        lane_module._junit_id_for_node(
+            "newsroom/tests/test_example.py::TestExample::test_value[a::b]"
+        )
+        == "newsroom.tests.test_example.TestExample::test_value[a::b]"
+    )
+
+
+def test_core_shard_command_has_fixed_scheduler_and_no_caller_file_surface(
+    tmp_path: Path,
+) -> None:
+    command = lane_module._core_worker_command(
+        report=tmp_path / "report.xml",
+        basetemp=tmp_path / "temp",
+        test_files=("newsroom/tests/test_one.py::test_one",),
+    )
+
+    assert command.count("xdist.plugin") == 1
+    assert command[command.index("-n") + 1] == "4"
+    assert "--dist=worksteal" in command
+    assert "--max-worker-restart=0" in command
+    assert "newsroom/tests" not in command
+    assert "newsroom/tests/test_one.py::test_one" in command
+
+
+def test_source_fragment_and_canonical_lane_use_the_same_portable_spec() -> None:
+    contract = lane_module.load_contract(REPO_ROOT)
+    route = {"base_sha": "a" * 40, "head_sha": "b" * 40}
+
+    fragment = lane_module._source_fragment_spec(contract=contract, route=route)
+    canonical = lane_module._expected_spec(
+        root=REPO_ROOT,
+        artifact_root=REPO_ROOT / ".sdlc-run" / "core",
+        contract=contract,
+        route=route,
+        gate_id="source-integrity",
+        phase="source",
+    )
+
+    assert fragment == canonical
+
+
+def test_core_shard_spec_binds_full_inventory_and_assigned_node_ids() -> None:
+    contract = lane_module.load_contract(REPO_ROOT)
+    inventory = tuple(
+        f"newsroom/tests/test_{index}.py::test_{index}" for index in range(8)
+    )
+    selected = lane_module._core_node_shards(inventory)[0]
+
+    spec = lane_module._core_shard_spec(
+        contract=contract,
+        shard_index=0,
+        node_inventory=inventory,
+        selected_node_ids=selected,
+        report=REPO_ROOT / ".sdlc-run/core-fragment/pytest.xml",
+        basetemp=REPO_ROOT / ".sdlc-run/core-fragment/pytest-temp",
+        clustering=False,
+    )
+
+    assert spec.argv[spec.argv.index("--node-inventory-digest") + 1] == (
+        lane_module.sha256_identity(list(inventory))
+    )
+    assert spec.argv[spec.argv.index("--selected-node-ids-digest") + 1] == (
+        lane_module.sha256_identity(list(selected))
+    )
+
+
+def test_core_shard_child_recomputes_bound_inventory_before_pytest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    nodes = tuple(f"newsroom/tests/test_{index}.py::test_{index}" for index in range(4))
+    selected = lane_module._core_node_shards(nodes)[0]
+    monkeypatch.setattr(
+        lane_module, "_collect_core_node_ids", lambda _root, **_kwargs: nodes
+    )
+
+    with pytest.raises(WorkflowLaneError, match="core_shard_inventory"):
+        lane_module.core_shard_tests(
+            repo_root=tmp_path,
+            report=tmp_path / "pytest.xml",
+            basetemp=tmp_path / "pytest-temp",
+            shard_index=0,
+            node_inventory_digest="sha256:" + "0" * 64,
+            selected_node_ids_digest=lane_module.sha256_identity(list(selected)),
+            clustering=False,
+        )
+
+
+@pytest.mark.parametrize(
+    ("results", "expected"),
+    [
+        (("PASS",) * 4, "PASS"),
+        (("FAIL", "PASS", "PASS", "PASS"), "FAIL"),
+        (("FAIL", "BUDGET_EXCEEDED", "PASS", "PASS"), "BUDGET_EXCEEDED"),
+        (("FAIL", "ENVIRONMENT_ERROR", "PASS", "PASS"), "ENVIRONMENT_ERROR"),
+        (("FAIL", "EVIDENCE_MISMATCH", "PASS", "PASS"), "EVIDENCE_MISMATCH"),
+    ],
+)
+def test_core_reducer_preserves_typed_outcome_precedence(
+    results: tuple[str, ...], expected: str
+) -> None:
+    assert lane_module._reduced_core_outcome(results)[0] == expected
+
+
+@pytest.mark.parametrize(
+    ("results", "junit_outcomes", "expected"),
+    [
+        (("PASS",) * 4, ("PASS", "FAIL", "PASS", "PASS"), "FAIL"),
+        (("PASS", "FAIL", "PASS", "PASS"), ("PASS",) * 4, "FAIL"),
+        (
+            ("PASS", "BUDGET_EXCEEDED", "PASS", "PASS"),
+            ("PASS", "FAIL", "PASS", "PASS"),
+            "BUDGET_EXCEEDED",
+        ),
+    ],
+)
+def test_core_reducer_preserves_required_skip_product_fail_and_timeout_precedence(
+    results: tuple[str, ...],
+    junit_outcomes: tuple[str, ...],
+    expected: str,
+) -> None:
+    summaries = tuple({"outcome": outcome} for outcome in junit_outcomes)
+    assert lane_module._reduced_core_outcome(results, summaries=summaries)[0] == (
+        expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("inner_result", "elapsed_ms", "expected"),
+    [
+        ("PASS", 220_001, "BUDGET_EXCEEDED"),
+        ("FAIL", 220_001, "BUDGET_EXCEEDED"),
+        ("EVIDENCE_MISMATCH", 220_001, "EVIDENCE_MISMATCH"),
+        ("ENVIRONMENT_ERROR", 220_001, "ENVIRONMENT_ERROR"),
+    ],
+)
+def test_full_lifecycle_budget_preserves_typed_precedence(
+    inner_result: str, elapsed_ms: int, expected: str
+) -> None:
+    assert (
+        lane_module._lifecycle_result(
+            inner_result,
+            elapsed_ms=elapsed_ms,
+            timeout_ms=220_000,
+        )
+        == expected
+    )
+
+
+def test_reducer_uses_source_shard_critical_path_plus_sequential_elapsed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    aggregate, order = _run_reducer_fixture(
+        tmp_path,
+        monkeypatch,
+        source_elapsed_ms=60_000,
+        shard_elapsed_ms=(200_000, 180_000, 170_000, 160_000),
+        reducer_elapsed_ms=19_000,
+    )
+
+    assert order[:3] == ["start", "load-fragments", "load-source"]
+    assert aggregate["gate_run"]["execution_ms"] == 219_000
+    assert aggregate["gate_run"]["result"] == "PASS"
+    accounting = json.loads(aggregate["gate_run"]["stdout"])
+    assert accounting["source_lifecycle_ms"] == 60_000
+    assert accounting["shard_lifecycle_ms"] == [
+        200_000,
+        180_000,
+        170_000,
+        160_000,
+    ]
+    assert accounting["reducer_lifecycle_ms"] == 19_000
+    assert accounting["critical_path_ms"] == 219_000
+
+
+@pytest.mark.parametrize(
+    ("reducer_elapsed_ms", "expected"),
+    [
+        (499, ("PASS", "PASS:core-deterministic:tests", 0, 219_999)),
+        (500, ("PASS", "PASS:core-deterministic:tests", 0, 220_000)),
+        (
+            501,
+            (
+                "BUDGET_EXCEEDED",
+                "BUDGET_EXCEEDED:core-deterministic:tests",
+                124,
+                220_001,
+            ),
+        ),
+    ],
+)
+def test_reducer_critical_path_boundary_emits_valid_immutable_outcome(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    reducer_elapsed_ms: int,
+    expected: tuple[str, str, int, int],
+) -> None:
+    aggregate, _order = _run_reducer_fixture(
+        tmp_path,
+        monkeypatch,
+        source_elapsed_ms=219_500,
+        shard_elapsed_ms=(1, 1, 1, 1),
+        reducer_elapsed_ms=reducer_elapsed_ms,
+    )
+
+    gate_run = aggregate["gate_run"]
+    assert isinstance(gate_run, dict)
+    assert (
+        gate_run["result"],
+        gate_run["result_reason"],
+        gate_run["returncode"],
+        gate_run["execution_ms"],
+    ) == expected
+    assert lane_module._validate_command_run(aggregate) == aggregate
+
+
+def test_slow_reducer_is_typed_budget_exceeded_from_before_input_loading(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with pytest.raises(
+        WorkflowLaneError, match="BUDGET_EXCEEDED:core-deterministic:reducer"
+    ):
+        _run_reducer_fixture(
+            tmp_path,
+            monkeypatch,
+            source_elapsed_ms=1,
+            shard_elapsed_ms=(1, 1, 1, 1),
+            reducer_elapsed_ms=220_001,
+        )
+
+    assert not (tmp_path / "output/core").exists()
+
+
+def test_reducer_stops_after_a_load_crosses_its_deadline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with pytest.raises(
+        lane_module.WorkflowLaneError,
+        match="BUDGET_EXCEEDED:core-deterministic:reducer",
+    ):
+        _run_reducer_fixture(
+            tmp_path,
+            monkeypatch,
+            source_elapsed_ms=1,
+            shard_elapsed_ms=(1, 1, 1, 1),
+            reducer_elapsed_ms=1,
+            load_elapsed_ms=220_001,
+        )
+
+    assert not (tmp_path / "output/core").exists()
+
+
+def test_reducer_output_time_is_bound_and_cannot_publish_pass(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    aggregate, _order = _run_reducer_fixture(
+        tmp_path,
+        monkeypatch,
+        source_elapsed_ms=1,
+        shard_elapsed_ms=(1, 1, 1, 1),
+        reducer_elapsed_ms=219_999,
+        output_elapsed_ms=220_001,
+    )
+
+    assert aggregate["gate_run"]["result"] == "BUDGET_EXCEEDED"
+    accounting = json.loads(aggregate["gate_run"]["stdout"])
+    assert accounting["reducer_lifecycle_ms"] == 220_001
+    persisted = json.loads(
+        (
+            tmp_path / "output/core/gates/core-deterministic/tests/command-run.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert persisted["gate_run"]["result"] == "BUDGET_EXCEEDED"
+
+
+def test_core_fragment_identity_is_canonical_and_tamper_evident() -> None:
+    body = {
+        "schema_version": lane_module._CORE_FRAGMENT_SCHEMA,
+        "shard_index": 0,
+        "selected_node_ids": ["newsroom/tests/test_a.py::test_a"],
+    }
+    identity = lane_module._fragment_identity(body)
+
+    assert identity == lane_module._fragment_identity(
+        {
+            "selected_node_ids": ["newsroom/tests/test_a.py::test_a"],
+            "shard_index": 0,
+            "schema_version": lane_module._CORE_FRAGMENT_SCHEMA,
+        }
+    )
+    assert identity != lane_module._fragment_identity(
+        {**body, "selected_node_ids": ["newsroom/tests/test_a.py::test_b"]}
+    )
+
+
+def test_core_fragment_binds_contract_lock_toolchain_and_exact_inventory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    contract = SimpleNamespace(
+        repo_root=tmp_path,
+        contract_version="sdlc-v2.5",
+        data=_contract_data(),
+    )
+    context = SimpleNamespace(
+        run_id=381,
+        run_attempt=2,
+        job_id="core_shard",
+        evaluated_sha="a" * 40,
+        evaluated_tree_sha="b" * 40,
+    )
+    route = {
+        "head_sha": context.evaluated_sha,
+        "head_tree_sha": context.evaluated_tree_sha,
+        "clustering_required": False,
+    }
+    files = tuple(f"newsroom/tests/test_{index}.py" for index in range(4))
+    nodes = tuple(f"{path}::test_{index}" for index, path in enumerate(files))
+    spec = SimpleNamespace(
+        as_dict=lambda: {"schema_version": "test-command-spec"},
+        digest="sha256:" + "c" * 64,
+    )
+    run = CommandRun(
+        spec.digest,
+        GateRunResult(
+            "core-deterministic",
+            "tests",
+            "BUDGET_EXCEEDED",
+            "BUDGET_EXCEEDED:core-deterministic:tests",
+            None,
+            219_950,
+            "",
+            "",
+            False,
+            False,
+        ),
+    )
+    expected_binding = {
+        "contract_version": "sdlc-v2.5",
+        "contract_digest": "sha256:" + "d" * 64,
+        "lockfile_digest": "sha256:" + "e" * 64,
+        "python_version": "3.12.11",
+        "uv_version": "0.8.0",
+        "toolchain_digest": "sha256:" + "f" * 64,
+    }
+    monkeypatch.setattr(lane_module, "load_contract", lambda _root: contract)
+    monkeypatch.setattr(lane_module, "context_from_environment", lambda _root: context)
+    monkeypatch.setattr(lane_module, "_load_json", lambda *_args: route)
+    monkeypatch.setattr(lane_module, "_validate_route", lambda *_args: route)
+    monkeypatch.setattr(lane_module, "_validate_test_topology", lambda *_args: None)
+    monkeypatch.setattr(lane_module, "_core_test_files", lambda _root: files)
+    monkeypatch.setattr(
+        lane_module, "_collect_core_node_ids", lambda _root, **_kwargs: nodes
+    )
+    monkeypatch.setattr(lane_module, "_core_shard_spec", lambda **_kwargs: spec)
+    monkeypatch.setattr(lane_module, "_execute", lambda **_kwargs: run)
+    monkeypatch.setattr(
+        lane_module,
+        "start_lane_deadline",
+        lambda *_args: lane_module.LaneDeadline.start(220),
+    )
+    monkeypatch.setattr(lane_module, "verify_tracked_checkout", lambda *_args: None)
+    monkeypatch.setattr(lane_module, "_report_summary", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        lane_module, "_fragment_provenance", lambda **_kwargs: expected_binding
+    )
+    (tmp_path / "artifacts").mkdir()
+
+    fragment = lane_module.execute_core_shard(
+        repo_root=tmp_path,
+        route_path="route.json",
+        shard_index=0,
+        artifact_root="artifacts/core-fragment",
+    )
+
+    assert {name: fragment[name] for name in expected_binding} == expected_binding
+    assert fragment["file_inventory"] == list(files)
+    assert fragment["node_inventory"] == list(nodes)
+    assert fragment["selected_node_ids"] == list(
+        lane_module._core_node_shards(nodes)[0]
+    )
+    assert fragment["shard_lifecycle"] == {
+        "schema_version": lane_module._CORE_SHARD_LIFECYCLE_SCHEMA,
+        "elapsed_ms": fragment["shard_lifecycle"]["elapsed_ms"],
+        "timeout_ms": 220_000,
+        "result": "BUDGET_EXCEEDED",
+    }
+    unsigned = dict(fragment)
+    identity = unsigned.pop("fragment_identity")
+    assert identity == lane_module._fragment_identity(unsigned)
+
+
+def test_fragment_provenance_hashes_exact_contract_and_lockfile_bytes() -> None:
+    contract = lane_module.load_contract(REPO_ROOT)
+    evaluated_sha = subprocess.run(
+        ("git", "rev-parse", "HEAD"),
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    provenance = lane_module._fragment_provenance(
+        contract=contract,
+        context=SimpleNamespace(evaluated_sha=evaluated_sha),
+    )
+
+    assert provenance["contract_digest"] == lane_module._file_digest(
+        contract.source_path
+    )
+    assert provenance["lockfile_digest"] == lane_module.git_blob_digest(
+        REPO_ROOT,
+        evaluated_sha,
+        "uv.lock",
+    )
+
+
+def test_fragment_summary_preserves_the_canonical_optional_skip_policy(
+    tmp_path: Path,
+) -> None:
+    optional_test_id = lane_module._OPTIONAL_CORE_TEST_IDS[0]
+    classname, name = optional_test_id.split("::", 1)
+    optional_node_id = f"{classname.replace('.', '/')}.py::{name}"
+    assert lane_module._core_shard_optional_test_ids(
+        ("newsroom/tests/test_required.py::test_required", optional_node_id)
+    ) == (optional_test_id,)
+    artifact = tmp_path / "artifact"
+    artifact.mkdir()
+    report = artifact / "pytest.xml"
+    report.write_text(
+        (
+            '<testsuite tests="1" failures="0" errors="0" skipped="1">'
+            f'<testcase classname="{classname}" name="{name}" time="0.001">'
+            '<skipped message="service disabled" />'
+            "</testcase></testsuite>"
+        ),
+        encoding="utf-8",
+    )
+
+    summary = lane_module._core_fragment_report_summary(
+        repo_root=tmp_path,
+        artifact_root=artifact,
+        report=report,
+        result="PASS",
+        optional_test_ids=(optional_test_id,),
+    )
+
+    assert summary is not None
+    assert summary.outcome == "PASS"
+    assert summary.skip_count == 1
+    assert summary.required_skip_count == 0
+
+
+def test_collection_time_tracked_mutation_prevents_fragment_publication(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    real_verify = lane_module.verify_tracked_checkout
+    _patch_core_shard_execution(
+        tmp_path,
+        monkeypatch,
+        result="PASS",
+        report_payload=_passing_report(),
+    )
+    tracked, head = _initialise_tracked_file(tmp_path)
+    context = SimpleNamespace(
+        run_id=381,
+        run_attempt=2,
+        job_id="core_shard",
+        evaluated_sha=head,
+        evaluated_tree_sha="b" * 40,
+    )
+    route = {
+        "head_sha": head,
+        "head_tree_sha": context.evaluated_tree_sha,
+        "clustering_required": False,
+    }
+    nodes = tuple(f"newsroom/tests/test_{index}.py::test_{index}" for index in range(4))
+
+    def collect(_root: Path, **_kwargs: object) -> tuple[str, ...]:
+        tracked.write_text("mutated during collection\n", encoding="utf-8")
+        return nodes
+
+    monkeypatch.setattr(lane_module, "context_from_environment", lambda _root: context)
+    monkeypatch.setattr(lane_module, "_load_json", lambda *_args: route)
+    monkeypatch.setattr(lane_module, "_validate_route", lambda *_args: route)
+    monkeypatch.setattr(lane_module, "_collect_core_node_ids", collect)
+    monkeypatch.setattr(lane_module, "verify_tracked_checkout", real_verify)
+
+    with pytest.raises(lane_module.EvidenceError, match="tracked_checkout_dirty"):
+        lane_module.execute_core_shard(
+            repo_root=tmp_path,
+            route_path="route.json",
+            shard_index=0,
+            artifact_root="artifacts/core-fragment",
+        )
+
+    assert not (tmp_path / "artifacts/core-fragment/fragment.json").exists()
+
+
+def test_test_time_tracked_mutation_prevents_fragment_publication(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    real_verify = lane_module.verify_tracked_checkout
+    _patch_core_shard_execution(
+        tmp_path,
+        monkeypatch,
+        result="PASS",
+        report_payload=_passing_report(),
+    )
+    tracked, head = _initialise_tracked_file(tmp_path)
+    context = SimpleNamespace(
+        run_id=381,
+        run_attempt=2,
+        job_id="core_shard",
+        evaluated_sha=head,
+        evaluated_tree_sha="b" * 40,
+    )
+    route = {
+        "head_sha": head,
+        "head_tree_sha": context.evaluated_tree_sha,
+        "clustering_required": False,
+    }
+    execute = lane_module._execute
+
+    def mutate(**kwargs: object) -> CommandRun:
+        run = execute(**kwargs)
+        tracked.write_text("mutated during pytest\n", encoding="utf-8")
+        return run
+
+    monkeypatch.setattr(lane_module, "context_from_environment", lambda _root: context)
+    monkeypatch.setattr(lane_module, "_load_json", lambda *_args: route)
+    monkeypatch.setattr(lane_module, "_validate_route", lambda *_args: route)
+    monkeypatch.setattr(lane_module, "_execute", mutate)
+    monkeypatch.setattr(lane_module, "verify_tracked_checkout", real_verify)
+
+    with pytest.raises(lane_module.EvidenceError, match="tracked_checkout_dirty"):
+        lane_module.execute_core_shard(
+            repo_root=tmp_path,
+            route_path="route.json",
+            shard_index=0,
+            artifact_root="artifacts/core-fragment",
+        )
+
+    assert not (tmp_path / "artifacts/core-fragment/fragment.json").exists()
+
+
+def test_collection_subprocess_timeout_is_typed_and_publishes_no_fragment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    collect = lane_module._collect_core_node_ids
+    _patch_core_shard_execution(
+        tmp_path,
+        monkeypatch,
+        result="PASS",
+        report_payload=_passing_report(),
+    )
+    deadline = lane_module.LaneDeadline.start(220)
+    observed: list[float | None] = []
+
+    def timeout(*args: object, **kwargs: object) -> object:
+        observed.append(kwargs.get("timeout"))  # type: ignore[arg-type]
+        raise subprocess.TimeoutExpired(args[0], kwargs.get("timeout", 0))
+
+    monkeypatch.setattr(lane_module, "start_lane_deadline", lambda *_args: deadline)
+    monkeypatch.setattr(lane_module, "_collect_core_node_ids", collect)
+    monkeypatch.setattr(lane_module.subprocess, "run", timeout)
+
+    with pytest.raises(
+        lane_module.WorkflowLaneError,
+        match="BUDGET_EXCEEDED:core-deterministic:collection",
+    ):
+        lane_module.execute_core_shard(
+            repo_root=tmp_path,
+            route_path="route.json",
+            shard_index=0,
+            artifact_root="artifacts/core-fragment",
+        )
+
+    assert observed and 0 < observed[0] <= 220
+    assert not (tmp_path / "artifacts/core-fragment/fragment.json").exists()
+
+
+def test_slow_collection_is_charged_to_the_shard_lifecycle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_core_shard_execution(
+        tmp_path,
+        monkeypatch,
+        result="PASS",
+        report_payload=_passing_report(),
+    )
+    deadline = lane_module.LaneDeadline.start(220)
+    elapsed = {"value": 1}
+    order: list[str] = []
+    collect = lane_module._collect_core_node_ids
+    execute = lane_module._execute
+
+    def start(*_args: object) -> object:
+        order.append("start")
+        return deadline
+
+    def slow_collection(root: Path, **_kwargs: object) -> tuple[str, ...]:
+        order.append("collect")
+        result = collect(root)
+        elapsed["value"] = 220_001
+        return result
+
+    def observed_execute(**kwargs: object) -> CommandRun:
+        order.append("execute")
+        assert kwargs["deadline"] is deadline
+        return execute(**kwargs)
+
+    monkeypatch.setattr(lane_module, "start_lane_deadline", start)
+    monkeypatch.setattr(lane_module, "_collect_core_node_ids", slow_collection)
+    monkeypatch.setattr(lane_module, "_execute", observed_execute)
+    monkeypatch.setattr(
+        lane_module,
+        "_deadline_elapsed_ms",
+        lambda observed: elapsed["value"] if observed is deadline else 0,
+    )
+
+    with pytest.raises(
+        WorkflowLaneError, match="BUDGET_EXCEEDED:core-deterministic:collection"
+    ):
+        lane_module.execute_core_shard(
+            repo_root=tmp_path,
+            route_path="route.json",
+            shard_index=0,
+            artifact_root="artifacts/core-fragment",
+        )
+
+    assert order == ["start", "collect"]
+    assert not (tmp_path / "artifacts/core-fragment/fragment.json").exists()
+
+
+def test_fragment_finalisation_timeout_overrides_a_product_pass(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_core_shard_execution(
+        tmp_path,
+        monkeypatch,
+        result="PASS",
+        report_payload=_passing_report(),
+    )
+    elapsed = {"value": 219_999}
+    provenance = lane_module._fragment_provenance
+
+    def slow_finalisation(**kwargs: object) -> dict[str, str]:
+        value = provenance(**kwargs)
+        elapsed["value"] = 220_001
+        return value
+
+    monkeypatch.setattr(lane_module, "_fragment_provenance", slow_finalisation)
+    monkeypatch.setattr(
+        lane_module, "_deadline_elapsed_ms", lambda _deadline: elapsed["value"]
+    )
+
+    fragment = lane_module.execute_core_shard(
+        repo_root=tmp_path,
+        route_path="route.json",
+        shard_index=0,
+        artifact_root="artifacts/core-fragment",
+    )
+
+    assert fragment["command_run"]["gate_run"]["result"] == "PASS"
+    assert fragment["shard_lifecycle"] == {
+        "schema_version": lane_module._CORE_SHARD_LIFECYCLE_SCHEMA,
+        "elapsed_ms": 220_001,
+        "timeout_ms": 220_000,
+        "result": "BUDGET_EXCEEDED",
+    }
+    assert fragment["junit_summary"] is None
+    assert fragment["report_digest"] is None
+
+
+def test_fragment_durable_write_time_cannot_publish_a_pass(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_core_shard_execution(
+        tmp_path,
+        monkeypatch,
+        result="PASS",
+        report_payload=_passing_report(),
+    )
+    elapsed = {"value": 219_999}
+    private_write = lane_module._private_write
+
+    def delayed_write(path: Path, value: object) -> None:
+        private_write(path, value)
+        if "fragment" in path.name:
+            elapsed["value"] = 220_001
+
+    monkeypatch.setattr(lane_module, "_private_write", delayed_write)
+    monkeypatch.setattr(
+        lane_module, "_deadline_elapsed_ms", lambda _deadline: elapsed["value"]
+    )
+
+    fragment = lane_module.execute_core_shard(
+        repo_root=tmp_path,
+        route_path="route.json",
+        shard_index=0,
+        artifact_root="artifacts/core-fragment",
+    )
+
+    assert fragment["shard_lifecycle"]["result"] == "BUDGET_EXCEEDED"
+    persisted = json.loads(
+        (tmp_path / "artifacts/core-fragment/fragment.json").read_text(encoding="utf-8")
+    )
+    assert persisted["shard_lifecycle"]["result"] == "BUDGET_EXCEEDED"
+    assert not (tmp_path / "artifacts/core-fragment/pytest.xml").exists()
+
+
+def test_source_callback_mutation_prevents_fragment_publication(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    real_verify = lane_module.verify_tracked_checkout
+    _patch_source_execution(tmp_path, monkeypatch)
+    tracked, head = _initialise_tracked_file(tmp_path)
+    context = SimpleNamespace(
+        run_id=381,
+        run_attempt=2,
+        job_id="source",
+        evaluated_sha=head,
+        evaluated_tree_sha="b" * 40,
+    )
+    route = {
+        "head_sha": head,
+        "head_tree_sha": context.evaluated_tree_sha,
+        "clustering_required": False,
+    }
+    execute = lane_module._execute
+
+    def mutate(**kwargs: object) -> CommandRun:
+        run = execute(**kwargs)
+        tracked.write_text("mutated during source execution\n", encoding="utf-8")
+        return run
+
+    monkeypatch.setattr(lane_module, "context_from_environment", lambda _root: context)
+    monkeypatch.setattr(lane_module, "_load_json", lambda *_args: route)
+    monkeypatch.setattr(lane_module, "_validate_route", lambda *_args: route)
+    monkeypatch.setattr(lane_module, "_execute", mutate)
+    monkeypatch.setattr(lane_module, "verify_tracked_checkout", real_verify)
+
+    with pytest.raises(lane_module.EvidenceError, match="tracked_checkout_dirty"):
+        lane_module.execute_source_fragment(
+            repo_root=tmp_path,
+            route_path="route.json",
+            artifact_root="artifacts/source-fragment",
+        )
+
+    assert not (tmp_path / "artifacts/source-fragment/source-fragment.json").exists()
+
+
+def test_source_lifecycle_starts_before_artifact_preparation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_source_execution(tmp_path, monkeypatch)
+    deadline = lane_module.LaneDeadline.start(220)
+    prepare = lane_module._prepare_artifact_root
+    execute = lane_module._execute
+    order: list[str] = []
+
+    def start(*_args: object) -> object:
+        order.append("start")
+        return deadline
+
+    def observed_prepare(*args: object, **kwargs: object) -> Path:
+        order.append("prepare")
+        return prepare(*args, **kwargs)  # type: ignore[arg-type]
+
+    def observed_execute(**kwargs: object) -> CommandRun:
+        order.append("execute")
+        assert kwargs["deadline"] is deadline
+        return execute(**kwargs)
+
+    monkeypatch.setattr(lane_module, "start_lane_deadline", start)
+    monkeypatch.setattr(lane_module, "_prepare_artifact_root", observed_prepare)
+    monkeypatch.setattr(lane_module, "_execute", observed_execute)
+
+    lane_module.execute_source_fragment(
+        repo_root=tmp_path,
+        route_path="route.json",
+        artifact_root="artifacts/source-fragment",
+    )
+
+    assert order[:3] == ["start", "prepare", "execute"]
+
+
+def test_source_output_time_is_bound_and_cannot_publish_pass(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_source_execution(tmp_path, monkeypatch)
+    elapsed = {"value": 219_999}
+    private_write = lane_module._private_write
+
+    def delayed_write(path: Path, value: object) -> None:
+        private_write(path, value)
+        if "source-fragment" in path.name:
+            elapsed["value"] = 220_001
+
+    monkeypatch.setattr(lane_module, "_private_write", delayed_write)
+    monkeypatch.setattr(
+        lane_module, "_deadline_elapsed_ms", lambda _deadline: elapsed["value"]
+    )
+
+    fragment = lane_module.execute_source_fragment(
+        repo_root=tmp_path,
+        route_path="route.json",
+        artifact_root="artifacts/source-fragment",
+    )
+
+    assert fragment["source_lifecycle"] == {
+        "schema_version": lane_module._SOURCE_LIFECYCLE_SCHEMA,
+        "elapsed_ms": 220_001,
+        "timeout_ms": 220_000,
+        "result": "BUDGET_EXCEEDED",
+    }
+    persisted = json.loads(
+        (tmp_path / "artifacts/source-fragment/source-fragment.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert persisted["source_lifecycle"]["result"] == "BUDGET_EXCEEDED"
+
+
+def test_true_shard_timeout_discards_incomplete_junit_and_stays_typed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_core_shard_execution(
+        tmp_path,
+        monkeypatch,
+        result="BUDGET_EXCEEDED",
+        report_payload="<testsuite>",
+    )
+
+    fragment = lane_module.execute_core_shard(
+        repo_root=tmp_path,
+        route_path="route.json",
+        shard_index=0,
+        artifact_root="artifacts/core-fragment",
+    )
+
+    assert fragment["command_run"]["gate_run"]["result"] == "BUDGET_EXCEEDED"
+    assert fragment["junit_summary"] is None
+    assert fragment["report_digest"] is None
+    assert not (tmp_path / "artifacts/core-fragment/pytest.xml").exists()
+
+
+def test_true_shard_timeout_discards_well_formed_partial_junit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_core_shard_execution(
+        tmp_path,
+        monkeypatch,
+        result="BUDGET_EXCEEDED",
+        report_payload=(
+            '<testsuite tests="1" failures="0" errors="0" skipped="0">'
+            '<testcase classname="newsroom.tests.test_0" name="test_0" '
+            'time="0.001" />'
+            "</testsuite>"
+        ),
+    )
+
+    fragment = lane_module.execute_core_shard(
+        repo_root=tmp_path,
+        route_path="route.json",
+        shard_index=0,
+        artifact_root="artifacts/core-fragment",
+    )
+
+    assert fragment["command_run"]["gate_run"]["result"] == "BUDGET_EXCEEDED"
+    assert fragment["junit_summary"] is None
+    assert fragment["report_digest"] is None
+    assert not (tmp_path / "artifacts/core-fragment/pytest.xml").exists()
+
+
+def test_product_result_without_junit_fails_closed_as_evidence_mismatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_core_shard_execution(
+        tmp_path,
+        monkeypatch,
+        result="FAIL",
+        report_payload=None,
+    )
+
+    with pytest.raises(WorkflowLaneError, match="core_fragment_report_required"):
+        lane_module.execute_core_shard(
+            repo_root=tmp_path,
+            route_path="route.json",
+            shard_index=0,
+            artifact_root="artifacts/core-fragment",
+        )
+
+
+def test_fragment_loader_is_input_order_deterministic_and_validates_bindings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fragments, contract, context, route = _write_fragment_set(
+        tmp_path,
+        monkeypatch,
+        directory_order=(3, 2, 1, 0),
+    )
+
+    loaded = lane_module._load_core_fragments(
+        root=tmp_path,
+        fragment_root=fragments,
+        contract=contract,  # type: ignore[arg-type]
+        context=context,
+        route=route,
+    )
+
+    assert tuple(fragment["shard_index"] for fragment, _report in loaded) == (
+        0,
+        1,
+        2,
+        3,
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement", "reason", "refresh_identity"),
+    [
+        ("fragment_identity", "sha256:" + "0" * 64, "core_fragment_identity", False),
+        ("evaluated_sha", "1" * 40, "core_fragment_provenance", True),
+        ("evaluated_tree_sha", "2" * 40, "core_fragment_provenance", True),
+        ("route_digest", "sha256:" + "3" * 64, "core_fragment_provenance", True),
+        ("contract_digest", "sha256:" + "4" * 64, "core_fragment_provenance", True),
+        (
+            "file_inventory",
+            ["newsroom/tests/test_unexpected.py"],
+            "core_fragment_provenance",
+            True,
+        ),
+        (
+            "selected_node_ids",
+            ["newsroom/tests/test_unexpected.py::test_unexpected"],
+            "core_fragment_provenance",
+            True,
+        ),
+        (
+            "command_spec",
+            {"schema_version": "tampered-command-spec"},
+            "core_fragment_spec",
+            True,
+        ),
+        (
+            "shard_lifecycle",
+            {
+                "schema_version": "newsroom.sdlc.core-shard-lifecycle.v1",
+                "elapsed_ms": 220_001,
+                "timeout_ms": 220_000,
+                "result": "PASS",
+            },
+            "core_fragment_lifecycle",
+            True,
+        ),
+    ],
+)
+def test_fragment_loader_rejects_tamper_and_wrong_provenance(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+    replacement: object,
+    reason: str,
+    refresh_identity: bool,
+) -> None:
+    fragments, contract, context, route = _write_fragment_set(tmp_path, monkeypatch)
+    _rewrite_fragment(
+        fragments / "input-0" / "fragment.json",
+        {field: replacement},
+        refresh_identity=refresh_identity,
+    )
+
+    with pytest.raises(WorkflowLaneError, match=reason):
+        lane_module._load_core_fragments(
+            root=tmp_path,
+            fragment_root=fragments,
+            contract=contract,  # type: ignore[arg-type]
+            context=context,
+            route=route,
+        )
+
+
+def test_fragment_loader_rejects_wrong_gate_run_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fragments, contract, context, route = _write_fragment_set(tmp_path, monkeypatch)
+    path = fragments / "input-0" / "fragment.json"
+    value = json.loads(path.read_text(encoding="utf-8"))
+    command_run = value["command_run"]
+    assert isinstance(command_run, dict)
+    gate_run = command_run["gate_run"]
+    assert isinstance(gate_run, dict)
+    gate_run.update(
+        {
+            "gate_id": "source-integrity",
+            "phase": "source",
+            "result_reason": "BUDGET_EXCEEDED:source-integrity:source",
+        }
+    )
+    _rewrite_fragment(path, {"command_run": command_run})
+
+    with pytest.raises(WorkflowLaneError, match="core_fragment_run_identity"):
+        lane_module._load_core_fragments(
+            root=tmp_path,
+            fragment_root=fragments,
+            contract=contract,  # type: ignore[arg-type]
+            context=context,
+            route=route,
+        )
+
+
+def test_fragment_loader_requires_junit_for_product_result(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fragments, contract, context, route = _write_fragment_set(tmp_path, monkeypatch)
+    path = fragments / "input-0" / "fragment.json"
+    value = json.loads(path.read_text(encoding="utf-8"))
+    command_run = value["command_run"]
+    assert isinstance(command_run, dict)
+    gate_run = command_run["gate_run"]
+    assert isinstance(gate_run, dict)
+    gate_run.update(
+        {
+            "result": "FAIL",
+            "result_reason": "FAIL:core-deterministic:tests:exit=1",
+            "returncode": 1,
+        }
+    )
+    lifecycle = value["shard_lifecycle"]
+    assert isinstance(lifecycle, dict)
+    lifecycle["result"] = "FAIL"
+    _rewrite_fragment(
+        path,
+        {"command_run": command_run, "shard_lifecycle": lifecycle},
+    )
+
+    with pytest.raises(WorkflowLaneError, match="core_fragment_report_required"):
+        lane_module._load_core_fragments(
+            root=tmp_path,
+            fragment_root=fragments,
+            contract=contract,  # type: ignore[arg-type]
+            context=context,
+            route=route,
+        )
+
+
+def test_fragment_loader_rejects_tampered_junit_bytes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fragments, contract, context, route = _write_fragment_set(tmp_path, monkeypatch)
+    path = fragments / "input-0" / "fragment.json"
+    _rewrite_fragment_as_pass(path)
+    _write_bound_junit(path)
+    report = path.with_name("pytest.xml")
+    report.write_text(
+        report.read_text(encoding="utf-8") + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(WorkflowLaneError, match="core_fragment_report_digest"):
+        lane_module._load_core_fragments(
+            root=tmp_path,
+            fragment_root=fragments,
+            contract=contract,  # type: ignore[arg-type]
+            context=context,
+            route=route,
+        )
+
+
+def test_reducer_rejects_self_consistent_junit_outside_assigned_union(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fragments, contract, context, route = _write_fragment_set(tmp_path, monkeypatch)
+    for index in range(4):
+        path = fragments / f"input-{index}" / "fragment.json"
+        _rewrite_fragment_as_pass(path)
+        _write_bound_junit(path)
+    _write_bound_junit(
+        fragments / "input-0" / "fragment.json",
+        node_id="newsroom/tests/test_unexpected.py::test_unexpected",
+    )
+    source_run = CommandRun(
+        "sha256:" + "9" * 64,
+        GateRunResult(
+            "source-integrity",
+            "source",
+            "PASS",
+            "PASS:source-integrity:source",
+            0,
+            1,
+            "",
+            "",
+            False,
+            False,
+        ),
+    )
+    source = {
+        "command_run": source_run.as_dict(),
+        "source_lifecycle": {
+            "schema_version": lane_module._SOURCE_LIFECYCLE_SCHEMA,
+            "elapsed_ms": 1,
+            "timeout_ms": 220_000,
+            "result": "PASS",
+        },
+    }
+    source_root = tmp_path / "source"
+    source_root.mkdir()
+    (tmp_path / "output").mkdir()
+    monkeypatch.setattr(
+        lane_module,
+        "_context_route",
+        lambda **_kwargs: (contract, context, route),
+    )
+    monkeypatch.setattr(
+        lane_module,
+        "start_lane_deadline",
+        lambda *_args: lane_module.LaneDeadline.start(220),
+    )
+    monkeypatch.setattr(
+        lane_module,
+        "_existing_artifact_root",
+        lambda _root, value: fragments if str(value) == "fragments" else source_root,
+    )
+    monkeypatch.setattr(lane_module, "_load_source_fragment", lambda **_kwargs: source)
+    monkeypatch.setattr(
+        lane_module,
+        "_expected_spec",
+        lambda **_kwargs: SimpleNamespace(digest=source_run.command_spec_digest),
+    )
+    with pytest.raises(WorkflowLaneError, match="core_fragment_report_inventory"):
+        lane_module.reduce_core_lane(
+            repo_root=tmp_path,
+            route_path="route.json",
+            fragment_root="fragments",
+            source_root="source",
+            artifact_root="output/core",
+        )
+
+
+def test_reducer_validates_available_junit_when_another_shard_timed_out(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fragments, contract, context, route = _write_fragment_set(tmp_path, monkeypatch)
+    path = fragments / "input-0" / "fragment.json"
+    _rewrite_fragment_as_pass(path)
+    _write_bound_junit(
+        path,
+        node_id="newsroom/tests/test_unexpected.py::test_unexpected",
+    )
+    source_run = CommandRun(
+        "sha256:" + "9" * 64,
+        GateRunResult(
+            "source-integrity",
+            "source",
+            "PASS",
+            "PASS:source-integrity:source",
+            0,
+            1,
+            "",
+            "",
+            False,
+            False,
+        ),
+    )
+    source_root = tmp_path / "source"
+    source_root.mkdir()
+    (tmp_path / "output").mkdir()
+    monkeypatch.setattr(
+        lane_module,
+        "_context_route",
+        lambda **_kwargs: (contract, context, route),
+    )
+    monkeypatch.setattr(
+        lane_module,
+        "start_lane_deadline",
+        lambda *_args: lane_module.LaneDeadline.start(220),
+    )
+    monkeypatch.setattr(
+        lane_module,
+        "_existing_artifact_root",
+        lambda _root, value: fragments if str(value) == "fragments" else source_root,
+    )
+    monkeypatch.setattr(
+        lane_module,
+        "_load_source_fragment",
+        lambda **_kwargs: {
+            "command_run": source_run.as_dict(),
+            "source_lifecycle": {
+                "schema_version": lane_module._SOURCE_LIFECYCLE_SCHEMA,
+                "elapsed_ms": 1,
+                "timeout_ms": 220_000,
+                "result": "PASS",
+            },
+            "fragment_identity": "sha256:" + "8" * 64,
+        },
+    )
+    monkeypatch.setattr(
+        lane_module,
+        "_expected_spec",
+        lambda **_kwargs: SimpleNamespace(digest=source_run.command_spec_digest),
+    )
+    monkeypatch.setattr(lane_module, "artifact_name", lambda _context: "artifact")
+
+    with pytest.raises(WorkflowLaneError, match="core_fragment_report_inventory"):
+        lane_module.reduce_core_lane(
+            repo_root=tmp_path,
+            route_path="route.json",
+            fragment_root="fragments",
+            source_root="source",
+            artifact_root="output/core",
+        )
+
+
+def test_fragment_loader_rejects_duplicate_and_noncanonical_fragments(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fragments, contract, context, route = _write_fragment_set(tmp_path, monkeypatch)
+    _rewrite_fragment(fragments / "input-1" / "fragment.json", {"shard_index": 0})
+    with pytest.raises(WorkflowLaneError, match="core_fragment_duplicate"):
+        lane_module._load_core_fragments(
+            root=tmp_path,
+            fragment_root=fragments,
+            contract=contract,  # type: ignore[arg-type]
+            context=context,
+            route=route,
+        )
+
+    fragments, contract, context, route = _write_fragment_set(
+        tmp_path / "noncanonical", monkeypatch
+    )
+    path = fragments / "input-0" / "fragment.json"
+    value = json.loads(path.read_text(encoding="utf-8"))
+    path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+    with pytest.raises(WorkflowLaneError, match="input_canonical"):
+        lane_module._load_core_fragments(
+            root=tmp_path / "noncanonical",
+            fragment_root=fragments,
+            contract=contract,  # type: ignore[arg-type]
+            context=context,
+            route=route,
+        )
+
+
+def test_reducer_rejects_missing_or_extra_fragment_count() -> None:
+    with pytest.raises(WorkflowLaneError, match="core_fragment_count"):
+        lane_module._reduced_core_outcome(("PASS",) * 3)
+    with pytest.raises(WorkflowLaneError, match="core_fragment_count"):
+        lane_module._reduced_core_outcome(("PASS",) * 5)
+
+
+def test_fragment_loader_rejects_missing_and_extra_artifact_inputs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fragments = tmp_path / "fragments"
+    fragments.mkdir()
+    for index in range(4):
+        directory = fragments / f"shard-{index}"
+        directory.mkdir()
+        (directory / "fragment.json").write_text("{}\n", encoding="utf-8")
+    monkeypatch.setattr(
+        lane_module,
+        "_core_test_files",
+        lambda _root: tuple(f"newsroom/tests/test_{index}.py" for index in range(4)),
+    )
+    monkeypatch.setattr(
+        lane_module,
+        "_collect_core_node_ids",
+        lambda _root, **_kwargs: tuple(
+            f"newsroom/tests/test_{index}.py::test_{index}" for index in range(4)
+        ),
+    )
+
+    (fragments / "shard-3" / "fragment.json").unlink()
+    with pytest.raises(WorkflowLaneError, match="core_fragment_count"):
+        lane_module._load_core_fragments(
+            root=tmp_path,
+            fragment_root=fragments,
+            contract=None,  # type: ignore[arg-type]
+            context=None,
+            route={},
+        )
+
+    (fragments / "shard-3" / "fragment.json").write_text("{}\n", encoding="utf-8")
+    (fragments / "unexpected").write_text("extra", encoding="utf-8")
+    with pytest.raises(WorkflowLaneError, match="core_fragment_count"):
+        lane_module._load_core_fragments(
+            root=tmp_path,
+            fragment_root=fragments,
+            contract=None,  # type: ignore[arg-type]
+            context=None,
+            route={},
+        )

--- a/newsroom/tests/test_sdlc_evidence.py
+++ b/newsroom/tests/test_sdlc_evidence.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
-from copy import deepcopy
 import hashlib
 import json
-from pathlib import Path
 import shutil
 import stat
 import subprocess
+from copy import deepcopy
+from pathlib import Path
 
-from jsonschema import Draft202012Validator, FormatChecker
 import pytest
+from jsonschema import Draft202012Validator, FormatChecker
 
 from scripts.sdlc import emit_evidence
 from scripts.sdlc.classify_change import resolve_commit, resolve_tree
@@ -19,11 +19,12 @@ from scripts.sdlc.emit_evidence import (
     build_gate_evidence,
     canonical_json_bytes,
     installed_uv_version,
-    main as evidence_main,
     sha256_identity,
     validate_evidence_record,
 )
-
+from scripts.sdlc.emit_evidence import (
+    main as evidence_main,
+)
 
 REPO_ROOT = Path(__file__).parents[2]
 COMMAND_DIGEST = "sha256:" + "a" * 64
@@ -54,6 +55,7 @@ def _copy_contract(root: Path) -> None:
         "docs/specs/sdlc/2026-07-22-sdlc-v2-owner-acceptance.md",
         "docs/specs/sdlc/2026-07-30-sdlc-v2.3-owner-budget-amendment.md",
         "docs/specs/sdlc/2026-08-02-sdlc-v2.4-owner-budget-amendment.md",
+        "docs/specs/sdlc/2026-08-10-sdlc-v2.5-core-sharding-amendment.md",
     )
     for relative in paths:
         target = root / relative
@@ -176,9 +178,7 @@ def _build(
 ) -> dict[str, object]:
     run = gate_run or _gate_run()
     if junit is _MISSING:
-        selected_junit: object | None = (
-            _junit() if run["result"] == "PASS" else None
-        )
+        selected_junit: object | None = _junit() if run["result"] == "PASS" else None
     else:
         selected_junit = junit
     return build_gate_evidence(

--- a/newsroom/tests/test_sdlc_evidence_workflow.py
+++ b/newsroom/tests/test_sdlc_evidence_workflow.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from pathlib import Path
 import re
-from typing import Any, Mapping
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
 
 import yaml
-
 
 REPO_ROOT = Path(__file__).parents[2]
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "evidence.yml"
@@ -107,6 +107,8 @@ def test_job_graph_is_exact_and_decision_always_reports() -> None:
     jobs = _jobs()
     assert set(jobs) == {
         "route",
+        "source",
+        "core_shard",
         "core",
         "service",
         "decision",
@@ -114,16 +116,26 @@ def test_job_graph_is_exact_and_decision_always_reports() -> None:
     }
     assert {job_id: jobs[job_id]["name"] for job_id in jobs} == {
         "route": "route",
+        "source": "source",
+        "core_shard": "core-shard-${{ matrix.shard }}",
         "core": "core",
         "service": "service",
         "decision": "decision",
         "signed-closeout": "signed-closeout",
     }
-    assert jobs["core"]["needs"] == ["route"]
+    assert jobs["source"]["needs"] == ["route"]
+    assert jobs["core_shard"]["needs"] == ["route"]
+    assert jobs["core"]["needs"] == ["route", "source", "core_shard"]
     assert jobs["service"]["needs"] == ["route"]
     assert jobs["decision"]["needs"] == ["route", "core", "service"]
     assert jobs["signed-closeout"]["needs"] == ["route", "decision"]
-    assert jobs["core"]["if"] == "needs.route.result == 'success'"
+    assert jobs["source"]["if"] == "needs.route.result == 'success'"
+    assert jobs["core_shard"]["if"] == "needs.route.result == 'success'"
+    assert jobs["core"]["if"] == "always() && needs.route.result == 'success'"
+    assert jobs["core_shard"]["strategy"] == {
+        "fail-fast": "false",
+        "matrix": {"shard": ["0", "1", "2", "3"]},
+    }
     assert jobs["service"]["if"] == (
         "needs.route.result == 'success' && "
         "needs.route.outputs.service_required == 'true'"
@@ -149,10 +161,10 @@ def test_job_graph_is_exact_and_decision_always_reports() -> None:
     assert jobs["route"]["outputs"] == {
         "service_required": "${{ steps.route_output.outputs.service_required }}"
     }
-    assert {
-        job_id: job["timeout-minutes"] for job_id, job in jobs.items()
-    } == {
+    assert {job_id: job["timeout-minutes"] for job_id, job in jobs.items()} == {
         "route": "6",
+        "source": "10",
+        "core_shard": "10",
         "core": "10",
         "service": "10",
         "decision": "10",
@@ -161,7 +173,6 @@ def test_job_graph_is_exact_and_decision_always_reports() -> None:
 
 
 def test_every_action_is_release_pinned_to_an_exact_sha() -> None:
-    workflow = _workflow()
     allowed = {CHECKOUT, SETUP_PYTHON, SETUP_UV, UPLOAD, DOWNLOAD, ATTEST}
     observed: list[str] = []
     for job_id in _jobs():
@@ -176,16 +187,18 @@ def test_every_action_is_release_pinned_to_an_exact_sha() -> None:
             assert selected in allowed
             observed.append(selected)
     assert set(observed) == allowed
-    assert observed.count(CHECKOUT) == 4
-    assert observed.count(SETUP_PYTHON) == 4
-    assert observed.count(SETUP_UV) == 3
-    assert observed.count(UPLOAD) == 5
-    assert observed.count(DOWNLOAD) == 3
+    assert observed.count(CHECKOUT) == 6
+    assert observed.count(SETUP_PYTHON) == 6
+    assert observed.count(SETUP_UV) == 5
+    assert observed.count(UPLOAD) == 7
+    assert observed.count(DOWNLOAD) == 7
     assert observed.count(ATTEST) == 1
 
 
-def test_execution_jobs_check_out_the_exact_evaluated_head_without_credentials() -> None:
-    for job_id in ("route", "core", "service", "decision"):
+def test_execution_jobs_check_out_the_exact_evaluated_head_without_credentials() -> (
+    None
+):
+    for job_id in ("route", "source", "core_shard", "core", "service", "decision"):
         checkouts = _uses_steps(job_id, CHECKOUT)
         assert len(checkouts) == 1
         assert _steps(job_id)[0] == checkouts[0]
@@ -203,10 +216,12 @@ def test_execution_jobs_check_out_the_exact_evaluated_head_without_credentials()
 
 
 def test_uv_cache_is_exact_observable_and_untrusted_prs_cannot_save() -> None:
+    source = _uses_steps("source", SETUP_UV)
+    shard = _uses_steps("core_shard", SETUP_UV)
     core = _uses_steps("core", SETUP_UV)
     service = _uses_steps("service", SETUP_UV)
     decision = _uses_steps("decision", SETUP_UV)
-    assert len(core) == len(service) == len(decision) == 1
+    assert len(source) == len(shard) == len(core) == len(service) == len(decision) == 1
     common = {
         "version": "0.8.0",
         "github-token": "",
@@ -221,22 +236,30 @@ def test_uv_cache_is_exact_observable_and_untrusted_prs_cannot_save() -> None:
         **common,
         "save-cache": "${{ github.event_name != 'pull_request' }}",
     }
+    assert source[0]["with"] == {**common, "save-cache": "false"}
+    assert shard[0]["with"] == {**common, "save-cache": "false"}
     assert service[0]["with"] == {**common, "save-cache": "false"}
     assert decision[0]["with"] == {**common, "save-cache": "false"}
-    assert decision[0]["if"] == (
-        "needs.route.outputs.service_required == 'true'"
-    )
+    assert decision[0]["if"] == ("needs.route.outputs.service_required == 'true'")
     assert not _uses_steps("route", SETUP_UV)
 
     expected_cache_env = {
         "NEWSROOM_SDLC_CACHE_KEY": "${{ steps.setup_uv.outputs.cache-key }}",
         "NEWSROOM_SDLC_CACHE_HIT": "${{ steps.setup_uv.outputs.cache-hit }}",
     }
+    for job_id, step_name in (
+        ("source", "Execute source integrity"),
+        ("core_shard", "Execute bounded core shard"),
+        ("core", "Reduce exact core fragments"),
+        ("service", "Execute evidence lane"),
+    ):
+        assert _step(job_id, step_name)["env"] == expected_cache_env
     for job_id in ("core", "service"):
-        assert _step(job_id, "Execute evidence lane")["env"] == expected_cache_env
         assert _step(job_id, "Finalize evidence")["env"] == expected_cache_env
     for job_id in ("route", "decision"):
-        assert all("NEWSROOM_SDLC_CACHE" not in text for text in _all_strings(_steps(job_id)))
+        assert all(
+            "NEWSROOM_SDLC_CACHE" not in text for text in _all_strings(_steps(job_id))
+        )
 
 
 def test_route_artifact_transport_is_attempt_and_head_scoped() -> None:
@@ -252,7 +275,7 @@ def test_route_artifact_transport_is_attempt_and_head_scoped() -> None:
         "include-hidden-files": "false",
         "archive": "true",
     }
-    for job_id in ("core", "service"):
+    for job_id in ("source", "core_shard", "core", "service"):
         download = _step(job_id, "Download exact route evidence")
         assert download["uses"] == DOWNLOAD
         assert download["with"] == {
@@ -307,6 +330,46 @@ def test_lane_and_decision_artifacts_are_compact_immutable_and_attempt_scoped() 
             ]
 
 
+def test_core_shards_are_exact_inputs_to_one_canonical_core_artifact() -> None:
+    shard_upload = _step("core_shard", "Upload canonical core fragment")
+    assert shard_upload["if"] == "always()"
+    assert shard_upload["with"]["name"] == (
+        "newsroom-sdlc-core-fragment-${{ github.run_id }}-"
+        "${{ github.run_attempt }}-" + EVALUATED_SHA + "-${{ matrix.shard }}"
+    )
+    assert shard_upload["with"]["path"] == ".sdlc-run/core-fragment"
+
+    download = _step("core", "Download exact core fragments")
+    assert download["with"]["pattern"] == (
+        "newsroom-sdlc-core-fragment-${{ github.run_id }}-"
+        "${{ github.run_attempt }}-" + EVALUATED_SHA + "-*"
+    )
+    assert download["with"]["merge-multiple"] == "false"
+    assert download["with"]["digest-mismatch"] == "error"
+
+    canonical_uploads = [
+        step
+        for step in _uses_steps("core", UPLOAD)
+        if step["with"]["name"].startswith("newsroom-sdlc-${{ github.run_id }}")
+    ]
+    assert len(canonical_uploads) == 1
+    assert not _uses_steps("core_shard", ATTEST)
+    reducer_invocations = [
+        text
+        for job_id in _jobs()
+        for text in _all_strings(_steps(job_id))
+        if "scripts.sdlc.workflow_lane reduce-core" in text
+    ]
+    assert len(reducer_invocations) == 1
+    assert "scripts.sdlc.workflow_lane execute --lane core" not in (
+        WORKFLOW_PATH.read_text(encoding="utf-8")
+    )
+
+    rendered_fast = (REPO_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    assert "pytest -q newsroom/tests" not in rendered_fast
+    assert "pytest -q \\\n              newsroom/tests \\" not in rendered_fast
+
+
 def test_signed_closeout_attests_only_the_validated_exact_main_receipt() -> None:
     job = _jobs()["signed-closeout"]
     download = _step("signed-closeout", "Download exact final decision evidence")
@@ -346,10 +409,7 @@ def test_signed_closeout_attests_only_the_validated_exact_main_receipt() -> None
     assert attest["uses"] == ATTEST
     assert attest["with"]["subject-path"].splitlines() == [
         ".sdlc-run/signed-closeout-input/decision.json",
-        (
-            ".sdlc-run/signed-closeout-input/"
-            "increment5e2-final-closeout.json"
-        ),
+        (".sdlc-run/signed-closeout-input/increment5e2-final-closeout.json"),
     ]
     upload = _step("signed-closeout", "Retain attestation bundle")
     assert upload["uses"] == UPLOAD
@@ -390,13 +450,9 @@ def test_lane_step_names_match_jobs_api_telemetry_contract() -> None:
         names = [step.get("name") for step in _steps(job_id)]
         assert all(isinstance(name, str) and name for name in names)
         assert len(names) == len(set(names))
-    assert "Sync locked environment" in {
-        step["name"] for step in _steps("core")
-    }
+    assert "Sync locked environment" in {step["name"] for step in _steps("core")}
     assert "Finalize evidence" in {step["name"] for step in _steps("core")}
-    assert "Sync locked environment" in {
-        step["name"] for step in _steps("service")
-    }
+    assert "Sync locked environment" in {step["name"] for step in _steps("service")}
     assert "Wait for authenticated Neo4j" in {
         step["name"] for step in _steps("service")
     }
@@ -410,11 +466,9 @@ def test_core_bootstrap_precompiles_exact_source_before_timed_lane() -> None:
     )
     names = [step["name"] for step in _steps("core")]
     assert names.index("Sync locked environment") < names.index(
-        "Execute evidence lane"
+        "Reduce exact core fragments"
     )
-    assert "compileall" not in _step(
-        "service", "Sync locked environment"
-    )["run"]
+    assert "compileall" not in _step("service", "Sync locked environment")["run"]
 
 
 def test_decision_bootstraps_locked_runtime_before_closeout_receipt() -> None:
@@ -428,8 +482,7 @@ def test_decision_bootstraps_locked_runtime_before_closeout_receipt() -> None:
     ]
     closeout = _step("decision", "Build Increment 5E2 final closeout receipt")
     invocation = (
-        "uv run --no-sync python -m "
-        "scripts.sdlc.increment5e2_closeout_receipt final"
+        "uv run --no-sync python -m scripts.sdlc.increment5e2_closeout_receipt final"
     )
     assert invocation in closeout["run"]
     names = [step["name"] for step in _steps("decision")]
@@ -460,8 +513,8 @@ def test_service_boundary_is_exact_authenticated_loopback_and_bounded() -> None:
     for required in (
         "::add-mask::${NEO4J_ADMIN_PASSWORD}",
         "::add-mask::${NEWSROOM_NEO4J_PROJECTOR_PASSWORD}",
-        '${RUNNER_TEMP}/newsroom-sdlc-neo4j-admin.env',
-        '${RUNNER_TEMP}/newsroom-sdlc-neo4j-projector.env',
+        "${RUNNER_TEMP}/newsroom-sdlc-neo4j-admin.env",
+        "${RUNNER_TEMP}/newsroom-sdlc-neo4j-projector.env",
         'chmod 600 "${admin_file}" "${projector_file}"',
         "--publish 127.0.0.1:7687:7687",
         "--pull=never",
@@ -478,8 +531,12 @@ def test_service_boundary_is_exact_authenticated_loopback_and_bounded() -> None:
     assert 'source "${projector_file}"' in execute
     assert 'source "${admin_file}"' not in execute
     assert 'test ! -e "${RUNNER_TEMP}/newsroom-sdlc-neo4j-admin.env"' in execute
-    assert "NEO4J_ADMIN_PASSWORD" not in _step("service", "Upload service lane evidence").get("env", {})
-    assert "NEWSROOM_NEO4J_PROJECTOR_PASSWORD" not in _step("service", "Upload service lane evidence").get("env", {})
+    assert "NEO4J_ADMIN_PASSWORD" not in _step(
+        "service", "Upload service lane evidence"
+    ).get("env", {})
+    assert "NEWSROOM_NEO4J_PROJECTOR_PASSWORD" not in _step(
+        "service", "Upload service lane evidence"
+    ).get("env", {})
     for required in (
         "time.monotonic() + 50.0",
         "connection_timeout=1.0",
@@ -490,23 +547,29 @@ def test_service_boundary_is_exact_authenticated_loopback_and_bounded() -> None:
 
     cleanup = _step("service", "Remove disposable Neo4j state")
     assert cleanup["if"] == "always()"
-    assert '${RUNNER_TEMP}/newsroom-sdlc-neo4j-admin.env' in cleanup["run"]
-    assert '${RUNNER_TEMP}/newsroom-sdlc-neo4j-projector.env' in cleanup["run"]
+    assert "${RUNNER_TEMP}/newsroom-sdlc-neo4j-admin.env" in cleanup["run"]
+    assert "${RUNNER_TEMP}/newsroom-sdlc-neo4j-projector.env" in cleanup["run"]
     assert "docker rm --force newsroom-sdlc-neo4j" in cleanup["run"]
     assert "kill-after=2s 20s" in cleanup["run"]
     service_names = [step["name"] for step in _steps("service")]
-    assert service_names.index("Execute evidence lane") < service_names.index("Remove disposable Neo4j state")
-    assert service_names.index("Remove disposable Neo4j state") < service_names.index("Finalize evidence")
-    assert service_names.index("Finalize evidence") < service_names.index("Upload service lane evidence")
+    assert service_names.index("Execute evidence lane") < service_names.index(
+        "Remove disposable Neo4j state"
+    )
+    assert service_names.index("Remove disposable Neo4j state") < service_names.index(
+        "Finalize evidence"
+    )
+    assert service_names.index("Finalize evidence") < service_names.index(
+        "Upload service lane evidence"
+    )
 
 
 def test_repository_owned_gate_budgets_drive_route_lane_and_decision() -> None:
     route = _step("route", "Classify exact change")["run"]
     assert "scripts.sdlc.workflow_budget route" in route
-    assert '${RUNNER_TEMP}/route-gate.json' in route
+    assert "${RUNNER_TEMP}/route-gate.json" in route
     assert ".sdlc-run/route-gate.json" not in route
 
-    for job_id, lane in (("core", "core"), ("service", "service")):
+    for job_id, lane in (("service", "service"),):
         execute = _step(job_id, "Execute evidence lane")["run"]
         finalize = _step(job_id, "Finalize evidence")
         assert "scripts.sdlc.workflow_lane execute" in execute
@@ -515,6 +578,19 @@ def test_repository_owned_gate_budgets_drive_route_lane_and_decision() -> None:
         assert "scripts.sdlc.workflow_budget finalize-lane" in finalize["run"]
         assert f"--lane {lane}" in finalize["run"]
         assert "${RUNNER_TEMP}" in finalize["run"]
+
+    shard = _step("core_shard", "Execute bounded core shard")["run"]
+    assert "scripts.sdlc.workflow_lane execute-core-shard" in shard
+    assert "--shard-index ${{ matrix.shard }}" in shard
+    source = _step("source", "Execute source integrity")["run"]
+    assert "scripts.sdlc.workflow_lane execute-source" in source
+    reduce = _step("core", "Reduce exact core fragments")["run"]
+    assert "scripts.sdlc.workflow_lane reduce-core" in reduce
+    assert "--fragment-root .sdlc-run/core-fragments" in reduce
+    core_finalize = _step("core", "Finalize evidence")
+    assert core_finalize["if"] == "always()"
+    assert "scripts.sdlc.workflow_budget finalize-lane" in core_finalize["run"]
+    assert "--lane core" in core_finalize["run"]
 
     collect = _step("decision", "Collect exact lane evidence")
     assert collect["env"] == {"GITHUB_TOKEN": "${{ github.token }}"}
@@ -565,13 +641,15 @@ def test_workflow_never_invokes_prohibited_product_runtime() -> None:
 
 
 def test_setup_uv_never_receives_the_github_token() -> None:
-    for job_id in ("core", "service", "decision"):
+    for job_id in ("source", "core_shard", "core", "service", "decision"):
         setup = _uses_steps(job_id, SETUP_UV)
         assert len(setup) == 1
         assert setup[0]["with"]["github-token"] == ""
 
 
-def test_service_credentials_are_removed_before_untrusted_finalization_or_actions() -> None:
+def test_service_credentials_are_removed_before_untrusted_finalization_or_actions() -> (
+    None
+):
     rendered = WORKFLOW_PATH.read_text(encoding="utf-8")
     assert "GITHUB_ENV" not in rendered
     admin_file = "${RUNNER_TEMP}/newsroom-sdlc-neo4j-admin.env"
@@ -580,15 +658,18 @@ def test_service_credentials_are_removed_before_untrusted_finalization_or_action
     assert rendered.count(projector_file) == 4
     service_steps = _steps("service")
     cleanup_index = next(
-        index for index, step in enumerate(service_steps)
+        index
+        for index, step in enumerate(service_steps)
         if step["name"] == "Remove disposable Neo4j state"
     )
     assert cleanup_index < next(
-        index for index, step in enumerate(service_steps)
+        index
+        for index, step in enumerate(service_steps)
         if step["name"] == "Finalize evidence"
     )
     assert cleanup_index < next(
-        index for index, step in enumerate(service_steps)
+        index
+        for index, step in enumerate(service_steps)
         if step["name"] == "Upload service lane evidence"
     )
     assert all(

--- a/newsroom/tests/test_sdlc_shadow_decision.py
+++ b/newsroom/tests/test_sdlc_shadow_decision.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, replace
 import json
-from pathlib import Path
 import stat
+from dataclasses import dataclass, replace
+from pathlib import Path
 
 import pytest
 
@@ -15,12 +15,13 @@ from scripts.sdlc.shadow_decision import (
     ShadowDecisionError,
     aggregate_shadow_decision,
     failure_shadow_decision,
-    main as decision_main,
     validate_shadow_decision,
+)
+from scripts.sdlc.shadow_decision import (
+    main as decision_main,
 )
 from scripts.sdlc.shadow_lane import ShadowLaneError
 from scripts.sdlc.workflow_event import WorkflowEvent
-
 
 REPOSITORY_ID = 1153895518
 RUN_ID = 123
@@ -133,7 +134,9 @@ class _Receipt:
     run_attempt: int = RUN_ATTEMPT
     consumer_job_id: str = "decision"
     consumer_runner_environment: str = "github-hosted"
-    workflow_ref: str = "fol2/newsroom/.github/workflows/evidence.yml@refs/pull/10/merge"
+    workflow_ref: str = (
+        "fol2/newsroom/.github/workflows/evidence.yml@refs/pull/10/merge"
+    )
     workflow_sha: str = "a" * 40
     event_name: str = "pull_request"
     event_sha: str = "b" * 40
@@ -225,7 +228,9 @@ def _lane(
         if lane_id == "core"
         else (_gate("service-neo4j", "tests"),)
     )
-    number = artifact_id if artifact_id is not None else (100 if lane_id == "core" else 101)
+    number = (
+        artifact_id if artifact_id is not None else (100 if lane_id == "core" else 101)
+    )
     return _Lane(
         lane_id=lane_id,
         receipt=_Receipt(
@@ -267,7 +272,9 @@ def _patch_lane_validator(monkeypatch: pytest.MonkeyPatch, *lanes: _Lane) -> Non
     monkeypatch.setattr(decision_module, "validate_shadow_lane_record", validate)
 
 
-def test_core_only_pass_is_exact_and_replayable(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_core_only_pass_is_exact_and_replayable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     route = _route()
     core = _lane("core", route)
     _patch_lane_validator(monkeypatch, core)
@@ -284,8 +291,36 @@ def test_core_only_pass_is_exact_and_replayable(monkeypatch: pytest.MonkeyPatch)
     assert decision.result_reason == "PASS:decision"
     assert decision.first_failure is None
     assert decision.totals.test_count == 2
-    assert decision.totals.execution_max_ms == 1000
-    assert validate_shadow_decision(decision.as_dict(), contract=_contract()) == decision
+    assert decision.totals.execution_max_ms == 500
+    assert (
+        validate_shadow_decision(decision.as_dict(), contract=_contract()) == decision
+    )
+
+
+def test_concurrent_core_gates_use_critical_path_not_duration_sum(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    route = _route()
+    core = _lane(
+        "core",
+        route,
+        gates=(
+            _gate("source-integrity", "source", execution_ms=60_000),
+            _gate("core-deterministic", "tests", execution_ms=200_000),
+        ),
+    )
+    _patch_lane_validator(monkeypatch, core)
+
+    decision = aggregate_shadow_decision(
+        context=_context(),
+        event=_event(),
+        core=core,  # type: ignore[arg-type]
+        service=None,
+        contract=_contract(),
+    )
+
+    assert decision.result == "PASS"
+    assert decision.totals.execution_max_ms == 200_000
 
 
 def test_service_is_required_exactly_when_route_requires_it(
@@ -358,9 +393,16 @@ def test_route_event_context_and_identity_conflicts_fail_closed(
     duplicate_service = replace(
         _lane("service", route),
         lane_identity=core.lane_identity,
-        replay=replace(_lane("service", route).replay, replay_identity=core.replay.replay_identity),
-        receipt=replace(_lane("service", route).receipt, receipt_identity=core.receipt.receipt_identity),
-        telemetry=replace(_lane("service", route).telemetry, job_id=core.telemetry.job_id),
+        replay=replace(
+            _lane("service", route).replay, replay_identity=core.replay.replay_identity
+        ),
+        receipt=replace(
+            _lane("service", route).receipt,
+            receipt_identity=core.receipt.receipt_identity,
+        ),
+        telemetry=replace(
+            _lane("service", route).telemetry, job_id=core.telemetry.job_id
+        ),
     )
     _patch_lane_validator(monkeypatch, core, duplicate_service)
     with pytest.raises(ShadowDecisionError, match="lane_identity_duplicate"):
@@ -455,7 +497,11 @@ def test_strict_record_rejects_tampering(monkeypatch: pytest.MonkeyPatch) -> Non
     core = _lane("core", route)
     _patch_lane_validator(monkeypatch, core)
     decision = aggregate_shadow_decision(
-        context=_context(), event=_event(), core=core, service=None, contract=_contract()  # type: ignore[arg-type]
+        context=_context(),
+        event=_event(),
+        core=core,
+        service=None,
+        contract=_contract(),  # type: ignore[arg-type]
     )
 
     for field, value, reason in (
@@ -482,7 +528,9 @@ def test_typed_failure_record_is_content_addressed() -> None:
     assert decision.event is None
     assert decision.lanes == ()
     assert decision.first_failure is not None
-    assert validate_shadow_decision(decision.as_dict(), contract=_contract()) == decision
+    assert (
+        validate_shadow_decision(decision.as_dict(), contract=_contract()) == decision
+    )
 
     with pytest.raises(ShadowDecisionError, match="decision_job"):
         failure_shadow_decision(context=_context(job_id="core"), code="bad")
@@ -498,7 +546,9 @@ def test_cli_always_emits_typed_failure_for_invalid_lane(
     core = tmp_path / "core.json"
     context.write_text(json.dumps(_context().as_dict()), encoding="utf-8")
     event.write_text(json.dumps(_event().as_dict()), encoding="utf-8")
-    core.write_text(json.dumps({"lane_identity": "sha256:" + "0" * 64}), encoding="utf-8")
+    core.write_text(
+        json.dumps({"lane_identity": "sha256:" + "0" * 64}), encoding="utf-8"
+    )
 
     def reject(*_args, **_kwargs):
         raise ShadowLaneError("lane_identity")
@@ -506,42 +556,47 @@ def test_cli_always_emits_typed_failure_for_invalid_lane(
     monkeypatch.setattr(decision_module, "validate_shadow_lane_record", reject)
     output = tmp_path / "decision.json"
     monkeypatch.setattr(decision_module, "load_contract", lambda _root: _contract())
-    assert decision_main(
-        (
-            "--repo-root",
-            str(tmp_path),
-            "--context",
-            str(context),
-            "--event",
-            str(event),
-            "--core",
-            str(core),
-            "--output",
-            "decision.json",
+    assert (
+        decision_main(
+            (
+                "--repo-root",
+                str(tmp_path),
+                "--context",
+                str(context),
+                "--event",
+                str(event),
+                "--core",
+                str(core),
+                "--output",
+                "decision.json",
+            )
         )
-    ) == 0
+        == 0
+    )
     payload = json.loads(output.read_text(encoding="utf-8"))
     assert payload["result"] == "EVIDENCE_MISMATCH"
     assert stat.S_IMODE(output.stat().st_mode) == 0o600
     assert capsys.readouterr().out
 
     original = output.read_bytes()
-    assert decision_main(
-        (
-            "--repo-root",
-            str(tmp_path),
-            "--context",
-            str(context),
-            "--event",
-            str(event),
-            "--core",
-            str(core),
-            "--output",
-            "decision.json",
+    assert (
+        decision_main(
+            (
+                "--repo-root",
+                str(tmp_path),
+                "--context",
+                str(context),
+                "--event",
+                str(event),
+                "--core",
+                str(core),
+                "--output",
+                "decision.json",
+            )
         )
-    ) == 2
+        == 2
+    )
     assert output.read_bytes() == original
-
 
 
 def test_service_lanes_must_share_workflow_creation_time(
@@ -599,25 +654,27 @@ def test_cli_contract_failure_after_context_is_typed(
 
     monkeypatch.setattr(decision_module, "load_contract", reject_contract)
     output = tmp_path / "decision.json"
-    assert decision_main(
-        (
-            "--repo-root",
-            str(tmp_path),
-            "--context",
-            str(context),
-            "--event",
-            "missing-event.json",
-            "--core",
-            "missing-core.json",
-            "--output",
-            "decision.json",
+    assert (
+        decision_main(
+            (
+                "--repo-root",
+                str(tmp_path),
+                "--context",
+                str(context),
+                "--event",
+                "missing-event.json",
+                "--core",
+                "missing-core.json",
+                "--output",
+                "decision.json",
+            )
         )
-    ) == 0
+        == 0
+    )
     payload = json.loads(output.read_text(encoding="utf-8"))
     assert payload["result"] == "EVIDENCE_MISMATCH"
     assert payload["result_reason"] == "EVIDENCE_MISMATCH:decision:invalid-input"
     assert stat.S_IMODE(output.stat().st_mode) == 0o600
-
 
 
 def test_direct_failure_summary_must_match_top_level_decision(
@@ -657,7 +714,6 @@ def test_direct_failure_summary_must_match_top_level_decision(
     )
     with pytest.raises(ShadowDecisionError, match="failure_record"):
         replace(typed, first_failure=changed)
-
 
 
 def test_consumer_runner_environment_must_match_decision_context(

--- a/newsroom/tests/test_sdlc_shadow_lane.py
+++ b/newsroom/tests/test_sdlc_shadow_lane.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -20,7 +20,6 @@ from scripts.sdlc.shadow_lane import (
 from scripts.sdlc.transport_replay import TransportReplay, TransportReplayError
 from scripts.sdlc.workflow_event import JobTelemetry, WorkflowEvidenceError
 
-
 RUN_ID = 123
 RUN_ATTEMPT = 2
 REPOSITORY_ID = 1153895518
@@ -29,6 +28,7 @@ HEAD_SHA = "a" * 40
 ARTIFACT_ID = 456
 ARTIFACT_NAME = f"newsroom-sdlc-{RUN_ID}-{RUN_ATTEMPT}-core-{HEAD_SHA}"
 ARTIFACT_DIGEST = "sha256:" + "1" * 64
+CORE_READY_AFTER_JOBS = ("core_shard", "route", "source")
 
 
 @dataclass(frozen=True)
@@ -42,7 +42,7 @@ class _Metadata:
 
 @dataclass(frozen=True)
 class _Route:
-    contract_version: str = "sdlc-v2.4"
+    contract_version: str = "sdlc-v2.5"
     risk_classifier_version: str = "sdlc-risk-v1"
     risk_tier: str = "R1_LOCAL_CODE"
     service_required: bool = False
@@ -115,7 +115,7 @@ def _replay(*, artifact_name: str = ARTIFACT_NAME) -> TransportReplay:
 def _telemetry(
     *,
     job_name: str = "core",
-    ready_after_jobs: tuple[str, ...] = ("route",),
+    ready_after_jobs: tuple[str, ...] = CORE_READY_AFTER_JOBS,
 ) -> JobTelemetry:
     return JobTelemetry(
         run_id=RUN_ID,
@@ -135,6 +135,19 @@ def _telemetry(
         finalization_completed_at="2026-07-22T12:00:41.000Z",
         job_completed_at="2026-07-22T12:00:42.000Z",
     )
+
+
+def _core_matrix_jobs() -> list[dict[str, object]]:
+    return [
+        {
+            "name": f"core-shard-{index}",
+            "run_id": RUN_ID,
+            "run_attempt": RUN_ATTEMPT,
+            "status": "completed",
+            "completed_at": f"2026-07-22T12:00:0{index + 1}Z",
+        }
+        for index in range(4)
+    ]
 
 
 def _identity(
@@ -205,7 +218,7 @@ def test_verify_shadow_lane_composes_replay_telemetry_and_receipt(
     transport = SimpleNamespace(
         replay=replay,
         run={"event": "pull_request", "created_at": telemetry.workflow_created_at},
-        jobs={"jobs": []},
+        jobs={"jobs": _core_matrix_jobs()},
         metadata={"id": ARTIFACT_ID},
         artifact_root=tmp_path / "artifact",
         archive_path=tmp_path / "artifact.zip",
@@ -233,18 +246,86 @@ def test_verify_shadow_lane_composes_replay_telemetry_and_receipt(
         lane_id="core",
         decision_context=decision_context,  # type: ignore[arg-type]
         contract=contract,  # type: ignore[arg-type]
-        now=datetime(2026, 7, 22, 12, 1, tzinfo=timezone.utc),
+        now=datetime(2026, 7, 22, 12, 1, tzinfo=UTC),
     )
 
     assert record.lane_id == "core"
     assert record.replay == replay
     assert record.receipt == receipt
     assert record.telemetry == telemetry
+    measured_jobs = calls["measure"][0]["jobs"]  # type: ignore[index]
+    assert measured_jobs[-1] == {
+        "name": "core_shard",
+        "run_id": RUN_ID,
+        "run_attempt": RUN_ATTEMPT,
+        "status": "completed",
+        "completed_at": "2026-07-22T12:00:04Z",
+    }
     assert calls["measure"][1]["job_name"] == "core"  # type: ignore[index]
-    assert calls["measure"][1]["ready_after_job_names"] == ("route",)  # type: ignore[index]
+    assert calls["measure"][1]["ready_after_job_names"] == (  # type: ignore[index]
+        CORE_READY_AFTER_JOBS
+    )
     assert calls["measure"][1]["bootstrap_end_step"] == "Sync locked environment"  # type: ignore[index]
     assert calls["verify"]["expected_job_id"] == "core"  # type: ignore[index]
     assert validate_shadow_lane_record(record.as_dict(), contract=contract) == record
+
+
+def test_core_telemetry_ready_dependencies_match_the_reducer_topology() -> None:
+    assert lane_module._POLICIES["core"].ready_after_jobs == (
+        "core_shard",
+        "route",
+        "source",
+    )
+
+
+@pytest.mark.parametrize(
+    "fault",
+    ["missing", "duplicate", "extra", "wrong-run", "wrong-attempt", "incomplete"],
+)
+def test_core_telemetry_rejects_noncanonical_matrix_dependencies(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fault: str,
+) -> None:
+    jobs = _core_matrix_jobs()
+    if fault == "missing":
+        jobs.pop()
+    elif fault == "duplicate":
+        jobs.append(dict(jobs[0]))
+    elif fault == "extra":
+        jobs.append({**jobs[0], "name": "core-shard-4"})
+    elif fault == "wrong-run":
+        jobs[0]["run_id"] = RUN_ID + 1
+    elif fault == "wrong-attempt":
+        jobs[0]["run_attempt"] = RUN_ATTEMPT + 1
+    else:
+        jobs[0]["status"] = "in_progress"
+    replay = _replay()
+    telemetry = _telemetry()
+    transport = SimpleNamespace(
+        replay=replay,
+        run={"event": "pull_request", "created_at": telemetry.workflow_created_at},
+        jobs={"jobs": jobs},
+        metadata={},
+        artifact_root=tmp_path / "artifact",
+        archive_path=tmp_path / "artifact.zip",
+    )
+    monkeypatch.setattr(lane_module, "load_verified_transport", lambda _root: transport)
+    monkeypatch.setattr(
+        lane_module, "measure_job_telemetry", lambda *_args, **_kwargs: telemetry
+    )
+    receipt = _Receipt(_Metadata())
+    monkeypatch.setattr(lane_module, "verify_artifact", lambda **_kwargs: receipt)
+    _patch_receipt_validator(monkeypatch, receipt)
+
+    with pytest.raises(ShadowLaneError, match="job_telemetry"):
+        verify_shadow_lane(
+            repo_root=tmp_path,
+            bundle_root=tmp_path / "bundle",
+            lane_id="core",
+            decision_context=SimpleNamespace(job_id="decision"),  # type: ignore[arg-type]
+            contract=SimpleNamespace(repo_root=tmp_path),  # type: ignore[arg-type]
+        )
 
 
 def test_service_lane_uses_exact_service_policy(
@@ -261,7 +342,7 @@ def test_service_lane_uses_exact_service_policy(
         gate_decisions=(_GateDecision("service-neo4j", "tests"),),
     )
     replay = _replay(artifact_name=receipt.metadata.name)
-    telemetry = _telemetry(job_name="service")
+    telemetry = _telemetry(job_name="service", ready_after_jobs=("route",))
     transport = SimpleNamespace(
         replay=replay,
         run={"event": "pull_request", "created_at": telemetry.workflow_created_at},
@@ -386,7 +467,7 @@ def test_route_and_lane_gate_semantics_fail_closed(
             run_created_at="2026-07-22T12:00:00.000Z",
             replay=service_replay,
             receipt=unexpected_service,  # type: ignore[arg-type]
-            telemetry=_telemetry(job_name="service"),
+            telemetry=_telemetry(job_name="service", ready_after_jobs=("route",)),
             lane_identity="sha256:" + "0" * 64,
         )
 

--- a/scripts/sdlc/contracts.py
+++ b/scripts/sdlc/contracts.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 import json
-from pathlib import Path
 import tomllib
-from typing import Any, Mapping
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
 
 
 class ContractError(ValueError):
@@ -94,7 +95,9 @@ class SdlcContract:
     @property
     def path_groups(self) -> Mapping[str, tuple[str, ...]]:
         raw = _mapping(self.classification["paths"], "classification.paths")
-        return {name: tuple(str(item) for item in values) for name, values in raw.items()}
+        return {
+            name: tuple(str(item) for item in values) for name, values in raw.items()
+        }
 
     @property
     def risk_rank(self) -> Mapping[str, int]:
@@ -137,7 +140,10 @@ def validate_contract_data(
         raise ContractError("unsupported SDLC contract schema")
     if data.get("status") != "accepted":
         raise ContractError("SDLC contract is not accepted")
-    if not isinstance(data.get("contract_version"), str) or not data["contract_version"]:
+    if (
+        not isinstance(data.get("contract_version"), str)
+        or not data["contract_version"]
+    ):
         raise ContractError("contract_version is required")
 
     global_config = _mapping(data.get("global"), "global")
@@ -174,7 +180,10 @@ def validate_contract_data(
         if gate_id in gate_ids:
             raise ContractError(f"duplicate gate id: {gate_id}")
         gate_ids.add(gate_id)
-        if gate_id != gate_name and (gate_name, gate_id) != ("science-shard", "science-*"):
+        if gate_id != gate_name and (gate_name, gate_id) != (
+            "science-shard",
+            "science-*",
+        ):
             raise ContractError(f"gate.{gate_name}.id differs from its table name")
         lane_name = gate.get("lane")
         if not isinstance(lane_name, str) or lane_name not in lanes:
@@ -198,6 +207,25 @@ def validate_contract_data(
         )
         if timeout > lane_limit:
             raise ContractError(f"lanes.{lane_name} exceeds the aggregate lane timeout")
+    core = _mapping(lanes.get("core"), "lanes.core")
+    if (
+        core.get("shard_count") != 4
+        or core.get("partition") != "sha256_node_id_balanced"
+        or core.get("workers_per_shard") != 4
+        or core.get("distribution") != "worksteal"
+        or core.get("max_worker_restart") != 0
+        or core.get("reducer_single_canonical_receipt") is not True
+    ):
+        raise ContractError(
+            "lanes.core sharding contract differs from the accepted topology"
+        )
+    shard_timeout = _positive_int(
+        core.get("per_shard_hard_timeout_seconds"),
+        "lanes.core.per_shard_hard_timeout_seconds",
+        below=_MAX_HARD_TIMEOUT_SECONDS,
+    )
+    if shard_timeout != command_limit:
+        raise ContractError("lanes.core shard timeout differs from the command timeout")
     science = _mapping(lanes.get("science"), "lanes.science")
     _positive_int(
         science.get("per_shard_hard_timeout_seconds"),
@@ -265,10 +293,10 @@ def validate_contract_data(
     if owner.get("review_net_executable_lines_trigger") != review.get(
         "net_executable_lines_trigger"
     ):
-        raise ContractError("accepted executable-line trigger differs from change_review")
-    if owner.get("review_changed_files_trigger") != review.get(
-        "changed_files_trigger"
-    ):
+        raise ContractError(
+            "accepted executable-line trigger differs from change_review"
+        )
+    if owner.get("review_changed_files_trigger") != review.get("changed_files_trigger"):
         raise ContractError("accepted changed-file trigger differs from change_review")
     for owner_key, strategy_key in (
         ("selector_shadow_calendar_days", "selector_shadow_calendar_days"),
@@ -288,7 +316,10 @@ def validate_contract_data(
         raise ContractError("accepted budget amendment date is missing")
     if owner.get("hard_budget_multiplier") != 2:
         raise ContractError("accepted hard-budget multiplier must be two")
-    if owner.get("prewarmed_runner_evaluation_permitted_after_measured_slo_failure") is not True:
+    if (
+        owner.get("prewarmed_runner_evaluation_permitted_after_measured_slo_failure")
+        is not True
+    ):
         raise ContractError("accepted runner evaluation policy is missing")
     if owner.get("critical_main_failure_pauses_merges") is not True:
         raise ContractError("critical main failure must pause merges")
@@ -310,11 +341,7 @@ def validate_contract_data(
             ),
             (
                 "route schema",
-                str(
-                    _mapping(data.get("evidence"), "evidence").get(
-                        "route_schema", ""
-                    )
-                ),
+                str(_mapping(data.get("evidence"), "evidence").get("route_schema", "")),
             ),
         ):
             path = _repository_file(root, relative, label=label)

--- a/scripts/sdlc/shadow_decision.py
+++ b/scripts/sdlc/shadow_decision.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 import argparse
-from dataclasses import dataclass
 import json
 import os
-from pathlib import Path
 import re
 import sys
 import tempfile
-from typing import Mapping, Sequence
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
 
 from .artifact_envelope import (
     ArtifactProvenanceError,
@@ -31,7 +31,6 @@ from .workflow_event import (
     WorkflowEvidenceError,
     validate_workflow_event,
 )
-
 
 SCHEMA_VERSION = "newsroom.sdlc.shadow-decision.v1"
 POLICY_VERSION = "sdlc-shadow-decision-v1"
@@ -380,7 +379,9 @@ def _normalize_lanes(
     route = normalized_core.receipt.route
     if route.service_required != (service is not None):
         raise ShadowDecisionError(
-            "service_lane_missing" if route.service_required else "service_lane_unexpected"
+            "service_lane_missing"
+            if route.service_required
+            else "service_lane_unexpected"
         )
     lanes = [normalized_core]
     if service is not None:
@@ -421,14 +422,15 @@ def _totals(lanes: tuple[ShadowLaneRecord, ...]) -> DecisionTotals:
         ),
         execution_max_ms=max(
             (
-                sum(item.execution_ms for item in lane.receipt.gate_decisions)
+                max(
+                    (item.execution_ms for item in lane.receipt.gate_decisions),
+                    default=0,
+                )
                 for lane in lanes
             ),
             default=0,
         ),
-        finalize_max_ms=max(
-            (lane.telemetry.finalize_ms for lane in lanes), default=0
-        ),
+        finalize_max_ms=max((lane.telemetry.finalize_ms for lane in lanes), default=0),
         test_count=sum(item.test_count for item in decisions),
         failure_count=sum(item.failure_count for item in decisions),
         error_count=sum(item.error_count for item in decisions),
@@ -452,7 +454,7 @@ def _gate_failure(lane: ShadowLaneRecord) -> FailureSummary | None:
     failed = [item for item in lane.receipt.gate_decisions if item.result != "PASS"]
     if not failed:
         return None
-    selected = sorted(
+    selected = min(
         failed,
         key=lambda item: (
             -_RESULT_PRECEDENCE[item.result],
@@ -460,7 +462,7 @@ def _gate_failure(lane: ShadowLaneRecord) -> FailureSummary | None:
             item.phase,
             item.result_reason,
         ),
-    )[0]
+    )
     return _failure(
         lane.lane_id,
         selected.gate_id,
@@ -487,7 +489,14 @@ def _derive_result(
                     f"ENVIRONMENT_ERROR:{lane.lane_id}:job-conclusion",
                 )
             )
-        execution = sum(item.execution_ms for item in lane.receipt.gate_decisions)
+        # The core reducer's synthetic execution already binds parallel source /
+        # shard critical-path time plus its sequential reduction time. Taking
+        # the maximum retains that complete lifecycle without double-charging
+        # the separately retained source decision.
+        execution = max(
+            (item.execution_ms for item in lane.receipt.gate_decisions),
+            default=0,
+        )
         if execution > lane_budget_ms:
             failures.append(
                 _failure(
@@ -520,7 +529,7 @@ def _derive_result(
         )
     if not failures:
         return "PASS", "PASS:decision", None
-    selected = sorted(
+    selected = min(
         failures,
         key=lambda item: (
             -_RESULT_PRECEDENCE[item.result],
@@ -529,7 +538,7 @@ def _derive_result(
             item.phase,
             item.result_reason,
         ),
-    )[0]
+    )
     return (
         selected.result,
         f"{selected.result}:decision:{selected.lane_id}:{selected.gate_id}:{selected.phase}",
@@ -562,9 +571,7 @@ def _build(
         "event": None if event is None else event.as_dict(),
         "lanes": [lane.as_dict() for lane in lanes],
         "totals": totals.as_dict(),
-        "first_failure": (
-            None if first_failure is None else first_failure.as_dict()
-        ),
+        "first_failure": (None if first_failure is None else first_failure.as_dict()),
     }
     return ShadowDecision(
         result,
@@ -628,9 +635,7 @@ def failure_shadow_decision(
         raise ShadowDecisionError("failure_result")
     suffix = _identifier(code, "failure_code")
     reason = f"{selected}:decision:{suffix}"
-    first = _failure(
-        "decision", "decision-input", "validation", selected, reason
-    )
+    first = _failure("decision", "decision-input", "validation", selected, reason)
     return _build(
         result=selected,
         reason=reason,
@@ -644,7 +649,10 @@ def failure_shadow_decision(
 
 def _parse_failure(value: object) -> FailureSummary:
     item = _mapping(value, "first_failure")
-    if frozenset(item) != _FAILURE_KEYS or item.get("schema_version") != FAILURE_SCHEMA_VERSION:
+    if (
+        frozenset(item) != _FAILURE_KEYS
+        or item.get("schema_version") != FAILURE_SCHEMA_VERSION
+    ):
         raise ShadowDecisionError("failure_shape")
     fingerprint = item.get("first_failure_fingerprint")
     return FailureSummary(
@@ -661,7 +669,10 @@ def _parse_failure(value: object) -> FailureSummary:
 
 def _parse_totals(value: object) -> DecisionTotals:
     item = _mapping(value, "totals")
-    if frozenset(item) != _TOTAL_KEYS or item.get("schema_version") != TOTALS_SCHEMA_VERSION:
+    if (
+        frozenset(item) != _TOTAL_KEYS
+        or item.get("schema_version") != TOTALS_SCHEMA_VERSION
+    ):
         raise ShadowDecisionError("totals_shape")
     return DecisionTotals(
         *(
@@ -715,8 +726,7 @@ def validate_shadow_decision(
         raise ShadowDecisionError("lanes")
     try:
         lanes = tuple(
-            validate_shadow_lane_record(value, contract=contract)
-            for value in raw_lanes
+            validate_shadow_lane_record(value, contract=contract) for value in raw_lanes
         )
     except ShadowLaneError as exc:
         raise ShadowDecisionError("lanes") from exc
@@ -737,9 +747,7 @@ def validate_shadow_decision(
             context=context,
             event=event,
             core=next(lane for lane in lanes if lane.lane_id == "core"),
-            service=next(
-                (lane for lane in lanes if lane.lane_id == "service"), None
-            ),
+            service=next((lane for lane in lanes if lane.lane_id == "service"), None),
             contract=contract,
         )
         if normalized != lanes:
@@ -865,7 +873,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     try:
         try:
             context = _context_from_mapping(_load_json(root, arguments.context))
-        except (ArtifactProvenanceError, ShadowDecisionError) as exc:
+        except (ArtifactProvenanceError, ShadowDecisionError):
             print("EVIDENCE_MISMATCH:shadow-decision:context", file=sys.stderr)
             return 2
         try:
@@ -920,7 +928,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         UnicodeError,
         json.JSONDecodeError,
     ) as exc:
-        code = str(exc) if isinstance(exc, ShadowDecisionError) and str(exc) else type(exc).__name__
+        code = (
+            str(exc)
+            if isinstance(exc, ShadowDecisionError) and str(exc)
+            else type(exc).__name__
+        )
         print(f"EVIDENCE_MISMATCH:shadow-decision:{code}", file=sys.stderr)
         return 2
 

--- a/scripts/sdlc/shadow_lane.py
+++ b/scripts/sdlc/shadow_lane.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+import re
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-import re
-from typing import Mapping
 
 from .artifact_envelope import GithubRunContext
 from .artifact_receipt import (
@@ -27,11 +27,13 @@ from .workflow_event import (
     measure_job_telemetry,
     validate_job_telemetry,
 )
-
+from .workflow_event import (
+    _timestamp as _workflow_timestamp,
+)
 
 SCHEMA_VERSION = "newsroom.sdlc.shadow-lane.v1"
 POLICY_VERSION = "sdlc-shadow-lane-v1"
-CONTRACT_VERSION = "sdlc-v2.4"
+CONTRACT_VERSION = "sdlc-v2.5"
 CLASSIFIER_VERSION = "sdlc-risk-v1"
 _SERVICE_RISKS = frozenset({"R3_EXTERNAL_SERVICE_SECURITY", "R4_RELEASE_OPERATIONAL"})
 _OWNER_RISKS = frozenset({"R4_RELEASE_OPERATIONAL"})
@@ -78,7 +80,7 @@ _POLICIES = {
         ),
         bootstrap_end_step="Sync locked environment",
         finalization_step="Finalize evidence",
-        ready_after_jobs=("route",),
+        ready_after_jobs=("core_shard", "route", "source"),
     ),
     "service": LanePolicy(
         lane_id="service",
@@ -110,7 +112,11 @@ class ShadowLaneRecord:
             replay = validate_transport_replay(self.replay.as_dict())
             receipt = validate_receipt(self.receipt.as_dict())
             telemetry = validate_job_telemetry(self.telemetry.as_dict())
-        except (TransportReplayError, ArtifactReceiptError, WorkflowEvidenceError) as exc:
+        except (
+            TransportReplayError,
+            ArtifactReceiptError,
+            WorkflowEvidenceError,
+        ) as exc:
             raise ShadowLaneError("nested_evidence") from exc
         if (
             replay != self.replay
@@ -177,7 +183,7 @@ def _timestamp(value: object) -> str:
     if _TIMESTAMP.fullmatch(text) is None:
         raise ShadowLaneError("run_created_at")
     try:
-        datetime.fromisoformat(text[:-1] + "+00:00")
+        datetime.fromisoformat(text)
     except ValueError as exc:
         raise ShadowLaneError("run_created_at") from exc
     return text
@@ -276,8 +282,7 @@ def _cross_check(
     if policy.lane_id == "service" and not route.service_required:
         raise ShadowLaneError("lane_route")
     gate_keys = frozenset(
-        (decision.gate_id, decision.phase)
-        for decision in receipt.gate_decisions
+        (decision.gate_id, decision.phase) for decision in receipt.gate_decisions
     )
     if gate_keys != policy.gate_keys:
         raise ShadowLaneError("lane_gates")
@@ -313,6 +318,50 @@ def validate_shadow_lane_record(
     )
 
 
+def _telemetry_jobs(
+    value: object, *, policy: LanePolicy, run_id: int, run_attempt: int
+) -> object:
+    if policy.lane_id != "core":
+        return value
+    jobs = value.get("jobs") if isinstance(value, dict) else None
+    if not isinstance(jobs, list):
+        raise WorkflowEvidenceError("jobs_shape")
+    matrix = [
+        job
+        for job in jobs
+        if isinstance(job, dict)
+        and isinstance(job.get("name"), str)
+        and str(job["name"]).startswith("core-shard-")
+    ]
+    expected = {f"core-shard-{index}" for index in range(4)}
+    if (
+        len(matrix) != 4
+        or {job["name"] for job in matrix} != expected
+        or any(job.get("name") == "core_shard" for job in jobs if isinstance(job, dict))
+        or any(
+            (job.get("run_id"), job.get("run_attempt"), job.get("status"))
+            != (run_id, run_attempt, "completed")
+            for job in matrix
+        )
+    ):
+        raise WorkflowEvidenceError("ready_after_job")
+    completed_at = max(
+        (
+            _workflow_timestamp(job.get("completed_at"), "ready_after_job_completed_at")
+            for job in matrix
+        ),
+        key=lambda item: item[1],
+    )[0]
+    dependency = {
+        "name": "core_shard",
+        "run_id": run_id,
+        "run_attempt": run_attempt,
+        "status": "completed",
+        "completed_at": completed_at,
+    }
+    return {**value, "jobs": [*jobs, dependency]}
+
+
 def verify_shadow_lane(
     *,
     repo_root: str | Path,
@@ -335,8 +384,14 @@ def verify_shadow_lane(
     run_event = _event_name(run.get("event"))
     run_created_at = _timestamp(run.get("created_at"))
     try:
-        telemetry = measure_job_telemetry(
+        jobs = _telemetry_jobs(
             transport.jobs,
+            policy=policy,
+            run_id=transport.replay.run_id,
+            run_attempt=transport.replay.run_attempt,
+        )
+        telemetry = measure_job_telemetry(
+            jobs,
             run_id=transport.replay.run_id,
             run_attempt=transport.replay.run_attempt,
             job_name=policy.producer_job_id,

--- a/scripts/sdlc/workflow_lane.py
+++ b/scripts/sdlc/workflow_lane.py
@@ -1,17 +1,20 @@
 from __future__ import annotations
 
 import argparse
-from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass
+import hashlib
 import json
 import os
-from pathlib import Path
+import platform
 import shutil
 import subprocess
 import sys
 import tempfile
-from typing import Mapping, Sequence
+import time
 import xml.etree.ElementTree as ET
+from collections.abc import Callable, Mapping, Sequence
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
 
 from .artifact_envelope import (
     ArtifactProvenanceError,
@@ -39,12 +42,19 @@ from .emit_evidence import (
     _validate_route,
     build_gate_evidence,
     canonical_json_bytes,
+    git_blob_digest,
     installed_uv_version,
     sha256_identity,
+    verify_tracked_checkout,
 )
 from .junit_evidence import JUnitEvidenceError, JUnitSummary, summarize_junit
-from .run_gate import GateRunError, LaneDeadline, run_configured_gate, start_lane_deadline
-
+from .run_gate import (
+    GateRunError,
+    GateRunResult,
+    LaneDeadline,
+    run_configured_gate,
+    start_lane_deadline,
+)
 
 SCHEMA_VERSION = "newsroom.sdlc.workflow-lane.v1"
 _SERVICE_IMAGE = "neo4j:2026.06.0-community-trixie"
@@ -52,47 +62,47 @@ _SERVICE_SERVER = "2026.06.0"
 _SERVICE_DRIVER = "6.2.0"
 _MAX_JSON_BYTES = 8 * 1024 * 1024
 _OPTIONAL_CORE_TEST_IDS = (
-    'newsroom.tests.test_complete_projection_2b_neo4j_service::test_actual_service_complete_generation_queries_and_promotes_exact_state',
-    'newsroom.tests.test_complete_projection_2b_neo4j_service::test_actual_service_partial_or_contract_mismatched_state_fails_closed[deleted-document]',
-    'newsroom.tests.test_complete_projection_2b_neo4j_service::test_actual_service_partial_or_contract_mismatched_state_fails_closed[missing-vector-index]',
-    'newsroom.tests.test_complete_projection_2b_neo4j_service::test_actual_service_partial_or_contract_mismatched_state_fails_closed[wrong-fulltext-analyzer]',
-    'newsroom.tests.test_complete_projection_2b_neo4j_service::test_actual_service_partial_or_contract_mismatched_state_fails_closed[wrong-vector-dimensions]',
-    'newsroom.tests.test_complete_projection_2b_neo4j_service::test_actual_service_replacement_generation_recovers_from_authority_only',
-    'newsroom.tests.test_complete_projection_2b_neo4j_service::test_actual_service_revocation_and_tombstone_remove_current_derivatives',
-    'newsroom.tests.test_complete_projection_2b_neo4j_service::test_actual_service_wrong_watermark_generation_and_vector_dimension_fail_closed',
-    'newsroom.tests.test_increment4e_neo4j_service::test_actual_service_increment4_admitted_state_projects_exactly_and_replays',
-    'newsroom.tests.test_increment4e_neo4j_service::test_actual_service_increment4_graph_loss_requires_isolated_replacement',
-    'newsroom.tests.test_increment4e_neo4j_service::test_actual_service_increment4_replacement_generation_is_only_serving_state',
-    'newsroom.tests.test_increment4e_neo4j_service::test_actual_service_increment4_tombstone_purges_and_never_resurrects',
-    'newsroom.tests.test_increment5b4_neo4j_service::test_increment5b4_fixed_port_excludes_future_observations',
-    'newsroom.tests.test_increment5b4_neo4j_service::test_increment5b4_fixed_port_reads_only_exact_generation_and_allowed_state',
-    'newsroom.tests.test_increment_2d_neo4j_service::test_actual_service_complete_increment_2_proof_admits_replays_and_restarts',
-    'newsroom.tests.test_increment_2d_neo4j_service::test_actual_service_complete_proof_fails_closed_when_required_surface_is_lost[fulltext]',
-    'newsroom.tests.test_increment_2d_neo4j_service::test_actual_service_complete_proof_fails_closed_when_required_surface_is_lost[relation]',
-    'newsroom.tests.test_increment_2d_neo4j_service::test_actual_service_complete_proof_fails_closed_when_required_surface_is_lost[vector]',
-    'newsroom.tests.test_increment_2d_neo4j_service::test_actual_service_dead_letter_blocks_complete_candidate_proof',
-    'newsroom.tests.test_increment_2d_neo4j_service::test_actual_service_governed_deletion_purges_derivative_and_never_requalifies',
-    'newsroom.tests.test_increment_2d_neo4j_service::test_actual_service_relation_revocation_changes_later_context_without_rewrite',
-    'newsroom.tests.test_increment_2d_neo4j_service::test_actual_service_replacement_generation_deduplicates_candidate_authority',
-    'newsroom.tests.test_increment_2d_neo4j_service::test_actual_service_required_gap_blocks_complete_candidate_proof',
-    'newsroom.tests.test_integrated_c1_neo4j_service::test_actual_service_integrated_foundation_replay_recovery_and_tombstone',
-    'newsroom.tests.test_projection_b2_increment5e2_neo4j_service::test_actual_service_increment5e2_target_and_report',
-    'newsroom.tests.test_projection_b2_neo4j_service::test_actual_service_private_adapter_exact_duplicate_and_digest_conflict',
-    'newsroom.tests.test_projection_b2_neo4j_service::test_actual_service_public_round_trip_duplicate_and_generation_isolation',
-    'newsroom.tests.test_projection_b2_neo4j_service::test_actual_service_requires_explicit_authentication_configuration',
-    'newsroom.tests.test_projection_b2_neo4j_service::test_actual_service_wrong_projector_credential_fails_closed_without_secret',
-    'newsroom.tests.test_projection_b3_neo4j_service::test_actual_service_3e_projects_complete_lineage_and_recovers_graph_loss',
-    'newsroom.tests.test_projection_b3_neo4j_service::test_actual_service_3e_replacement_generation_becomes_only_active_lineage',
-    'newsroom.tests.test_projection_b3_neo4j_service::test_actual_service_active_generation_revalidates_after_incremental_delivery',
-    'newsroom.tests.test_projection_b3_neo4j_service::test_actual_service_active_read_resolves_only_authority_promoted_generation',
-    'newsroom.tests.test_projection_b3_neo4j_service::test_actual_service_graph_loss_and_process_restart_rebuild_from_authority',
-    'newsroom.tests.test_projection_b3_neo4j_service::test_actual_service_promotion_rejects_graph_loss_after_validation',
-    'newsroom.tests.test_projection_b3_neo4j_service::test_actual_service_rebuild_cleanup_cannot_cross_generation_namespace',
-    'newsroom.tests.test_projection_b3_neo4j_service::test_actual_service_tombstone_does_not_resurrect_after_wipe_rebuild',
-    'newsroom.tests.test_retrieval_2c_neo4j_service::test_actual_service_executes_all_four_branches_and_hydrates_authority',
-    'newsroom.tests.test_retrieval_2c_neo4j_service::test_actual_service_missing_admitted_relation_is_incomplete_not_no_match',
-    'newsroom.tests.test_retrieval_2c_neo4j_service::test_actual_service_missing_fulltext_index_is_unavailable_not_no_match',
-    'newsroom.tests.test_retrieval_2c_neo4j_service::test_actual_service_missing_vector_index_is_unavailable_not_no_match',
+    "newsroom.tests.test_complete_projection_2b_neo4j_service::test_actual_service_complete_generation_queries_and_promotes_exact_state",
+    "newsroom.tests.test_complete_projection_2b_neo4j_service::test_actual_service_partial_or_contract_mismatched_state_fails_closed[deleted-document]",
+    "newsroom.tests.test_complete_projection_2b_neo4j_service::test_actual_service_partial_or_contract_mismatched_state_fails_closed[missing-vector-index]",
+    "newsroom.tests.test_complete_projection_2b_neo4j_service::test_actual_service_partial_or_contract_mismatched_state_fails_closed[wrong-fulltext-analyzer]",
+    "newsroom.tests.test_complete_projection_2b_neo4j_service::test_actual_service_partial_or_contract_mismatched_state_fails_closed[wrong-vector-dimensions]",
+    "newsroom.tests.test_complete_projection_2b_neo4j_service::test_actual_service_replacement_generation_recovers_from_authority_only",
+    "newsroom.tests.test_complete_projection_2b_neo4j_service::test_actual_service_revocation_and_tombstone_remove_current_derivatives",
+    "newsroom.tests.test_complete_projection_2b_neo4j_service::test_actual_service_wrong_watermark_generation_and_vector_dimension_fail_closed",
+    "newsroom.tests.test_increment4e_neo4j_service::test_actual_service_increment4_admitted_state_projects_exactly_and_replays",
+    "newsroom.tests.test_increment4e_neo4j_service::test_actual_service_increment4_graph_loss_requires_isolated_replacement",
+    "newsroom.tests.test_increment4e_neo4j_service::test_actual_service_increment4_replacement_generation_is_only_serving_state",
+    "newsroom.tests.test_increment4e_neo4j_service::test_actual_service_increment4_tombstone_purges_and_never_resurrects",
+    "newsroom.tests.test_increment5b4_neo4j_service::test_increment5b4_fixed_port_excludes_future_observations",
+    "newsroom.tests.test_increment5b4_neo4j_service::test_increment5b4_fixed_port_reads_only_exact_generation_and_allowed_state",
+    "newsroom.tests.test_increment_2d_neo4j_service::test_actual_service_complete_increment_2_proof_admits_replays_and_restarts",
+    "newsroom.tests.test_increment_2d_neo4j_service::test_actual_service_complete_proof_fails_closed_when_required_surface_is_lost[fulltext]",
+    "newsroom.tests.test_increment_2d_neo4j_service::test_actual_service_complete_proof_fails_closed_when_required_surface_is_lost[relation]",
+    "newsroom.tests.test_increment_2d_neo4j_service::test_actual_service_complete_proof_fails_closed_when_required_surface_is_lost[vector]",
+    "newsroom.tests.test_increment_2d_neo4j_service::test_actual_service_dead_letter_blocks_complete_candidate_proof",
+    "newsroom.tests.test_increment_2d_neo4j_service::test_actual_service_governed_deletion_purges_derivative_and_never_requalifies",
+    "newsroom.tests.test_increment_2d_neo4j_service::test_actual_service_relation_revocation_changes_later_context_without_rewrite",
+    "newsroom.tests.test_increment_2d_neo4j_service::test_actual_service_replacement_generation_deduplicates_candidate_authority",
+    "newsroom.tests.test_increment_2d_neo4j_service::test_actual_service_required_gap_blocks_complete_candidate_proof",
+    "newsroom.tests.test_integrated_c1_neo4j_service::test_actual_service_integrated_foundation_replay_recovery_and_tombstone",
+    "newsroom.tests.test_projection_b2_increment5e2_neo4j_service::test_actual_service_increment5e2_target_and_report",
+    "newsroom.tests.test_projection_b2_neo4j_service::test_actual_service_private_adapter_exact_duplicate_and_digest_conflict",
+    "newsroom.tests.test_projection_b2_neo4j_service::test_actual_service_public_round_trip_duplicate_and_generation_isolation",
+    "newsroom.tests.test_projection_b2_neo4j_service::test_actual_service_requires_explicit_authentication_configuration",
+    "newsroom.tests.test_projection_b2_neo4j_service::test_actual_service_wrong_projector_credential_fails_closed_without_secret",
+    "newsroom.tests.test_projection_b3_neo4j_service::test_actual_service_3e_projects_complete_lineage_and_recovers_graph_loss",
+    "newsroom.tests.test_projection_b3_neo4j_service::test_actual_service_3e_replacement_generation_becomes_only_active_lineage",
+    "newsroom.tests.test_projection_b3_neo4j_service::test_actual_service_active_generation_revalidates_after_incremental_delivery",
+    "newsroom.tests.test_projection_b3_neo4j_service::test_actual_service_active_read_resolves_only_authority_promoted_generation",
+    "newsroom.tests.test_projection_b3_neo4j_service::test_actual_service_graph_loss_and_process_restart_rebuild_from_authority",
+    "newsroom.tests.test_projection_b3_neo4j_service::test_actual_service_promotion_rejects_graph_loss_after_validation",
+    "newsroom.tests.test_projection_b3_neo4j_service::test_actual_service_rebuild_cleanup_cannot_cross_generation_namespace",
+    "newsroom.tests.test_projection_b3_neo4j_service::test_actual_service_tombstone_does_not_resurrect_after_wipe_rebuild",
+    "newsroom.tests.test_retrieval_2c_neo4j_service::test_actual_service_executes_all_four_branches_and_hydrates_authority",
+    "newsroom.tests.test_retrieval_2c_neo4j_service::test_actual_service_missing_admitted_relation_is_incomplete_not_no_match",
+    "newsroom.tests.test_retrieval_2c_neo4j_service::test_actual_service_missing_fulltext_index_is_unavailable_not_no_match",
+    "newsroom.tests.test_retrieval_2c_neo4j_service::test_actual_service_missing_vector_index_is_unavailable_not_no_match",
 )
 _SERVICE_CONFIGURATION = {
     "NEWSROOM_NEO4J_COMPLETE_SERVICE_REQUIRED": "1",
@@ -106,7 +116,33 @@ _SERVICE_CONFIGURATION = {
 }
 _CORE_TESTS = ("newsroom/tests",)
 _CORE_WORKER_COUNT = 4
+_CORE_SHARD_COUNT = 4
 _CORE_DISTRIBUTION = "worksteal"
+_CORE_FRAGMENT_SCHEMA = "newsroom.sdlc.core-shard-fragment.v1"
+_CORE_SHARD_LIFECYCLE_SCHEMA = "newsroom.sdlc.core-shard-lifecycle.v1"
+_SOURCE_FRAGMENT_SCHEMA = "newsroom.sdlc.source-fragment.v1"
+_SOURCE_LIFECYCLE_SCHEMA = "newsroom.sdlc.source-fragment-lifecycle.v1"
+_LIFECYCLE_RESULTS = frozenset(
+    [
+        "PASS",
+        "FAIL",
+        "BUDGET_EXCEEDED",
+        "CLASSIFIER_ERROR",
+        "ENVIRONMENT_ERROR",
+        "EVIDENCE_MISMATCH",
+        "UNAUTHORISED_EFFECT",
+    ]
+)
+_FRAGMENT_PROVENANCE_KEYS = frozenset(
+    {
+        "contract_version",
+        "contract_digest",
+        "lockfile_digest",
+        "python_version",
+        "uv_version",
+        "toolchain_digest",
+    }
+)
 _CACHE_KEY_ENV = "NEWSROOM_SDLC_CACHE_KEY"
 _CACHE_HIT_ENV = "NEWSROOM_SDLC_CACHE_HIT"
 _MAX_CACHE_KEY_CHARS = 512
@@ -191,9 +227,7 @@ def _load_json(root: Path, value: str | Path) -> object:
         payload = _safe_machine_file(
             absolute, maximum=_MAX_JSON_BYTES, code="input_file"
         )
-        parsed = json.loads(
-            payload.decode("utf-8"), object_pairs_hook=_unique_object
-        )
+        parsed = json.loads(payload.decode("utf-8"), object_pairs_hook=_unique_object)
         _validate_json_depth(parsed)
     except (
         ArtifactProvenanceError,
@@ -288,6 +322,13 @@ def _static_environment() -> dict[str, str]:
     return values
 
 
+def _portable_static_environment() -> dict[str, str]:
+    values = _static_environment()
+    for name in ("HOME", "RUNNER_TEMP", "TMPDIR", "UV_CACHE_DIR"):
+        values.pop(name, None)
+    return values
+
+
 def _cache_evidence(
     environment: Mapping[str, str] | None = None,
 ) -> tuple[str | None, bool]:
@@ -350,8 +391,7 @@ def _spec(
 
 def _service_environment() -> dict[str, str]:
     if any(
-        os.environ.get(name) != value
-        for name, value in _SERVICE_CONFIGURATION.items()
+        os.environ.get(name) != value for name, value in _SERVICE_CONFIGURATION.items()
     ):
         raise WorkflowLaneError("service_configuration")
     return dict(_SERVICE_CONFIGURATION)
@@ -397,7 +437,15 @@ def _expected_spec(
     phase: str,
 ) -> CommandSpec:
     key = (gate_id, phase)
-    environment = _static_environment()
+    environment = (
+        _portable_static_environment()
+        if key
+        in {
+            ("source-integrity", "source"),
+            ("core-deterministic", "tests"),
+        }
+        else _static_environment()
+    )
     pass_env: Sequence[str] = ()
     if key == ("source-integrity", "source"):
         argv: list[str] = _uv_command(
@@ -413,14 +461,7 @@ def _expected_spec(
         )
     elif key == ("core-deterministic", "tests"):
         environment["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
-        report = (
-            artifact_root
-            / "gates"
-            / gate_id
-            / phase
-            / "reports"
-            / "pytest.xml"
-        )
+        report = artifact_root / "gates" / gate_id / phase / "reports" / "pytest.xml"
         argv = _uv_command(
             "-m",
             "scripts.sdlc.workflow_lane",
@@ -433,14 +474,7 @@ def _expected_spec(
         if route["clustering_required"]:
             argv.append("--clustering")
     elif key == ("service-neo4j", "tests"):
-        report = (
-            artifact_root
-            / "gates"
-            / gate_id
-            / phase
-            / "reports"
-            / "pytest.xml"
-        )
+        report = artifact_root / "gates" / gate_id / phase / "reports" / "pytest.xml"
         environment.update(_service_environment())
         environment["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
         pass_env = (
@@ -521,7 +555,10 @@ def _report_summary(
         (repository_relative,),
         optional_test_ids=optional_test_ids,
     )
-    if len(summary.report_digests) != 1 or summary.report_digests[0][0] != repository_relative:
+    if (
+        len(summary.report_digests) != 1
+        or summary.report_digests[0][0] != repository_relative
+    ):
         raise WorkflowLaneError("report_summary")
     return JUnitSummary(
         outcome=summary.outcome,
@@ -549,17 +586,11 @@ def _discard_incomplete_shard_reports(
     ):
         raise WorkflowLaneError("shard_report_count")
     expected = frozenset(
-        report.with_name(
-            f"{report.stem}-shard-{index:02d}{report.suffix}"
-        )
+        report.with_name(f"{report.stem}-shard-{index:02d}{report.suffix}")
         for index in range(shard_count)
     )
     candidates = tuple(
-        sorted(
-            report.parent.glob(
-                f"{report.stem}-shard-*{report.suffix}"
-            )
-        )
+        sorted(report.parent.glob(f"{report.stem}-shard-*{report.suffix}"))
     )
     if any(path not in expected for path in candidates):
         raise WorkflowLaneError("shard_report_identity")
@@ -724,7 +755,9 @@ def _existing_artifact_root(repo_root: Path, relative: str | Path) -> Path:
     return resolved
 
 
-def _layout(artifact_root: Path, lane_id: str) -> tuple[tuple[str, str, Path, Path], ...]:
+def _layout(
+    artifact_root: Path, lane_id: str
+) -> tuple[tuple[str, str, Path, Path], ...]:
     if lane_id == "core":
         values = (
             ("source-integrity", "source", False),
@@ -761,9 +794,7 @@ def execute_lane(
     try:
         _private_write(output / "route.json", route)
         selected = (
-            _run_core(
-                root=root, artifact_root=output, contract=contract, route=route
-            )
+            _run_core(root=root, artifact_root=output, contract=contract, route=route)
             if lane_id == "core"
             else _run_service(
                 root=root, artifact_root=output, contract=contract, route=route
@@ -888,7 +919,9 @@ def source_check(*, repo_root: str | Path, base_sha: str, head_sha: str) -> int:
         for path in sorted(directory.rglob("*.py")):
             if path.is_symlink() or not path.is_file():
                 raise WorkflowLaneError("source_file")
-            compile(path.read_text(encoding="utf-8"), str(path), "exec", dont_inherit=True)
+            compile(
+                path.read_text(encoding="utf-8"), str(path), "exec", dont_inherit=True
+            )
     commands = (
         ("uv", "lock", "--check"),
         ("git", "diff", "--check", base_sha, head_sha, "--"),
@@ -914,13 +947,87 @@ def _core_test_files(root: Path) -> tuple[str, ...]:
     return tuple(values)
 
 
+def _collect_core_node_ids(
+    root: Path, *, deadline: LaneDeadline | None = None
+) -> tuple[str, ...]:
+    command = (
+        sys.executable,
+        "-m",
+        "pytest",
+        "--collect-only",
+        "-q",
+        "--assert=plain",
+        "-p",
+        "no:cacheprovider",
+        "--rootdir=.",
+        *_CORE_TESTS,
+    )
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=root,
+            env={**os.environ, "PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1"},
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=None if deadline is None else deadline.remaining_seconds(),
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise WorkflowLaneError(
+            "BUDGET_EXCEEDED:core-deterministic:collection"
+        ) from exc
+    except OSError as exc:
+        raise WorkflowLaneError("core_collection") from exc
+    if completed.returncode:
+        raise WorkflowLaneError("core_collection")
+    files = frozenset(_core_test_files(root))
+    values = tuple(
+        sorted(
+            line.strip()
+            for line in completed.stdout.splitlines()
+            if "::" in line and line.strip().split("::", 1)[0] in files
+        )
+    )
+    if (
+        not values
+        or len(values) != len(set(values))
+        or any(node_id.split("::", 1)[0] not in files for node_id in values)
+    ):
+        raise WorkflowLaneError("core_collection")
+    return values
+
+
+def _core_node_shards(node_ids: Sequence[str]) -> tuple[tuple[str, ...], ...]:
+    inventory = tuple(sorted(node_ids))
+    if not inventory or len(inventory) != len(set(inventory)):
+        raise WorkflowLaneError("core_node_inventory")
+    ordered = sorted(
+        inventory,
+        key=lambda value: (hashlib.sha256(value.encode("utf-8")).digest(), value),
+    )
+    shards = tuple(
+        tuple(sorted(ordered[index::_CORE_SHARD_COUNT]))
+        for index in range(_CORE_SHARD_COUNT)
+    )
+    flattened = tuple(item for shard in shards for item in shard)
+    if (
+        any(not shard for shard in shards)
+        or len(flattened) != len(set(flattened))
+        or tuple(sorted(flattened)) != inventory
+        or max(map(len, shards)) - min(map(len, shards)) > 1
+    ):
+        raise WorkflowLaneError("core_node_coverage")
+    return shards
+
+
 def _core_worker_command(
     *,
     report: Path,
     basetemp: Path,
+    test_files: Sequence[str] = _CORE_TESTS,
 ) -> tuple[str, ...]:
-    test_paths = tuple(_CORE_TESTS)
-    if test_paths != ("newsroom/tests",):
+    test_paths = tuple(test_files)
+    if not test_paths or len(test_paths) != len(set(test_paths)):
         raise WorkflowLaneError("core_test_topology")
     return (
         sys.executable,
@@ -940,6 +1047,893 @@ def _core_worker_command(
         f"--basetemp={basetemp}",
         f"--junitxml={report}",
     )
+
+
+def _core_shard_spec(
+    *,
+    contract: SdlcContract,
+    shard_index: int,
+    node_inventory: Sequence[str],
+    selected_node_ids: Sequence[str],
+    report: Path,
+    basetemp: Path,
+    clustering: bool,
+) -> CommandSpec:
+    inventory = tuple(node_inventory)
+    selected = tuple(selected_node_ids)
+    if (
+        shard_index not in range(_CORE_SHARD_COUNT)
+        or inventory != tuple(sorted(inventory))
+        or len(inventory) != len(set(inventory))
+        or selected != _core_node_shards(inventory)[shard_index]
+    ):
+        raise WorkflowLaneError("core_shard_index")
+    environment = _portable_static_environment()
+    environment["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
+    return _spec(
+        contract=contract,
+        gate_id="core-deterministic",
+        phase="tests",
+        argv=_uv_command(
+            "-m",
+            "scripts.sdlc.workflow_lane",
+            "core-shard-tests",
+            "--repo-root",
+            ".",
+            "--report",
+            report.relative_to(contract.repo_root).as_posix(),
+            "--basetemp",
+            basetemp.relative_to(contract.repo_root).as_posix(),
+            "--shard-index",
+            str(shard_index),
+            "--node-inventory-digest",
+            sha256_identity(list(inventory)),
+            "--selected-node-ids-digest",
+            sha256_identity(list(selected)),
+            *(("--clustering",) if clustering else ()),
+        ),
+        static_env=environment,
+    )
+
+
+def _source_fragment_spec(
+    *, contract: SdlcContract, route: Mapping[str, object]
+) -> CommandSpec:
+    return _spec(
+        contract=contract,
+        gate_id="source-integrity",
+        phase="source",
+        argv=_uv_command(
+            "-m",
+            "scripts.sdlc.workflow_lane",
+            "source-check",
+            "--repo-root",
+            ".",
+            "--base-sha",
+            str(route["base_sha"]),
+            "--head-sha",
+            str(route["head_sha"]),
+        ),
+        static_env=_portable_static_environment(),
+    )
+
+
+def _file_digest(path: Path) -> str:
+    if path.is_symlink() or not path.is_file():
+        raise WorkflowLaneError("fragment_report")
+    return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _fragment_identity(value: Mapping[str, object]) -> str:
+    return sha256_identity(value)
+
+
+def _fragment_provenance(*, contract: SdlcContract, context: object) -> dict[str, str]:
+    python_version = platform.python_version()
+    uv_version = installed_uv_version()
+    return {
+        "contract_version": contract.contract_version,
+        "contract_digest": _file_digest(contract.source_path),
+        "lockfile_digest": git_blob_digest(
+            contract.repo_root,
+            str(context.evaluated_sha),
+            "uv.lock",
+        ),
+        "python_version": python_version,
+        "uv_version": uv_version,
+        "toolchain_digest": sha256_identity(
+            {
+                "python_implementation": platform.python_implementation(),
+                "python_version": python_version,
+                "runner_arch": platform.machine(),
+                "runner_os": platform.system().lower(),
+                "uv_version": uv_version,
+            }
+        ),
+    }
+
+
+def _core_timeout_ms(contract: SdlcContract) -> int:
+    core = contract.data["lanes"]["core"]
+    return int(core["per_shard_hard_timeout_seconds"] * 1000)
+
+
+def _deadline_elapsed_ms(deadline: LaneDeadline) -> int:
+    return max(0, (time.monotonic_ns() - deadline.started_ns) // 1_000_000)
+
+
+def _require_deadline(deadline: LaneDeadline, phase: str) -> None:
+    if _deadline_elapsed_ms(deadline) >= deadline.timeout_ms:
+        raise WorkflowLaneError(f"BUDGET_EXCEEDED:core-deterministic:{phase}")
+
+
+def _checked_fragment_write(
+    root: Path,
+    path: Path,
+    value: object,
+    deadline: LaneDeadline,
+    head_sha: str,
+    stage: bool = False,
+) -> int:
+    target = path.with_name(f".{path.name}.stage") if stage else path
+    published = False
+    try:
+        _private_write(target, value)
+        verify_tracked_checkout(root, head_sha)
+        published = True
+        return _deadline_elapsed_ms(deadline)
+    finally:
+        if stage or not published:
+            target.unlink(missing_ok=True)
+
+
+def _valid_elapsed_ms(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+
+
+def _lifecycle_result(result: str, *, elapsed_ms: int, timeout_ms: int) -> str:
+    if result not in _LIFECYCLE_RESULTS:
+        raise WorkflowLaneError("core_lifecycle_result")
+    if not timeout_ms or not all(map(_valid_elapsed_ms, (elapsed_ms, timeout_ms))):
+        raise WorkflowLaneError("core_lifecycle_time")
+    if result not in {"PASS", "FAIL", "BUDGET_EXCEEDED"}:
+        return result
+    if result == "BUDGET_EXCEEDED" or elapsed_ms > timeout_ms:
+        return "BUDGET_EXCEEDED"
+    return result
+
+
+def _shard_lifecycle(
+    *,
+    command_result: str,
+    elapsed_ms: int,
+    timeout_ms: int,
+    schema_version: str = _CORE_SHARD_LIFECYCLE_SCHEMA,
+) -> dict[str, object]:
+    return {
+        "schema_version": schema_version,
+        "elapsed_ms": elapsed_ms,
+        "timeout_ms": timeout_ms,
+        "result": _lifecycle_result(
+            command_result,
+            elapsed_ms=elapsed_ms,
+            timeout_ms=timeout_ms,
+        ),
+    }
+
+
+def _publish_lifecycle_fragment(
+    *,
+    root: Path,
+    path: Path,
+    body: dict[str, object],
+    field: str,
+    schema: str,
+    command_result: str,
+    deadline: LaneDeadline,
+    head_sha: str,
+    on_budget: Callable[[], None] | None = None,
+) -> dict[str, object]:
+    def bind(elapsed_ms: int) -> dict[str, object]:
+        body[field] = _shard_lifecycle(
+            command_result=command_result,
+            elapsed_ms=elapsed_ms,
+            timeout_ms=deadline.timeout_ms,
+            schema_version=schema,
+        )
+        return {**body, "fragment_identity": _fragment_identity(body)}
+
+    def write(value: object, *, stage: bool = False) -> int:
+        return _checked_fragment_write(root, path, value, deadline, head_sha, stage)
+
+    elapsed_ms = write(bind(_deadline_elapsed_ms(deadline)), stage=True)
+    fragment = bind(elapsed_ms)
+    lifecycle = body[field]
+    if lifecycle["result"] not in {"PASS", "FAIL"} and on_budget is not None:
+        on_budget()
+        fragment = bind(_deadline_elapsed_ms(deadline))
+    published_ms = write(fragment)
+    if lifecycle["result"] in {"PASS", "FAIL"} and published_ms > deadline.timeout_ms:
+        path.unlink()
+        if on_budget is not None:
+            on_budget()
+        fragment = bind(published_ms)
+        write(fragment)
+    return fragment
+
+
+def _validate_shard_lifecycle(
+    value: object,
+    *,
+    command_result: str,
+    command_execution_ms: int,
+    timeout_ms: int,
+    schema_version: str = _CORE_SHARD_LIFECYCLE_SCHEMA,
+    error: str = "core_fragment_lifecycle",
+) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise WorkflowLaneError(error)
+    elapsed_ms = value.get("elapsed_ms")
+    if not _valid_elapsed_ms(elapsed_ms) or elapsed_ms < command_execution_ms:
+        raise WorkflowLaneError(error)
+    if value != _shard_lifecycle(
+        command_result=command_result,
+        elapsed_ms=elapsed_ms,
+        timeout_ms=timeout_ms,
+        schema_version=schema_version,
+    ):
+        raise WorkflowLaneError(error)
+    return value
+
+
+def _core_fragment_report_summary(
+    *,
+    repo_root: Path,
+    artifact_root: Path,
+    report: Path,
+    result: str,
+    optional_test_ids: Sequence[str],
+) -> JUnitSummary | None:
+    if result not in {"PASS", "FAIL"}:
+        if report.is_symlink() or (report.exists() and not report.is_file()):
+            raise WorkflowLaneError("core_fragment_report_cleanup")
+        if not report.exists():
+            return None
+        try:
+            report.unlink()
+        except OSError as exc:
+            raise WorkflowLaneError("core_fragment_report_cleanup") from exc
+        return None
+    summary = _report_summary(
+        repo_root=repo_root,
+        artifact_root=artifact_root,
+        report=report,
+        optional_test_ids=optional_test_ids,
+    )
+    if summary is None:
+        raise WorkflowLaneError("core_fragment_report_required")
+    return summary
+
+
+def execute_core_shard(
+    *,
+    repo_root: str | Path,
+    route_path: str | Path,
+    shard_index: int,
+    artifact_root: str | Path,
+) -> dict[str, object]:
+    root = Path(repo_root).resolve()
+    contract = load_contract(root)
+    context = context_from_environment(root)
+    if context.job_id != "core_shard" or shard_index not in range(_CORE_SHARD_COUNT):
+        raise WorkflowLaneError("core_shard_identity")
+    route = _validate_route(contract, _load_json(root, route_path))
+    _validate_test_topology(contract, route)
+    if (route["head_sha"], route["head_tree_sha"]) != (
+        context.evaluated_sha,
+        context.evaluated_tree_sha,
+    ):
+        raise WorkflowLaneError("route_identity")
+    deadline = start_lane_deadline(contract, "core-deterministic")
+    timeout_ms = _core_timeout_ms(contract)
+    if deadline.timeout_ms != timeout_ms:
+        raise WorkflowLaneError("core_lifecycle_contract")
+    output = _prepare_artifact_root(root, artifact_root)
+    report = output / "pytest.xml"
+    basetemp = output / "pytest-temp"
+    files = _core_test_files(root)
+    inventory = _collect_core_node_ids(root, deadline=deadline)
+    verify_tracked_checkout(root, str(route["head_sha"]))
+    _require_deadline(deadline, "collection")
+    selected = _core_node_shards(inventory)[shard_index]
+    spec = _core_shard_spec(
+        contract=contract,
+        shard_index=shard_index,
+        node_inventory=inventory,
+        selected_node_ids=selected,
+        report=report,
+        basetemp=basetemp,
+        clustering=bool(route["clustering_required"]),
+    )
+    run = _execute(
+        contract=contract,
+        spec=spec,
+        deadline=deadline,
+    )
+    shutil.rmtree(basetemp, ignore_errors=True)
+    summary = _core_fragment_report_summary(
+        repo_root=root,
+        artifact_root=output,
+        report=report,
+        result=run.gate_run.result,
+        optional_test_ids=_core_shard_optional_test_ids(selected),
+    )
+    report_digest = None if summary is None else _file_digest(report)
+    provenance = _fragment_provenance(contract=contract, context=context)
+    body: dict[str, object] = {
+        "schema_version": _CORE_FRAGMENT_SCHEMA,
+        "run_id": context.run_id,
+        "run_attempt": context.run_attempt,
+        "job_id": context.job_id,
+        "evaluated_sha": context.evaluated_sha,
+        "evaluated_tree_sha": context.evaluated_tree_sha,
+        "route_digest": sha256_identity(route),
+        "shard_index": shard_index,
+        "shard_count": _CORE_SHARD_COUNT,
+        "file_inventory": list(files),
+        "file_inventory_digest": sha256_identity(list(files)),
+        "node_inventory": list(inventory),
+        "node_inventory_digest": sha256_identity(list(inventory)),
+        "selected_node_ids": list(selected),
+        "selected_node_ids_digest": sha256_identity(list(selected)),
+        "command_spec": spec.as_dict(),
+        "command_run": run.as_dict(),
+        **provenance,
+    }
+    body.update(
+        junit_summary=None if summary is None else summary.as_dict(),
+        report_digest=report_digest,
+    )
+
+    def discard_report() -> None:
+        _core_fragment_report_summary(
+            repo_root=root,
+            artifact_root=output,
+            report=report,
+            result="BUDGET_EXCEEDED",
+            optional_test_ids=_core_shard_optional_test_ids(selected),
+        )
+        body.update(junit_summary=None, report_digest=None)
+
+    return _publish_lifecycle_fragment(
+        root=root,
+        path=output / "fragment.json",
+        body=body,
+        field="shard_lifecycle",
+        schema=_CORE_SHARD_LIFECYCLE_SCHEMA,
+        command_result=run.gate_run.result,
+        deadline=deadline,
+        head_sha=str(route["head_sha"]),
+        on_budget=discard_report,
+    )
+
+
+def _load_core_fragments(
+    *,
+    root: Path,
+    fragment_root: Path,
+    contract: SdlcContract,
+    context: object,
+    route: Mapping[str, object],
+    deadline: LaneDeadline | None = None,
+) -> tuple[tuple[dict[str, object], Path], ...]:
+    expected_files = _core_test_files(root)
+    expected_inventory = _collect_core_node_ids(root, deadline=deadline)
+    if deadline is not None:
+        _require_deadline(deadline, "reducer")
+    expected_shards = _core_node_shards(expected_inventory)
+    paths = tuple(sorted(fragment_root.glob("*/fragment.json")))
+    root_entries = tuple(sorted(fragment_root.iterdir()))
+    if (
+        len(paths) != _CORE_SHARD_COUNT
+        or len(root_entries) != _CORE_SHARD_COUNT
+        or any(path.is_symlink() or not path.is_dir() for path in root_entries)
+    ):
+        raise WorkflowLaneError("core_fragment_count")
+    expected_binding = _fragment_provenance(contract=contract, context=context)
+    observed: dict[int, tuple[dict[str, object], Path]] = {}
+    identities: set[str] = set()
+    for path in paths:
+        value = _load_json(root, path)
+        if deadline is not None:
+            _require_deadline(deadline, "reducer")
+        if not isinstance(value, dict) or set(value) != {
+            "schema_version",
+            "run_id",
+            "run_attempt",
+            "job_id",
+            "evaluated_sha",
+            "evaluated_tree_sha",
+            "route_digest",
+            "shard_index",
+            "shard_count",
+            "file_inventory",
+            "file_inventory_digest",
+            "node_inventory",
+            "node_inventory_digest",
+            "selected_node_ids",
+            "selected_node_ids_digest",
+            "command_spec",
+            "command_run",
+            "shard_lifecycle",
+            "junit_summary",
+            "report_digest",
+            "fragment_identity",
+            *_FRAGMENT_PROVENANCE_KEYS,
+        }:
+            raise WorkflowLaneError("core_fragment_shape")
+        identity = value.pop("fragment_identity")
+        if not isinstance(identity, str) or identity != _fragment_identity(value):
+            raise WorkflowLaneError("core_fragment_identity")
+        value["fragment_identity"] = identity
+        index = value["shard_index"]
+        if (
+            isinstance(index, bool)
+            or not isinstance(index, int)
+            or index not in range(_CORE_SHARD_COUNT)
+        ):
+            raise WorkflowLaneError("core_fragment_index")
+        if index in observed or identity in identities:
+            raise WorkflowLaneError("core_fragment_duplicate")
+        if (
+            value["schema_version"] != _CORE_FRAGMENT_SCHEMA
+            or value["run_id"] != context.run_id
+            or value["run_attempt"] != context.run_attempt
+            or value["job_id"] != "core_shard"
+            or value["evaluated_sha"] != context.evaluated_sha
+            or value["evaluated_tree_sha"] != context.evaluated_tree_sha
+            or value["route_digest"] != sha256_identity(route)
+            or value["shard_count"] != _CORE_SHARD_COUNT
+            or value["file_inventory"] != list(expected_files)
+            or value["file_inventory_digest"] != sha256_identity(list(expected_files))
+            or value["node_inventory"] != list(expected_inventory)
+            or value["node_inventory_digest"]
+            != sha256_identity(list(expected_inventory))
+            or value["selected_node_ids"] != list(expected_shards[index])
+            or value["selected_node_ids_digest"]
+            != sha256_identity(list(expected_shards[index]))
+            or any(
+                value[name] != expected_binding[name]
+                for name in _FRAGMENT_PROVENANCE_KEYS
+            )
+        ):
+            raise WorkflowLaneError("core_fragment_provenance")
+        report = path.parent / "pytest.xml"
+        expected_spec = _core_shard_spec(
+            contract=contract,
+            shard_index=index,
+            node_inventory=expected_inventory,
+            selected_node_ids=expected_shards[index],
+            report=root / ".sdlc-run/core-fragment/pytest.xml",
+            basetemp=root / ".sdlc-run/core-fragment/pytest-temp",
+            clustering=bool(route["clustering_required"]),
+        )
+        if value["command_spec"] != expected_spec.as_dict():
+            raise WorkflowLaneError("core_fragment_spec")
+        try:
+            command = _validate_command_run(value["command_run"])
+        except ArtifactReceiptError as exc:
+            raise WorkflowLaneError("core_fragment_run") from exc
+        if (
+            command["gate_run"]["gate_id"] != "core-deterministic"
+            or command["gate_run"]["phase"] != "tests"
+        ):
+            raise WorkflowLaneError("core_fragment_run_identity")
+        if command["command_spec_digest"] != expected_spec.digest:
+            raise WorkflowLaneError("core_fragment_spec_digest")
+        lifecycle = _validate_shard_lifecycle(
+            value["shard_lifecycle"],
+            command_result=str(command["gate_run"]["result"]),
+            command_execution_ms=int(command["gate_run"]["execution_ms"]),
+            timeout_ms=_core_timeout_ms(contract),
+        )
+        summary = value["junit_summary"]
+        expected_names = {"fragment.json"}
+        if summary is not None:
+            expected_names.add("pytest.xml")
+        if {item.name for item in path.parent.iterdir()} != expected_names:
+            raise WorkflowLaneError("core_fragment_extra")
+        run_result = lifecycle["result"]
+        if summary is None:
+            if value["report_digest"] is not None or report.exists():
+                raise WorkflowLaneError("core_fragment_report")
+            if run_result in {"PASS", "FAIL"}:
+                raise WorkflowLaneError("core_fragment_report_required")
+        else:
+            if run_result not in {"PASS", "FAIL"}:
+                raise WorkflowLaneError("core_fragment_report_unexpected")
+            actual_summary = _report_summary(
+                repo_root=root,
+                artifact_root=path.parent,
+                report=report,
+                optional_test_ids=_core_shard_optional_test_ids(expected_shards[index]),
+            )
+            if (
+                actual_summary is None
+                or summary != actual_summary.as_dict()
+                or value["report_digest"] != _file_digest(report)
+            ):
+                raise WorkflowLaneError("core_fragment_report_digest")
+        if deadline is not None:
+            _require_deadline(deadline, "reducer")
+        observed[index] = (value, report)
+        identities.add(identity)
+    return tuple(observed[index] for index in range(_CORE_SHARD_COUNT))
+
+
+def execute_source_fragment(
+    *, repo_root: str | Path, route_path: str | Path, artifact_root: str | Path
+) -> dict[str, object]:
+    root = Path(repo_root).resolve()
+    contract = load_contract(root)
+    context = context_from_environment(root)
+    if context.job_id != "source":
+        raise WorkflowLaneError("source_fragment_identity")
+    route = _validate_route(contract, _load_json(root, route_path))
+    _validate_test_topology(contract, route)
+    if (route["head_sha"], route["head_tree_sha"]) != (
+        context.evaluated_sha,
+        context.evaluated_tree_sha,
+    ):
+        raise WorkflowLaneError("route_identity")
+    deadline = start_lane_deadline(contract, "source-integrity")
+    output = _prepare_artifact_root(root, artifact_root)
+    spec = _source_fragment_spec(contract=contract, route=route)
+    run = _execute(
+        contract=contract,
+        spec=spec,
+        deadline=deadline,
+    )
+    verify_tracked_checkout(root, str(route["head_sha"]))
+    body: dict[str, object] = {
+        "schema_version": _SOURCE_FRAGMENT_SCHEMA,
+        "run_id": context.run_id,
+        "run_attempt": context.run_attempt,
+        "job_id": context.job_id,
+        "evaluated_sha": context.evaluated_sha,
+        "evaluated_tree_sha": context.evaluated_tree_sha,
+        "route_digest": sha256_identity(route),
+        "command_spec": spec.as_dict(),
+        "command_run": run.as_dict(),
+        **_fragment_provenance(contract=contract, context=context),
+    }
+    return _publish_lifecycle_fragment(
+        root=root,
+        path=output / "source-fragment.json",
+        body=body,
+        field="source_lifecycle",
+        schema=_SOURCE_LIFECYCLE_SCHEMA,
+        command_result=run.gate_run.result,
+        deadline=deadline,
+        head_sha=str(route["head_sha"]),
+    )
+
+
+def _load_source_fragment(
+    *,
+    root: Path,
+    source_root: Path,
+    contract: SdlcContract,
+    context: object,
+    route: Mapping[str, object],
+) -> dict[str, object]:
+    paths = tuple(source_root.glob("*/source-fragment.json"))
+    root_entries = tuple(source_root.iterdir())
+    if (
+        len(paths) != 1
+        or len(root_entries) != 1
+        or root_entries[0].is_symlink()
+        or not root_entries[0].is_dir()
+        or {item.name for item in root_entries[0].iterdir()} != {"source-fragment.json"}
+    ):
+        raise WorkflowLaneError("source_fragment_count")
+    value = _load_json(root, paths[0])
+    expected_binding = _fragment_provenance(contract=contract, context=context)
+    if not isinstance(value, dict) or set(value) != {
+        "schema_version",
+        "run_id",
+        "run_attempt",
+        "job_id",
+        "evaluated_sha",
+        "evaluated_tree_sha",
+        "route_digest",
+        "command_spec",
+        "command_run",
+        "source_lifecycle",
+        "fragment_identity",
+        *_FRAGMENT_PROVENANCE_KEYS,
+    }:
+        raise WorkflowLaneError("source_fragment_shape")
+    identity = value.pop("fragment_identity")
+    if not isinstance(identity, str) or identity != _fragment_identity(value):
+        raise WorkflowLaneError("source_fragment_identity")
+    value["fragment_identity"] = identity
+    if (
+        value["schema_version"] != _SOURCE_FRAGMENT_SCHEMA
+        or value["run_id"] != context.run_id
+        or value["run_attempt"] != context.run_attempt
+        or value["job_id"] != "source"
+        or value["evaluated_sha"] != context.evaluated_sha
+        or value["evaluated_tree_sha"] != context.evaluated_tree_sha
+        or value["route_digest"] != sha256_identity(route)
+        or any(
+            value[name] != expected_binding[name] for name in _FRAGMENT_PROVENANCE_KEYS
+        )
+    ):
+        raise WorkflowLaneError("source_fragment_provenance")
+    expected = _source_fragment_spec(contract=contract, route=route)
+    if value["command_spec"] != expected.as_dict():
+        raise WorkflowLaneError("source_fragment_spec")
+    try:
+        command = _validate_command_run(value["command_run"])
+    except ArtifactReceiptError as exc:
+        raise WorkflowLaneError("source_fragment_run") from exc
+    if (
+        command["gate_run"]["gate_id"] != "source-integrity"
+        or command["gate_run"]["phase"] != "source"
+    ):
+        raise WorkflowLaneError("source_fragment_run_identity")
+    if command["command_spec_digest"] != expected.digest:
+        raise WorkflowLaneError("source_fragment_spec_digest")
+    _validate_shard_lifecycle(
+        value["source_lifecycle"],
+        command_result=str(command["gate_run"]["result"]),
+        command_execution_ms=int(command["gate_run"]["execution_ms"]),
+        timeout_ms=_core_timeout_ms(contract),
+        schema_version=_SOURCE_LIFECYCLE_SCHEMA,
+        error="source_fragment_lifecycle",
+    )
+    return value
+
+
+def _junit_case_ids(report: Path) -> frozenset[str]:
+    try:
+        document = ET.parse(report).getroot()
+    except (OSError, ET.ParseError) as exc:
+        raise WorkflowLaneError("core_fragment_report_xml") from exc
+    values: list[str] = []
+    for case in document.iter():
+        if _xml_local_name(case.tag) != "testcase":
+            continue
+        classname = case.attrib.get("classname", "").strip()
+        name = case.attrib.get("name", "").strip()
+        if not classname or not name:
+            raise WorkflowLaneError("core_fragment_report_case")
+        values.append(f"{classname}::{name}")
+    if not values or len(values) != len(set(values)):
+        raise WorkflowLaneError("core_fragment_report_cases")
+    return frozenset(values)
+
+
+def _junit_id_for_node(node_id: str) -> str:
+    unparameterised, bracket, parameters = node_id.partition("[")
+    parts = unparameterised.split("::")
+    parts[-1] += bracket + parameters
+    module = parts[0][:-3].replace("/", ".")
+    return f"{'.'.join((module, *parts[1:-1]))}::{parts[-1]}"
+
+
+def _core_shard_optional_test_ids(node_ids: Sequence[str]) -> tuple[str, ...]:
+    junit_ids = frozenset(_junit_id_for_node(node_id) for node_id in node_ids)
+    return tuple(sorted(junit_ids.intersection(_OPTIONAL_CORE_TEST_IDS)))
+
+
+def _reduced_core_outcome(
+    results: Sequence[str],
+    *,
+    summaries: Sequence[Mapping[str, object] | None] | None = None,
+) -> tuple[str, str, int | None]:
+    if len(results) != _CORE_SHARD_COUNT:
+        raise WorkflowLaneError("core_fragment_count")
+    if summaries is not None and len(summaries) != _CORE_SHARD_COUNT:
+        raise WorkflowLaneError("core_fragment_count")
+    for exceptional in (
+        "UNAUTHORISED_EFFECT",
+        "EVIDENCE_MISMATCH",
+        "ENVIRONMENT_ERROR",
+        "CLASSIFIER_ERROR",
+    ):
+        if exceptional in results:
+            return exceptional, f"{exceptional}:core-deterministic:tests", None
+    if "BUDGET_EXCEEDED" in results:
+        return (
+            "BUDGET_EXCEEDED",
+            "BUDGET_EXCEEDED:core-deterministic:tests",
+            124,
+        )
+    junit_failed = summaries is not None and any(
+        summary is not None and summary.get("outcome") == "FAIL"
+        for summary in summaries
+    )
+    if any(item != "PASS" for item in results) or junit_failed:
+        return "FAIL", "FAIL:core-deterministic:tests:exit=1", 1
+    return "PASS", "PASS:core-deterministic:tests", 0
+
+
+def reduce_core_lane(
+    *,
+    repo_root: str | Path,
+    route_path: str | Path,
+    fragment_root: str | Path,
+    source_root: str | Path,
+    artifact_root: str | Path,
+) -> LaneExecutionOutput:
+    root = Path(repo_root).resolve()
+    contract, context, route = _context_route(
+        root=root, route_path=route_path, lane_id="core"
+    )
+    reducer_deadline = start_lane_deadline(contract, "core-deterministic")
+    timeout_ms = _core_timeout_ms(contract)
+    if reducer_deadline.timeout_ms != timeout_ms:
+        raise WorkflowLaneError("core_lifecycle_contract")
+    fragments_dir = _existing_artifact_root(root, fragment_root)
+    _require_deadline(reducer_deadline, "reducer")
+    sources_dir = _existing_artifact_root(root, source_root)
+    _require_deadline(reducer_deadline, "reducer")
+    output = _prepare_artifact_root(root, artifact_root)
+    _require_deadline(reducer_deadline, "reducer")
+    complete = False
+    try:
+        fragments = _load_core_fragments(
+            root=root,
+            fragment_root=fragments_dir,
+            contract=contract,
+            context=context,
+            route=route,
+            deadline=reducer_deadline,
+        )
+        _require_deadline(reducer_deadline, "reducer")
+        source = _load_source_fragment(
+            root=root,
+            source_root=sources_dir,
+            contract=contract,
+            context=context,
+            route=route,
+        )
+        _require_deadline(reducer_deadline, "reducer")
+        _private_write(output / "route.json", route)
+        _require_deadline(reducer_deadline, "reducer")
+        source_dir = _gate_directory(output, "source-integrity", "source")
+        source_lifecycle = source["source_lifecycle"]
+        source_command = dict(source["command_run"])
+        source_gate_run = dict(source_command["gate_run"])
+        source_gate_run["execution_ms"] = source_lifecycle["elapsed_ms"]
+        if source_gate_run["result"] != source_lifecycle["result"]:
+            source_gate_run.update(
+                result=source_lifecycle["result"],
+                result_reason=f"{source_lifecycle['result']}:source-integrity:source",
+                returncode=None,
+            )
+        source_command["gate_run"] = source_gate_run
+        _private_write(source_dir / "command-run.json", source_command)
+        _require_deadline(reducer_deadline, "reducer")
+        core_dir = _gate_directory(output, "core-deterministic", "tests")
+        reports = core_dir / "reports"
+        reports.mkdir(mode=0o700)
+        lifecycles = [value["shard_lifecycle"] for value, _report in fragments]
+        results = [str(lifecycle["result"]) for lifecycle in lifecycles]
+        reports_available = all(
+            value["junit_summary"] is not None for value, _ in fragments
+        )
+        for value, report in fragments:
+            if value["junit_summary"] is None:
+                continue
+            expected_cases = frozenset(
+                _junit_id_for_node(str(item)) for item in value["selected_node_ids"]
+            )
+            if _junit_case_ids(report) != expected_cases:
+                raise WorkflowLaneError("core_fragment_report_inventory")
+            _require_deadline(reducer_deadline, "reducer")
+        if reports_available:
+            report = reports / "pytest.xml"
+            _merge_junit_reports(
+                root=root,
+                report=report,
+                shard_reports=[item[1] for item in fragments],
+                expected_count=_CORE_SHARD_COUNT,
+                identity="core",
+            )
+            _require_deadline(reducer_deadline, "reducer")
+            expected_all = frozenset(
+                _junit_id_for_node(item)
+                for item in _collect_core_node_ids(root, deadline=reducer_deadline)
+            )
+            _require_deadline(reducer_deadline, "reducer")
+            if _junit_case_ids(report) != expected_all:
+                raise WorkflowLaneError("core_reduced_report_inventory")
+        reduced_outcome = _reduced_core_outcome(
+            results,
+            summaries=[value["junit_summary"] for value, _report in fragments],
+        )
+        expected_digest = _expected_spec(
+            root=root,
+            artifact_root=output,
+            contract=contract,
+            route=route,
+            gate_id="core-deterministic",
+            phase="tests",
+        ).digest
+        shard_ms = [int(value["elapsed_ms"]) for value in lifecycles]
+        source_ms = int(source_lifecycle["elapsed_ms"])
+
+        def build(elapsed_ms: int, base: tuple[str, str, int | None]) -> CommandRun:
+            critical_path_ms = max(source_ms, max(shard_ms)) + elapsed_ms
+            effective_outcome = (
+                ("BUDGET_EXCEEDED", "BUDGET_EXCEEDED:core-deterministic:tests", 124)
+                if _lifecycle_result(
+                    base[0],
+                    elapsed_ms=critical_path_ms,
+                    timeout_ms=timeout_ms,
+                )
+                == "BUDGET_EXCEEDED"
+                else base
+            )
+            result, reason, returncode = effective_outcome
+            accounting = {
+                "schema_version": "newsroom.sdlc.core-reduction-accounting.v1",
+                "source_fragment_identity": source["fragment_identity"],
+                "source_lifecycle_ms": source_ms,
+                "shard_fragment_identities": [
+                    value["fragment_identity"] for value, _report in fragments
+                ],
+                "shard_lifecycle_ms": shard_ms,
+                "reducer_lifecycle_ms": elapsed_ms,
+                "critical_path_ms": critical_path_ms,
+            }
+            return CommandRun(
+                expected_digest,
+                GateRunResult(
+                    "core-deterministic",
+                    "tests",
+                    result,
+                    reason,
+                    returncode,
+                    critical_path_ms,
+                    canonical_json_bytes(accounting).decode("utf-8"),
+                    "",
+                    False,
+                    False,
+                ),
+            )
+
+        command_path = core_dir / "command-run.json"
+        head_sha = str(route["head_sha"])
+
+        def publish(command: CommandRun, stage: bool = False) -> int:
+            return _checked_fragment_write(
+                root, command_path, command.as_dict(), reducer_deadline, head_sha, stage
+            )
+
+        aggregate = build(_deadline_elapsed_ms(reducer_deadline), reduced_outcome)
+        staged_ms = publish(aggregate, True)
+        aggregate = build(staged_ms, reduced_outcome)
+        published_ms = publish(aggregate)
+        if aggregate.gate_run.result in {"PASS", "FAIL"} and published_ms > timeout_ms:
+            command_path.unlink()
+            aggregate = build(published_ms, reduced_outcome)
+            publish(aggregate)
+        complete = True
+        return LaneExecutionOutput(
+            "core",
+            artifact_name(context),
+            (
+                ("source-integrity", "source", str(source_lifecycle["result"])),
+                ("core-deterministic", "tests", aggregate.gate_run.result),
+            ),
+        )
+    finally:
+        if not complete:
+            shutil.rmtree(output, ignore_errors=True)
 
 
 def _run_pytest_shard(*, argv: Sequence[str], root: Path, log: Path) -> int:
@@ -985,9 +1979,7 @@ def _publish_private_bytes(path: Path, payload: bytes) -> None:
             stream.flush()
             os.fsync(stream.fileno())
         os.link(temporary, path, follow_symlinks=False)
-        directory = os.open(
-            path.parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
-        )
+        directory = os.open(path.parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
         try:
             os.fsync(directory)
         finally:
@@ -1042,9 +2034,7 @@ def _merge_junit_reports(
             merged.append(document)
         elif name == "testsuites":
             suites = [
-                child
-                for child in document
-                if _xml_local_name(child.tag) == "testsuite"
+                child for child in document if _xml_local_name(child.tag) == "testsuite"
             ]
             if not suites:
                 raise WorkflowLaneError(f"{identity}_shard_report_xml")
@@ -1109,6 +2099,55 @@ def _run_core_pytest_workers(*, root: Path, report: Path) -> int:
         except OSError as exc:
             raise WorkflowLaneError("core_worker_process") from exc
     return completed.returncode
+
+
+def core_shard_tests(
+    *,
+    repo_root: str | Path,
+    report: str | Path,
+    basetemp: str | Path,
+    shard_index: int,
+    node_inventory_digest: str,
+    selected_node_ids_digest: str,
+    clustering: bool,
+) -> int:
+    root = Path(repo_root).resolve()
+    report_path = Path(report).resolve()
+    basetemp_path = Path(basetemp).resolve()
+    if (
+        shard_index not in range(_CORE_SHARD_COUNT)
+        or not report_path.is_relative_to(root)
+        or not basetemp_path.is_relative_to(root)
+    ):
+        raise WorkflowLaneError("core_shard_command")
+    inventory = _collect_core_node_ids(root)
+    selected = _core_node_shards(inventory)[shard_index]
+    if node_inventory_digest != sha256_identity(
+        list(inventory)
+    ) or selected_node_ids_digest != sha256_identity(list(selected)):
+        raise WorkflowLaneError("core_shard_inventory")
+    command = _core_worker_command(
+        report=report_path,
+        basetemp=basetemp_path,
+        test_files=selected,
+    )
+    try:
+        completed = subprocess.run(command, cwd=root, check=False)
+    except OSError as exc:
+        raise WorkflowLaneError("core_worker_process") from exc
+    if completed.returncode or not clustering or shard_index != 0:
+        return completed.returncode
+    return _run_subprocess(
+        (
+            sys.executable,
+            "scripts/eval_clustering_metrics.py",
+            "--dataset",
+            "newsroom/evals/clustering_eval_dataset_v1.jsonl",
+            "--baseline",
+            "newsroom/evals/clustering_eval_metrics_baseline_v1.json",
+            "--fail-on-regression",
+        )
+    )
 
 
 def core_tests(*, repo_root: str | Path, report: str | Path, clustering: bool) -> int:
@@ -1253,9 +2292,7 @@ def _run_service_pytest_shards(
             except OSError as exc:
                 raise WorkflowLaneError("service_shard_log") from exc
         sys.stdout.buffer.flush()
-    _merge_service_junit_reports(
-        root=root, report=report, shard_reports=shard_reports
-    )
+    _merge_service_junit_reports(root=root, report=report, shard_reports=shard_reports)
     for shard_report in shard_reports:
         shard_report.unlink(missing_ok=True)
     return next((code if code > 0 else 1 for code in codes if code), 0)
@@ -1297,6 +2334,33 @@ def main(argv: Sequence[str] | None = None) -> int:
     core_parser.add_argument("--report", required=True)
     core_parser.add_argument("--clustering", action="store_true")
 
+    shard_parser = subparsers.add_parser("execute-core-shard")
+    shard_parser.add_argument("--repo-root", default=".")
+    shard_parser.add_argument("--route", required=True)
+    shard_parser.add_argument("--shard-index", required=True, type=int)
+    shard_parser.add_argument("--artifact-root", required=True)
+
+    shard_tests_parser = subparsers.add_parser("core-shard-tests")
+    shard_tests_parser.add_argument("--repo-root", default=".")
+    shard_tests_parser.add_argument("--report", required=True)
+    shard_tests_parser.add_argument("--basetemp", required=True)
+    shard_tests_parser.add_argument("--shard-index", required=True, type=int)
+    shard_tests_parser.add_argument("--node-inventory-digest", required=True)
+    shard_tests_parser.add_argument("--selected-node-ids-digest", required=True)
+    shard_tests_parser.add_argument("--clustering", action="store_true")
+
+    source_fragment_parser = subparsers.add_parser("execute-source")
+    source_fragment_parser.add_argument("--repo-root", default=".")
+    source_fragment_parser.add_argument("--route", required=True)
+    source_fragment_parser.add_argument("--artifact-root", required=True)
+
+    reduce_parser = subparsers.add_parser("reduce-core")
+    reduce_parser.add_argument("--repo-root", default=".")
+    reduce_parser.add_argument("--route", required=True)
+    reduce_parser.add_argument("--fragment-root", required=True)
+    reduce_parser.add_argument("--source-root", required=True)
+    reduce_parser.add_argument("--artifact-root", required=True)
+
     service_parser = subparsers.add_parser("service-tests")
     service_parser.add_argument("--repo-root", default=".")
     service_parser.add_argument("--report", required=True)
@@ -1323,7 +2387,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             if arguments.output:
                 root = Path(arguments.repo_root).resolve()
                 output = root / arguments.output
-                if not output.parent.is_dir() or not output.resolve().is_relative_to(root):
+                if not output.parent.is_dir() or not output.resolve().is_relative_to(
+                    root
+                ):
                     raise WorkflowLaneError("output_path")
                 _private_write(output, result.as_dict())
             else:
@@ -1341,6 +2407,43 @@ def main(argv: Sequence[str] | None = None) -> int:
                 report=arguments.report,
                 clustering=arguments.clustering,
             )
+        if arguments.command == "execute-core-shard":
+            fragment = execute_core_shard(
+                repo_root=arguments.repo_root,
+                route_path=arguments.route,
+                shard_index=arguments.shard_index,
+                artifact_root=arguments.artifact_root,
+            )
+            sys.stdout.buffer.write(canonical_json_bytes(fragment) + b"\n")
+            return 0
+        if arguments.command == "core-shard-tests":
+            return core_shard_tests(
+                repo_root=arguments.repo_root,
+                report=arguments.report,
+                basetemp=arguments.basetemp,
+                shard_index=arguments.shard_index,
+                node_inventory_digest=arguments.node_inventory_digest,
+                selected_node_ids_digest=arguments.selected_node_ids_digest,
+                clustering=arguments.clustering,
+            )
+        if arguments.command == "execute-source":
+            fragment = execute_source_fragment(
+                repo_root=arguments.repo_root,
+                route_path=arguments.route,
+                artifact_root=arguments.artifact_root,
+            )
+            sys.stdout.buffer.write(canonical_json_bytes(fragment) + b"\n")
+            return 0
+        if arguments.command == "reduce-core":
+            result = reduce_core_lane(
+                repo_root=arguments.repo_root,
+                route_path=arguments.route,
+                fragment_root=arguments.fragment_root,
+                source_root=arguments.source_root,
+                artifact_root=arguments.artifact_root,
+            )
+            sys.stdout.buffer.write(canonical_json_bytes(result.as_dict()) + b"\n")
+            return 0
         return service_tests(
             repo_root=arguments.repo_root,
             report=arguments.report,
@@ -1361,7 +2464,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         json.JSONDecodeError,
     ) as exc:
         reason = str(exc) if str(exc) else type(exc).__name__
-        print(f"EVIDENCE_MISMATCH:workflow-lane:{reason}", file=sys.stderr)
+        prefix = (
+            ""
+            if reason.startswith("BUDGET_EXCEEDED:")
+            else "EVIDENCE_MISMATCH:workflow-lane:"
+        )
+        print(f"{prefix}{reason}", file=sys.stderr)
         return 2
 
 


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: sdlc-v2-5-core-sharding
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

## Scope

Closes #381.

Replaces the single-runner deterministic core gate with four repository-fixed exact pytest-node-ID shards and one fail-closed reducer. Source integrity runs in parallel; the existing outer decision still consumes one canonical core lane artifact. Each shard uses four isolated xdist worksteal workers, one plugin, zero worker restarts and an unchanged 220-second whole-lifecycle watchdog.

The lifecycle corrections bind complete source/shard/reducer execution, preparation and durable publication time; prove the tracked checkout after execution and at publication; bound node collection and reducer load/recollection boundaries; and remove mutable outcome composition from the reducer command builder. Every reducer build now receives the same immutable reduced outcome and derives result, canonical reason and return code together. A critical-path budget result is therefore always valid `BUDGET_EXCEEDED:core-deterministic:tests` evidence with non-zero return code 124 rather than stale PASS fields.

## Exact state

```text
base: a9f6766be24c722d50c8bc9ae90ed1e63033335a
base tree: 956fbed18c18d0146efc8969402245f1770b8ce3
head: 1f9a0bb8456c6a34bd3ba7fe37b37d062ff9240e
tree: c37684a1e2b98dbc6dc9703218c6e9981b567c35
commits over base: 1
changed files: 15 (+3,881 / -323)
```

The final rebase to the exact base above was the explicitly approved dependency-base advance after the atom-gate harness merge. It prevents newly accepted harness files being misclassified as head deletions. No further rebase was performed.

## RED / GREEN

- Final immutable-outcome RED: critical path 219,999 ms and 220,000 ms passed, while 220,001 ms reproduced a persisted `BUDGET_EXCEEDED` result carrying stale PASS reason/return code and failing command validation.
- Final immutable-outcome GREEN: the under/equal/over boundary cases all pass and validate canonically; the bounded targeted selection covering sub-budget accounting, typed precedence and output finalisation passed 17 tests.
- Whole-lifecycle/tracked-tree RED/GREEN: six focused source mutation, bounded collection/load and shard/source/reducer output-crossing cases failed before their correction and passed afterwards.
- Earlier live telemetry RED: [run 31401396902](https://github.com/fol2/newsroom/actions/runs/31401396902) proved all producers and the reducer passed, then the decision failed closed because GitHub exposes matrix display names `core-shard-0..3` rather than the `core_shard` job ID. Its focused correction went from 7 failures to 7 passes, then the full shadow-lane file passed 18 tests.

## Verification

- Final focused SDLC/workflow selection: 189 passed in 4.34s, including `test_ci_workflow.py`; no unchanged full-repository suite was run.
- Ruff 0.16.2 check and format check PASS; targeted compileall, `uv lock --check`, workflow YAML/topology parse and diff-check PASS.
- Fast CI workflow remains byte-identical to the exact base.
- Production bound: the existing six production files only, 1,524 additions plus 172 deletions = 1,696 changed lines, below the explicit final 1,700 cap recorded on [Issue #381](https://github.com/fol2/newsroom/issues/381#issuecomment-5242441012).
- Exact-head [SDLC Evidence Shadow run 31408124672](https://github.com/fol2/newsroom/actions/runs/31408124672): route, source, all four shards, core reducer, service and decision PASS; signed closeout is correctly skipped for a draft PR.
- Recursive inventory: 3,084 canonical node IDs, fixed assignments 771 / 771 / 771 / 771. Downloaded fragments prove every shard's assigned IDs exactly equal its actual JUnit IDs; both unions are exactly the full 3,084-ID inventory with no duplicate or missing ID.
- Whole-shard lifecycles: 67,938 / 79,525 / 113,002 / 61,829 ms. Source lifecycle: 1,795 ms. Reducer lifecycle: 7,904 ms. Accepted core critical path: `max(source, shards) + reducer = 120,906 ms`, below the unchanged 220,000 ms contract.
- The exact-head core command independently validates as `PASS` / `PASS:core-deterministic:tests` / return code 0. Decision telemetry records canonical dependencies `core_shard`, `route`, `source`; both exact-head Fast CI runs and PR Lifecycle validation pass.

The draft still requires substantive review before readiness.

## Non-effects

CI/evidence capacity only. No product interface, authority record, migration, table, transaction, rights rule, model/provider, credential, external request, publication, egress, shadow, canary or production-effect change. No timeout, job or policy expansion.
