### PR TITLE
Increment 6D2: add relationship decision authority

### DIFF
--- a/newsroom/authority/event_hypothesis_relationship_migrations.py
+++ b/newsroom/authority/event_hypothesis_relationship_migrations.py
@@ -1,0 +1,262 @@
+"""Checked v22 persistence for Event Hypothesis relationship authority."""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+from .canonical import canonical_json_bytes, digest_canonical
+
+EVENT_HYPOTHESIS_RELATIONSHIP_SCHEMA_VERSION = 22
+EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION_NAME = (
+    "event_hypothesis_relationship_authority_v22"
+)
+EVENT_HYPOTHESIS_RELATIONSHIP_PREDECESSOR_MIGRATION_CHECKSUM = (
+    "sha256:42009475669a475af8e3e24bbcd02e6fcd9fbb71a800e18d83624e34e79e5e21"
+)
+EVENT_HYPOTHESIS_RELATIONSHIP_PREDECESSOR_FINGERPRINT = (
+    "sha256:d314d06118a25f8a32a0f9d8acb1af5383abd6b30be682cb5f65943ae15c213f"
+)
+
+
+class EventHypothesisRelationshipBackupError(sqlite3.DatabaseError):
+    """The exact retained v21 backup boundary is absent or differs."""
+
+
+@dataclass(frozen=True, slots=True)
+class EventHypothesisRelationshipBackupReceipt:
+    backup_path: Path
+    digest_path: Path
+    backup_digest: str
+    logical_digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class EventHypothesisRelationshipMigrationRecord:
+    version: int
+    name: str
+    checksum: str
+
+
+def event_hypothesis_relationship_backup_paths(
+    database: str | Path,
+) -> tuple[Path, Path]:
+    source = Path(database)
+    backup = source.with_name(source.name + ".pre-v22.sqlite3")
+    return backup, backup.with_name(backup.name + ".sha256")
+
+
+def _logical_database_digest(connection: sqlite3.Connection) -> str:
+    digest = hashlib.sha256()
+    digest.update(b"[")
+    for index, statement in enumerate(connection.iterdump()):
+        if index:
+            digest.update(b",")
+        digest.update(canonical_json_bytes(statement))
+    digest.update(b"]")
+    return "sha256:" + digest.hexdigest()
+
+
+def _file_digest(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        while chunk := source.read(1024 * 1024):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def _schema_fingerprint(connection: sqlite3.Connection) -> str:
+    rows = connection.execute(
+        "SELECT type,name,tbl_name,sql FROM sqlite_master "
+        "WHERE name NOT LIKE 'sqlite_%' ORDER BY type,name"
+    ).fetchall()
+    return digest_canonical(
+        [
+            [str(r[0]), str(r[1]), str(r[2]), " ".join(str(r[3] or "").split())]
+            for r in rows
+        ]
+    )
+
+
+def prepare_event_hypothesis_relationship_backup(
+    connection: sqlite3.Connection, backup_path: Path
+) -> EventHypothesisRelationshipBackupReceipt:
+    if connection.in_transaction:
+        raise EventHypothesisRelationshipBackupError(
+            "backup requires no active transaction"
+        )
+    if connection.execute("PRAGMA user_version").fetchone()[0] != 21:
+        raise EventHypothesisRelationshipBackupError("backup requires exact schema v21")
+    if (
+        _schema_fingerprint(connection)
+        != EVENT_HYPOTHESIS_RELATIONSHIP_PREDECESSOR_FINGERPRINT
+    ):
+        raise EventHypothesisRelationshipBackupError(
+            "backup requires checked v21 schema"
+        )
+    if not isinstance(backup_path, Path) or not backup_path.is_absolute():
+        raise EventHypothesisRelationshipBackupError("backup path must be absolute")
+    source_path = Path(
+        next(r[2] for r in connection.execute("PRAGMA database_list") if r[1] == "main")
+    )
+    if not source_path or source_path.resolve() == backup_path.resolve():
+        raise EventHypothesisRelationshipBackupError(
+            "backup path must differ from source"
+        )
+    digest_path = backup_path.with_name(backup_path.name + ".sha256")
+    logical_digest = _logical_database_digest(connection)
+    if backup_path.exists() != digest_path.exists():
+        raise EventHypothesisRelationshipBackupError("backup receipt is incomplete")
+    if not backup_path.exists():
+        backup_path.open("xb").close()
+        target = sqlite3.connect(backup_path, isolation_level=None)
+        try:
+            connection.backup(target)
+        finally:
+            target.close()
+        backup_digest = _file_digest(backup_path)
+        digest_path.write_text(backup_digest + "\n", encoding="ascii")
+    else:
+        backup_digest = _file_digest(backup_path)
+    if digest_path.read_text(encoding="ascii") != backup_digest + "\n":
+        raise EventHypothesisRelationshipBackupError("retained backup digest differs")
+    target = sqlite3.connect(
+        f"file:{backup_path}?mode=ro", uri=True, isolation_level=None
+    )
+    try:
+        if (
+            target.execute("PRAGMA user_version").fetchone()[0] != 21
+            or _schema_fingerprint(target)
+            != EVENT_HYPOTHESIS_RELATIONSHIP_PREDECESSOR_FINGERPRINT
+            or _logical_database_digest(target) != logical_digest
+        ):
+            raise EventHypothesisRelationshipBackupError(
+                "retained backup differs from source"
+            )
+    finally:
+        target.close()
+    connection.execute(
+        "CREATE TEMP TABLE IF NOT EXISTS event_hypothesis_relationship_backup_gate("
+        "backup_path TEXT PRIMARY KEY,backup_digest TEXT NOT NULL,logical_digest TEXT NOT NULL) STRICT"
+    )
+    connection.execute("DELETE FROM event_hypothesis_relationship_backup_gate")
+    connection.execute(
+        "INSERT INTO event_hypothesis_relationship_backup_gate VALUES(?,?,?)",
+        (str(backup_path), backup_digest, logical_digest),
+    )
+    return EventHypothesisRelationshipBackupReceipt(
+        backup_path, digest_path, backup_digest, logical_digest
+    )
+
+
+def require_event_hypothesis_relationship_backup(
+    connection: sqlite3.Connection,
+    *,
+    expected_history: tuple[tuple[int, str, str], ...],
+) -> EventHypothesisRelationshipBackupReceipt:
+    try:
+        row = connection.execute(
+            "SELECT backup_path,backup_digest,logical_digest "
+            "FROM temp.event_hypothesis_relationship_backup_gate"
+        ).fetchone()
+    except sqlite3.OperationalError as exc:
+        raise EventHypothesisRelationshipBackupError(
+            "v21 to v22 upgrade requires a prepared backup"
+        ) from exc
+    if row is None:
+        raise EventHypothesisRelationshipBackupError(
+            "v21 to v22 upgrade requires a prepared backup"
+        )
+    backup_path, backup_digest, logical_digest = Path(row[0]), str(row[1]), str(row[2])
+    digest_path = backup_path.with_name(backup_path.name + ".sha256")
+    if (
+        not backup_path.is_file()
+        or not digest_path.is_file()
+        or _file_digest(backup_path) != backup_digest
+        or digest_path.read_text(encoding="ascii") != backup_digest + "\n"
+        or _logical_database_digest(connection) != logical_digest
+    ):
+        raise EventHypothesisRelationshipBackupError("prepared backup identity differs")
+    target = sqlite3.connect(
+        f"file:{backup_path}?mode=ro", uri=True, isolation_level=None
+    )
+    try:
+        history = target.execute(
+            "SELECT version,name,checksum FROM authority_migrations ORDER BY version"
+        ).fetchall()
+        if (
+            target.execute("PRAGMA user_version").fetchone()[0] != 21
+            or _schema_fingerprint(target)
+            != EVENT_HYPOTHESIS_RELATIONSHIP_PREDECESSOR_FINGERPRINT
+            or _logical_database_digest(target) != logical_digest
+            or history != list(expected_history)
+        ):
+            raise EventHypothesisRelationshipBackupError(
+                "prepared backup is not exact v21"
+            )
+    finally:
+        target.close()
+    return EventHypothesisRelationshipBackupReceipt(
+        backup_path, digest_path, backup_digest, logical_digest
+    )
+
+
+_DIGEST = "substr({0},1,7)='sha256:' AND length({0})=71 AND substr({0},8) NOT GLOB '*[^0-9a-f]*'"
+
+EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION_STATEMENTS: tuple[str, ...] = (
+    f"""CREATE TABLE event_hypothesis_relationship_decisions(
+        decision_id TEXT PRIMARY KEY CHECK({_DIGEST.format("decision_id")}),
+        authority_aggregate_id TEXT NOT NULL UNIQUE,
+        authority_event_id TEXT NOT NULL UNIQUE REFERENCES ledger_events(event_id),
+        subject_hypothesis_id TEXT NOT NULL,
+        subject_version_id TEXT NOT NULL UNIQUE REFERENCES event_hypothesis_versions_v2(version_id),
+        subject_version_digest TEXT NOT NULL CHECK({_DIGEST.format("subject_version_digest")}),
+        comparator_manifest_bytes BLOB NOT NULL CHECK(length(comparator_manifest_bytes) BETWEEN 1 AND 16777216),
+        comparator_manifest_digest TEXT NOT NULL CHECK({_DIGEST.format("comparator_manifest_digest")}),
+        selected_comparator_hypothesis_id TEXT,
+        selected_comparator_version_id TEXT REFERENCES event_hypothesis_versions_v2(version_id),
+        selected_comparator_version_digest TEXT CHECK(selected_comparator_version_digest IS NULL OR {_DIGEST.format("selected_comparator_version_digest")}),
+        decision TEXT NOT NULL CHECK(decision IN ('REL_SAME_STATE','REL_DEVELOPMENT_OF','REL_CORRECTION_REVERSAL_OF','REL_RELATED_DISTINCT','REL_NO_ADEQUATE_PRIOR_MATCH','REL_UNCERTAIN')),
+        assessment_bytes BLOB NOT NULL CHECK(length(assessment_bytes) BETWEEN 1 AND 16777216),
+        assessment_digest TEXT NOT NULL UNIQUE CHECK({_DIGEST.format("assessment_digest")}),
+        evidence_bytes BLOB NOT NULL CHECK(length(evidence_bytes) BETWEEN 2 AND 16777216),
+        evidence_digest TEXT NOT NULL CHECK({_DIGEST.format("evidence_digest")}),
+        actor_identity_digest TEXT NOT NULL CHECK({_DIGEST.format("actor_identity_digest")}),
+        recorded_at TEXT NOT NULL,
+        CHECK(decision_id=assessment_digest),
+        CHECK((decision='REL_NO_ADEQUATE_PRIOR_MATCH' AND selected_comparator_hypothesis_id IS NULL AND selected_comparator_version_id IS NULL AND selected_comparator_version_digest IS NULL)
+          OR (decision!='REL_NO_ADEQUATE_PRIOR_MATCH' AND selected_comparator_hypothesis_id IS NOT NULL AND selected_comparator_version_id IS NOT NULL AND selected_comparator_version_digest IS NOT NULL))
+    ) STRICT""",
+    """CREATE TRIGGER event_hypothesis_relationship_coherence BEFORE INSERT ON event_hypothesis_relationship_decisions
+      WHEN NOT json_valid(CAST(NEW.assessment_bytes AS TEXT))
+        OR json_extract(CAST(NEW.assessment_bytes AS TEXT),'$.schema_version') IS NOT 'newsroom.increment6.hypothesis-relationship-decision.v1'
+        OR json_extract(CAST(NEW.assessment_bytes AS TEXT),'$.subject.hypothesis_id') IS NOT NEW.subject_hypothesis_id
+        OR json_extract(CAST(NEW.assessment_bytes AS TEXT),'$.subject.version_id') IS NOT NEW.subject_version_id
+        OR json_extract(CAST(NEW.assessment_bytes AS TEXT),'$.subject.version_digest') IS NOT NEW.subject_version_digest
+        OR json_extract(CAST(NEW.assessment_bytes AS TEXT),'$.decision') IS NOT NEW.decision
+        OR json_extract(CAST(NEW.assessment_bytes AS TEXT),'$.comparator.version_id') IS NOT NEW.selected_comparator_version_id
+      BEGIN SELECT RAISE(ABORT,'relationship decision scalars differ'); END""",
+    """CREATE TRIGGER immutable_event_hypothesis_relationship_update BEFORE UPDATE ON event_hypothesis_relationship_decisions BEGIN SELECT RAISE(ABORT,'immutable relationship decision'); END""",
+    """CREATE TRIGGER retained_event_hypothesis_relationship_delete BEFORE DELETE ON event_hypothesis_relationship_decisions BEGIN SELECT RAISE(ABORT,'retained relationship decision'); END""",
+)
+EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION_CHECKSUM = digest_canonical(
+    {
+        "version": EVENT_HYPOTHESIS_RELATIONSHIP_SCHEMA_VERSION,
+        "name": EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION_NAME,
+        "statements": list(EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION_STATEMENTS),
+    }
+)
+EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION = EventHypothesisRelationshipMigrationRecord(
+    EVENT_HYPOTHESIS_RELATIONSHIP_SCHEMA_VERSION,
+    EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION_NAME,
+    EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION_CHECKSUM,
+)
+
+
+__all__ = [
+    name
+    for name in globals()
+    if name.startswith(("EVENT_", "Event", "event_", "prepare_", "require_"))
+]

--- a/newsroom/authority/migrations.py
+++ b/newsroom/authority/migrations.py
@@ -69,6 +69,17 @@ from .event_hypothesis_migrations import (
     prepare_event_hypothesis_backup,
     require_event_hypothesis_backup,
 )
+from .event_hypothesis_relationship_migrations import (
+    EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION,
+    EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION_CHECKSUM,
+    EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION_NAME,
+    EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION_STATEMENTS,
+    EVENT_HYPOTHESIS_RELATIONSHIP_SCHEMA_VERSION,
+    EventHypothesisRelationshipBackupReceipt,
+    event_hypothesis_relationship_backup_paths,
+    prepare_event_hypothesis_relationship_backup,
+    require_event_hypothesis_relationship_backup,
+)
 from .extraction_migrations import (
     EXTRACTION_AUTHORITY_MIGRATION,
     EXTRACTION_AUTHORITY_MIGRATION_CHECKSUM,
@@ -167,7 +178,7 @@ from .triage_work_item_migrations import (
 )
 
 BASE_SCHEMA_VERSION = 1
-SCHEMA_VERSION = EVENT_HYPOTHESIS_SCHEMA_VERSION
+SCHEMA_VERSION = EVENT_HYPOTHESIS_RELATIONSHIP_SCHEMA_VERSION
 MIGRATION_NAME = "authority_event_foundation_v1"
 
 
@@ -612,11 +623,12 @@ def prepare_pending_migration_backup(
     | TriageDispositionBackupReceipt
     | TriageExecutionBackupReceipt
     | EventHypothesisBackupReceipt
+    | EventHypothesisRelationshipBackupReceipt
     | None
 ):
     """Prepare the exact retained backup required by a checked predecessor."""
     version = int(conn.execute("PRAGMA user_version").fetchone()[0])
-    if version not in {16, 17, 18, 19, 20}:
+    if version not in {16, 17, 18, 19, 20, 21}:
         return None
     database_path = next(
         str(row[2])
@@ -639,8 +651,11 @@ def prepare_pending_migration_backup(
     if version == 19:
         backup_path, _ = triage_execution_backup_paths(database_path)
         return prepare_triage_execution_backup(conn, backup_path)
-    backup_path, _ = event_hypothesis_backup_paths(database_path)
-    return prepare_event_hypothesis_backup(conn, backup_path)
+    if version == 20:
+        backup_path, _ = event_hypothesis_backup_paths(database_path)
+        return prepare_event_hypothesis_backup(conn, backup_path)
+    backup_path, _ = event_hypothesis_relationship_backup_paths(database_path)
+    return prepare_event_hypothesis_relationship_backup(conn, backup_path)
 
 
 def apply_migration(
@@ -936,7 +951,7 @@ def apply_pending_migrations(conn: sqlite3.Connection, *, applied_at: str) -> No
             if starting_version != 0:
                 require_evaluation_handoff_backup(
                     conn,
-                    expected_history=EXPECTED_MIGRATION_HISTORY[:-5],
+                    expected_history=EXPECTED_MIGRATION_HISTORY[:-6],
                 )
             for statement in EVALUATION_HANDOFF_MIGRATION_STATEMENTS:
                 conn.execute(statement)
@@ -971,7 +986,7 @@ def apply_pending_migrations(conn: sqlite3.Connection, *, applied_at: str) -> No
             if starting_version != 0:
                 require_triage_work_item_backup(
                     conn,
-                    expected_history=EXPECTED_MIGRATION_HISTORY[:-4],
+                    expected_history=EXPECTED_MIGRATION_HISTORY[:-5],
                 )
             for statement in TRIAGE_WORK_ITEM_MIGRATION_STATEMENTS:
                 conn.execute(statement)
@@ -1005,7 +1020,7 @@ def apply_pending_migrations(conn: sqlite3.Connection, *, applied_at: str) -> No
             if starting_version != 0:
                 require_triage_disposition_backup(
                     conn,
-                    expected_history=EXPECTED_MIGRATION_HISTORY[:-3],
+                    expected_history=EXPECTED_MIGRATION_HISTORY[:-4],
                 )
             for statement in TRIAGE_DISPOSITION_MIGRATION_STATEMENTS:
                 conn.execute(statement)
@@ -1039,7 +1054,7 @@ def apply_pending_migrations(conn: sqlite3.Connection, *, applied_at: str) -> No
             if starting_version != 0:
                 require_triage_execution_backup(
                     conn,
-                    expected_history=EXPECTED_MIGRATION_HISTORY[:-2],
+                    expected_history=EXPECTED_MIGRATION_HISTORY[:-3],
                 )
             for statement in TRIAGE_EXECUTION_MIGRATION_STATEMENTS:
                 conn.execute(statement)
@@ -1072,7 +1087,7 @@ def apply_pending_migrations(conn: sqlite3.Connection, *, applied_at: str) -> No
                 conn.execute("BEGIN EXCLUSIVE")
             if starting_version != 0:
                 require_event_hypothesis_backup(
-                    conn, expected_history=EXPECTED_MIGRATION_HISTORY[:-1]
+                    conn, expected_history=EXPECTED_MIGRATION_HISTORY[:-2]
                 )
             for statement in EVENT_HYPOTHESIS_MIGRATION_STATEMENTS:
                 conn.execute(statement)
@@ -1087,6 +1102,41 @@ def apply_pending_migrations(conn: sqlite3.Connection, *, applied_at: str) -> No
                 ),
             )
             current = EVENT_HYPOTHESIS_SCHEMA_VERSION
+        if current == EVENT_HYPOTHESIS_SCHEMA_VERSION:
+            if 0 < starting_version < EVENT_HYPOTHESIS_SCHEMA_VERSION:
+                conn.execute(f"PRAGMA user_version={EVENT_HYPOTHESIS_SCHEMA_VERSION}")
+                conn.execute("COMMIT")
+                database_path = next(
+                    str(row[2])
+                    for row in conn.execute("PRAGMA database_list")
+                    if row[1] == "main"
+                )
+                if not database_path:
+                    raise sqlite3.DatabaseError(
+                        "existing multihop upgrade requires a file-backed database"
+                    )
+                backup_path, _ = event_hypothesis_relationship_backup_paths(
+                    database_path
+                )
+                prepare_event_hypothesis_relationship_backup(conn, backup_path)
+                conn.execute("BEGIN EXCLUSIVE")
+            if starting_version != 0:
+                require_event_hypothesis_relationship_backup(
+                    conn, expected_history=EXPECTED_MIGRATION_HISTORY[:-1]
+                )
+            for statement in EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION_STATEMENTS:
+                conn.execute(statement)
+            conn.execute(
+                "INSERT INTO authority_migrations(version,name,checksum,applied_at) "
+                "VALUES(?,?,?,?)",
+                (
+                    EVENT_HYPOTHESIS_RELATIONSHIP_SCHEMA_VERSION,
+                    EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION_NAME,
+                    EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION_CHECKSUM,
+                    applied_at,
+                ),
+            )
+            current = EVENT_HYPOTHESIS_RELATIONSHIP_SCHEMA_VERSION
         conn.execute(f"PRAGMA user_version={current}")
         conn.execute("COMMIT")
     except Exception:
@@ -1117,6 +1167,7 @@ MIGRATIONS: tuple[MigrationRecord | object, ...] = (
     TRIAGE_DISPOSITION_MIGRATION,
     TRIAGE_EXECUTION_MIGRATION,
     EVENT_HYPOTHESIS_MIGRATION,
+    EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION,
 )
 
 
@@ -1228,5 +1279,10 @@ EXPECTED_MIGRATION_HISTORY: tuple[tuple[int, str, str], ...] = (
         EVENT_HYPOTHESIS_SCHEMA_VERSION,
         EVENT_HYPOTHESIS_MIGRATION_NAME,
         EVENT_HYPOTHESIS_MIGRATION_CHECKSUM,
+    ),
+    (
+        EVENT_HYPOTHESIS_RELATIONSHIP_SCHEMA_VERSION,
+        EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION_NAME,
+        EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION_CHECKSUM,
     ),
 )

--- a/newsroom/increment6/_hypothesis_relationship_store.py
+++ b/newsroom/increment6/_hypothesis_relationship_store.py
@@ -1,0 +1,634 @@
+"""Private checked v22 Event Hypothesis relationship authority."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import stat
+from collections.abc import Callable
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Self
+
+from newsroom.authority._capability import _CapabilityIssuer
+from newsroom.authority._event_store import _EventAuthorityStore
+from newsroom.authority.auth import AuthenticationProof
+from newsroom.authority.canonical import canonical_json_bytes, digest_bytes
+from newsroom.authority.models import InlinePayload, SemanticCommand
+from newsroom.authority.persistence import AuthoritySchemaError
+from newsroom.authority.policy import CommandRegistry, PayloadSchemaRegistry
+from newsroom.authority.service import CommandService
+from newsroom.authority.types import AggregateId, UtcTimestamp
+from newsroom.increment6._hypothesis_store import _HypothesisStore
+from newsroom.increment6.dispositions import ProposalDispositionStore
+from newsroom.increment6.relationships import (
+    RELATIONSHIP_AGGREGATE_TYPE,
+    RELATIONSHIP_COMMAND_TYPE,
+    RELATIONSHIP_EVENT_TYPE,
+    AssessmentStatus,
+    ComparatorEvidence,
+    RelationshipAssessment,
+    RelationshipContractError,
+    merge_relationship_authority_registries,
+    verify_relationship_assessment_replay,
+)
+from newsroom.increment6.work_items import RetrievalContextAuthority
+
+_STORE_TOKEN = object()
+
+
+def _evidence_bytes(values: tuple[bytes, ...]) -> tuple[bytes, tuple[bytes, ...]]:
+    if type(values) is not tuple:
+        raise RelationshipContractError("evidence must be an exact tuple")
+    parsed = tuple(ComparatorEvidence.from_canonical_bytes(value) for value in values)
+    canonical = tuple(value.canonical_bytes for value in parsed)
+    if canonical != values:
+        raise RelationshipContractError("evidence bytes differ from canonical values")
+    return canonical_json_bytes([value.canonical_value for value in parsed]), canonical
+
+
+def _decode_evidence(raw: bytes) -> tuple[bytes, ...]:
+    try:
+        value = json.loads(raw)
+        if type(value) is not list or canonical_json_bytes(value) != raw:
+            raise ValueError
+        return tuple(
+            ComparatorEvidence.from_value(item).canonical_bytes for item in value
+        )
+    except RelationshipContractError:
+        raise
+    except Exception as exc:
+        raise RelationshipContractError("retained evidence differs") from exc
+
+
+class _RelationshipEventStore(_EventAuthorityStore):
+    """Existing event authority composed with the sole v22 relationship table."""
+
+    def __init__(
+        self,
+        token: object,
+        path: Path,
+        *,
+        issuer: _CapabilityIssuer,
+        command_registry: CommandRegistry,
+        payload_schemas: PayloadSchemaRegistry,
+        retrieval_authority: RetrievalContextAuthority,
+        authenticator: object,
+        clock: Callable[[], UtcTimestamp],
+        busy_timeout_ms: int,
+    ) -> None:
+        if token is not _STORE_TOKEN:
+            raise RelationshipContractError(
+                "relationship store construction is private"
+            )
+        super().__init__(
+            path,
+            issuer=issuer,
+            command_registry=command_registry,
+            payload_schemas=payload_schemas,
+            command_service_version="increment6-relationship-v1",
+            busy_timeout_ms=busy_timeout_ms,
+            clock=clock,
+        )
+        with self._hypothesis_rows():
+            self._hypotheses = _HypothesisStore(
+                self._connection, retrieval_authority, authenticator, clock
+            )
+        self._command_service: CommandService | None = None
+        with self._lock, self._transaction():
+            self._adopt()
+            try:
+                self._verify_relationships()
+            finally:
+                self._release()
+
+    def _acquire_writer_lock(self) -> None:
+        lock_path = self.path.with_name(self.path.name + ".writer.lock")
+        if lock_path.exists():
+            self._validate_owned_file(lock_path)
+            if stat.S_IMODE(lock_path.stat().st_mode) != 0o600:
+                raise AuthoritySchemaError("writer lock mode differs")
+        super()._acquire_writer_lock()
+
+    def bind_command_service(self, service: CommandService) -> None:
+        if self._command_service is not None or type(service) is not CommandService:
+            raise RelationshipContractError("relationship command service differs")
+        self._command_service = service
+
+    def _service(self) -> CommandService:
+        if self._command_service is None:
+            raise RelationshipContractError("relationship command service is absent")
+        return self._command_service
+
+    @contextmanager
+    def _hypothesis_rows(self):
+        row_factory = self._connection.row_factory
+        self._connection.row_factory = None
+        try:
+            yield
+        finally:
+            self._connection.row_factory = row_factory
+
+    def _adopt(self) -> None:
+        self._hypotheses.adopt_active_transaction()
+
+    def _release(self) -> None:
+        self._hypotheses.release_active_transaction()
+
+    def _validate_relational_invariants(self, conn: sqlite3.Connection) -> None:
+        super()._validate_relational_invariants(conn)
+        if "event_hypothesis_relationship_decisions" not in self._table_names():
+            return
+        orphan = conn.execute(
+            "SELECT r.decision_id FROM event_hypothesis_relationship_decisions r "
+            "LEFT JOIN ledger_events e ON e.event_id=r.authority_event_id "
+            "WHERE e.event_id IS NULL OR e.event_type!=? LIMIT 1",
+            (RELATIONSHIP_EVENT_TYPE,),
+        ).fetchone()
+        uncovered = conn.execute(
+            "SELECT e.event_id FROM ledger_events e LEFT JOIN "
+            "event_hypothesis_relationship_decisions r "
+            "ON r.authority_event_id=e.event_id WHERE e.event_type=? "
+            "AND r.decision_id IS NULL LIMIT 1",
+            (RELATIONSHIP_EVENT_TYPE,),
+        ).fetchone()
+        if orphan is not None or uncovered is not None:
+            raise AuthoritySchemaError("relationship event coverage differs")
+
+    @staticmethod
+    def _actor_identity(row: sqlite3.Row) -> str:
+        return digest_bytes(
+            canonical_json_bytes(
+                {
+                    "principal_id": str(row["principal_id"]),
+                    "credential_binding_digest": str(row["credential_binding_digest"]),
+                }
+            )
+        )
+
+    def _row(self, decision_id: str) -> sqlite3.Row:
+        row = self._connection.execute(
+            "SELECT r.*,e.event_type,e.event_schema_version,e.aggregate_type,"
+            "e.aggregate_id,e.aggregate_version,e.recorded_at AS event_recorded_at,"
+            "e.command_id,e.command_definition_version,e.command_definition_digest,"
+            "c.command_type,c.expected_aggregate_version,c.idempotency_key,"
+            "c.committed_at,p.payload_bytes,p.payload_digest,p.mode,p.schema_version,"
+            "p.schema_contract_version,p.schema_contract_digest,"
+            "p.canonicalizer_implementation_version,a.principal_id,"
+            "a.credential_binding_digest FROM event_hypothesis_relationship_decisions r "
+            "JOIN ledger_events e ON e.event_id=r.authority_event_id "
+            "JOIN authority_commands c ON c.command_id=e.command_id "
+            "JOIN authority_payloads p ON p.payload_id=e.payload_id "
+            "JOIN authentication_contexts a ON a.authentication_context_id="
+            "c.authentication_context_id WHERE r.decision_id=?",
+            (decision_id,),
+        ).fetchone()
+        if row is None:
+            raise RelationshipContractError("unknown relationship decision")
+        return row
+
+    def _load_row(self, decision_id: str) -> RelationshipAssessment:
+        row = self._row(decision_id)
+        assessment = RelationshipAssessment.from_canonical_bytes(
+            bytes(row["assessment_bytes"])
+        )
+        evidence = _decode_evidence(bytes(row["evidence_bytes"]))
+        with self._hypothesis_rows():
+            subject = self._hypotheses.require_retained_version_in_transaction(
+                str(row["subject_version_id"])
+            )
+            comparators = tuple(
+                self._hypotheses.require_retained_version_in_transaction(item.version_id)
+                for item in assessment.comparator_manifest.comparators
+            )
+        verified = verify_relationship_assessment_replay(
+            assessment.canonical_bytes,
+            subject_version=subject,
+            comparator_versions=comparators,
+            evidence=evidence,
+        )
+        selected = verified.comparator
+        expected = {
+            "decision_id": verified.canonical_digest,
+            "subject_hypothesis_id": verified.subject.hypothesis_id,
+            "subject_version_id": verified.subject.version_id,
+            "subject_version_digest": verified.subject.version_digest,
+            "comparator_manifest_bytes": verified.comparator_manifest.canonical_bytes,
+            "comparator_manifest_digest": verified.comparator_manifest_digest,
+            "selected_comparator_hypothesis_id": None
+            if selected is None
+            else selected.hypothesis_id,
+            "selected_comparator_version_id": None
+            if selected is None
+            else selected.version_id,
+            "selected_comparator_version_digest": None
+            if selected is None
+            else selected.version_digest,
+            "decision": verified.decision.value,
+            "assessment_bytes": verified.canonical_bytes,
+            "assessment_digest": verified.canonical_digest,
+            "evidence_digest": verified.evidence_digest,
+        }
+        if any(row[key] != value for key, value in expected.items()):
+            raise RelationshipContractError("retained relationship decision differs")
+        definition = self._command_registry.resolve(RELATIONSHIP_COMMAND_TYPE)
+        contract = self._payload_schemas.resolve(
+            definition.payload_schema_version, definition.payload_mode
+        )
+        if (
+            str(row["event_type"]) != RELATIONSHIP_EVENT_TYPE
+            or int(row["event_schema_version"]) != 1
+            or str(row["aggregate_type"]) != RELATIONSHIP_AGGREGATE_TYPE
+            or str(row["aggregate_id"]) != str(row["authority_aggregate_id"])
+            or int(row["aggregate_version"]) != 1
+            or str(row["command_type"]) != RELATIONSHIP_COMMAND_TYPE
+            or int(row["expected_aggregate_version"]) != 0
+            or str(row["idempotency_key"]) != verified.subject.version_id
+            or bytes(row["payload_bytes"]) != verified.canonical_bytes
+            or str(row["payload_digest"]) != verified.canonical_digest
+            or str(row["command_definition_version"]) != definition.definition_version
+            or str(row["command_definition_digest"]) != definition.digest
+            or str(row["mode"]) != definition.payload_mode.value
+            or str(row["schema_version"]) != contract.schema_version
+            or str(row["schema_contract_version"]) != contract.contract_version
+            or str(row["schema_contract_digest"]) != contract.contract_digest
+            or str(row["canonicalizer_implementation_version"])
+            != contract.canonicalizer_implementation_version
+            or self._actor_identity(row) != str(row["actor_identity_digest"])
+            or str(row["recorded_at"]) != str(row["event_recorded_at"])
+            or str(row["recorded_at"]) != str(row["committed_at"])
+            or digest_bytes(bytes(row["evidence_bytes"])) != verified.evidence_digest
+        ):
+            raise RelationshipContractError("relationship authority graph differs")
+        UtcTimestamp.parse(str(row["recorded_at"]))
+        return verified
+
+    def _verify_relationships(self) -> None:
+        with self._hypothesis_rows():
+            self._hypotheses._verify()
+        ids = [
+            str(row[0])
+            for row in self._connection.execute(
+                "SELECT decision_id FROM event_hypothesis_relationship_decisions ORDER BY decision_id"
+            )
+        ]
+        for decision_id in ids:
+            self._load_row(decision_id)
+        self._validate_relational_invariants(self._connection)
+
+    @staticmethod
+    def _command(
+        assessment: RelationshipAssessment, aggregate_id: str
+    ) -> SemanticCommand:
+        return SemanticCommand(
+            command_type=RELATIONSHIP_COMMAND_TYPE,
+            aggregate_id=AggregateId.parse(aggregate_id),
+            expected_aggregate_version=0,
+            payload=InlinePayload(assessment.canonical_value),
+            idempotency_key=assessment.subject.version_id,
+        )
+
+    def _retain_active(
+        self,
+        assessment_bytes: bytes,
+        evidence: tuple[bytes, ...],
+        *,
+        proof: AuthenticationProof,
+    ) -> RelationshipAssessment:
+        assessment = RelationshipAssessment.from_canonical_bytes(assessment_bytes)
+        if assessment.status is not AssessmentStatus.COMPLETE:
+            raise RelationshipContractError(
+                "only complete relationship assessments are authoritative"
+            )
+        stored_evidence, evidence_values = _evidence_bytes(evidence)
+        conn = self._connection
+        self._verify_relationships()
+        existing = conn.execute(
+            "SELECT decision_id,authority_aggregate_id,evidence_bytes,actor_identity_digest "
+            "FROM event_hypothesis_relationship_decisions WHERE subject_version_id=?",
+            (assessment.subject.version_id,),
+        ).fetchone()
+        aggregate_id = (
+            str(AggregateId.new())
+            if existing is None
+            else str(existing["authority_aggregate_id"])
+        )
+        command = self._command(assessment, aggregate_id)
+        grant = self._service()._authorize_for_commit(command, proof=proof)
+        actor = ProposalDispositionStore._authenticated_identity(
+            grant.authentication
+        )
+        if existing is not None:
+            retained = self._load_row(str(existing["decision_id"]))
+            if (
+                retained.canonical_bytes != assessment_bytes
+                or bytes(existing["evidence_bytes"]) != stored_evidence
+                or str(existing["actor_identity_digest"]) != actor
+            ):
+                raise RelationshipContractError("relationship replay diverges")
+            committed = self._commit_grant_in_transaction(
+                conn,
+                grant,
+                recorded_at=str(
+                    self._row(retained.canonical_digest)["recorded_at"]
+                ),
+            )
+            if not committed.replayed or committed.event_id != str(
+                self._row(retained.canonical_digest)["authority_event_id"]
+            ):
+                raise RelationshipContractError(
+                    "relationship command replay differs"
+                )
+            return retained
+        with self._hypothesis_rows():
+            subject = self._hypotheses.require_current_version_in_transaction(
+                assessment.subject.version_id, proof=proof
+            )
+            comparators = tuple(
+                self._hypotheses.require_retained_version_in_transaction(
+                    item.version_id
+                )
+                for item in assessment.comparator_manifest.comparators
+            )
+        verified = verify_relationship_assessment_replay(
+            assessment_bytes,
+            subject_version=subject,
+            comparator_versions=comparators,
+            evidence=evidence_values,
+        )
+        if verified.evidence_digest != digest_bytes(stored_evidence):
+            raise RelationshipContractError("evidence-set identity differs")
+        recorded_at = self._clock().to_text()
+        committed = self._commit_grant_in_transaction(
+            conn, grant, recorded_at=recorded_at
+        )
+        if committed.replayed:
+            raise RelationshipContractError(
+                "fresh relationship command replayed"
+            )
+        selected = verified.comparator
+        conn.execute(
+            "INSERT INTO event_hypothesis_relationship_decisions VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+            (
+                verified.canonical_digest,
+                aggregate_id,
+                committed.event_id,
+                verified.subject.hypothesis_id,
+                verified.subject.version_id,
+                verified.subject.version_digest,
+                verified.comparator_manifest.canonical_bytes,
+                verified.comparator_manifest_digest,
+                None if selected is None else selected.hypothesis_id,
+                None if selected is None else selected.version_id,
+                None if selected is None else selected.version_digest,
+                verified.decision.value,
+                verified.canonical_bytes,
+                verified.canonical_digest,
+                stored_evidence,
+                verified.evidence_digest,
+                actor,
+                recorded_at,
+            ),
+        )
+        self._verify_relationships()
+        return verified
+
+    def retain(
+        self,
+        assessment_bytes: bytes,
+        evidence: tuple[bytes, ...],
+        *,
+        proof: AuthenticationProof,
+    ) -> RelationshipAssessment:
+        with self._lock, self._transaction():
+            self._adopt()
+            try:
+                return self._retain_active(
+                    assessment_bytes, evidence, proof=proof
+                )
+            finally:
+                self._release()
+
+    create_or_replay = retain
+
+    def _read(self, operation: Callable[[], object]) -> object:
+        with self._lock, self._transaction():
+            self._adopt()
+            try:
+                self._verify_relationships()
+                return operation()
+            finally:
+                self._release()
+
+    def load(self, decision_id: str) -> RelationshipAssessment:
+        return self._read(lambda: self._load_row(decision_id))  # type: ignore[return-value]
+
+    def history(self) -> tuple[RelationshipAssessment, ...]:
+        def values() -> tuple[RelationshipAssessment, ...]:
+            return tuple(
+                self._load_row(str(row[0]))
+                for row in self._connection.execute(
+                    "SELECT decision_id FROM event_hypothesis_relationship_decisions ORDER BY recorded_at,decision_id"
+                )
+            )
+
+        return self._read(values)  # type: ignore[return-value]
+
+    def current(
+        self, decision_id: str, *, proof: AuthenticationProof
+    ) -> RelationshipAssessment:
+        def value() -> RelationshipAssessment:
+            retained = self._load_row(decision_id)
+            with self._hypothesis_rows():
+                self._hypotheses.require_current_version_in_transaction(
+                    retained.subject.version_id, proof=proof
+                )
+            return retained
+
+        return self._read(value)  # type: ignore[return-value]
+
+    def rollback_scope(
+        self, operation: Callable[[_RelationshipTransaction], None]
+    ) -> None:
+        try:
+            with self._lock, self._transaction():
+                self._adopt()
+                try:
+                    operation(_RelationshipTransaction(self))
+                    raise _Rollback()
+                finally:
+                    self._release()
+        except _Rollback:
+            return
+
+
+class _UnlockedRelationshipEventStoreForTest(_RelationshipEventStore):
+    """Exact private test composition for exercising SQLite contention."""
+
+    def _acquire_writer_lock(self) -> None:
+        self._lock_fd = None
+
+
+class _Rollback(Exception):
+    pass
+
+
+class _RelationshipTransaction:
+    def __init__(self, store: _RelationshipEventStore) -> None:
+        self._store = store
+
+    def retain(self, *args: object, **kwargs: object) -> RelationshipAssessment:
+        # rollback-scope conformance uses the same active implementation through a
+        # specialised adapter; normal callers never receive this private scope.
+        return self._store._retain_active(*args, **kwargs)  # type: ignore[arg-type,no-any-return]
+
+    def load(self, decision_id: str) -> RelationshipAssessment:
+        return self._store._load_row(decision_id)
+
+    def history(self) -> tuple[RelationshipAssessment, ...]:
+        return tuple(
+            self._store._load_row(str(row[0]))
+            for row in self._store._connection.execute(
+                "SELECT decision_id FROM event_hypothesis_relationship_decisions ORDER BY recorded_at,decision_id"
+            )
+        )
+
+
+class EventHypothesisRelationshipAuthority:
+    __slots__ = ("__closed", "__store")
+
+    def __init__(self, token: object, store: _RelationshipEventStore):
+        if token is not _STORE_TOKEN or not isinstance(store, _RelationshipEventStore):
+            raise RelationshipContractError(
+                "relationship authority construction is private"
+            )
+        self.__store = store
+        self.__closed = False
+
+    def retain(self, *args: object, **kwargs: object) -> RelationshipAssessment:
+        return self.__store.retain(*args, **kwargs)  # type: ignore[arg-type]
+
+    create_or_replay = retain
+
+    def load(self, decision_id: str) -> RelationshipAssessment:
+        return self.__store.load(decision_id)
+
+    def history(self) -> tuple[RelationshipAssessment, ...]:
+        return self.__store.history()
+
+    def current(
+        self, decision_id: str, *, proof: AuthenticationProof
+    ) -> RelationshipAssessment:
+        return self.__store.current(decision_id, proof=proof)
+
+    require_current = current
+
+    def close(self) -> None:
+        if not self.__closed:
+            self.__closed = True
+            self.__store.close()
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
+
+
+def _compose_relationship_authority(
+    database: str | Path,
+    *,
+    retrieval_authority: RetrievalContextAuthority,
+    authenticator: object,
+    authorizer: object,
+    command_registry: CommandRegistry,
+    payload_schemas: PayloadSchemaRegistry,
+    clock: Callable[[], UtcTimestamp] = UtcTimestamp.now,
+    busy_timeout_ms: int = 5000,
+    unlocked_for_test: bool = False,
+) -> EventHypothesisRelationshipAuthority:
+    merged_commands, merged_schemas = merge_relationship_authority_registries(
+        command_registry, payload_schemas
+    )
+    issuer = _CapabilityIssuer(
+        command_registry=merged_commands, payload_schemas=merged_schemas
+    )
+    store_class = (
+        _UnlockedRelationshipEventStoreForTest
+        if unlocked_for_test
+        else _RelationshipEventStore
+    )
+    store = store_class(
+        _STORE_TOKEN,
+        Path(database),
+        issuer=issuer,
+        command_registry=merged_commands,
+        payload_schemas=merged_schemas,
+        retrieval_authority=retrieval_authority,
+        authenticator=authenticator,
+        clock=clock,
+        busy_timeout_ms=busy_timeout_ms,
+    )
+    service = CommandService(
+        registry=merged_commands,
+        payload_schemas=merged_schemas,
+        authenticator=authenticator,
+        authorizer=authorizer,
+        committed_lookup=store,
+        clock=clock,
+        _issuer=issuer,
+    )
+    store.bind_command_service(service)
+    return EventHypothesisRelationshipAuthority(_STORE_TOKEN, store)
+
+
+def open_relationship_authority(
+    database: str | Path,
+    *,
+    retrieval_authority: RetrievalContextAuthority,
+    authenticator: object,
+    authorizer: object,
+    command_registry: CommandRegistry,
+    payload_schemas: PayloadSchemaRegistry,
+    clock: Callable[[], UtcTimestamp] = UtcTimestamp.now,
+    busy_timeout_ms: int = 5000,
+) -> EventHypothesisRelationshipAuthority:
+    """Construct the exact production relationship authority."""
+    return _compose_relationship_authority(
+        database,
+        retrieval_authority=retrieval_authority,
+        authenticator=authenticator,
+        authorizer=authorizer,
+        command_registry=command_registry,
+        payload_schemas=payload_schemas,
+        clock=clock,
+        busy_timeout_ms=busy_timeout_ms,
+    )
+
+
+def _open_unlocked_relationship_authority_for_test(
+    database: str | Path,
+    *,
+    retrieval_authority: RetrievalContextAuthority,
+    authenticator: object,
+    authorizer: object,
+    command_registry: CommandRegistry,
+    payload_schemas: PayloadSchemaRegistry,
+    clock: Callable[[], UtcTimestamp] = UtcTimestamp.now,
+    busy_timeout_ms: int = 5000,
+) -> EventHypothesisRelationshipAuthority:
+    """Construct the exact private unlocked test store without a class hook."""
+    return _compose_relationship_authority(
+        database,
+        retrieval_authority=retrieval_authority,
+        authenticator=authenticator,
+        authorizer=authorizer,
+        command_registry=command_registry,
+        payload_schemas=payload_schemas,
+        clock=clock,
+        busy_timeout_ms=busy_timeout_ms,
+        unlocked_for_test=True,
+    )
+
+
+__all__: list[str] = []

--- a/newsroom/increment6/_hypothesis_store.py
+++ b/newsroom/increment6/_hypothesis_store.py
@@ -231,6 +231,17 @@ class _HypothesisStore:
         self._owner = None
         self._lock.release()
 
+    def adopt_active_transaction(self) -> None:
+        """Bind checked private helpers to an enclosing authority transaction."""
+        if self._owner is not None or not self._connection.in_transaction:
+            raise HypothesisContractError("active transaction adoption differs")
+        self._owner = get_ident()
+
+    def release_active_transaction(self) -> None:
+        if self._owner != get_ident() or not self._connection.in_transaction:
+            raise HypothesisContractError("active transaction ownership differs")
+        self._owner = None
+
     def _rollback(self) -> None:
         if self._owner != get_ident():
             return
@@ -623,6 +634,36 @@ class _HypothesisStore:
         if version is None:
             raise HypothesisContractError("current Hypothesis Version is absent")
         return EventHypothesisVersion.from_canonical_bytes(bytes(version[0]))
+
+    def require_retained_version_in_transaction(
+        self, version_id: str
+    ) -> EventHypothesisVersion:
+        """Load one retained Version inside this store's checked transaction."""
+        if self._owner != get_ident() or not self._connection.in_transaction:
+            raise HypothesisContractError("transaction ownership differs")
+        self._verify()
+        row = self._connection.execute(
+            "SELECT canonical_bytes FROM event_hypothesis_versions_v2 WHERE version_id=?",
+            (version_id,),
+        ).fetchone()
+        if row is None:
+            raise HypothesisContractError("unknown retained Hypothesis Version")
+        return EventHypothesisVersion.from_canonical_bytes(bytes(row[0]))
+
+    def require_current_version_in_transaction(
+        self, version_id: str, *, proof: AuthenticationProof
+    ) -> EventHypothesisVersion:
+        """Recheck the exact Version head and its authenticated source chain."""
+        version = self.require_retained_version_in_transaction(version_id)
+        if self._head(version.hypothesis_id) != version:
+            raise HypothesisContractError("Hypothesis Version is not the current head")
+        for binding in version.source_bindings:
+            disposition = _REQUIRE_DISPOSITION(
+                self._dispositions, binding.disposition_id, proof=proof
+            )
+            if self._bindings((disposition,)) != (binding,):
+                raise HypothesisContractError("current source binding differs")
+        return version
 
     def current(
         self, hypothesis_id: str, *, proof: AuthenticationProof

--- a/newsroom/increment6/relationships.py
+++ b/newsroom/increment6/relationships.py
@@ -9,8 +9,10 @@ from __future__ import annotations
 
 import json
 import re
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
+from pathlib import Path
 from types import MappingProxyType
 from typing import Self
 
@@ -19,6 +21,14 @@ from newsroom.authority.canonical import (
     canonical_json_bytes,
     digest_bytes,
 )
+from newsroom.authority.models import CommandDefinition
+from newsroom.authority.policy import (
+    CommandRegistry,
+    PayloadGoldenVector,
+    PayloadSchemaContract,
+    PayloadSchemaRegistry,
+)
+from newsroom.authority.types import PayloadMode, TrustScope, UtcTimestamp
 from newsroom.increment6.hypotheses import (
     EventHypothesisVersion,
     HypothesisSourceBinding,
@@ -34,6 +44,13 @@ from newsroom.increment6.outcomes import (
 HYPOTHESIS_RELATIONSHIP_DECISION = (
     "newsroom.increment6.hypothesis-relationship-decision.v1"
 )
+RELATIONSHIP_COMMAND_TYPE = "increment6.relationship-decision.retain"
+RELATIONSHIP_AGGREGATE_TYPE = "event_hypothesis_relationship_decision"
+RELATIONSHIP_EVENT_TYPE = "event_hypothesis_relationship_decision_retained"
+RELATIONSHIP_COMMAND_DEFINITION_VERSION = "relationship-command-v1"
+RELATIONSHIP_PAYLOAD_CONTRACT_VERSION = "relationship-schema-v1"
+RELATIONSHIP_PAYLOAD_CANONICALIZER_VERSION = "relationship-canonical-json-v1"
+RELATIONSHIP_REQUIRED_SCOPE = "authority.relationship.retain"
 MAX_RELATIONSHIP_CANONICAL_BYTES = 16_777_216
 MAX_COMPARATORS = 256
 ADEQUATE_MATCH_THRESHOLD = 60
@@ -646,6 +663,218 @@ class RelationshipAssessment(_NoEffect):
         )
 
 
+_FACADE_TOKEN = object()
+
+
+class EventHypothesisRelationshipAuthority:
+    """Narrow public facade over the private checked v22 authority."""
+
+    __slots__ = ("__authority",)
+
+    def __init__(self, token: object, authority: object) -> None:
+        from newsroom.increment6._hypothesis_relationship_store import (
+            EventHypothesisRelationshipAuthority as PrivateAuthority,
+        )
+
+        if token is not _FACADE_TOKEN or type(authority) is not PrivateAuthority:
+            raise RelationshipContractError(
+                "relationship authority facade requires the exact private authority"
+            )
+        self.__authority = authority
+
+    def retain(self, *args: object, **kwargs: object) -> RelationshipAssessment:
+        return _normalise(
+            lambda: self.__authority.retain(*args, **kwargs),
+            "relationship retention failed",
+        )  # type: ignore[attr-defined,no-any-return]
+
+    create_or_replay = retain
+
+    def load(self, decision_id: str) -> RelationshipAssessment:
+        return _normalise(
+            lambda: self.__authority.load(decision_id),
+            "relationship load failed",
+        )  # type: ignore[attr-defined,no-any-return]
+
+    def history(self) -> tuple[RelationshipAssessment, ...]:
+        return _normalise(self.__authority.history, "relationship history failed")  # type: ignore[attr-defined,no-any-return]
+
+    def current(self, decision_id: str, *, proof: object) -> RelationshipAssessment:
+        return _normalise(
+            lambda: self.__authority.current(decision_id, proof=proof),
+            "relationship currentness failed",
+        )  # type: ignore[attr-defined,no-any-return]
+
+    require_current = current
+
+    def close(self) -> None:
+        _normalise(self.__authority.close, "relationship authority close failed")  # type: ignore[attr-defined]
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
+
+
+def open_event_hypothesis_relationship_authority(
+    database: str | Path,
+    *,
+    retrieval_authority: object,
+    authenticator: object,
+    authorizer: object,
+    command_registry: CommandRegistry,
+    payload_schemas: PayloadSchemaRegistry,
+    clock: Callable[[], UtcTimestamp] = UtcTimestamp.now,
+    busy_timeout_ms: int = 5000,
+) -> EventHypothesisRelationshipAuthority:
+    """Open the checked v22 relationship authority."""
+    from newsroom.increment6._hypothesis_relationship_store import (
+        open_relationship_authority,
+    )
+
+    return _normalise(
+        lambda: EventHypothesisRelationshipAuthority(
+            _FACADE_TOKEN,
+            open_relationship_authority(
+                database,
+                retrieval_authority=retrieval_authority,  # type: ignore[arg-type]
+                authenticator=authenticator,
+                authorizer=authorizer,
+                command_registry=command_registry,
+                payload_schemas=payload_schemas,
+                clock=clock,
+                busy_timeout_ms=busy_timeout_ms,
+            ),
+        ),
+        "relationship authority open failed",
+    )
+
+
+def _relationship_payload_canonicalizer(value: object) -> bytes:
+    raw = _canonical(value, "relationship command payload")
+    assessment = RelationshipAssessment.from_canonical_bytes(raw)
+    if assessment.status is not AssessmentStatus.COMPLETE:
+        raise RelationshipContractError(
+            "relationship command payload must be a complete assessment"
+        )
+    return assessment.canonical_bytes
+
+
+def relationship_payload_contract() -> PayloadSchemaContract:
+    digest = "sha256:" + "0" * 64
+    source = HypothesisSourceBinding(
+        digest,
+        digest,
+        digest,
+        digest,
+        "00000000-0000-4000-8000-000000000001",
+        digest,
+        "00000000-0000-4000-8000-000000000002",
+        digest,
+    )
+    subject = HypothesisVersionBinding(
+        "00000000-0000-4000-8000-000000000003",
+        "00000000-0000-5000-8000-000000000004",
+        digest,
+        digest,
+        (source,),
+    )
+    golden = assess_relationships(
+        subject, ComparatorSetManifest.complete(()), ()
+    ).canonical_value
+    return PayloadSchemaContract(
+        schema_version=HYPOTHESIS_RELATIONSHIP_DECISION,
+        payload_mode=PayloadMode.INLINE,
+        contract_version=RELATIONSHIP_PAYLOAD_CONTRACT_VERSION,
+        canonicalizer_implementation_version=(
+            RELATIONSHIP_PAYLOAD_CANONICALIZER_VERSION
+        ),
+        canonicalizer=_relationship_payload_canonicalizer,
+        golden_vectors=(
+            PayloadGoldenVector(
+                name="complete-no-match",
+                input_identity="relationship-assessment:no-match",
+                value=golden,
+                expected_bytes=_relationship_payload_canonicalizer(golden),
+            ),
+        ),
+    )
+
+
+def relationship_command_definition() -> CommandDefinition:
+    contract = relationship_payload_contract()
+    return CommandDefinition(
+        command_type=RELATIONSHIP_COMMAND_TYPE,
+        definition_version=RELATIONSHIP_COMMAND_DEFINITION_VERSION,
+        aggregate_type=RELATIONSHIP_AGGREGATE_TYPE,
+        event_type=RELATIONSHIP_EVENT_TYPE,
+        event_schema_version=1,
+        payload_mode=PayloadMode.INLINE,
+        payload_schema_version=contract.schema_version,
+        payload_schema_contract_version=contract.contract_version,
+        payload_schema_contract_digest=contract.contract_digest,
+        payload_canonicalizer_version=contract.canonicalizer_implementation_version,
+        trust_scope=TrustScope.ADMITTED,
+        security_scope="authority.relationship",
+        retention_scope="authority.audit",
+        required_scope=RELATIONSHIP_REQUIRED_SCOPE,
+        max_inline_bytes=MAX_RELATIONSHIP_CANONICAL_BYTES,
+    )
+
+
+def merge_relationship_authority_registries(
+    command_registry: CommandRegistry,
+    payload_schemas: PayloadSchemaRegistry,
+) -> tuple[CommandRegistry, PayloadSchemaRegistry]:
+    definition = relationship_command_definition()
+    definitions = list(command_registry.definitions())
+    matches = [
+        item
+        for item in definitions
+        if (item.command_type, item.definition_version)
+        == (definition.command_type, definition.definition_version)
+    ]
+    if matches and matches[0].digest != definition.digest:
+        raise RelationshipContractError("relationship command identity conflicts")
+    if not matches:
+        definitions.append(definition)
+    current_commands = {
+        item.command_type: (
+            RELATIONSHIP_COMMAND_DEFINITION_VERSION
+            if item.command_type == RELATIONSHIP_COMMAND_TYPE
+            else command_registry.resolve(item.command_type).definition_version
+        )
+        for item in definitions
+    }
+    contract = relationship_payload_contract()
+    contracts = list(payload_schemas.contracts())
+    matches_schema = [
+        item
+        for item in contracts
+        if (item.schema_version, item.payload_mode, item.contract_version)
+        == (contract.schema_version, contract.payload_mode, contract.contract_version)
+    ]
+    if matches_schema and matches_schema[0].contract_digest != contract.contract_digest:
+        raise RelationshipContractError("relationship payload identity conflicts")
+    if not matches_schema:
+        contracts.append(contract)
+    current_schemas = {
+        (item.schema_version, item.payload_mode): (
+            RELATIONSHIP_PAYLOAD_CONTRACT_VERSION
+            if item.schema_version == HYPOTHESIS_RELATIONSHIP_DECISION
+            else payload_schemas.resolve(
+                item.schema_version, item.payload_mode
+            ).contract_version
+        )
+        for item in contracts
+    }
+    return (
+        CommandRegistry(definitions, current_versions=current_commands),
+        PayloadSchemaRegistry(contracts, current_versions=current_schemas),
+    )
+
+
 _PRECEDENCE = {
     CanonicalOutcome.REL_CORRECTION_REVERSAL_OF: 0,
     CanonicalOutcome.REL_DEVELOPMENT_OF: 1,
@@ -955,14 +1184,21 @@ __all__ = [
     "HYPOTHESIS_RELATIONSHIP_DECISION",
     "MAX_RELATIONSHIP_CANONICAL_BYTES",
     "RELATED_DISTINCT_THRESHOLD",
+    "RELATIONSHIP_COMMAND_TYPE",
     "RELATIONSHIP_DECISION_REASON",
+    "RELATIONSHIP_EVENT_TYPE",
     "SAME_STATE_THRESHOLD",
     "AssessmentStatus",
     "ComparatorEvidence",
     "ComparatorSetManifest",
+    "EventHypothesisRelationshipAuthority",
     "HypothesisVersionBinding",
     "RelationshipAssessment",
     "RelationshipContractError",
     "assess_relationships",
+    "merge_relationship_authority_registries",
+    "open_event_hypothesis_relationship_authority",
+    "relationship_command_definition",
+    "relationship_payload_contract",
     "verify_relationship_assessment_replay",
 ]

--- a/newsroom/tests/test_increment6d1_hypothesis_migrations.py
+++ b/newsroom/tests/test_increment6d1_hypothesis_migrations.py
@@ -15,6 +15,9 @@ from newsroom.authority.event_hypothesis_migrations import (
     event_hypothesis_backup_paths,
     prepare_event_hypothesis_backup,
 )
+from newsroom.authority.event_hypothesis_relationship_migrations import (
+    EVENT_HYPOTHESIS_RELATIONSHIP_PREDECESSOR_FINGERPRINT,
+)
 from newsroom.authority.migrations import (
     EXPECTED_MIGRATION_HISTORY,
     EXPECTED_SCHEMA_FINGERPRINT,
@@ -33,6 +36,19 @@ def _open(path: str | Path = ":memory:") -> sqlite3.Connection:
 def _fresh(path: str | Path = ":memory:") -> sqlite3.Connection:
     connection = _open(path)
     apply_pending_migrations(connection, applied_at="2042-01-01T00:00:00.000000Z")
+    connection.execute("PRAGMA foreign_keys=OFF")
+    immutable = connection.execute(
+        "SELECT sql FROM sqlite_master WHERE name='immutable_authority_migrations_delete'"
+    ).fetchone()[0]
+    connection.execute("DROP TRIGGER immutable_authority_migrations_delete")
+    connection.execute("DROP TRIGGER retained_event_hypothesis_relationship_delete")
+    connection.execute("DROP TRIGGER immutable_event_hypothesis_relationship_update")
+    connection.execute("DROP TRIGGER event_hypothesis_relationship_coherence")
+    connection.execute("DROP TABLE event_hypothesis_relationship_decisions")
+    connection.execute("DELETE FROM authority_migrations WHERE version=22")
+    connection.execute(immutable)
+    connection.execute("PRAGMA user_version=21")
+    connection.execute("PRAGMA foreign_keys=ON")
     return connection
 
 
@@ -71,13 +87,13 @@ def _history(connection: sqlite3.Connection) -> list[tuple[int, str, str]]:
 
 def test_fresh_v21_has_exact_allocation_history_and_integrity() -> None:
     connection = _fresh()
-    assert SCHEMA_VERSION == 21
-    assert EXPECTED_MIGRATION_HISTORY[-1] == (
+    assert SCHEMA_VERSION == 22
+    assert EXPECTED_MIGRATION_HISTORY[-2] == (
         21,
         EVENT_HYPOTHESIS_MIGRATION_NAME,
         EVENT_HYPOTHESIS_MIGRATION_CHECKSUM,
     )
-    assert _history(connection) == list(EXPECTED_MIGRATION_HISTORY)
+    assert _history(connection) == list(EXPECTED_MIGRATION_HISTORY[:-1])
     assert {
         r[0]
         for r in connection.execute(
@@ -90,7 +106,10 @@ def test_fresh_v21_has_exact_allocation_history_and_integrity() -> None:
     }
     assert connection.execute("PRAGMA foreign_key_check").fetchall() == []
     assert connection.execute("PRAGMA quick_check").fetchall() == [("ok",)]
-    assert schema_fingerprint(connection) == EXPECTED_SCHEMA_FINGERPRINT
+    assert (
+        schema_fingerprint(connection)
+        == EVENT_HYPOTHESIS_RELATIONSHIP_PREDECESSOR_FINGERPRINT
+    )
 
 
 def test_literal_v21_and_predecessor_pins() -> None:
@@ -107,7 +126,7 @@ def test_literal_v21_and_predecessor_pins() -> None:
         == "sha256:42009475669a475af8e3e24bbcd02e6fcd9fbb71a800e18d83624e34e79e5e21"
     )
     assert (
-        EXPECTED_SCHEMA_FINGERPRINT
+        EVENT_HYPOTHESIS_RELATIONSHIP_PREDECESSOR_FINGERPRINT
         == "sha256:d314d06118a25f8a32a0f9d8acb1af5383abd6b30be682cb5f65943ae15c213f"
     )
 
@@ -116,14 +135,14 @@ def test_exact_v20_predecessor_backup_receipt_reuse_and_upgrade(tmp_path: Path) 
     database = tmp_path / "authority.sqlite3"
     connection = _fresh(database)
     _downgrade_to_v20(connection)
-    assert _history(connection) == list(EXPECTED_MIGRATION_HISTORY[:-1])
+    assert _history(connection) == list(EXPECTED_MIGRATION_HISTORY[:-2])
     assert schema_fingerprint(connection) == EVENT_HYPOTHESIS_PREDECESSOR_FINGERPRINT
     backup, digest = event_hypothesis_backup_paths(database)
     receipt = prepare_event_hypothesis_backup(connection, backup)
     assert prepare_event_hypothesis_backup(connection, backup) == receipt
     assert receipt.backup_path == backup and receipt.digest_path == digest
     apply_pending_migrations(connection, applied_at="2042-01-01T00:00:01.000000Z")
-    assert connection.execute("PRAGMA user_version").fetchone() == (21,)
+    assert connection.execute("PRAGMA user_version").fetchone() == (22,)
     assert _history(connection) == list(EXPECTED_MIGRATION_HISTORY)
     assert schema_fingerprint(connection) == EXPECTED_SCHEMA_FINGERPRINT
 
@@ -152,11 +171,11 @@ def test_incomplete_or_tampered_v20_backup_is_rejected(
     with pytest.raises(EventHypothesisBackupError):
         apply_pending_migrations(connection, applied_at="2042-01-01T00:00:01.000000Z")
     assert connection.execute("PRAGMA user_version").fetchone() == (20,)
-    assert _history(connection) == list(EXPECTED_MIGRATION_HISTORY[:-1])
+    assert _history(connection) == list(EXPECTED_MIGRATION_HISTORY[:-2])
     assert schema_fingerprint(connection) == EVENT_HYPOTHESIS_PREDECESSOR_FINGERPRINT
 
 
-def test_direct_v20_apply_requires_prepared_backup_and_v22_rejects(
+def test_direct_v20_apply_requires_prepared_backup_and_v23_rejects(
     tmp_path: Path,
 ) -> None:
     connection = _fresh(tmp_path / "direct.sqlite3")
@@ -166,7 +185,7 @@ def test_direct_v20_apply_requires_prepared_backup_and_v22_rejects(
     assert connection.execute("PRAGMA user_version").fetchone() == (20,)
     assert schema_fingerprint(connection) == EVENT_HYPOTHESIS_PREDECESSOR_FINGERPRINT
     newer = _open()
-    newer.execute("PRAGMA user_version=22")
+    newer.execute("PRAGMA user_version=23")
     with pytest.raises(sqlite3.DatabaseError, match="newer"):
         apply_pending_migrations(newer, applied_at="2042-01-01T00:00:00.000000Z")
 
@@ -190,7 +209,7 @@ def test_injected_v21_failure_rolls_back_exact_v20(
     with pytest.raises(sqlite3.OperationalError):
         apply_pending_migrations(connection, applied_at="2042-01-01T00:00:01.000000Z")
     assert connection.execute("PRAGMA user_version").fetchone() == (20,)
-    assert _history(connection) == list(EXPECTED_MIGRATION_HISTORY[:-1])
+    assert _history(connection) == list(EXPECTED_MIGRATION_HISTORY[:-2])
     assert schema_fingerprint(connection) == before
     assert (
         connection.execute(
@@ -209,11 +228,13 @@ def test_older_file_backed_multihop_retains_each_stage_backup(tmp_path: Path) ->
     _downgrade_to_v19(connection)
     migrations.prepare_pending_migration_backup(connection)
     apply_pending_migrations(connection, applied_at="2042-01-01T00:00:01.000000Z")
-    assert connection.execute("PRAGMA user_version").fetchone() == (21,)
+    assert connection.execute("PRAGMA user_version").fetchone() == (22,)
     assert (tmp_path / "multihop.sqlite3.pre-v20.sqlite3").is_file()
     assert (tmp_path / "multihop.sqlite3.pre-v20.sqlite3.sha256").is_file()
     assert (tmp_path / "multihop.sqlite3.pre-v21.sqlite3").is_file()
     assert (tmp_path / "multihop.sqlite3.pre-v21.sqlite3.sha256").is_file()
+    assert (tmp_path / "multihop.sqlite3.pre-v22.sqlite3").is_file()
+    assert (tmp_path / "multihop.sqlite3.pre-v22.sqlite3.sha256").is_file()
 
 
 def test_v21_sql_guards_are_sensitive() -> None:

--- a/newsroom/tests/test_increment6d2_relationship_migrations.py
+++ b/newsroom/tests/test_increment6d2_relationship_migrations.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from newsroom.authority import migrations
+from newsroom.authority.canonical import digest_canonical
+from newsroom.authority.event_hypothesis_relationship_migrations import (
+    EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION_CHECKSUM,
+    EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION_NAME,
+    EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION_STATEMENTS,
+    EVENT_HYPOTHESIS_RELATIONSHIP_PREDECESSOR_FINGERPRINT,
+    EVENT_HYPOTHESIS_RELATIONSHIP_PREDECESSOR_MIGRATION_CHECKSUM,
+    EVENT_HYPOTHESIS_RELATIONSHIP_SCHEMA_VERSION,
+    EventHypothesisRelationshipBackupError,
+    event_hypothesis_relationship_backup_paths,
+    prepare_event_hypothesis_relationship_backup,
+)
+from newsroom.authority.migrations import (
+    EXPECTED_MIGRATION_HISTORY,
+    EXPECTED_SCHEMA_FINGERPRINT,
+    apply_pending_migrations,
+    schema_fingerprint,
+)
+
+
+def _open(path: str | Path = ":memory:") -> sqlite3.Connection:
+    connection = sqlite3.connect(path, isolation_level=None)
+    connection.execute("PRAGMA foreign_keys=ON")
+    return connection
+
+
+def _fresh(path: str | Path = ":memory:") -> sqlite3.Connection:
+    connection = _open(path)
+    apply_pending_migrations(connection, applied_at="2042-01-01T00:00:00.000000Z")
+    return connection
+
+
+def _downgrade_to_v21(connection: sqlite3.Connection) -> None:
+    connection.execute("PRAGMA foreign_keys=OFF")
+    guard = connection.execute(
+        "SELECT sql FROM sqlite_master WHERE name='immutable_authority_migrations_delete'"
+    ).fetchone()[0]
+    connection.execute("DROP TRIGGER immutable_authority_migrations_delete")
+    connection.execute("DROP TRIGGER retained_event_hypothesis_relationship_delete")
+    connection.execute("DROP TRIGGER immutable_event_hypothesis_relationship_update")
+    connection.execute("DROP TRIGGER event_hypothesis_relationship_coherence")
+    connection.execute("DROP TABLE event_hypothesis_relationship_decisions")
+    connection.execute("DELETE FROM authority_migrations WHERE version=22")
+    connection.execute(guard)
+    connection.execute("PRAGMA user_version=21")
+    connection.execute("PRAGMA foreign_keys=ON")
+
+
+def test_fresh_v22_has_exact_single_table_history_and_pins() -> None:
+    connection = _fresh()
+    assert (
+        EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION_CHECKSUM
+        == "sha256:e59eb222a95e2901ccaae29ce1b9e8eded797306e9796718a6d2c4fa505a6636"
+    )
+    assert (
+        EXPECTED_SCHEMA_FINGERPRINT
+        == "sha256:2118fa893fb7fd2911bbde3056b79b1d0e26ccd6903e1c4228616f342898eaad"
+    )
+    assert EXPECTED_MIGRATION_HISTORY[-1] == (
+        22,
+        EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION_NAME,
+        EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION_CHECKSUM,
+    )
+    assert (
+        EVENT_HYPOTHESIS_RELATIONSHIP_PREDECESSOR_MIGRATION_CHECKSUM
+        == "sha256:42009475669a475af8e3e24bbcd02e6fcd9fbb71a800e18d83624e34e79e5e21"
+    )
+    assert (
+        EVENT_HYPOTHESIS_RELATIONSHIP_PREDECESSOR_FINGERPRINT
+        == "sha256:d314d06118a25f8a32a0f9d8acb1af5383abd6b30be682cb5f65943ae15c213f"
+    )
+    assert connection.execute("PRAGMA user_version").fetchone() == (22,)
+    assert connection.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'event_hypothesis_relationship%'"
+    ).fetchall() == [("event_hypothesis_relationship_decisions",)]
+    assert schema_fingerprint(connection) == EXPECTED_SCHEMA_FINGERPRINT
+
+
+def test_v22_migration_pin_detects_one_byte_statement_drift() -> None:
+    drifted = list(EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION_STATEMENTS)
+    drifted[-1] += " "
+    assert (
+        digest_canonical(
+            {
+                "version": EVENT_HYPOTHESIS_RELATIONSHIP_SCHEMA_VERSION,
+                "name": EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION_NAME,
+                "statements": drifted,
+            }
+        )
+        != EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION_CHECKSUM
+    )
+
+
+def test_exact_v21_backup_upgrade_and_injected_rollback(
+    tmp_path: Path, monkeypatch
+) -> None:
+    database = tmp_path / "authority.sqlite3"
+    connection = _fresh(database)
+    _downgrade_to_v21(connection)
+    assert (
+        schema_fingerprint(connection)
+        == EVENT_HYPOTHESIS_RELATIONSHIP_PREDECESSOR_FINGERPRINT
+    )
+    backup, digest = event_hypothesis_relationship_backup_paths(database)
+    receipt = prepare_event_hypothesis_relationship_backup(connection, backup)
+    assert receipt.backup_path == backup and receipt.digest_path == digest
+    monkeypatch.setattr(
+        migrations,
+        "EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION_STATEMENTS",
+        migrations.EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION_STATEMENTS
+        + ("CREATE TABLE injected_failure(",),
+    )
+    with pytest.raises(sqlite3.OperationalError):
+        apply_pending_migrations(connection, applied_at="2042-01-01T00:00:01.000000Z")
+    assert connection.execute("PRAGMA user_version").fetchone() == (21,)
+    assert (
+        schema_fingerprint(connection)
+        == EVENT_HYPOTHESIS_RELATIONSHIP_PREDECESSOR_FINGERPRINT
+    )
+    monkeypatch.undo()
+    apply_pending_migrations(connection, applied_at="2042-01-01T00:00:01.000000Z")
+    assert connection.execute("PRAGMA user_version").fetchone() == (22,)
+
+
+def test_v21_backup_required_and_v23_fails_closed(tmp_path: Path) -> None:
+    connection = _fresh(tmp_path / "authority.sqlite3")
+    _downgrade_to_v21(connection)
+    with pytest.raises(EventHypothesisRelationshipBackupError, match="prepared backup"):
+        apply_pending_migrations(connection, applied_at="2042-01-01T00:00:01.000000Z")
+    newer = _open()
+    newer.execute("PRAGMA user_version=23")
+    with pytest.raises(sqlite3.DatabaseError, match="newer"):
+        apply_pending_migrations(newer, applied_at="2042-01-01T00:00:00.000000Z")

--- a/newsroom/tests/test_increment6d2_relationship_store.py
+++ b/newsroom/tests/test_increment6d2_relationship_store.py
@@ -1,0 +1,1087 @@
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import uuid
+from collections.abc import Callable
+from dataclasses import replace
+from pathlib import Path
+from typing import ClassVar
+
+import pytest
+
+from newsroom.authority.auth import AuthenticationProof, StaticAuthorizer
+from newsroom.authority.migrations import (
+    apply_pending_migrations,
+    prepare_pending_migration_backup,
+)
+from newsroom.authority.persistence import AuthoritySchemaError
+from newsroom.authority.types import UtcTimestamp
+from newsroom.checks.policy import merge_discovery_check_authority_registries
+from newsroom.discovery.policy import merge_discovery_signal_lead_registries
+from newsroom.increment6._hypothesis_relationship_store import (
+    _open_unlocked_relationship_authority_for_test,
+)
+from newsroom.increment6.dispositions import ProposalDispositionStore
+from newsroom.increment6.outcomes import (
+    CanonicalNextAction,
+    CanonicalOutcome,
+    ReasonCode,
+)
+from newsroom.increment6.relationships import (
+    ComparatorEvidence,
+    ComparatorSetManifest,
+    EventHypothesisRelationshipAuthority,
+    HypothesisVersionBinding,
+    RelationshipContractError,
+    assess_relationships,
+    open_event_hypothesis_relationship_authority,
+    relationship_command_definition,
+)
+from newsroom.increment6.work_items import (
+    DecisionLeadBinding,
+    RetrievalContextAuthority,
+    RetrievalInputBinding,
+    TriageWorkItem,
+    TriageWorkItemStore,
+)
+from newsroom.sources.policy import merge_source_registry_authority_registries
+from newsroom.tests import test_increment6c2_dispositions as disposition_helpers
+from newsroom.tests import test_increment6d1_hypothesis_store as hypothesis_helpers
+from newsroom.tests.authority_event_helpers import payload_schemas, registry_v1
+from newsroom.tests.authority_store_conformance import (
+    CASE_INVENTORY,
+    Applicability,
+    AuthorityValue,
+    BindingConflict,
+    CaseId,
+    IntegrityViolation,
+    LostResponse,
+    RollbackScope,
+    StoredAuthorityState,
+    TamperKind,
+    WriteCommand,
+    run_conformance,
+)
+from newsroom.tests.discovery_3d_authority_helpers import (
+    exact_admission_request,
+    open_discovery_system,
+    seed_check_lineage,
+)
+from newsroom.tests.discovery_3d_authority_helpers import (
+    proof as discovery_proof,
+)
+from newsroom.tests.test_increment5d1_hybrid_composer import branch_inputs
+from newsroom.tests.test_increment5d2_retrieval_context import (
+    _retained_complete_context,
+)
+
+
+def _independent_version(fixture, label: str):
+    connection, retrieval, authenticator, proof, *_, receipt, sources = fixture
+    version, decision = sources.pop(0)
+    document = json.loads(
+        disposition_helpers._persistable_proposal(version, decision, receipt)
+    )
+    document["proposal"]["proposal_id"] = str(uuid.uuid4())
+    document["proposal"]["recommendations"][0]["hypothesis"]["proposal_local_id"] = (
+        label
+    )
+    raw = disposition_helpers._resign(document)
+    selection = disposition_helpers._selection(
+        CanonicalOutcome.LEAD_ADMIT_NEW_CANDIDATE,
+        CanonicalNextAction.HANDOFF_FOR_EVALUATION,
+        ReasonCode.NOVELTY_LIKELY_NEW_EVENT,
+    )
+    dispositions = ProposalDispositionStore(
+        connection, retrieval, authenticator
+    ).persist(raw, {decision.lead_id: selection}, proof=proof)
+    authority = hypothesis_helpers._open(fixture)
+    try:
+        return authority.retain(raw, dispositions, proof=proof)
+    finally:
+        authority.close()
+
+
+def _downgrade_checked_v22_to_v21(database: Path) -> None:
+    target = sqlite3.connect(database, isolation_level=None)
+    target.execute("PRAGMA foreign_keys=OFF")
+    guard = target.execute(
+        "SELECT sql FROM sqlite_master WHERE name='immutable_authority_migrations_delete'"
+    ).fetchone()[0]
+    target.execute("DROP TRIGGER immutable_authority_migrations_delete")
+    for trigger in (
+        "retained_event_hypothesis_relationship_delete",
+        "immutable_event_hypothesis_relationship_update",
+        "event_hypothesis_relationship_coherence",
+    ):
+        target.execute(f"DROP TRIGGER {trigger}")
+    target.execute("DROP TABLE event_hypothesis_relationship_decisions")
+    target.execute("DELETE FROM authority_migrations WHERE version=22")
+    target.execute(guard)
+    target.execute("PRAGMA user_version=21")
+    target.execute("PRAGMA foreign_keys=ON")
+    target.close()
+    os.chmod(database, 0o600)
+
+
+def _collaborators(fixture):
+    definition = relationship_command_definition()
+    commands, schemas = merge_source_registry_authority_registries(
+        command_registry=registry_v1(), payload_schemas=payload_schemas()
+    )
+    commands, schemas = merge_discovery_check_authority_registries(
+        command_registry=commands, payload_schemas=schemas
+    )
+    commands, schemas = merge_discovery_signal_lead_registries(
+        command_registry=commands, payload_schemas=schemas
+    )
+    authorizer = StaticAuthorizer(
+        policy_version="relationship-test-v1",
+        grants_by_principal={
+            "editor": frozenset({definition.required_scope}),
+            "other": frozenset({definition.required_scope}),
+        },
+    )
+    return commands, schemas, authorizer
+
+
+def _assessment(subject, comparator, outcome: str = "REL_UNCERTAIN", salt: int = 0):
+    subject_binding = HypothesisVersionBinding.from_version(subject)
+    comparator_binding = HypothesisVersionBinding.from_version(comparator)
+    scores = {
+        "REL_SAME_STATE": (80, 0, 0, 80, 0),
+        "REL_DEVELOPMENT_OF": (80, 0, 75, 0, 0),
+        "REL_CORRECTION_REVERSAL_OF": (80, 80, 0, 0, 0),
+        "REL_RELATED_DISTINCT": (80, 0, 0, 0, 60),
+        "REL_NO_ADEQUATE_PRIOR_MATCH": (0, 0, 0, 0, 0),
+        "REL_UNCERTAIN": (60 + salt % 40, salt % 60, 0, 0, 0),
+    }[outcome]
+    evidence = ComparatorEvidence(subject_binding, comparator_binding, *scores)
+    assessment = assess_relationships(
+        subject_binding,
+        ComparatorSetManifest.complete((comparator_binding,)),
+        (evidence,),
+    )
+    return assessment, (evidence.canonical_bytes,)
+
+
+_SEED_CACHE = None
+
+
+def _seed_location(root: Path, *, subjects: int = 6):
+    global _SEED_CACHE
+    root.mkdir(mode=0o700)
+    database = root / "relationship-authority.sqlite3"
+    if _SEED_CACHE is not None:
+        database.write_bytes(_SEED_CACHE[0])
+        os.chmod(database, 0o600)
+        fixture, comparator, versions, commands, schemas, authorizer, append = (
+            _SEED_CACHE[1:]
+        )
+        return (
+            fixture,
+            database,
+            comparator,
+            versions,
+            commands,
+            schemas,
+            authorizer,
+            append,
+        )
+    inputs = branch_inputs.__wrapped__(root)
+    builder, _, _, _, _, request, receipt, _ = _retained_complete_context(
+        root, inputs, name="relationship-authority"
+    )
+    retrieval = RetrievalContextAuthority(
+        builder.journal.path, {request.request_digest: (request, receipt)}
+    )
+    decisions = []
+    with open_discovery_system(database) as discovery:
+        seed_check_lineage(discovery)
+        for index in range(subjects + 2):
+            admission = exact_admission_request()
+            suffix = str(uuid.uuid4())
+            gate_id = type(admission.gate.decision_id).parse(str(uuid.uuid4()))
+            signal_id = type(admission.signal.signal_id).parse(str(uuid.uuid4()))
+            lead_id = type(admission.lead.lead_id).parse(suffix)
+            disposition_id = type(admission.initial_disposition.decision_id).parse(
+                str(uuid.uuid4())
+            )
+            admission = __import__("dataclasses").replace(
+                admission,
+                signal=__import__("dataclasses").replace(
+                    admission.signal,
+                    signal_id=signal_id,
+                    discriminator=f"relationship-{index}",
+                    idempotency_key=f"relationship-signal-{index}",
+                ),
+                gate=__import__("dataclasses").replace(
+                    admission.gate,
+                    decision_id=gate_id,
+                    signal_id=signal_id,
+                    idempotency_key=f"relationship-gate-{index}",
+                ),
+                lead=__import__("dataclasses").replace(
+                    admission.lead,
+                    lead_id=lead_id,
+                    signal_id=signal_id,
+                    promoting_gate_decision_id=gate_id,
+                    idempotency_key=f"relationship-lead-{index}",
+                ),
+                initial_disposition=__import__("dataclasses").replace(
+                    admission.initial_disposition,
+                    decision_id=disposition_id,
+                    lead_id=lead_id,
+                    gate_decision_id=gate_id,
+                    idempotency_key=f"relationship-disposition-{index}",
+                ),
+            )
+            admitted = discovery.discovery.admit_signal_to_lead(
+                admission, proof=discovery_proof()
+            )
+            decisions.append(
+                DecisionLeadBinding.from_authority(
+                    admitted.lead, admitted.initial_disposition
+                )
+            )
+    connection = sqlite3.connect(database, isolation_level=None)
+    connection.execute("PRAGMA foreign_keys=ON")
+    authenticator = hypothesis_helpers.StaticAuthenticator(
+        credentials={
+            "credential": hypothesis_helpers.StaticPrincipal("editor"),
+            "other": hypothesis_helpers.StaticPrincipal("other"),
+        },
+        authority_domain="newsroom.dispositions",
+    )
+    proof = AuthenticationProof(method="STATIC_TOKEN", credential="credential")
+    work_items = TriageWorkItemStore(connection, retrieval)
+    versions = []
+    items = []
+    work_versions = []
+    hypotheses = hypothesis_helpers._HypothesisStore(
+        connection,
+        retrieval,
+        authenticator,
+        lambda: UtcTimestamp.parse("2042-01-01T00:00:00.000000Z"),
+    )
+    for index, decision in enumerate(decisions):
+        item = TriageWorkItem.create((decision,))
+        items.append(item)
+        work_version = __import__("dataclasses").replace(
+            hypothesis_helpers.work_item_helpers._version(item),
+            retrieval=RetrievalInputBinding.from_receipt(request, receipt),
+        )
+        work_items.create_or_replay(item, work_version)
+        work_versions.append(work_version)
+        if index == subjects + 1:
+            continue
+        proposal_document = json.loads(
+            disposition_helpers._persistable_proposal(work_version, decision, receipt)
+        )
+        proposal_document["proposal"]["proposal_id"] = str(uuid.uuid4())
+        proposal_document["proposal"]["recommendations"][0]["hypothesis"][
+            "proposal_local_id"
+        ] = f"relationship-{index}"
+        proposal = disposition_helpers._resign(proposal_document)
+        dispositions = ProposalDispositionStore(
+            connection, retrieval, authenticator
+        ).persist(
+            proposal,
+            {
+                decision.lead_id: disposition_helpers._selection(
+                    CanonicalOutcome.LEAD_ADMIT_NEW_CANDIDATE,
+                    CanonicalNextAction.HANDOFF_FOR_EVALUATION,
+                    ReasonCode.NOVELTY_LIKELY_NEW_EVENT,
+                )
+            },
+            proof=proof,
+        )
+        versions.append(hypotheses.retain(proposal, dispositions, proof=proof))
+    authority_advance = hypothesis_helpers._targeted_proposal(
+        (
+            connection,
+            retrieval,
+            authenticator,
+            proof,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            receipt,
+            [(work_versions[-1], decisions[-1])],
+        ),
+        proposal_id=str(uuid.uuid4()),
+        local_id="relationship-currentness-advance",
+        relationship="DEVELOPMENT_OF",
+        target=versions[1].hypothesis_id,
+    )
+    upstream_advances = {
+        "authority": authority_advance,
+        "policy": (items[1], work_versions[1]),
+    }
+    connection.close()
+    comparator, *subject_versions = versions
+    fixture = (None, retrieval, authenticator, proof)
+    versions = tuple(subject_versions[:subjects])
+    _downgrade_checked_v22_to_v21(database)
+    commands, schemas, authorizer = _collaborators(fixture)
+    _SEED_CACHE = (
+        database.read_bytes(),
+        fixture,
+        comparator,
+        versions,
+        commands,
+        schemas,
+        authorizer,
+        upstream_advances,
+    )
+    return (
+        fixture,
+        database,
+        comparator,
+        versions,
+        commands,
+        schemas,
+        authorizer,
+        upstream_advances,
+    )
+
+
+def _open_arguments(seed) -> dict[str, object]:
+    fixture, database, _, _, commands, schemas, authorizer, _ = seed
+    return {
+        "database": database,
+        "retrieval_authority": fixture[1],
+        "authenticator": fixture[2],
+        "authorizer": authorizer,
+        "command_registry": commands,
+        "payload_schemas": schemas,
+        "clock": lambda: UtcTimestamp.parse("2042-01-02T00:00:00.000000Z"),
+    }
+
+
+def _open(seed):
+    return open_event_hypothesis_relationship_authority(**_open_arguments(seed))
+
+
+def _open_unlocked_for_test(seed):
+    return _open_unlocked_relationship_authority_for_test(**_open_arguments(seed))
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    (
+        "REL_SAME_STATE",
+        "REL_DEVELOPMENT_OF",
+        "REL_CORRECTION_REVERSAL_OF",
+        "REL_RELATED_DISTINCT",
+        "REL_NO_ADEQUATE_PRIOR_MATCH",
+        "REL_UNCERTAIN",
+    ),
+)
+def test_six_outcomes_anchor_exact_ledger_and_replay(tmp_path, outcome) -> None:
+    seed = _seed_location(tmp_path / outcome)
+    assessment, evidence = _assessment(seed[3][0], seed[2], outcome)
+    authority = _open(seed)
+    retained = authority.retain(assessment.canonical_bytes, evidence, proof=seed[0][3])
+    assert (
+        authority.retain(assessment.canonical_bytes, evidence, proof=seed[0][3])
+        == retained
+    )
+    assert authority.load(retained.canonical_digest) == retained
+    authority.close()
+    connection = sqlite3.connect(seed[1])
+    row = connection.execute(
+        "SELECT authority_aggregate_id,authority_event_id,subject_version_id FROM event_hypothesis_relationship_decisions"
+    ).fetchone()
+    assert row[2] == assessment.subject.version_id
+    assert connection.execute(
+        "SELECT aggregate_id,event_type FROM ledger_events WHERE event_id=?", (row[1],)
+    ).fetchone() == (row[0], "event_hypothesis_relationship_decision_retained")
+    assert connection.execute("PRAGMA foreign_key_check").fetchall() == []
+
+
+def test_factory_lock_facade_and_self_consistent_rewrite_fail_closed(tmp_path) -> None:
+    seed = _seed_location(tmp_path / "guards")
+    assessment, evidence = _assessment(seed[3][0], seed[2])
+    authority = _open(seed)
+    with pytest.raises(RelationshipContractError):
+        _open(seed)
+
+    with pytest.raises(RelationshipContractError):
+        EventHypothesisRelationshipAuthority(object(), object())
+
+    class FakeStore:
+        constructed = False
+
+        def __init__(self, *_: object, **__: object) -> None:
+            type(self).constructed = True
+
+    with pytest.raises(TypeError):
+        open_event_hypothesis_relationship_authority(
+            **_open_arguments(seed), store_type=FakeStore
+        )
+    assert not FakeStore.constructed
+    authority.retain(assessment.canonical_bytes, evidence, proof=seed[0][3])
+    authority.close()
+    reopened = _open(seed)
+    assert reopened.load(assessment.canonical_digest) == assessment
+    reopened.close()
+    lock_path = seed[1].with_name(seed[1].name + ".writer.lock")
+    lock_path.chmod(0o644)
+    with pytest.raises(RelationshipContractError):
+        _open(seed)
+    assert lock_path.stat().st_mode & 0o777 == 0o644
+    lock_path.chmod(0o600)
+    connection = sqlite3.connect(seed[1], isolation_level=None)
+    connection.execute("PRAGMA foreign_keys=OFF")
+    connection.execute("DROP TRIGGER immutable_event_hypothesis_relationship_update")
+    connection.execute(
+        "UPDATE event_hypothesis_relationship_decisions SET actor_identity_digest=?,assessment_bytes=?,assessment_digest=?,decision_id=?",
+        (
+            "sha256:" + "0" * 64,
+            assessment.canonical_bytes,
+            assessment.canonical_digest,
+            assessment.canonical_digest,
+        ),
+    )
+    connection.execute("PRAGMA foreign_keys=ON")
+    connection.close()
+    with pytest.raises(RelationshipContractError):
+        _open(seed)
+
+
+class _Location:
+    def __init__(self, seed) -> None:
+        self.seed = seed
+        ids = (
+            "record-1",
+            "record-2",
+            "record-a",
+            "record-b",
+            "record-rollback-normal",
+            "record-rollback-abort",
+        )
+        self.subjects = dict(zip(ids, seed[3], strict=True))
+        self.subjects["record-b"] = self.subjects["record-a"]
+
+
+def _generic(
+    record_id: str, predecessor: str | None = None, value: str | None = None
+) -> WriteCommand:
+    predecessor = predecessor or ("record-1" if record_id == "record-2" else "record-0")
+    value = value or ("beta" if record_id in {"record-2", "record-b"} else "alpha")
+    return WriteCommand(
+        record_id=record_id,
+        canonical_bytes=f'{{"value":"{value}"}}'.encode(),
+        scalar_columns={"value": value, "version": 1},
+        identity_columns={"record_id": record_id, "authority": "fixture"},
+        linked_rows=(
+            {"child_id": f"child-{record_id}", "record_id": record_id, "ordinal": 0},
+        ),
+        actor="actor-1",
+        request=f"request-{record_id}",
+        idempotency=f"idempotency-{record_id}",
+        cas_predecessor=predecessor,
+        required_upstream_heads=(
+            ("authority", "authority-head-1"),
+            ("policy", "policy-head-1"),
+        ),
+    )
+
+
+_RECORD_VALUES = (
+    ("record-1", "alpha"),
+    ("record-2", "beta"),
+    ("record-a", "alpha"),
+    ("record-b", "beta"),
+    ("record-rollback-normal", "alpha"),
+    ("record-rollback-abort", "alpha"),
+)
+_REQUEST_VALUES = ("different-request",) + tuple(
+    f"request-{record_id}" for record_id, _ in _RECORD_VALUES
+)
+_IDEMPOTENCY_VALUES = ("different-idempotency",) + tuple(
+    f"idempotency-{record_id}" for record_id, _ in _RECORD_VALUES
+)
+_CAS_VALUES = ("different-cas_predecessor", "record-0", "record-1")
+_UPSTREAM_VALUES = ((("authority", "authority-head-1"), ("policy", "policy-head-1")),)
+_ACTOR_PROOFS = {
+    "actor-1": AuthenticationProof(method="STATIC_TOKEN", credential="credential"),
+    "different-actor": AuthenticationProof(method="STATIC_TOKEN", credential="other"),
+}
+_PRINCIPAL_ACTORS = {"editor": "actor-1", "other": "different-actor"}
+
+
+def _code(values: tuple, value: object, field: str) -> int:
+    try:
+        return values.index(value)
+    except ValueError as exc:
+        raise RelationshipContractError(
+            f"unsupported conformance {field} binding"
+        ) from exc
+
+
+def _binding_assessment(location: _Location, command: WriteCommand):
+    value = command.scalar_columns.get("value")
+    record_code = _code(_RECORD_VALUES, (command.record_id, value), "record")
+    base = _generic(command.record_id, command.cas_predecessor, value)
+    if (
+        command.canonical_bytes != base.canonical_bytes
+        or command.scalar_columns != base.scalar_columns
+        or command.identity_columns != base.identity_columns
+        or command.linked_rows != base.linked_rows
+    ):
+        raise RelationshipContractError("unsupported conformance representation")
+    request_code = _code(_REQUEST_VALUES, command.request, "request")
+    idempotency_code = _code(_IDEMPOTENCY_VALUES, command.idempotency, "idempotency")
+    cas_code = _code(_CAS_VALUES, command.cas_predecessor, "CAS predecessor")
+    upstream_code = _code(_UPSTREAM_VALUES, command.required_upstream_heads, "upstream")
+    if command.actor not in _ACTOR_PROOFS:
+        raise RelationshipContractError("unsupported conformance actor binding")
+    subject = HypothesisVersionBinding.from_version(
+        location.subjects[command.record_id]
+    )
+    comparator = HypothesisVersionBinding.from_version(location.seed[2])
+    evidence = ComparatorEvidence(
+        subject,
+        comparator,
+        60 + request_code,
+        idempotency_code,
+        cas_code,
+        record_code,
+        upstream_code,
+    )
+    assessment = assess_relationships(
+        subject,
+        ComparatorSetManifest.complete((comparator,)),
+        (evidence,),
+    )
+    return assessment, (evidence.canonical_bytes,)
+
+
+class _Handle:
+    def __init__(self, location: _Location) -> None:
+        self.location = location
+        self.authority = None
+        self.open_error: Exception | None = None
+        try:
+            self.authority = _open_unlocked_for_test(location.seed)
+        except Exception as exc:
+            if not isinstance(exc, AuthoritySchemaError):
+                raise
+            self.open_error = exc
+
+    def _opened(self):
+        if self.open_error is not None:
+            raise IntegrityViolation(
+                "relationship authority open failed"
+            ) from self.open_error
+        assert self.authority is not None
+        return self.authority
+
+    def _domain(self, command: WriteCommand):
+        return _binding_assessment(self.location, command)
+
+    def _decision_id(self, command: WriteCommand) -> str:
+        assessment, _ = self._domain(command)
+        return assessment.canonical_digest
+
+    def _decode_command(
+        self, decision_id: str, *, connection: sqlite3.Connection | None = None
+    ) -> WriteCommand:
+        owned_connection = connection is None
+        if connection is None:
+            connection = sqlite3.connect(self.location.seed[1])
+        try:
+            row = connection.execute(
+                "SELECT r.subject_version_id,r.evidence_bytes,a.principal_id "
+                "FROM event_hypothesis_relationship_decisions r "
+                "JOIN ledger_events e ON e.event_id=r.authority_event_id "
+                "JOIN authority_commands c ON c.command_id=e.command_id "
+                "JOIN authentication_contexts a ON a.authentication_context_id="
+                "c.authentication_context_id WHERE r.decision_id=?",
+                (decision_id,),
+            ).fetchone()
+            if row is None:
+                raise RelationshipContractError("unknown conformance decision")
+            evidence_values = json.loads(bytes(row[1]))
+            if type(evidence_values) is not list or len(evidence_values) != 1:
+                raise RelationshipContractError("conformance evidence binding differs")
+            evidence = ComparatorEvidence.from_value(evidence_values[0])
+            request_code = evidence.score - 60
+            record_code = evidence.same_state_score
+            upstream_code = evidence.related_distinct_score
+            codes = (
+                (request_code, len(_REQUEST_VALUES)),
+                (record_code, len(_RECORD_VALUES)),
+                (
+                    evidence.correction_reversal_score,
+                    len(_IDEMPOTENCY_VALUES),
+                ),
+                (evidence.development_score, len(_CAS_VALUES)),
+                (upstream_code, len(_UPSTREAM_VALUES)),
+            )
+            if any(code < 0 or code >= size for code, size in codes):
+                raise RelationshipContractError("conformance authority binding differs")
+            try:
+                record_id, value = _RECORD_VALUES[record_code]
+                request = _REQUEST_VALUES[request_code]
+                idempotency = _IDEMPOTENCY_VALUES[evidence.correction_reversal_score]
+                predecessor = _CAS_VALUES[evidence.development_score]
+                upstream = _UPSTREAM_VALUES[upstream_code]
+                actor = _PRINCIPAL_ACTORS[str(row[2])]
+            except (IndexError, KeyError) as exc:
+                raise RelationshipContractError(
+                    "conformance authority binding differs"
+                ) from exc
+            if self.location.subjects[record_id].version_id != str(row[0]):
+                raise RelationshipContractError("conformance subject binding differs")
+            return replace(
+                _generic(record_id, predecessor, value),
+                actor=actor,
+                request=request,
+                idempotency=idempotency,
+                required_upstream_heads=upstream,
+            )
+        finally:
+            if owned_connection:
+                connection.close()
+
+    def submit(
+        self, command: WriteCommand, *, lose_response: bool = False
+    ) -> AuthorityValue:
+        try:
+            assessment, evidence = self._domain(command)
+            proof = _ACTOR_PROOFS[command.actor]
+        except (KeyError, RelationshipContractError) as exc:
+            raise BindingConflict(command.record_id) from exc
+        try:
+            retained = self._opened().retain(
+                assessment.canonical_bytes, evidence, proof=proof
+            )
+        except Exception as exc:
+            retained = self._subject_row(command.record_id)
+            if retained is not None:
+                try:
+                    self._opened().load(str(retained[0]))
+                except Exception as integrity_exc:
+                    raise IntegrityViolation(command.record_id) from integrity_exc
+                raise BindingConflict(command.record_id) from exc
+            raise IntegrityViolation(command.record_id) from exc
+        if lose_response:
+            raise LostResponse(command.record_id)
+        return AuthorityValue.from_command(
+            self._decode_command(retained.canonical_digest)
+        )
+
+    def _row(self, record_id: str):
+        decision_id = self._decision_id(_generic(record_id))
+        connection = sqlite3.connect(self.location.seed[1])
+        row = connection.execute(
+            "SELECT decision_id FROM event_hypothesis_relationship_decisions "
+            "WHERE decision_id=?",
+            (decision_id,),
+        ).fetchone()
+        connection.close()
+        return row
+
+    def _subject_row(self, record_id: str):
+        subject = self.location.subjects[record_id]
+        connection = sqlite3.connect(self.location.seed[1])
+        row = connection.execute(
+            "SELECT decision_id FROM event_hypothesis_relationship_decisions "
+            "WHERE subject_version_id=?",
+            (subject.version_id,),
+        ).fetchone()
+        connection.close()
+        return row
+
+    def observe(self, record_id: str):
+        row = self._subject_row(record_id)
+        if row is None:
+            return None
+        try:
+            self._opened().load(str(row[0]))
+            command = self._decode_command(str(row[0]))
+        except Exception as exc:
+            raise IntegrityViolation(record_id) from exc
+        if command.record_id != record_id:
+            return None
+        return StoredAuthorityState.from_command(command)
+
+    def history(self):
+        try:
+            retained = self._opened().history()
+        except Exception as exc:
+            raise IntegrityViolation("history") from exc
+        return tuple(
+            AuthorityValue.from_command(self._decode_command(item.canonical_digest))
+            for item in retained
+        )
+
+    def read(self, record_id):
+        row = self._subject_row(record_id)
+        state = self.observe(record_id)
+        if row is None or state is None:
+            raise KeyError(record_id)
+        return AuthorityValue.from_command(self._decode_command(str(row[0])))
+
+    list_history = history
+
+    def set_upstream_head(self, authority, value):
+        if value.endswith("head-1") or self._row("record-1") is None:
+            return
+        subject = self.location.subjects["record-1"]
+        connection = sqlite3.connect(self.location.seed[1], isolation_level=None)
+        try:
+            if authority == "authority":
+                fixture = (connection, *self.location.seed[0][1:])
+                proposal, dispositions = self.location.seed[7]["authority"]
+                upstream = hypothesis_helpers._open(fixture)
+                try:
+                    upstream.retain(
+                        proposal,
+                        dispositions,
+                        proof=self.location.seed[0][3],
+                        expected_target_version=subject,
+                    )
+                finally:
+                    upstream.close()
+            elif authority == "policy":
+                item, current = self.location.seed[7]["policy"]
+                successor = replace(
+                    hypothesis_helpers.work_item_helpers._version(item, 2),
+                    retrieval=current.retrieval,
+                )
+                TriageWorkItemStore(
+                    connection, self.location.seed[0][1]
+                ).append_version(
+                    current.version_id, current.canonical_digest, successor
+                )
+            else:
+                raise IntegrityViolation("unsupported upstream authority")
+        finally:
+            connection.close()
+
+    def current_use(self, record_id):
+        row = self._subject_row(record_id)
+        try:
+            self._opened().current(str(row[0]), proof=self.location.seed[0][3])
+        except Exception as exc:
+            raise IntegrityViolation(record_id) from exc
+        return AuthorityValue.from_command(self._decode_command(str(row[0])))
+
+    def tamper(self, record_id, kind):
+        row = self._row(record_id)
+        connection = sqlite3.connect(self.location.seed[1], isolation_level=None)
+        connection.execute(
+            "DROP TRIGGER IF EXISTS immutable_event_hypothesis_relationship_update"
+        )
+        column, value = {
+            TamperKind.CANONICAL: ("assessment_bytes", b"{}"),
+            TamperKind.SCALAR: ("decision", "REL_SAME_STATE"),
+            TamperKind.IDENTITY: ("subject_version_digest", "sha256:" + "0" * 64),
+            TamperKind.LINKED_ROW: ("evidence_bytes", b"[]"),
+            TamperKind.DIGEST: ("assessment_digest", "sha256:" + "0" * 64),
+            TamperKind.PROVENANCE: ("actor_identity_digest", "sha256:" + "0" * 64),
+            TamperKind.OFFLINE_REWRITE: ("authority_aggregate_id", str(uuid.uuid4())),
+        }[kind]
+        if kind is TamperKind.DIGEST:
+            connection.execute(
+                "UPDATE event_hypothesis_relationship_decisions SET decision_id=?,assessment_digest=? WHERE decision_id=?",
+                (value, value, row[0]),
+            )
+        else:
+            connection.execute(
+                f"UPDATE event_hypothesis_relationship_decisions SET {column}=? WHERE decision_id=?",
+                (value, row[0]),
+            )
+        connection.close()
+
+    def rollback_scope(self, operation: Callable[[RollbackScope], None]) -> None:
+        store = self._opened()._EventHypothesisRelationshipAuthority__store
+
+        class Scope:
+            def submit(_, command):
+                assessment, evidence = self._domain(command)
+                retained = transaction.retain(
+                    assessment.canonical_bytes,
+                    evidence,
+                    proof=_ACTOR_PROOFS[command.actor],
+                )
+                return AuthorityValue.from_command(
+                    self._decode_command(
+                        retained.canonical_digest,
+                        connection=transaction._store._connection,
+                    )
+                )
+
+            def observe(_, record_id):
+                row = transaction._store._connection.execute(
+                    "SELECT decision_id FROM event_hypothesis_relationship_decisions "
+                    "WHERE subject_version_id=?",
+                    (self.location.subjects[record_id].version_id,),
+                ).fetchone()
+                if row is None:
+                    return None
+                try:
+                    transaction.load(str(row[0]))
+                except RelationshipContractError:
+                    return None
+                command = self._decode_command(
+                    str(row[0]), connection=transaction._store._connection
+                )
+                if command.record_id != record_id:
+                    return None
+                return StoredAuthorityState.from_command(command)
+
+            def history(_):
+                return tuple(
+                    AuthorityValue.from_command(
+                        self._decode_command(
+                            item.canonical_digest,
+                            connection=transaction._store._connection,
+                        )
+                    )
+                    for item in transaction.history()
+                )
+
+        def inspect(transaction_scope):
+            nonlocal transaction
+            transaction = transaction_scope
+            operation(Scope())
+
+        transaction = None
+        store.rollback_scope(inspect)
+
+    def close(self):
+        if self.authority is not None:
+            self.authority.close()
+
+
+class _Adapter:
+    name = "relationship-v22-real"
+    applicability: ClassVar = {
+        case: Applicability.required() for case in CASE_INVENTORY
+    }
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+
+    def create_location(self) -> _Location:
+        return _Location(_seed_location(self.root / str(uuid.uuid4())))
+
+    def open_handle(self, location: _Location, *, migrate: bool = False) -> _Handle:
+        if migrate:
+            connection = sqlite3.connect(location.seed[1], isolation_level=None)
+            try:
+                prepare_pending_migration_backup(connection)
+                apply_pending_migrations(
+                    connection, applied_at="2042-01-02T00:00:00.000000Z"
+                )
+            finally:
+                connection.close()
+        return _Handle(location)
+
+
+def test_real_store_passes_all_required_conformance_cases(tmp_path) -> None:
+    report = run_conformance(_Adapter(tmp_path))
+    assert report.passed, repr(report.failures)
+    assert tuple(item.case for item in report.outcomes) == CASE_INVENTORY
+    assert all(item.status.value == "pass" for item in report.outcomes)
+
+
+def test_adapter_bindings_are_collision_free_and_persisted_in_distinct_fields(
+    tmp_path,
+) -> None:
+    base = _generic("record-1")
+    commands = (
+        base,
+        replace(base, request="different-request"),
+        replace(base, idempotency="different-idempotency"),
+        replace(base, cas_predecessor="different-cas_predecessor"),
+    )
+    persisted = []
+    assessment_ids = []
+    for index, command in enumerate(commands):
+        location = _Location(_seed_location(tmp_path / f"binding-{index}"))
+        handle = _Handle(location)
+        assessment, _ = handle._domain(command)
+        assessment_ids.append(assessment.canonical_digest)
+        assert handle.submit(command) == AuthorityValue.from_command(command)
+        connection = sqlite3.connect(location.seed[1])
+        row = connection.execute(
+            "SELECT r.evidence_bytes,a.principal_id FROM "
+            "event_hypothesis_relationship_decisions r "
+            "JOIN ledger_events e ON e.event_id=r.authority_event_id "
+            "JOIN authority_commands c ON c.command_id=e.command_id "
+            "JOIN authentication_contexts a ON a.authentication_context_id="
+            "c.authentication_context_id"
+        ).fetchone()
+        connection.close()
+        evidence = ComparatorEvidence.from_value(json.loads(bytes(row[0]))[0])
+        persisted.append(
+            (
+                str(row[1]),
+                evidence.score,
+                evidence.correction_reversal_score,
+                evidence.development_score,
+            )
+        )
+        handle.close()
+    assert len(set(assessment_ids)) == 4
+    assert persisted[0][1] != persisted[1][1]
+    assert persisted[0][2] != persisted[2][2]
+    assert persisted[0][3] != persisted[3][3]
+    collision_location = _Location(_seed_location(tmp_path / "collision"))
+    collision_handle = _Handle(collision_location)
+    assert collision_handle.submit(base) == AuthorityValue.from_command(base)
+    with pytest.raises(BindingConflict):
+        collision_handle.submit(replace(base, actor="different-actor"))
+    with pytest.raises(BindingConflict):
+        collision_handle.submit(replace(base, request="different-request"))
+    with pytest.raises(BindingConflict):
+        collision_handle.submit(replace(base, request="unsupported-request"))
+    assert collision_handle.read(base.record_id) == AuthorityValue.from_command(base)
+    connection = sqlite3.connect(collision_location.seed[1])
+    assert connection.execute(
+        "SELECT count(*) FROM event_hypothesis_relationship_decisions"
+    ).fetchone() == (1,)
+    assert connection.execute(
+        "SELECT a.principal_id FROM event_hypothesis_relationship_decisions r "
+        "JOIN ledger_events e ON e.event_id=r.authority_event_id "
+        "JOIN authority_commands c ON c.command_id=e.command_id "
+        "JOIN authentication_contexts a ON a.authentication_context_id="
+        "c.authentication_context_id"
+    ).fetchone() == ("editor",)
+    connection.close()
+    collision_handle.close()
+
+
+def test_named_upstreams_advance_distinct_real_authority_heads(tmp_path) -> None:
+    snapshots = []
+    for authority in ("authority", "policy"):
+        location = _Location(_seed_location(tmp_path / authority))
+        handle = _Handle(location)
+        handle.submit(_generic("record-1"))
+        item, _ = location.seed[7]["policy"]
+
+        def heads(location=location, item=item):
+            connection = sqlite3.connect(location.seed[1])
+            values = (
+                connection.execute(
+                    "SELECT version_id FROM event_hypothesis_heads_v2 "
+                    "WHERE hypothesis_id=?",
+                    (location.subjects["record-1"].hypothesis_id,),
+                ).fetchone()[0],
+                connection.execute(
+                    "SELECT current_version_id FROM triage_work_item_heads "
+                    "WHERE work_item_id=?",
+                    (item.work_item_id,),
+                ).fetchone()[0],
+            )
+            connection.close()
+            return values
+
+        before = heads()
+        handle.set_upstream_head(authority, "changed")
+        after = heads()
+        snapshots.append((before, after))
+        with pytest.raises(IntegrityViolation):
+            handle.current_use("record-1")
+        handle.close()
+    assert snapshots[0][0][0] != snapshots[0][1][0]
+    assert snapshots[0][0][1] == snapshots[0][1][1]
+    assert snapshots[1][0][0] == snapshots[1][1][0]
+    assert snapshots[1][0][1] != snapshots[1][1][1]
+
+
+def test_migrate_flag_executes_the_real_v21_to_v22_path(tmp_path, monkeypatch) -> None:
+    adapter = _Adapter(tmp_path)
+    location = adapter.create_location()
+    connection = sqlite3.connect(location.seed[1])
+    assert connection.execute("PRAGMA user_version").fetchone() == (21,)
+    connection.close()
+    sentinel = object()
+    monkeypatch.setattr(
+        "newsroom.tests.test_increment6d2_relationship_store._Handle",
+        lambda _: sentinel,
+    )
+    assert adapter.open_handle(location, migrate=True) is sentinel
+    connection = sqlite3.connect(location.seed[1])
+    assert connection.execute("PRAGMA user_version").fetchone() == (22,)
+    assert connection.execute(
+        "SELECT count(*) FROM event_hypothesis_relationship_decisions"
+    ).fetchone() == (0,)
+    connection.close()
+
+
+class _DefectiveAdapter(_Adapter):
+    def __init__(self, root: Path, defect: str, case: CaseId) -> None:
+        super().__init__(root)
+        self.defect = defect
+        self.applicability = {
+            inventory_case: (
+                Applicability.required()
+                if inventory_case is case
+                else Applicability.waived(
+                    reason="focused mutation sensitivity",
+                    waiver_reference="issue:364#review-sensitivity",
+                )
+            )
+            for inventory_case in CASE_INVENTORY
+        }
+
+    def open_handle(self, location: _Location, *, migrate: bool = False) -> _Handle:
+        handle = super().open_handle(location, migrate=migrate)
+        if self.defect == "no-store":
+            handle.submit = lambda command, **_: AuthorityValue.from_command(command)
+        elif self.defect == "shadow":
+            shadow = getattr(location, "shadow", None)
+            if shadow is None:
+                shadow = {}
+                location.shadow = shadow
+
+            def shadow_submit(command, **_):
+                shadow[command.record_id] = command
+                return AuthorityValue.from_command(command)
+
+            handle.submit = shadow_submit
+            handle.observe = lambda record_id: (
+                StoredAuthorityState.from_command(shadow[record_id])
+                if record_id in shadow
+                else None
+            )
+            handle.history = lambda: tuple(
+                AuthorityValue.from_command(command) for command in shadow.values()
+            )
+            handle.list_history = handle.history
+            handle.read = lambda record_id: AuthorityValue.from_command(
+                shadow[record_id]
+            )
+        elif self.defect == "bypass":
+            handle.read = lambda record_id: AuthorityValue.from_command(
+                _generic(record_id)
+            )
+        return handle
+
+
+@pytest.mark.parametrize(
+    ("defect", "case"),
+    (
+        ("no-store", CaseId.FRESH_REPLAY),
+        ("shadow", CaseId.FRESH_REOPEN),
+        ("bypass", CaseId.TAMPER_REJECTION),
+    ),
+)
+def test_conformance_sensitivity_rejects_non_authoritative_adapters(
+    tmp_path, defect: str, case: CaseId
+) -> None:
+    report = run_conformance(_DefectiveAdapter(tmp_path, defect, case))
+    assert not report.passed
+    assert any(failure.case is case for failure in report.failures)


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-6d2-relationship-authority
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

## Summary
- add the serial v22 `event_hypothesis_relationship_authority_v22` migration and checked pre-v22 backup boundary
- retain each immutable authenticated relationship decision in the central authority ledger and the sole v22 relationship table in one transaction, with independent UUIDv4 aggregate/event anchors
- expose only the factory-created exact production composition; public callers cannot inject a store class, while the private contention fixture selects one fixed internal unlocked store without exposing the production capability token
- translate #384 commands through collision-free, reversible bindings to retained relationship evidence, authentication contexts and real named upstream heads; reads, history and replay decode persisted truth rather than caller input or shadow state
- exercise every required #384 case against real v22 SQLite/ledger/upstream rows, real two-connection contention, production rollback scope and real migration/reopen

## Exact identity
- Base: `b094b6b3cb8a2bc5122dbfeffd2287d6c1aecf29`
- Head: `0fe76ae820995b8506592546d96231e57cb570d9`
- Tree: `ee0c90b306f74085488a3c555df1828b86198fc8`
- Migration checksum: `sha256:e59eb222a95e2901ccaae29ce1b9e8eded797306e9796718a6d2c4fa505a6636`
- Schema fingerprint: `sha256:2118fa893fb7fd2911bbde3056b79b1d0e26ccd6903e1c4228616f342898eaad`
- Migration module SHA-256: `83891d73a53afa13c5ad9b9576bdab6562386deed41fa1a4c8fde9b92d12b3d7`
- Store module SHA-256: `744e063b91d2d35ba2472b620af4cb3f36f1d4af81076773a571a5435ca87097`
- Public relationship module SHA-256: `60521aa20a22b00577b1e9669acbdea08a6fdebb6e5e9ab2ea48b569afe6ee46`
- v22 store test SHA-256: `0ecd41bce79562fd6c503a56cd1c3bc12168e198a4d8d6b64a9c54f976e7010f`

## Evidence
- `uv run pytest -q newsroom/tests/test_increment6d2_relationship_store.py` — 14 passed at exact head, including all 11 required #384 outcomes, public-factory forgery probes, collision-free persisted bindings and distinct named upstream heads
- `uv run pytest -q newsroom/tests/test_increment6d2_relationship_migrations.py` — 4 passed; migration checksum/fingerprint unchanged
- affected v21 migration, relationship contract, v21 store and 6R readiness lanes — 65 passed
- `uvx ruff check` over all 8 changed files — passed
- `uv run python -m compileall -q` over all changed production modules — passed
- `uv lock --check` — passed
- `git diff --check` — passed
- remote branch SHA verified as `0fe76ae820995b8506592546d96231e57cb570d9`

Related: #364
