### PR TITLE
Fix authority harness rollback ownership seam

### DIFF
--- a/docs/operations/authority-store-conformance.md
+++ b/docs/operations/authority-store-conformance.md
@@ -23,25 +23,35 @@ class MyStoreHandle:
     def set_upstream_head(self, authority, value): ...
     def current_use(self, record_id): ...
     def tamper(self, record_id, kind): ...
-    def begin(self): ...
+    def rollback_scope(self, operation): ...
     def close(self): ...
-
-
-class MyTransaction:
-    def submit(self, command): ...
-    def observe(self, record_id): ...
-    def history(self): ...
-    def rollback(self): ...
-
 
 report = assert_conformant(MyStoreAdapter())
 ```
 
 The adapter does not implement replay, reopen, competing-writer or rollback
-scenarios and does not provide expected values or success booleans. The kernel
-owns those sequences and their fixed commands. Adapters translate product
-exceptions to `IntegrityViolation`, `BindingConflict` and `LostResponse` at
-the test seam.
+scenarios and does not provide expected values or success booleans. The
+`rollback_scope` primitive is the narrow exception needed for stores whose
+authority submission is internally atomic. The adapter opens a real
+store-owned transaction, passes a narrow scope with `submit`, `observe` and
+`history` operations to the kernel callback exactly once, and rolls the
+transaction back in a `finally` block. It must also roll back and re-raise the
+original exception when the callback raises. A product adapter may map that
+scope to private active-transaction helpers; it does not expose a production
+transaction API. The kernel callback owns the command, submission and staged
+assertions. The kernel also owns callback-count checks, deliberate abort,
+same-handle checks, close/reopen sequence and post-rollback assertions.
+Adapters translate product exceptions to `IntegrityViolation`,
+`BindingConflict` and `LostResponse` at the test seam.
+
+This test-only protocol is a reviewed mapping boundary. A generic black-box
+kernel cannot cryptographically distinguish a malicious, perfect in-memory
+scope from the real store. Reviewers therefore **must** verify that each
+adapter wraps the real store and its private transaction, never a shadow
+transaction or in-memory substitute, and never fabricates staged state or
+history. Runtime sensitivity checks still reject omitted or duplicate
+callbacks, swallowed or replaced callback exceptions, wrong staged evidence,
+and commits on both normal and abort paths.
 
 ## Kernel-owned scenarios
 
@@ -58,15 +68,18 @@ The kernel performs these observations in fixed inventory order:
 | `current_use_revalidation` | accept matching heads and independently reject every changed required head |
 | `tamper_rejection` | reject direct canonical, linked-row and self-consistent offline rewrites through fresh and reopened reads |
 | `competing_writers` | coordinate two independent handles with a kernel barrier and threads; require one winner, one binding conflict, one row and one history append |
-| `transaction_rollback` | begin, submit, observe transaction-visible state/history, roll back, open a new handle, then require absence and unchanged history |
+| `transaction_rollback` | invoke two store-owned rollback scopes; in each kernel callback submit and require exact transaction-visible state plus one history append; require normal return for the first and exact rethrow of a deliberate kernel sentinel for the second; after each require same-handle absence and unchanged history, then close and require both rows absent through a newly opened distinct handle |
 | `restart_migration` | close and create distinct restart and migration handles over the same location; require validated value, full state and history parity |
 
-The focused persisted in-memory fake uses shared state, locks, independent
-handles and copy-on-write transactions. Its sensitivity tests inject defects
-into primitive submission, validation, handle creation, concurrency and
-transaction behaviour, including a point-read-validating implementation whose
-history list skips validation, then require the exact family-specific
-`FailureCode`.
+The focused persisted in-memory fake uses shared state, locks and independent
+handles. Its store-owned rollback primitive stages against that shared store
+and restores its snapshot in `finally`, including when the kernel callback
+raises. Sensitivity tests inject defects into primitive submission,
+validation, handle creation, concurrency and transaction behaviour, including
+a point-read-validating implementation whose history list skips validation, a
+primitive which commits instead of rolling back, omitted and duplicate
+callbacks, fabricated evidence, and swallowed or replaced exceptions; each
+must produce the exact family-specific `FailureCode`.
 
 ## Exhaustive applicability
 

--- a/newsroom/tests/authority_store_conformance.py
+++ b/newsroom/tests/authority_store_conformance.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, replace
 from enum import Enum
@@ -205,12 +205,13 @@ class AuthorityValue:
         )
 
 
-@runtime_checkable
-class StoreTransaction(Protocol):
+class RollbackScope(Protocol):
     def submit(self, command: WriteCommand) -> AuthorityValue: ...
     def observe(self, record_id: str) -> StoredAuthorityState | None: ...
     def history(self) -> tuple[AuthorityValue, ...]: ...
-    def rollback(self) -> None: ...
+
+
+RollbackOperation = Callable[[RollbackScope], None]
 
 
 @runtime_checkable
@@ -225,7 +226,7 @@ class AuthorityStoreHandle(Protocol):
     def set_upstream_head(self, authority: str, value: str) -> None: ...
     def current_use(self, record_id: str) -> AuthorityValue: ...
     def tamper(self, record_id: str, kind: TamperKind) -> None: ...
-    def begin(self) -> StoreTransaction: ...
+    def rollback_scope(self, operation: RollbackOperation) -> None: ...
     def close(self) -> None: ...
 
 
@@ -314,6 +315,10 @@ _CASE_FAILURES = {
 
 
 class _CaseFailed(AssertionError):
+    pass
+
+
+class _RollbackInspectionAbort(Exception):
     pass
 
 
@@ -622,29 +627,110 @@ def _competing_writers(adapter: AuthorityStoreAdapter) -> None:
 
 
 def _rollback(adapter: AuthorityStoreAdapter) -> None:
-    command = _command()
     location, handle = _new_handle(adapter)
     before_history = handle.history()
-    transaction = handle.begin()
-    transaction.submit(command)
+    normal_command = _command("record-rollback-normal")
+    normal_invocations = 0
+    normal_complete = False
+
+    def normal_operation(scope: RollbackScope) -> None:
+        nonlocal normal_invocations, normal_complete
+        normal_invocations += 1
+        _require(
+            normal_invocations == 1,
+            "normal rollback scope invoked kernel callback more than once",
+        )
+        scope.submit(normal_command)
+        _require(
+            scope.observe(normal_command.record_id)
+            == StoredAuthorityState.from_command(normal_command),
+            "normal rollback scope cannot observe submitted state",
+        )
+        _require(
+            scope.history()
+            == before_history + (AuthorityValue.from_command(normal_command),),
+            "normal rollback scope history did not append exactly once",
+        )
+        normal_complete = True
+
+    try:
+        handle.rollback_scope(normal_operation)
+    except _CaseFailed:
+        raise
+    except Exception as exc:
+        raise _CaseFailed(f"normal rollback scope raised {type(exc).__name__}") from exc
+    _require(normal_invocations == 1, "normal rollback scope skipped kernel callback")
+    _require(normal_complete, "normal rollback scope swallowed kernel inspection")
     _require(
-        transaction.observe(command.record_id)
-        == StoredAuthorityState.from_command(command),
-        "transaction cannot observe submitted state",
+        handle.observe(normal_command.record_id) is None,
+        "normal rolled-back row remains visible on same handle",
     )
     _require(
-        len(transaction.history()) == len(before_history) + 1,
-        "transaction history did not append once",
+        handle.history() == before_history,
+        "normal rollback changed same-handle append-only history",
     )
-    transaction.rollback()
+
+    abort_command = _command("record-rollback-abort")
+    abort_invocations = 0
+    abort_complete = False
+    sentinel = _RollbackInspectionAbort()
+
+    def abort_operation(scope: RollbackScope) -> None:
+        nonlocal abort_invocations, abort_complete
+        abort_invocations += 1
+        _require(
+            abort_invocations == 1,
+            "abort rollback scope invoked kernel callback more than once",
+        )
+        scope.submit(abort_command)
+        _require(
+            scope.observe(abort_command.record_id)
+            == StoredAuthorityState.from_command(abort_command),
+            "abort rollback scope cannot observe submitted state",
+        )
+        _require(
+            scope.history()
+            == before_history + (AuthorityValue.from_command(abort_command),),
+            "abort rollback scope history did not append exactly once",
+        )
+        abort_complete = True
+        raise sentinel
+
+    abort_rethrown = False
+    try:
+        handle.rollback_scope(abort_operation)
+    except Exception as exc:
+        if exc is sentinel:
+            abort_rethrown = True
+        elif isinstance(exc, _CaseFailed):
+            raise
+        else:
+            raise _CaseFailed(
+                f"abort rollback scope raised {type(exc).__name__}"
+            ) from exc
+    _require(abort_invocations == 1, "abort rollback scope skipped kernel callback")
+    _require(abort_complete, "abort rollback scope swallowed kernel inspection")
+    _require(abort_rethrown, "abort rollback scope swallowed kernel sentinel")
+    _require(
+        handle.observe(abort_command.record_id) is None,
+        "abort rolled-back row remains visible on same handle",
+    )
+    _require(
+        handle.history() == before_history,
+        "abort rollback changed same-handle append-only history",
+    )
+
     handle.close()
     reopened = adapter.open_handle(location)
     _require(reopened is not handle, "post-rollback reopen returned original handle")
+    for command in (normal_command, abort_command):
+        _require(
+            reopened.observe(command.record_id) is None,
+            f"rolled-back row remains visible after reopen: {command.record_id}",
+        )
     _require(
-        reopened.observe(command.record_id) is None, "rolled-back row remains visible"
-    )
-    _require(
-        reopened.history() == before_history, "rollback changed append-only history"
+        reopened.history() == before_history,
+        "rollback changed reopened append-only history",
     )
 
 
@@ -852,7 +938,8 @@ __all__ = [
     "IntegrityViolation",
     "LostResponse",
     "OutcomeStatus",
-    "StoreTransaction",
+    "RollbackOperation",
+    "RollbackScope",
     "StoredAuthorityState",
     "TamperKind",
     "WriteCommand",

--- a/newsroom/tests/test_authority_store_conformance.py
+++ b/newsroom/tests/test_authority_store_conformance.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from copy import deepcopy
 from dataclasses import dataclass, field, replace
 from threading import RLock
@@ -18,8 +19,8 @@ from .authority_store_conformance import (
     IntegrityViolation,
     LostResponse,
     OutcomeStatus,
+    RollbackScope,
     StoredAuthorityState,
-    StoreTransaction,
     TamperKind,
     WriteCommand,
     run_conformance,
@@ -38,6 +39,25 @@ class MemoryLocation:
     head: str = "record-0"
     open_count: int = 0
     lock: RLock = field(default_factory=RLock)
+
+
+class MemoryRollbackScope:
+    def __init__(self, owner: InMemoryStoreAdapter, location: MemoryLocation) -> None:
+        self.owner = owner
+        self.location = location
+
+    def submit(self, command: WriteCommand) -> AuthorityValue:
+        return self.owner._submit(self.location, command)
+
+    def observe(self, record_id: str) -> StoredAuthorityState | None:
+        if self.owner.defect == "rollback_wrong_state_swallow":
+            return None
+        return deepcopy(self.location.rows.get(record_id))
+
+    def history(self) -> tuple[AuthorityValue, ...]:
+        if self.owner.defect == "rollback_wrong_history_wrap":
+            return ()
+        return tuple(deepcopy(self.location.history_entries))
 
 
 class MemoryHandle:
@@ -112,45 +132,54 @@ class MemoryHandle:
         self._open()
         self.owner._tamper(self.location, record_id, kind)
 
-    def begin(self) -> StoreTransaction:
+    def rollback_scope(self, operation: Callable[[RollbackScope], None]) -> None:
         self._open()
-        return MemoryTransaction(self.owner, self.location)
+        with self.location.lock:
+            snapshot = (
+                deepcopy(self.location.rows),
+                deepcopy(self.location.commands),
+                deepcopy(self.location.trusted_digests),
+                deepcopy(self.location.history_entries),
+                self.location.head,
+            )
+            failed = False
+            try:
+                if self.owner.defect == "rollback_omit_callback":
+                    return
+                scope = MemoryRollbackScope(self.owner, self.location)
+                operation(scope)
+                if self.owner.defect == "rollback_duplicate_callback":
+                    operation(scope)
+            except Exception as exc:
+                failed = True
+                if self.owner.defect in {
+                    "rollback_wrong_state_swallow",
+                    "rollback_swallow_exception",
+                }:
+                    return
+                if self.owner.defect == "rollback_wrong_history_wrap":
+                    raise RuntimeError("wrapped scope failure") from exc
+                if self.owner.defect == "rollback_wrong_rethrow":
+                    raise RuntimeError("wrong rollback exception") from exc
+                if self.owner.defect == "rollback_same_type_rethrow":
+                    raise type(exc) from exc
+                raise
+            finally:
+                commit = self.owner.defect == "rollback_commit_normal" and not failed
+                commit = commit or (
+                    self.owner.defect == "rollback_commit_on_exception" and failed
+                )
+                if not commit:
+                    (
+                        self.location.rows,
+                        self.location.commands,
+                        self.location.trusted_digests,
+                        self.location.history_entries,
+                        self.location.head,
+                    ) = snapshot
 
     def close(self) -> None:
         self.closed = True
-
-
-class MemoryTransaction:
-    def __init__(self, owner: InMemoryStoreAdapter, target: MemoryLocation) -> None:
-        self.owner = owner
-        self.target = target
-        with target.lock:
-            self.working = MemoryLocation(
-                rows=deepcopy(target.rows),
-                commands=deepcopy(target.commands),
-                trusted_digests=deepcopy(target.trusted_digests),
-                history_entries=deepcopy(target.history_entries),
-                upstream_heads=deepcopy(target.upstream_heads),
-                head=target.head,
-            )
-
-    def submit(self, command: WriteCommand) -> AuthorityValue:
-        return self.owner._submit(self.working, command)
-
-    def observe(self, record_id: str) -> StoredAuthorityState | None:
-        return deepcopy(self.working.rows.get(record_id))
-
-    def history(self) -> tuple[AuthorityValue, ...]:
-        return tuple(deepcopy(self.working.history_entries))
-
-    def rollback(self) -> None:
-        if self.owner.defect == "rollback":
-            with self.target.lock:
-                self.target.rows = self.working.rows
-                self.target.commands = self.working.commands
-                self.target.trusted_digests = self.working.trusted_digests
-                self.target.history_entries = self.working.history_entries
-                self.target.head = self.working.head
 
 
 class InMemoryStoreAdapter:
@@ -494,7 +523,47 @@ def test_stateful_all_required_store_passes_every_kernel_owned_scenario() -> Non
             FailureCode.COMPETING_WRITERS_NONDETERMINISTIC,
         ),
         (
-            "rollback",
+            "rollback_commit_normal",
+            CaseId.TRANSACTION_ROLLBACK,
+            FailureCode.TRANSACTION_NOT_ROLLED_BACK,
+        ),
+        (
+            "rollback_commit_on_exception",
+            CaseId.TRANSACTION_ROLLBACK,
+            FailureCode.TRANSACTION_NOT_ROLLED_BACK,
+        ),
+        (
+            "rollback_omit_callback",
+            CaseId.TRANSACTION_ROLLBACK,
+            FailureCode.TRANSACTION_NOT_ROLLED_BACK,
+        ),
+        (
+            "rollback_duplicate_callback",
+            CaseId.TRANSACTION_ROLLBACK,
+            FailureCode.TRANSACTION_NOT_ROLLED_BACK,
+        ),
+        (
+            "rollback_wrong_state_swallow",
+            CaseId.TRANSACTION_ROLLBACK,
+            FailureCode.TRANSACTION_NOT_ROLLED_BACK,
+        ),
+        (
+            "rollback_wrong_history_wrap",
+            CaseId.TRANSACTION_ROLLBACK,
+            FailureCode.TRANSACTION_NOT_ROLLED_BACK,
+        ),
+        (
+            "rollback_swallow_exception",
+            CaseId.TRANSACTION_ROLLBACK,
+            FailureCode.TRANSACTION_NOT_ROLLED_BACK,
+        ),
+        (
+            "rollback_wrong_rethrow",
+            CaseId.TRANSACTION_ROLLBACK,
+            FailureCode.TRANSACTION_NOT_ROLLED_BACK,
+        ),
+        (
+            "rollback_same_type_rethrow",
             CaseId.TRANSACTION_ROLLBACK,
             FailureCode.TRANSACTION_NOT_ROLLED_BACK,
         ),
@@ -508,6 +577,90 @@ def test_primitive_store_defects_have_exact_family_classification(
     assert [(failure.case, failure.code) for failure in report.failures] == [
         (case, code)
     ]
+
+
+def test_rollback_seam_is_store_owned_not_an_externally_held_transaction() -> None:
+    assert not hasattr(MemoryHandle, "begin")
+    assert not hasattr(AuthorityStoreHandle, "begin")
+    assert hasattr(AuthorityStoreHandle, "rollback_scope")
+
+
+def test_rollback_inspection_runs_against_staged_state_and_history() -> None:
+    adapter = InMemoryStoreAdapter()
+    location = adapter.create_location()
+    handle = adapter.open_handle(location)
+    command = WriteCommand(
+        record_id="record-inspection",
+        canonical_bytes=b'{"value":"visible"}',
+        scalar_columns={"value": "visible", "version": 1},
+        identity_columns={"record_id": "record-inspection", "authority": "fixture"},
+        linked_rows=(),
+        actor="actor",
+        request="request",
+        idempotency="idempotency",
+        cas_predecessor="record-0",
+        required_upstream_heads=(),
+    )
+    seen: list[tuple[StoredAuthorityState | None, tuple[AuthorityValue, ...]]] = []
+
+    def operate(scope: RollbackScope) -> None:
+        scope.submit(command)
+        state = scope.observe(command.record_id)
+        history = scope.history()
+        assert handle.observe(command.record_id) == state
+        assert handle.history() == history
+        seen.append((state, history))
+
+    handle.rollback_scope(operate)
+
+    assert seen == [
+        (
+            StoredAuthorityState.from_command(command),
+            (AuthorityValue.from_command(command),),
+        )
+    ]
+    assert handle.observe(command.record_id) is None
+    assert handle.history() == ()
+
+
+def test_rollback_scope_rolls_back_when_inspection_raises() -> None:
+    adapter = InMemoryStoreAdapter()
+    location = adapter.create_location()
+    handle = adapter.open_handle(location)
+    command = WriteCommand(
+        record_id="record-inspection-error",
+        canonical_bytes=b'{"value":"visible"}',
+        scalar_columns={"value": "visible", "version": 1},
+        identity_columns={
+            "record_id": "record-inspection-error",
+            "authority": "fixture",
+        },
+        linked_rows=(),
+        actor="actor",
+        request="request",
+        idempotency="idempotency",
+        cas_predecessor="record-0",
+        required_upstream_heads=(),
+    )
+
+    def fail_inspection(scope: RollbackScope) -> None:
+        scope.submit(command)
+        assert scope.observe(command.record_id) == StoredAuthorityState.from_command(
+            command
+        )
+        assert scope.history() == (AuthorityValue.from_command(command),)
+        raise RuntimeError("inspection failed")
+
+    with pytest.raises(RuntimeError, match="inspection failed"):
+        handle.rollback_scope(fail_inspection)
+
+    assert handle.observe(command.record_id) is None
+    assert handle.history() == ()
+    handle.close()
+    reopened = adapter.open_handle(location)
+    assert reopened is not handle
+    assert reopened.observe(command.record_id) is None
+    assert reopened.history() == ()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: authority-store-rollback
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

## Objective

Replace the externally held transaction seam in the tests-only authority-store conformance harness with a store-owned rollback scope suitable for internally atomic authority stores.

## Changes

- make `rollback_scope(operation)` the adapter primitive, with the kernel callback owning submission and staged assertions through a narrow scope
- exercise both normal rollback and deliberate callback-abort rollback, including same-handle and distinct reopened-handle proof
- require rethrow of the exact sentinel instance, rejecting replacement with a new instance of the same type
- detect omitted/duplicate callbacks, swallowed/wrapped assertions, wrong evidence, commits on either path, swallowed sentinels and wrong rethrows with the exact rollback failure family
- document the reviewed real-store mapping boundary without claiming black-box enforcement against a malicious perfect substitute

## Verification

- RED: same-type sentinel replacement fixture passed conformance before the identity check (`1 failed, 50 deselected`)
- `uv run pytest newsroom/tests/test_authority_store_conformance.py -q` — 51 passed
- Ruff check and format check on both Python files — passed
- `git diff --check` — passed

## Exact evidence

- Head: `e484cb52a16ef5d72be028c7acc64ee94aa484d7`
- Tree: `956fbed18c18d0146efc8969402245f1770b8ce3`
- Base: `91bfc9a8684f57f304905ac86d478afb932d85c1`
- Commit count from base: 1

Refs #389

