### PR TITLE
Increment 6D3a: add hypothesis lineage contract

### DIFF
--- a/newsroom/increment6/lineage.py
+++ b/newsroom/increment6/lineage.py
@@ -1,0 +1,1445 @@
+"""Pure append-only Event Hypothesis lineage contract.
+
+The values in this module bind already-existing 6D1 Hypothesis Versions and
+already-decided 6D2 relationship assessments.  They allocate no Version,
+write no authority state, and grant no Candidate, evidence, publication,
+model, provider, egress, or external-effect capability.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Self
+
+from newsroom.authority.canonical import (
+    MAX_SAFE_INTEGER,
+    canonical_json_bytes,
+    digest_bytes,
+)
+from newsroom.increment6.hypotheses import EventHypothesisVersion
+from newsroom.increment6.outcomes import CanonicalOutcome
+from newsroom.increment6.relationships import (
+    AssessmentStatus,
+    ComparatorEvidence,
+    ComparatorSetManifest,
+    HypothesisVersionBinding,
+    RelationshipAssessment,
+    assess_relationships,
+)
+
+HYPOTHESIS_LINEAGE = "newsroom.increment6.hypothesis-lineage.v1"
+HYPOTHESIS_CONSOLIDATION = "HYPOTHESIS_CONSOLIDATION"
+HYPOTHESIS_SPLIT = "HYPOTHESIS_SPLIT"
+HYPOTHESIS_REVERSAL_LINEAGE = "HYPOTHESIS_REVERSAL_LINEAGE"
+MAX_LINEAGE_CANONICAL_BYTES = 1_048_576
+MAX_LINEAGE_INPUTS = 32
+MAX_LINEAGE_OUTPUTS = 32
+MAX_LINEAGE_RELATIONSHIP_BINDINGS = 32
+MAX_LINEAGE_COMPARATOR_EVIDENCE = 1_024
+MAX_LINEAGE_REPLAY_RECEIPTS = 1_024
+MAX_LINEAGE_REPLAY_NODES = 32_800
+
+_NAMESPACE = uuid.UUID("ddbe290d-e859-53cb-870a-19c71238a66f")
+_UUID = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z"
+)
+_DIGEST = re.compile(r"sha256:[0-9a-f]{64}\Z")
+_MAX_JSON_DEPTH = 16
+_MAX_JSON_NODES = 32_768
+
+
+class HypothesisLineageContractError(ValueError):
+    """A lineage value, receipt, or replay failed closed."""
+
+
+class HypothesisLineageKind(StrEnum):
+    CONSOLIDATION = HYPOTHESIS_CONSOLIDATION
+    SPLIT = HYPOTHESIS_SPLIT
+    REVERSAL = HYPOTHESIS_REVERSAL_LINEAGE
+
+
+class _NoEffect:
+    authorises_authority = False
+    authorises_persistence = False
+    authorises_external_effect = False
+    authorises_publication = False
+    authorises_evidence = False
+    authorises_egress = False
+    authorises_relationship = False
+    creates_candidate = False
+    creates_hypothesis = False
+    creates_version = False
+    creates_relationship = False
+
+
+def _normalise[T](operation: object, message: str) -> T:
+    try:
+        return operation()  # type: ignore[operator,no-any-return]
+    except HypothesisLineageContractError:
+        raise
+    except Exception as exc:
+        raise HypothesisLineageContractError(message) from exc
+
+
+def _uuid(value: object, field: str) -> str:
+    if type(value) is not str or _UUID.fullmatch(value) is None:
+        raise HypothesisLineageContractError(f"{field} must be a canonical UUID")
+    return value
+
+
+def _digest(value: object, field: str) -> str:
+    if type(value) is not str or _DIGEST.fullmatch(value) is None:
+        raise HypothesisLineageContractError(
+            f"{field} must be a canonical SHA-256 digest"
+        )
+    return value
+
+
+def _generation(value: object, field: str = "expected_generation") -> int:
+    if type(value) is not int or not 0 <= value < MAX_SAFE_INTEGER:
+        raise HypothesisLineageContractError(
+            f"{field} must be an exact bounded non-negative integer"
+        )
+    return value
+
+
+def _exact(value: object, fields: set[str], field: str) -> dict[str, object]:
+    if type(value) is not dict:
+        raise HypothesisLineageContractError(f"{field} fields are not exact")
+    try:
+        if set(value) != fields:
+            raise HypothesisLineageContractError(f"{field} fields are not exact")
+    except HypothesisLineageContractError:
+        raise
+    except Exception as exc:
+        raise HypothesisLineageContractError(f"{field} fields are not exact") from exc
+    return value
+
+
+def _canonical(value: object, field: str) -> bytes:
+    try:
+        raw = canonical_json_bytes(value)
+    except HypothesisLineageContractError:
+        raise
+    except Exception as exc:
+        raise HypothesisLineageContractError(
+            f"{field} cannot be canonicalised"
+        ) from exc
+    if not raw or len(raw) > MAX_LINEAGE_CANONICAL_BYTES:
+        raise HypothesisLineageContractError(
+            f"{field} exceeds the canonical byte bound"
+        )
+    return raw
+
+
+def _decode(raw: bytes) -> dict[str, object]:
+    if type(raw) is not bytes or not raw or len(raw) > MAX_LINEAGE_CANONICAL_BYTES:
+        raise HypothesisLineageContractError(
+            "lineage receipt requires bounded immutable bytes"
+        )
+
+    def unique(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        result: dict[str, object] = {}
+        for key, value in pairs:
+            if key in result:
+                raise HypothesisLineageContractError(
+                    "lineage receipt contains a duplicate key"
+                )
+            result[key] = value
+        return result
+
+    def integer(text: str) -> int:
+        if len(text.lstrip("-")) > 16:
+            raise HypothesisLineageContractError(
+                "lineage receipt integer exceeds bounds"
+            )
+        value = int(text)
+        if not -MAX_SAFE_INTEGER <= value <= MAX_SAFE_INTEGER:
+            raise HypothesisLineageContractError(
+                "lineage receipt integer exceeds bounds"
+            )
+        return value
+
+    def unsupported(_: str) -> float:
+        raise HypothesisLineageContractError(
+            "lineage receipt contains an unsupported number"
+        )
+
+    try:
+        value = json.loads(
+            raw.decode("utf-8"),
+            object_pairs_hook=unique,
+            parse_int=integer,
+            parse_float=unsupported,
+            parse_constant=unsupported,
+        )
+    except HypothesisLineageContractError:
+        raise
+    except Exception as exc:
+        raise HypothesisLineageContractError(
+            "lineage receipt is not valid UTF-8 JSON"
+        ) from exc
+    pending: list[tuple[object, int]] = [(value, 1)]
+    nodes = 0
+    while pending:
+        item, depth = pending.pop()
+        nodes += 1
+        if depth > _MAX_JSON_DEPTH or nodes > _MAX_JSON_NODES:
+            raise HypothesisLineageContractError(
+                "lineage receipt exceeds structural bounds"
+            )
+        if type(item) is dict:
+            pending.extend((child, depth + 1) for child in item.values())
+        elif type(item) is list:
+            pending.extend((child, depth + 1) for child in item)
+        elif type(item) not in (str, int, bool, type(None)):
+            raise HypothesisLineageContractError(
+                "lineage receipt contains an unsupported value"
+            )
+    if type(value) is not dict:
+        raise HypothesisLineageContractError("lineage receipt must be an object")
+    try:
+        if canonical_json_bytes(value) != raw:
+            raise HypothesisLineageContractError(
+                "lineage receipt is not canonical JSON"
+            )
+    except HypothesisLineageContractError:
+        raise
+    except Exception as exc:
+        raise HypothesisLineageContractError(
+            "lineage receipt cannot be normalised"
+        ) from exc
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class HypothesisLineageNodeBinding(_NoEffect):
+    hypothesis_id: str
+    version_id: str
+    version_digest: str
+
+    def __post_init__(self) -> None:
+        if type(self) is not HypothesisLineageNodeBinding:
+            raise HypothesisLineageContractError("node binding requires the exact type")
+        _uuid(self.hypothesis_id, "hypothesis_id")
+        _uuid(self.version_id, "version_id")
+        _digest(self.version_digest, "version_digest")
+
+    @classmethod
+    def from_version(cls, version: EventHypothesisVersion) -> Self:
+        if type(version) is not EventHypothesisVersion:
+            raise HypothesisLineageContractError(
+                "node binding requires an exact Hypothesis Version"
+            )
+
+        def bind() -> Self:
+            raw = version.canonical_bytes
+            if EventHypothesisVersion.from_canonical_bytes(raw) != version:
+                raise HypothesisLineageContractError(
+                    "Hypothesis Version differs from its canonical replay"
+                )
+            return cls(version.hypothesis_id, version.version_id, digest_bytes(raw))
+
+        return _normalise(bind, "Hypothesis Version cannot be bound")
+
+    @property
+    def canonical_value(self) -> dict[str, object]:
+        return _normalise(
+            lambda: {
+                "hypothesis_id": self.hypothesis_id,
+                "version_id": self.version_id,
+                "version_digest": self.version_digest,
+            },
+            "node binding cannot be represented",
+        )
+
+    @classmethod
+    def from_value(cls, value: object) -> Self:
+        item = _exact(
+            value,
+            {"hypothesis_id", "version_id", "version_digest"},
+            "node binding",
+        )
+        return _normalise(
+            lambda: cls(
+                item["hypothesis_id"],  # type: ignore[arg-type]
+                item["version_id"],  # type: ignore[arg-type]
+                item["version_digest"],  # type: ignore[arg-type]
+            ),
+            "node binding replay failed",
+        )
+
+
+def _node_key(node: HypothesisLineageNodeBinding) -> tuple[str, str, str]:
+    return node.hypothesis_id, node.version_id, node.version_digest
+
+
+@dataclass(frozen=True, slots=True)
+class HypothesisLineageEvidenceBinding(_NoEffect):
+    evidence_digest: str
+    subject_version_id: str
+    comparator_version_id: str
+    classification: CanonicalOutcome
+
+    def __post_init__(self) -> None:
+        if type(self) is not HypothesisLineageEvidenceBinding:
+            raise HypothesisLineageContractError(
+                "evidence binding requires the exact type"
+            )
+        _digest(self.evidence_digest, "evidence_digest")
+        _uuid(self.subject_version_id, "evidence subject_version_id")
+        _uuid(self.comparator_version_id, "evidence comparator_version_id")
+        if self.subject_version_id == self.comparator_version_id:
+            raise HypothesisLineageContractError("evidence cannot contain a self edge")
+        if type(self.classification) is not CanonicalOutcome:
+            raise HypothesisLineageContractError(
+                "evidence classification must be exact"
+            )
+
+    @property
+    def canonical_value(self) -> dict[str, object]:
+        return _normalise(
+            lambda: {
+                "evidence_digest": self.evidence_digest,
+                "subject_version_id": self.subject_version_id,
+                "comparator_version_id": self.comparator_version_id,
+                "classification": self.classification.value,
+            },
+            "evidence binding cannot be represented",
+        )
+
+    @classmethod
+    def from_value(cls, value: object) -> Self:
+        item = _exact(
+            value,
+            {
+                "evidence_digest",
+                "subject_version_id",
+                "comparator_version_id",
+                "classification",
+            },
+            "evidence binding",
+        )
+        return _normalise(
+            lambda: cls(
+                item["evidence_digest"],  # type: ignore[arg-type]
+                item["subject_version_id"],  # type: ignore[arg-type]
+                item["comparator_version_id"],  # type: ignore[arg-type]
+                CanonicalOutcome(item["classification"]),  # type: ignore[arg-type]
+            ),
+            "evidence binding replay failed",
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class HypothesisLineageRelationshipBinding(_NoEffect):
+    assessment_digest: str
+    outcome: CanonicalOutcome
+    subject: HypothesisLineageNodeBinding
+    comparator_manifest_digest: str
+    evidence_set_digest: str
+    evidence: tuple[HypothesisLineageEvidenceBinding, ...]
+
+    def __post_init__(self) -> None:
+        if type(self) is not HypothesisLineageRelationshipBinding:
+            raise HypothesisLineageContractError(
+                "relationship binding requires the exact type"
+            )
+        _digest(self.assessment_digest, "assessment_digest")
+        _digest(self.comparator_manifest_digest, "comparator_manifest_digest")
+        _digest(self.evidence_set_digest, "evidence_set_digest")
+        if type(self.outcome) is not CanonicalOutcome:
+            raise HypothesisLineageContractError("relationship outcome must be exact")
+        if type(self.subject) is not HypothesisLineageNodeBinding:
+            raise HypothesisLineageContractError(
+                "relationship subject must be an exact node binding"
+            )
+        if (
+            type(self.evidence) is not tuple
+            or not self.evidence
+            or len(self.evidence) > MAX_LINEAGE_OUTPUTS
+            or any(
+                type(item) is not HypothesisLineageEvidenceBinding
+                for item in self.evidence
+            )
+        ):
+            raise HypothesisLineageContractError(
+                "relationship evidence must be a non-empty bounded exact tuple"
+            )
+        comparator_ids = tuple(item.comparator_version_id for item in self.evidence)
+        if comparator_ids != tuple(sorted(set(comparator_ids))):
+            raise HypothesisLineageContractError(
+                "relationship evidence must be comparator-sorted and unique"
+            )
+        if any(
+            item.subject_version_id != self.subject.version_id for item in self.evidence
+        ):
+            raise HypothesisLineageContractError(
+                "relationship evidence subject differs from the decision subject"
+            )
+
+    @classmethod
+    def from_assessment(
+        cls,
+        assessment: RelationshipAssessment,
+        evidence: tuple[ComparatorEvidence, ...],
+    ) -> Self:
+        return HypothesisLineageRelationshipProof.from_assessment(
+            assessment, evidence
+        ).binding
+
+    @property
+    def canonical_value(self) -> dict[str, object]:
+        return _normalise(
+            lambda: {
+                "assessment_digest": self.assessment_digest,
+                "outcome": self.outcome.value,
+                "subject": self.subject.canonical_value,
+                "comparator_manifest_digest": self.comparator_manifest_digest,
+                "evidence_set_digest": self.evidence_set_digest,
+                "evidence": [item.canonical_value for item in self.evidence],
+            },
+            "relationship binding cannot be represented",
+        )
+
+    @classmethod
+    def from_value(cls, value: object) -> Self:
+        item = _exact(
+            value,
+            {
+                "assessment_digest",
+                "outcome",
+                "subject",
+                "comparator_manifest_digest",
+                "evidence_set_digest",
+                "evidence",
+            },
+            "relationship binding",
+        )
+        raw_evidence = item["evidence"]
+        if type(raw_evidence) is not list or not 1 <= len(raw_evidence) <= 32:
+            raise HypothesisLineageContractError(
+                "relationship evidence must be a bounded array"
+            )
+        return _normalise(
+            lambda: cls(
+                item["assessment_digest"],  # type: ignore[arg-type]
+                CanonicalOutcome(item["outcome"]),  # type: ignore[arg-type]
+                HypothesisLineageNodeBinding.from_value(item["subject"]),
+                item["comparator_manifest_digest"],  # type: ignore[arg-type]
+                item["evidence_set_digest"],  # type: ignore[arg-type]
+                tuple(
+                    HypothesisLineageEvidenceBinding.from_value(entry)
+                    for entry in raw_evidence
+                ),
+            ),
+            "relationship binding replay failed",
+        )
+
+
+def _relationship_key(
+    binding: HypothesisLineageRelationshipBinding,
+) -> tuple[str, str]:
+    return binding.subject.version_id, binding.assessment_digest
+
+
+def _verified_relationship_binding(
+    assessment: RelationshipAssessment,
+    evidence: tuple[ComparatorEvidence, ...],
+) -> HypothesisLineageRelationshipBinding:
+    if type(assessment) is not RelationshipAssessment:
+        raise HypothesisLineageContractError(
+            "relationship proof requires an exact Relationship Assessment"
+        )
+    if (
+        type(evidence) is not tuple
+        or not evidence
+        or len(evidence) > MAX_LINEAGE_OUTPUTS
+        or any(type(item) is not ComparatorEvidence for item in evidence)
+    ):
+        raise HypothesisLineageContractError(
+            "relationship proof requires bounded exact Comparator Evidence"
+        )
+    if (
+        assessment.status is not AssessmentStatus.COMPLETE
+        or type(assessment.decision) is not CanonicalOutcome
+        or type(assessment.subject) is not HypothesisVersionBinding
+        or assessment.evidence_digest is None
+    ):
+        raise HypothesisLineageContractError(
+            "relationship proof requires a complete decision"
+        )
+    assessment_raw = assessment.canonical_bytes
+    if RelationshipAssessment.from_canonical_bytes(assessment_raw) != assessment:
+        raise HypothesisLineageContractError(
+            "Relationship Assessment differs from its canonical replay"
+        )
+    ordered = tuple(sorted(evidence, key=lambda item: item.comparator.version_id))
+    compact: list[HypothesisLineageEvidenceBinding] = []
+    for item in ordered:
+        raw = item.canonical_bytes
+        if ComparatorEvidence.from_canonical_bytes(raw) != item:
+            raise HypothesisLineageContractError(
+                "Comparator Evidence differs from its canonical replay"
+            )
+        classified = assess_relationships(
+            item.subject,
+            ComparatorSetManifest.complete((item.comparator,)),
+            (item,),
+        )
+        if type(classified.decision) is not CanonicalOutcome:
+            raise HypothesisLineageContractError(
+                "Comparator Evidence has no deterministic classification"
+            )
+        compact.append(
+            HypothesisLineageEvidenceBinding(
+                digest_bytes(raw),
+                item.subject.version_id,
+                item.comparator.version_id,
+                classified.decision,
+            )
+        )
+    replayed = assess_relationships(
+        assessment.subject, assessment.comparator_manifest, ordered
+    )
+    if replayed.canonical_bytes != assessment_raw:
+        raise HypothesisLineageContractError(
+            "relationship proof differs from the public D2 policy replay"
+        )
+    return HypothesisLineageRelationshipBinding(
+        digest_bytes(assessment_raw),
+        assessment.decision,
+        HypothesisLineageNodeBinding(
+            assessment.subject.hypothesis_id,
+            assessment.subject.version_id,
+            assessment.subject.version_digest,
+        ),
+        assessment.comparator_manifest_digest,
+        assessment.evidence_digest,
+        tuple(compact),
+    )
+
+
+class HypothesisLineageRelationshipProof(_NoEffect):
+    """Exact D2 producer proof; instances are created only by the factory."""
+
+    __slots__ = ("__assessment", "__evidence")
+
+    def __init__(self) -> None:
+        raise HypothesisLineageContractError(
+            "relationship proof must be created from exact D2 producers"
+        )
+
+    @classmethod
+    def from_assessment(
+        cls,
+        assessment: RelationshipAssessment,
+        evidence: tuple[ComparatorEvidence, ...],
+    ) -> Self:
+        def build() -> Self:
+            _verified_relationship_binding(assessment, evidence)
+            value = object.__new__(cls)
+            object.__setattr__(
+                value, "_HypothesisLineageRelationshipProof__assessment", assessment
+            )
+            object.__setattr__(
+                value,
+                "_HypothesisLineageRelationshipProof__evidence",
+                tuple(sorted(evidence, key=lambda item: item.comparator.version_id)),
+            )
+            return value
+
+        return _normalise(build, "relationship proof construction failed")
+
+    @property
+    def assessment(self) -> RelationshipAssessment:
+        return _normalise(
+            lambda: self.__assessment, "relationship proof assessment is unavailable"
+        )
+
+    @property
+    def evidence(self) -> tuple[ComparatorEvidence, ...]:
+        return _normalise(
+            lambda: self.__evidence, "relationship proof evidence is unavailable"
+        )
+
+    @property
+    def binding(self) -> HypothesisLineageRelationshipBinding:
+        return _normalise(
+            lambda: _verified_relationship_binding(self.assessment, self.evidence),
+            "relationship proof verification failed",
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class HypothesisLineageTarget(_NoEffect):
+    lineage_id: str
+    lineage_digest: str
+
+    def __post_init__(self) -> None:
+        if type(self) is not HypothesisLineageTarget:
+            raise HypothesisLineageContractError(
+                "lineage target requires the exact type"
+            )
+        _uuid(self.lineage_id, "target lineage_id")
+        _digest(self.lineage_digest, "target lineage_digest")
+
+    @property
+    def canonical_value(self) -> dict[str, object]:
+        return _normalise(
+            lambda: {
+                "lineage_id": self.lineage_id,
+                "lineage_digest": self.lineage_digest,
+            },
+            "lineage target cannot be represented",
+        )
+
+    @classmethod
+    def from_value(cls, value: object) -> Self:
+        item = _exact(value, {"lineage_id", "lineage_digest"}, "lineage target")
+        return _normalise(
+            lambda: cls(
+                item["lineage_id"],  # type: ignore[arg-type]
+                item["lineage_digest"],  # type: ignore[arg-type]
+            ),
+            "lineage target replay failed",
+        )
+
+
+def _versions(values: object, field: str) -> tuple[HypothesisLineageNodeBinding, ...]:
+    if type(values) is not tuple or any(
+        type(item) is not EventHypothesisVersion for item in values
+    ):
+        raise HypothesisLineageContractError(
+            f"{field} must be an exact tuple of Hypothesis Versions"
+        )
+    return _normalise(
+        lambda: tuple(
+            sorted(
+                (HypothesisLineageNodeBinding.from_version(item) for item in values),
+                key=_node_key,
+            )
+        ),
+        f"{field} Versions cannot be bound",
+    )
+
+
+def _relationship_proofs(
+    values: object,
+) -> tuple[HypothesisLineageRelationshipBinding, ...]:
+    if type(values) is not tuple or any(
+        type(item) is not HypothesisLineageRelationshipProof for item in values
+    ):
+        raise HypothesisLineageContractError(
+            "relationship_proofs must be an exact tuple of producer proofs"
+        )
+    return _normalise(
+        lambda: tuple(
+            sorted(
+                (item.binding for item in values),
+                key=_relationship_key,
+            )
+        ),
+        "relationship proofs cannot be bound",
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class HypothesisLineageReceipt(_NoEffect):
+    lineage_id: str
+    kind: HypothesisLineageKind
+    expected_generation: int
+    inputs: tuple[HypothesisLineageNodeBinding, ...]
+    outputs: tuple[HypothesisLineageNodeBinding, ...]
+    relationships: tuple[HypothesisLineageRelationshipBinding, ...]
+    reversal_target: HypothesisLineageTarget | None = None
+
+    def __post_init__(self) -> None:
+        if type(self) is not HypothesisLineageReceipt:
+            raise HypothesisLineageContractError(
+                "lineage receipt requires the exact type"
+            )
+        _normalise(self._validate, "lineage receipt construction failed")
+
+    def _validate(self) -> None:
+        _uuid(self.lineage_id, "lineage_id")
+        if type(self.kind) is not HypothesisLineageKind:
+            raise HypothesisLineageContractError("lineage kind must be exact")
+        _generation(self.expected_generation)
+        for field, values, limit in (
+            ("inputs", self.inputs, MAX_LINEAGE_INPUTS),
+            ("outputs", self.outputs, MAX_LINEAGE_OUTPUTS),
+        ):
+            if (
+                type(values) is not tuple
+                or not values
+                or len(values) > limit
+                or any(
+                    type(item) is not HypothesisLineageNodeBinding for item in values
+                )
+            ):
+                raise HypothesisLineageContractError(
+                    f"{field} must be a non-empty bounded exact tuple"
+                )
+            keys = tuple(_node_key(item) for item in values)
+            if keys != tuple(sorted(set(keys))):
+                raise HypothesisLineageContractError(
+                    f"{field} must be sorted and unique"
+                )
+            version_ids = tuple(item.version_id for item in values)
+            if len(version_ids) != len(set(version_ids)):
+                raise HypothesisLineageContractError(
+                    f"{field} cannot rebind one Version identity"
+                )
+            hypothesis_ids = tuple(item.hypothesis_id for item in values)
+            if len(hypothesis_ids) != len(set(hypothesis_ids)):
+                raise HypothesisLineageContractError(
+                    f"{field} must bind distinct Hypothesis identities"
+                )
+        if any(
+            left.version_id == right.version_id
+            for left in self.inputs
+            for right in self.outputs
+        ):
+            raise HypothesisLineageContractError("lineage cannot contain a self edge")
+        if (
+            type(self.relationships) is not tuple
+            or len(self.relationships) > MAX_LINEAGE_RELATIONSHIP_BINDINGS
+            or any(
+                type(item) is not HypothesisLineageRelationshipBinding
+                for item in self.relationships
+            )
+        ):
+            raise HypothesisLineageContractError(
+                "relationships must be a bounded exact tuple"
+            )
+        relationship_keys = tuple(
+            _relationship_key(item) for item in self.relationships
+        )
+        if relationship_keys != tuple(sorted(set(relationship_keys))):
+            raise HypothesisLineageContractError(
+                "relationships must be sorted and unique"
+            )
+        if len({item.assessment_digest for item in self.relationships}) != len(
+            self.relationships
+        ):
+            raise HypothesisLineageContractError(
+                "one relationship assessment cannot be reused"
+            )
+        if len({item.subject.version_id for item in self.relationships}) != len(
+            self.relationships
+        ):
+            raise HypothesisLineageContractError(
+                "one relationship decision per unique subject is required"
+            )
+        if (
+            sum(len(item.evidence) for item in self.relationships)
+            > MAX_LINEAGE_COMPARATOR_EVIDENCE
+        ):
+            raise HypothesisLineageContractError(
+                "compact comparator evidence bound exceeded"
+            )
+        if self.kind is HypothesisLineageKind.REVERSAL:
+            if type(self.reversal_target) is not HypothesisLineageTarget:
+                raise HypothesisLineageContractError(
+                    "reversal requires an exact lineage target"
+                )
+        elif self.reversal_target is not None:
+            raise HypothesisLineageContractError(
+                "only reversal may contain a lineage target"
+            )
+        expected_id = self._derived_lineage_id
+        if self.lineage_id != expected_id:
+            raise HypothesisLineageContractError(
+                "lineage_id differs from its semantic identity"
+            )
+        self._validate_shape_and_basis()
+        _ = self.canonical_bytes
+
+    @property
+    def _semantic_value(self) -> dict[str, object]:
+        return {
+            "kind": self.kind.value,
+            "expected_generation": self.expected_generation,
+            "inputs": [item.canonical_value for item in self.inputs],
+            "reversal_target": (
+                None
+                if self.reversal_target is None
+                else self.reversal_target.canonical_value
+            ),
+        }
+
+    @property
+    def _derived_lineage_id(self) -> str:
+        return _normalise(
+            lambda: str(
+                uuid.uuid5(
+                    _NAMESPACE, canonical_json_bytes(self._semantic_value).decode()
+                )
+            ),
+            "lineage identity cannot be derived",
+        )
+
+    def _validate_shape_and_basis(self) -> None:
+        actual = {item.subject.version_id: item for item in self.relationships}
+        required: dict[str, tuple[set[str], CanonicalOutcome]] = {}
+        if self.kind is HypothesisLineageKind.CONSOLIDATION:
+            if len(self.inputs) < 2 or len(self.outputs) != 1:
+                raise HypothesisLineageContractError(
+                    "consolidation requires two to 32 inputs and one output"
+                )
+            output = self.outputs[0]
+            required = {
+                output.version_id: (
+                    {item.version_id for item in self.inputs},
+                    CanonicalOutcome.REL_SAME_STATE,
+                )
+            }
+        elif self.kind is HypothesisLineageKind.SPLIT:
+            if len(self.inputs) != 1 or not 2 <= len(self.outputs) <= 32:
+                raise HypothesisLineageContractError(
+                    "split requires one input and two to 32 outputs"
+                )
+            source = self.inputs[0]
+            required = {
+                output.version_id: (
+                    {
+                        source.version_id,
+                        *(item.version_id for item in self.outputs if item != output),
+                    },
+                    CanonicalOutcome.REL_RELATED_DISTINCT,
+                )
+                for output in self.outputs
+            }
+        else:
+            if not self.inputs or not self.outputs:
+                raise HypothesisLineageContractError(
+                    "reversal requires non-empty inputs and outputs"
+                )
+            required = {
+                output.version_id: (
+                    {item.version_id for item in self.inputs},
+                    CanonicalOutcome.REL_CORRECTION_REVERSAL_OF,
+                )
+                for output in self.outputs
+            }
+        if set(actual) != set(required):
+            raise HypothesisLineageContractError(
+                "relationship basis has missing or extra endpoints"
+            )
+        for subject_id, (comparators, outcome) in required.items():
+            binding = actual[subject_id]
+            if binding.outcome is not outcome:
+                raise HypothesisLineageContractError(
+                    "relationship basis has the wrong outcome"
+                )
+            subject = next(
+                item for item in self.outputs if item.version_id == subject_id
+            )
+            if binding.subject != subject:
+                raise HypothesisLineageContractError(
+                    "relationship subject differs from the exact lineage output"
+                )
+            if {item.comparator_version_id for item in binding.evidence} != comparators:
+                raise HypothesisLineageContractError(
+                    "relationship basis has missing or extra comparator endpoints"
+                )
+            if any(item.classification is not outcome for item in binding.evidence):
+                raise HypothesisLineageContractError(
+                    "relationship evidence has the wrong classification"
+                )
+
+    @classmethod
+    def _build(
+        cls,
+        kind: HypothesisLineageKind,
+        expected_generation: int,
+        inputs: tuple[HypothesisLineageNodeBinding, ...],
+        outputs: tuple[HypothesisLineageNodeBinding, ...],
+        relationships: tuple[HypothesisLineageRelationshipBinding, ...],
+        reversal_target: HypothesisLineageTarget | None = None,
+    ) -> Self:
+        semantic = {
+            "kind": kind.value,
+            "expected_generation": _generation(expected_generation),
+            "inputs": [item.canonical_value for item in inputs],
+            "reversal_target": (
+                None if reversal_target is None else reversal_target.canonical_value
+            ),
+        }
+        lineage_id = _normalise(
+            lambda: str(
+                uuid.uuid5(_NAMESPACE, canonical_json_bytes(semantic).decode())
+            ),
+            "lineage identity cannot be derived",
+        )
+        return _normalise(
+            lambda: cls(
+                lineage_id,
+                kind,
+                expected_generation,
+                inputs,
+                outputs,
+                relationships,
+                reversal_target,
+            ),
+            "lineage receipt construction failed",
+        )
+
+    @classmethod
+    def consolidation(
+        cls,
+        *,
+        expected_generation: int,
+        inputs: tuple[EventHypothesisVersion, ...],
+        output: EventHypothesisVersion,
+        relationship_proofs: tuple[HypothesisLineageRelationshipProof, ...],
+    ) -> Self:
+        if type(output) is not EventHypothesisVersion:
+            raise HypothesisLineageContractError(
+                "consolidation output must be an exact Hypothesis Version"
+            )
+        return cls._build(
+            HypothesisLineageKind.CONSOLIDATION,
+            expected_generation,
+            _versions(inputs, "inputs"),
+            _versions((output,), "outputs"),
+            _relationship_proofs(relationship_proofs),
+        )
+
+    @classmethod
+    def split(
+        cls,
+        *,
+        expected_generation: int,
+        source: EventHypothesisVersion,
+        outputs: tuple[EventHypothesisVersion, ...],
+        relationship_proofs: tuple[HypothesisLineageRelationshipProof, ...],
+    ) -> Self:
+        if type(source) is not EventHypothesisVersion:
+            raise HypothesisLineageContractError(
+                "split source must be an exact Hypothesis Version"
+            )
+        return cls._build(
+            HypothesisLineageKind.SPLIT,
+            expected_generation,
+            _versions((source,), "inputs"),
+            _versions(outputs, "outputs"),
+            _relationship_proofs(relationship_proofs),
+        )
+
+    @classmethod
+    def reversal(
+        cls,
+        *,
+        expected_generation: int,
+        target: HypothesisLineageReceipt,
+        outputs: tuple[EventHypothesisVersion, ...],
+        relationship_proofs: tuple[HypothesisLineageRelationshipProof, ...],
+    ) -> Self:
+        def build() -> Self:
+            if type(target) is not HypothesisLineageReceipt:
+                raise HypothesisLineageContractError(
+                    "reversal target must be an exact lineage receipt"
+                )
+            if target.kind is HypothesisLineageKind.REVERSAL:
+                raise HypothesisLineageContractError(
+                    "a reversal cannot target a reversal"
+                )
+            return cls._build(
+                HypothesisLineageKind.REVERSAL,
+                expected_generation,
+                target.outputs,
+                _versions(outputs, "outputs"),
+                _relationship_proofs(relationship_proofs),
+                HypothesisLineageTarget(target.lineage_id, target.canonical_digest),
+            )
+
+        return _normalise(build, "reversal construction failed")
+
+    @property
+    def canonical_value(self) -> dict[str, object]:
+        return _normalise(
+            lambda: {
+                "schema_version": HYPOTHESIS_LINEAGE,
+                "lineage_id": self.lineage_id,
+                "kind": self.kind.value,
+                "expected_generation": self.expected_generation,
+                "inputs": [item.canonical_value for item in self.inputs],
+                "outputs": [item.canonical_value for item in self.outputs],
+                "relationships": [item.canonical_value for item in self.relationships],
+                "reversal_target": (
+                    None
+                    if self.reversal_target is None
+                    else self.reversal_target.canonical_value
+                ),
+            },
+            "lineage receipt cannot be represented",
+        )
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return _canonical(self.canonical_value, "lineage receipt")
+
+    @property
+    def canonical_digest(self) -> str:
+        return _normalise(
+            lambda: digest_bytes(self.canonical_bytes),
+            "lineage receipt cannot be digested",
+        )
+
+    @classmethod
+    def from_canonical_bytes(cls, raw: bytes) -> Self:
+        """Parse structural bytes without granting semantic producer trust."""
+
+        fields = {
+            "schema_version",
+            "lineage_id",
+            "kind",
+            "expected_generation",
+            "inputs",
+            "outputs",
+            "relationships",
+            "reversal_target",
+        }
+        item = _exact(_decode(raw), fields, "lineage receipt")
+        if item["schema_version"] != HYPOTHESIS_LINEAGE:
+            raise HypothesisLineageContractError(
+                "lineage receipt schema is unsupported"
+            )
+        for field, limit in (
+            ("inputs", MAX_LINEAGE_INPUTS),
+            ("outputs", MAX_LINEAGE_OUTPUTS),
+            ("relationships", MAX_LINEAGE_RELATIONSHIP_BINDINGS),
+        ):
+            value = item[field]
+            if type(value) is not list or len(value) > limit:
+                raise HypothesisLineageContractError(f"{field} must be a bounded array")
+        return _normalise(
+            lambda: cls(
+                item["lineage_id"],  # type: ignore[arg-type]
+                HypothesisLineageKind(item["kind"]),  # type: ignore[arg-type]
+                item["expected_generation"],  # type: ignore[arg-type]
+                tuple(
+                    HypothesisLineageNodeBinding.from_value(value)
+                    for value in item["inputs"]  # type: ignore[union-attr]
+                ),
+                tuple(
+                    HypothesisLineageNodeBinding.from_value(value)
+                    for value in item["outputs"]  # type: ignore[union-attr]
+                ),
+                tuple(
+                    HypothesisLineageRelationshipBinding.from_value(value)
+                    for value in item["relationships"]  # type: ignore[union-attr]
+                ),
+                (
+                    None
+                    if item["reversal_target"] is None
+                    else HypothesisLineageTarget.from_value(item["reversal_target"])
+                ),
+            ),
+            "lineage receipt replay failed",
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class HypothesisLineageHead(_NoEffect):
+    node: HypothesisLineageNodeBinding
+    generation: int
+
+    def __post_init__(self) -> None:
+        if type(self) is not HypothesisLineageHead:
+            raise HypothesisLineageContractError("lineage head requires the exact type")
+        if type(self.node) is not HypothesisLineageNodeBinding:
+            raise HypothesisLineageContractError("lineage head node must be exact")
+        _generation(self.generation, "generation")
+
+    @classmethod
+    def from_version(cls, version: EventHypothesisVersion, generation: int = 0) -> Self:
+        return _normalise(
+            lambda: cls(HypothesisLineageNodeBinding.from_version(version), generation),
+            "lineage head cannot be bound",
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class HypothesisLineageEdge(_NoEffect):
+    lineage_id: str
+    kind: HypothesisLineageKind
+    predecessor: HypothesisLineageNodeBinding
+    successor: HypothesisLineageNodeBinding
+
+    def __post_init__(self) -> None:
+        if type(self) is not HypothesisLineageEdge:
+            raise HypothesisLineageContractError("lineage edge requires the exact type")
+        _uuid(self.lineage_id, "lineage_id")
+        if type(self.kind) is not HypothesisLineageKind:
+            raise HypothesisLineageContractError("lineage edge kind must be exact")
+        if (
+            type(self.predecessor) is not HypothesisLineageNodeBinding
+            or type(self.successor) is not HypothesisLineageNodeBinding
+        ):
+            raise HypothesisLineageContractError("lineage edge nodes must be exact")
+        if self.predecessor.version_id == self.successor.version_id:
+            raise HypothesisLineageContractError("lineage edge cannot be a self edge")
+
+
+@dataclass(frozen=True, slots=True)
+class HypothesisLineageReplay(_NoEffect):
+    history: tuple[HypothesisLineageReceipt, ...]
+    active_heads: tuple[HypothesisLineageHead, ...]
+    edges: tuple[HypothesisLineageEdge, ...]
+    consumed: tuple[HypothesisLineageNodeBinding, ...]
+
+    def __post_init__(self) -> None:
+        if type(self) is not HypothesisLineageReplay:
+            raise HypothesisLineageContractError(
+                "lineage replay requires the exact type"
+            )
+        if (
+            type(self.history) is not tuple
+            or any(type(item) is not HypothesisLineageReceipt for item in self.history)
+            or type(self.active_heads) is not tuple
+            or any(
+                type(item) is not HypothesisLineageHead for item in self.active_heads
+            )
+            or type(self.edges) is not tuple
+            or any(type(item) is not HypothesisLineageEdge for item in self.edges)
+            or type(self.consumed) is not tuple
+            or any(
+                type(item) is not HypothesisLineageNodeBinding for item in self.consumed
+            )
+        ):
+            raise HypothesisLineageContractError("lineage replay values must be exact")
+
+
+def verify_hypothesis_lineage_receipt(
+    receipt: HypothesisLineageReceipt,
+    *,
+    versions: tuple[EventHypothesisVersion, ...],
+    relationship_proofs: tuple[HypothesisLineageRelationshipProof, ...],
+    reversal_target: HypothesisLineageReceipt | None,
+) -> HypothesisLineageReceipt:
+    """Rebind a structural receipt to exact D1 and replayed D2 producers."""
+
+    def verify() -> HypothesisLineageReceipt:
+        if type(receipt) is not HypothesisLineageReceipt:
+            raise HypothesisLineageContractError(
+                "semantic verification requires an exact lineage receipt"
+            )
+        expected_nodes = tuple(
+            sorted({*receipt.inputs, *receipt.outputs}, key=_node_key)
+        )
+        producer_nodes = _versions(versions, "semantic producer")
+        if producer_nodes != expected_nodes:
+            raise HypothesisLineageContractError(
+                "lineage nodes differ from exact Hypothesis Version producers"
+            )
+        if _relationship_proofs(relationship_proofs) != receipt.relationships:
+            raise HypothesisLineageContractError(
+                "lineage decisions differ from exact D2 producer proofs"
+            )
+        node_by_version_id = {item.version_id: item for item in producer_nodes}
+
+        def require_endpoint(binding: HypothesisVersionBinding) -> None:
+            expected = node_by_version_id.get(binding.version_id)
+            actual = HypothesisLineageNodeBinding(
+                binding.hypothesis_id,
+                binding.version_id,
+                binding.version_digest,
+            )
+            if expected != actual:
+                raise HypothesisLineageContractError(
+                    "D2 proof endpoint differs from its exact D1 producer"
+                )
+
+        for proof in relationship_proofs:
+            assessment = proof.assessment
+            require_endpoint(assessment.subject)
+            for comparator in assessment.comparator_manifest.comparators:
+                require_endpoint(comparator)
+            for evidence in proof.evidence:
+                require_endpoint(evidence.subject)
+                require_endpoint(evidence.comparator)
+
+        if receipt.kind is HypothesisLineageKind.REVERSAL:
+            if type(reversal_target) is not HypothesisLineageReceipt:
+                raise HypothesisLineageContractError(
+                    "reversal semantic verification requires the exact target receipt"
+                )
+            target_raw = reversal_target.canonical_bytes
+            if (
+                HypothesisLineageReceipt.from_canonical_bytes(target_raw)
+                != reversal_target
+                or reversal_target.kind is HypothesisLineageKind.REVERSAL
+                or receipt.reversal_target is None
+                or receipt.reversal_target.lineage_id != reversal_target.lineage_id
+                or receipt.reversal_target.lineage_digest != digest_bytes(target_raw)
+                or receipt.inputs != reversal_target.outputs
+            ):
+                raise HypothesisLineageContractError(
+                    "reversal target receipt is missing, changed, or inconsistent"
+                )
+            if sorted(item.hypothesis_id for item in receipt.outputs) != sorted(
+                item.hypothesis_id for item in reversal_target.inputs
+            ):
+                raise HypothesisLineageContractError(
+                    "reversal outputs do not restore target input identities one-to-one"
+                )
+        elif reversal_target is not None:
+            raise HypothesisLineageContractError(
+                "non-reversal semantic verification cannot receive a target"
+            )
+        return receipt
+
+    return _normalise(verify, "lineage semantic verification failed")
+
+
+def replay_hypothesis_lineage(
+    receipts: tuple[HypothesisLineageReceipt, ...],
+    *,
+    initial_heads: tuple[HypothesisLineageHead, ...],
+    versions: tuple[EventHypothesisVersion, ...],
+    relationship_proofs: tuple[HypothesisLineageRelationshipProof, ...],
+) -> HypothesisLineageReplay:
+    """Replay bounded receipts without mutating a Version or an authority store."""
+
+    def replay() -> HypothesisLineageReplay:
+        if (
+            type(receipts) is not tuple
+            or len(receipts) > MAX_LINEAGE_REPLAY_RECEIPTS
+            or any(type(item) is not HypothesisLineageReceipt for item in receipts)
+        ):
+            raise HypothesisLineageContractError(
+                "receipts must be a bounded exact tuple"
+            )
+        if (
+            type(initial_heads) is not tuple
+            or len(initial_heads) > MAX_LINEAGE_REPLAY_NODES
+            or any(type(item) is not HypothesisLineageHead for item in initial_heads)
+        ):
+            raise HypothesisLineageContractError(
+                "initial_heads must be a bounded exact tuple"
+            )
+        if any(head.generation != 0 for head in initial_heads):
+            raise HypothesisLineageContractError(
+                "lineage replay is full-rebuild-only from generation-zero roots"
+            )
+        all_nodes = tuple(
+            sorted(
+                {
+                    *(head.node for head in initial_heads),
+                    *(
+                        node
+                        for receipt in receipts
+                        for node in (*receipt.inputs, *receipt.outputs)
+                    ),
+                },
+                key=_node_key,
+            )
+        )
+        rebound_versions = _versions(versions, "replay producer")
+        if (
+            len(rebound_versions) > MAX_LINEAGE_REPLAY_NODES
+            or rebound_versions != all_nodes
+        ):
+            raise HypothesisLineageContractError(
+                "replay Versions differ from the complete exact producer set"
+            )
+        if (
+            type(relationship_proofs) is not tuple
+            or len(relationship_proofs)
+            > MAX_LINEAGE_REPLAY_RECEIPTS * MAX_LINEAGE_RELATIONSHIP_BINDINGS
+            or any(
+                type(item) is not HypothesisLineageRelationshipProof
+                for item in relationship_proofs
+            )
+        ):
+            raise HypothesisLineageContractError(
+                "relationship_proofs must be a bounded exact tuple"
+            )
+        proof_by_digest: dict[str, HypothesisLineageRelationshipProof] = {}
+        for proof in relationship_proofs:
+            binding = proof.binding
+            if binding.assessment_digest in proof_by_digest:
+                raise HypothesisLineageContractError(
+                    "relationship proofs contain a duplicate assessment"
+                )
+            proof_by_digest[binding.assessment_digest] = proof
+        expected_proof_digests = {
+            binding.assessment_digest
+            for receipt in receipts
+            for binding in receipt.relationships
+        }
+        if set(proof_by_digest) != expected_proof_digests:
+            raise HypothesisLineageContractError(
+                "relationship proofs differ from the complete receipt set"
+            )
+        version_by_id = {version.version_id: version for version in versions}
+        if len(version_by_id) != len(versions):
+            raise HypothesisLineageContractError(
+                "replay producers contain a duplicate Version identity"
+            )
+        verified_receipts: dict[str, HypothesisLineageReceipt] = {}
+        for receipt in receipts:
+            receipt_versions = tuple(
+                version_by_id[node.version_id]
+                for node in (*receipt.inputs, *receipt.outputs)
+            )
+            receipt_proofs = tuple(
+                proof_by_digest[binding.assessment_digest]
+                for binding in receipt.relationships
+            )
+            target = (
+                None
+                if receipt.reversal_target is None
+                else verified_receipts.get(receipt.reversal_target.lineage_id)
+            )
+            verify_hypothesis_lineage_receipt(
+                receipt,
+                versions=receipt_versions,
+                relationship_proofs=receipt_proofs,
+                reversal_target=target,
+            )
+            verified_receipts.setdefault(receipt.lineage_id, receipt)
+
+        active: dict[str, HypothesisLineageHead] = {}
+        node_by_id: dict[str, HypothesisLineageNodeBinding] = {}
+        for head in initial_heads:
+            version_id = head.node.version_id
+            hypothesis_id = head.node.hypothesis_id
+            if hypothesis_id in active:
+                raise HypothesisLineageContractError(
+                    "initial heads contain a duplicate active Hypothesis"
+                )
+            active[hypothesis_id] = head
+            node_by_id[version_id] = head.node
+        history: list[HypothesisLineageReceipt] = []
+        receipt_by_id: dict[str, HypothesisLineageReceipt] = {}
+        edges: list[HypothesisLineageEdge] = []
+        consumed: dict[str, HypothesisLineageNodeBinding] = {}
+        for receipt in receipts:
+            retained = receipt_by_id.get(receipt.lineage_id)
+            if retained is not None:
+                if retained.canonical_bytes == receipt.canonical_bytes:
+                    continue
+                raise HypothesisLineageContractError(
+                    "semantic lineage identity has divergent canonical bytes"
+                )
+            if len(history) >= MAX_LINEAGE_REPLAY_RECEIPTS:
+                raise HypothesisLineageContractError("lineage receipt bound exceeded")
+            target: HypothesisLineageReceipt | None = None
+            if receipt.kind is HypothesisLineageKind.REVERSAL:
+                target_binding = receipt.reversal_target
+                if target_binding is None:
+                    raise HypothesisLineageContractError("reversal target is absent")
+                target = receipt_by_id.get(target_binding.lineage_id)
+                if (
+                    target is None
+                    or target.kind is HypothesisLineageKind.REVERSAL
+                    or target.canonical_digest != target_binding.lineage_digest
+                ):
+                    raise HypothesisLineageContractError(
+                        "reversal target is missing, changed, or itself a reversal"
+                    )
+            input_heads: list[HypothesisLineageHead] = []
+            for node in receipt.inputs:
+                head = active.get(node.hypothesis_id)
+                if head is None:
+                    if node.version_id in consumed:
+                        raise HypothesisLineageContractError(
+                            "a consumed lineage node cannot be reused"
+                        )
+                    raise HypothesisLineageContractError(
+                        "lineage input is not an active head"
+                    )
+                if head.node != node:
+                    raise HypothesisLineageContractError(
+                        "lineage input differs from the exact active head"
+                    )
+                input_heads.append(head)
+            generations = {head.generation for head in input_heads}
+            if generations != {receipt.expected_generation}:
+                raise HypothesisLineageContractError(
+                    "lineage inputs are mixed-generation or stale"
+                )
+            if receipt.kind is HypothesisLineageKind.REVERSAL:
+                assert target is not None
+                if receipt.inputs != target.outputs:
+                    raise HypothesisLineageContractError(
+                        "reversal inputs differ from the target outputs"
+                    )
+            for node in receipt.outputs:
+                if node.hypothesis_id in active and node.hypothesis_id not in {
+                    item.hypothesis_id for item in receipt.inputs
+                }:
+                    raise HypothesisLineageContractError(
+                        "lineage output Hypothesis is already active"
+                    )
+                prior = node_by_id.get(node.version_id)
+                if prior is not None:
+                    if prior != node:
+                        raise HypothesisLineageContractError(
+                            "one Version identity has divergent bindings"
+                        )
+                    raise HypothesisLineageContractError(
+                        "lineage output Version has already been seen"
+                    )
+            if len(node_by_id) + len(receipt.outputs) > MAX_LINEAGE_REPLAY_NODES:
+                raise HypothesisLineageContractError("lineage node bound exceeded")
+            for node in receipt.inputs:
+                consumed[node.version_id] = node
+                del active[node.hypothesis_id]
+            next_generation = receipt.expected_generation + 1
+            for node in receipt.outputs:
+                node_by_id[node.version_id] = node
+                active[node.hypothesis_id] = HypothesisLineageHead(
+                    node, next_generation
+                )
+            edges.extend(
+                HypothesisLineageEdge(receipt.lineage_id, receipt.kind, source, output)
+                for source in receipt.inputs
+                for output in receipt.outputs
+            )
+            history.append(receipt)
+            receipt_by_id[receipt.lineage_id] = receipt
+        return HypothesisLineageReplay(
+            tuple(history),
+            tuple(sorted(active.values(), key=lambda item: _node_key(item.node))),
+            tuple(edges),
+            tuple(sorted(consumed.values(), key=_node_key)),
+        )
+
+    return _normalise(replay, "lineage replay failed")
+
+
+__all__ = [
+    "HYPOTHESIS_CONSOLIDATION",
+    "HYPOTHESIS_LINEAGE",
+    "HYPOTHESIS_REVERSAL_LINEAGE",
+    "HYPOTHESIS_SPLIT",
+    "MAX_LINEAGE_CANONICAL_BYTES",
+    "MAX_LINEAGE_COMPARATOR_EVIDENCE",
+    "MAX_LINEAGE_INPUTS",
+    "MAX_LINEAGE_OUTPUTS",
+    "MAX_LINEAGE_RELATIONSHIP_BINDINGS",
+    "MAX_LINEAGE_REPLAY_NODES",
+    "MAX_LINEAGE_REPLAY_RECEIPTS",
+    "HypothesisLineageContractError",
+    "HypothesisLineageEdge",
+    "HypothesisLineageEvidenceBinding",
+    "HypothesisLineageHead",
+    "HypothesisLineageKind",
+    "HypothesisLineageNodeBinding",
+    "HypothesisLineageReceipt",
+    "HypothesisLineageRelationshipBinding",
+    "HypothesisLineageRelationshipProof",
+    "HypothesisLineageReplay",
+    "HypothesisLineageTarget",
+    "replay_hypothesis_lineage",
+    "verify_hypothesis_lineage_receipt",
+]

--- a/newsroom/tests/test_increment6d3_lineage.py
+++ b/newsroom/tests/test_increment6d3_lineage.py
@@ -1,0 +1,816 @@
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import replace
+
+import pytest
+
+from newsroom.authority.canonical import canonical_json_bytes
+from newsroom.increment6.hypotheses import (
+    EventHypothesis,
+    EventHypothesisVersion,
+    HypothesisSourceBinding,
+)
+from newsroom.increment6.lineage import (
+    HYPOTHESIS_CONSOLIDATION,
+    HYPOTHESIS_LINEAGE,
+    HYPOTHESIS_REVERSAL_LINEAGE,
+    HYPOTHESIS_SPLIT,
+    HypothesisLineageContractError,
+    HypothesisLineageHead,
+    HypothesisLineageKind,
+    HypothesisLineageNodeBinding,
+    HypothesisLineageReceipt,
+    HypothesisLineageRelationshipBinding,
+    HypothesisLineageRelationshipProof,
+    HypothesisLineageTarget,
+    replay_hypothesis_lineage,
+    verify_hypothesis_lineage_receipt,
+)
+from newsroom.increment6.outcomes import CanonicalOutcome
+from newsroom.increment6.proposals import HypothesisRelationship
+from newsroom.increment6.relationships import (
+    AssessmentStatus,
+    ComparatorEvidence,
+    ComparatorSetManifest,
+    HypothesisVersionBinding,
+    RelationshipAssessment,
+    assess_relationships,
+)
+
+D1 = "sha256:" + "1" * 64
+D2 = "sha256:" + "2" * 64
+_VERSIONS: dict[str, EventHypothesisVersion] = {}
+_PROOFS: dict[str, HypothesisLineageRelationshipProof] = {}
+
+
+def _version(seed: int) -> EventHypothesisVersion:
+    proposal_id = str(uuid.UUID(int=seed))
+    hypothesis = EventHypothesis.allocate(proposal_id, f"local-{seed}")
+    source = HypothesisSourceBinding(
+        "sha256:" + f"{seed:064x}",
+        D2,
+        D1,
+        D2,
+        str(uuid.UUID(int=seed + 10_000)),
+        D1,
+        str(uuid.UUID(int=seed + 20_000)),
+        D2,
+    )
+    version = EventHypothesisVersion(
+        str(uuid.uuid5(uuid.UUID(hypothesis.hypothesis_id), "version:1")),
+        hypothesis.hypothesis_id,
+        1,
+        None,
+        None,
+        f"Summary {seed}",
+        HypothesisRelationship.NO_ADEQUATE_PRIOR_MATCH,
+        None,
+        None,
+        None,
+        proposal_id,
+        D1,
+        D2,
+        f"local-{seed}",
+        f"work-{seed}",
+        f"work-version-{seed}",
+        D1,
+        f"context-{seed}",
+        D2,
+        (source,),
+        D1,
+        str(uuid.UUID(int=seed + 30_000)),
+        "2042-01-01T00:00:00.000000Z",
+    )
+    _VERSIONS[version.version_id] = version
+    return version
+
+
+def _successor(version: EventHypothesisVersion, seed: int) -> EventHypothesisVersion:
+    ordinal = version.ordinal + 1
+    successor = replace(
+        version,
+        version_id=str(
+            uuid.uuid5(uuid.UUID(version.hypothesis_id), f"version:{ordinal}")
+        ),
+        ordinal=ordinal,
+        previous_version_id=version.version_id,
+        previous_version_digest=version.canonical_digest,
+        proposed_summary=f"Restored {seed}",
+        proposed_relationship=HypothesisRelationship.CORRECTION_REVERSAL_OF,
+        proposed_target_hypothesis_id=version.hypothesis_id,
+        target_version_id=version.version_id,
+        target_version_digest=version.canonical_digest,
+        proposal_id=f"proposal-{seed}",
+        proposal_local_id=f"restore-{seed}",
+        authority_event_id=str(uuid.UUID(int=seed + 40_000)),
+    )
+    _VERSIONS[successor.version_id] = successor
+    return successor
+
+
+def _decision(
+    subject_version: EventHypothesisVersion,
+    comparator_versions: tuple[EventHypothesisVersion, ...],
+    outcome: CanonicalOutcome,
+) -> tuple[RelationshipAssessment, tuple[ComparatorEvidence, ...]]:
+    subject = HypothesisVersionBinding.from_version(subject_version)
+    comparators = tuple(
+        HypothesisVersionBinding.from_version(version)
+        for version in comparator_versions
+    )
+    evidence: list[ComparatorEvidence] = []
+    for comparator in comparators:
+        scores = {
+            "score": 59,
+            "correction_reversal_score": 0,
+            "development_score": 0,
+            "same_state_score": 0,
+            "related_distinct_score": 0,
+        }
+        if outcome is CanonicalOutcome.REL_SAME_STATE:
+            scores["same_state_score"] = 80
+        elif outcome is CanonicalOutcome.REL_RELATED_DISTINCT:
+            scores["related_distinct_score"] = 60
+        elif outcome is CanonicalOutcome.REL_CORRECTION_REVERSAL_OF:
+            scores["correction_reversal_score"] = 80
+        else:  # pragma: no cover - test helper guard
+            raise AssertionError(outcome)
+        evidence.append(ComparatorEvidence(subject, comparator, **scores))
+    result = assess_relationships(
+        subject, ComparatorSetManifest.complete(comparators), tuple(evidence)
+    )
+    assert result.decision is outcome
+    return result, tuple(evidence)
+
+
+def _assessment(
+    subject: EventHypothesisVersion,
+    comparator: EventHypothesisVersion,
+    outcome: CanonicalOutcome,
+) -> RelationshipAssessment:
+    return _decision(subject, (comparator,), outcome)[0]
+
+
+def _proof(
+    subject: EventHypothesisVersion,
+    comparators: tuple[EventHypothesisVersion, ...],
+    outcome: CanonicalOutcome,
+) -> HypothesisLineageRelationshipProof:
+    assessment, evidence = _decision(subject, comparators, outcome)
+    proof = HypothesisLineageRelationshipProof.from_assessment(assessment, evidence)
+    _PROOFS[proof.binding.assessment_digest] = proof
+    return proof
+
+
+def _consolidation(
+    inputs: tuple[EventHypothesisVersion, ...],
+    output: EventHypothesisVersion,
+    generation: int = 0,
+) -> HypothesisLineageReceipt:
+    return HypothesisLineageReceipt.consolidation(
+        expected_generation=generation,
+        inputs=inputs,
+        output=output,
+        relationship_proofs=(_proof(output, inputs, CanonicalOutcome.REL_SAME_STATE),),
+    )
+
+
+def _split(
+    source: EventHypothesisVersion,
+    outputs: tuple[EventHypothesisVersion, ...],
+    generation: int = 0,
+) -> HypothesisLineageReceipt:
+    return HypothesisLineageReceipt.split(
+        expected_generation=generation,
+        source=source,
+        outputs=outputs,
+        relationship_proofs=tuple(
+            _proof(
+                output,
+                (source, *(item for item in outputs if item != output)),
+                CanonicalOutcome.REL_RELATED_DISTINCT,
+            )
+            for output in outputs
+        ),
+    )
+
+
+def _heads(*versions: EventHypothesisVersion) -> tuple[HypothesisLineageHead, ...]:
+    return tuple(HypothesisLineageHead.from_version(version) for version in versions)
+
+
+def _replay(
+    receipts: tuple[HypothesisLineageReceipt, ...],
+    initial_heads: tuple[HypothesisLineageHead, ...],
+) -> object:
+    nodes = {
+        node.version_id: node
+        for receipt in receipts
+        for node in (*receipt.inputs, *receipt.outputs)
+    }
+    nodes.update({head.node.version_id: head.node for head in initial_heads})
+    proofs = {
+        binding.assessment_digest: _PROOFS[binding.assessment_digest]
+        for receipt in receipts
+        for binding in receipt.relationships
+    }
+    return replay_hypothesis_lineage(
+        receipts,
+        initial_heads=initial_heads,
+        versions=tuple(_VERSIONS[version_id] for version_id in nodes),
+        relationship_proofs=tuple(proofs.values()),
+    )
+
+
+def test_public_contract_roundtrip_identity_and_no_effect_boundary() -> None:
+    left, right, output = _version(1), _version(2), _version(3)
+    receipt = _consolidation((right, left), output)
+    replayed = HypothesisLineageReceipt.from_canonical_bytes(receipt.canonical_bytes)
+
+    assert replayed == receipt
+    assert replayed.canonical_digest.startswith("sha256:")
+    assert receipt.inputs == tuple(
+        sorted(
+            receipt.inputs,
+            key=lambda item: (item.hypothesis_id, item.version_id, item.version_digest),
+        )
+    )
+    assert HYPOTHESIS_LINEAGE == "newsroom.increment6.hypothesis-lineage.v1"
+    assert {
+        HYPOTHESIS_CONSOLIDATION,
+        HYPOTHESIS_SPLIT,
+        HYPOTHESIS_REVERSAL_LINEAGE,
+    } == {item.value for item in HypothesisLineageKind}
+    for name in (
+        "authorises_authority",
+        "authorises_persistence",
+        "authorises_external_effect",
+        "authorises_publication",
+        "authorises_evidence",
+        "authorises_egress",
+        "authorises_relationship",
+        "creates_candidate",
+        "creates_hypothesis",
+        "creates_version",
+        "creates_relationship",
+    ):
+        assert getattr(receipt, name) is False
+
+
+def test_semantic_id_excludes_outputs_and_basis_but_divergent_retry_fails() -> None:
+    left, right = _version(10), _version(11)
+    first = _consolidation((left, right), _version(12))
+    divergent = _consolidation((left, right), _version(13))
+    assert first.lineage_id == divergent.lineage_id
+    assert first.canonical_bytes != divergent.canonical_bytes
+
+    initial = _heads(left, right)
+    result = _replay((first, first), initial_heads=initial)
+    assert result.history == (first,)
+    assert len(result.edges) == 2
+    with pytest.raises(HypothesisLineageContractError, match="divergent"):
+        _replay((first, divergent), initial_heads=initial)
+
+
+def test_valid_consolidation_consumes_heads_without_mutating_predecessors() -> None:
+    left, right, output = _version(20), _version(21), _version(22)
+    left_bytes, right_bytes = left.canonical_bytes, right.canonical_bytes
+    receipt = _consolidation((left, right), output)
+    result = _replay((receipt,), initial_heads=_heads(left, right))
+
+    assert result.active_heads == (HypothesisLineageHead.from_version(output, 1),)
+    assert {item.version_id for item in result.consumed} == {
+        left.version_id,
+        right.version_id,
+    }
+    assert left.canonical_bytes == left_bytes
+    assert right.canonical_bytes == right_bytes
+
+
+def test_mixed_generation_replay_fails_and_retained_result_is_immutable() -> None:
+    left, right, merged, unrelated = (
+        _version(30),
+        _version(31),
+        _version(32),
+        _version(33),
+    )
+    first = _consolidation((left, right), merged)
+    retained = _replay((first,), initial_heads=_heads(left, right, unrelated))
+    before = retained.active_heads
+    mixed = _consolidation((merged, unrelated), _version(34), generation=1)
+    with pytest.raises(HypothesisLineageContractError, match="mixed-generation"):
+        _replay((first, mixed), initial_heads=_heads(left, right, unrelated))
+    assert retained.active_heads == before
+
+
+def test_valid_split_and_exact_32_way_pair_coverage_envelope() -> None:
+    source = _version(100)
+    outputs = tuple(_version(seed) for seed in range(101, 133))
+    receipt = _split(source, outputs)
+    assert len(receipt.relationships) == 32
+    assert sum(len(item.evidence) for item in receipt.relationships) == 1_024
+    assert len({item.subject.version_id for item in receipt.relationships}) == 32
+    assert len(receipt.canonical_bytes) < 1_048_576
+    result = _replay((receipt,), initial_heads=_heads(source))
+    assert len(result.active_heads) == 32
+    assert {head.generation for head in result.active_heads} == {1}
+
+
+def test_split_rejects_missing_extra_wrong_or_incomplete_decision_basis() -> None:
+    source, left, right = _version(200), _version(201), _version(202)
+    valid = _split(source, (left, right))
+    cases = (
+        valid.relationships[:-1],
+        valid.relationships
+        + (_proof(source, (left,), CanonicalOutcome.REL_RELATED_DISTINCT).binding,),
+        tuple(
+            replace(item, outcome=CanonicalOutcome.REL_SAME_STATE)
+            if index == 0
+            else item
+            for index, item in enumerate(valid.relationships)
+        ),
+        (
+            replace(
+                valid.relationships[0], evidence=valid.relationships[0].evidence[:-1]
+            ),
+        )
+        + valid.relationships[1:],
+    )
+    for relationships in cases:
+        with pytest.raises(HypothesisLineageContractError):
+            HypothesisLineageReceipt._build(
+                HypothesisLineageKind.SPLIT,
+                0,
+                valid.inputs,
+                valid.outputs,
+                tuple(
+                    sorted(
+                        relationships,
+                        key=lambda item: (
+                            item.subject.version_id,
+                            item.assessment_digest,
+                        ),
+                    )
+                ),
+            )
+
+
+def test_valid_reversal_restores_exact_hypothesis_identities_with_new_versions() -> (
+    None
+):
+    left, right, merged = _version(300), _version(301), _version(302)
+    consolidation = _consolidation((left, right), merged)
+    restored = (_successor(left, 303), _successor(right, 304))
+    reversal = HypothesisLineageReceipt.reversal(
+        expected_generation=1,
+        target=consolidation,
+        outputs=restored,
+        relationship_proofs=tuple(
+            _proof(output, (merged,), CanonicalOutcome.REL_CORRECTION_REVERSAL_OF)
+            for output in restored
+        ),
+    )
+    result = _replay((consolidation, reversal), initial_heads=_heads(left, right))
+    assert {head.node.hypothesis_id for head in result.active_heads} == {
+        left.hypothesis_id,
+        right.hypothesis_id,
+    }
+    assert {head.generation for head in result.active_heads} == {2}
+    assert result.history == (consolidation, reversal)
+
+
+def test_split_reversal_uses_one_subject_for_all_superseded_outputs() -> None:
+    source = _version(305)
+    split_outputs = (_version(306), _version(307))
+    split = _split(source, split_outputs)
+    restored = _successor(source, 308)
+    proof = _proof(
+        restored,
+        split_outputs,
+        CanonicalOutcome.REL_CORRECTION_REVERSAL_OF,
+    )
+    reversal = HypothesisLineageReceipt.reversal(
+        expected_generation=1,
+        target=split,
+        outputs=(restored,),
+        relationship_proofs=(proof,),
+    )
+    assert len(reversal.relationships) == 1
+    assert len(reversal.relationships[0].evidence) == 2
+    assert (
+        verify_hypothesis_lineage_receipt(
+            reversal,
+            versions=(*split_outputs, restored),
+            relationship_proofs=(proof,),
+            reversal_target=split,
+        )
+        == reversal
+    )
+    result = _replay((split, reversal), initial_heads=_heads(source))
+    assert result.active_heads == (HypothesisLineageHead.from_version(restored, 2),)
+
+
+def test_reversal_rejects_wrong_target_stale_target_and_wrong_restoration() -> None:
+    left, right, merged = _version(400), _version(401), _version(402)
+    target = _consolidation((left, right), merged)
+    restored = (_successor(left, 403), _successor(right, 404))
+    reversal = HypothesisLineageReceipt.reversal(
+        expected_generation=1,
+        target=target,
+        outputs=restored,
+        relationship_proofs=tuple(
+            _proof(item, (merged,), CanonicalOutcome.REL_CORRECTION_REVERSAL_OF)
+            for item in restored
+        ),
+    )
+    with pytest.raises(HypothesisLineageContractError, match="target"):
+        _replay((reversal,), initial_heads=_heads(merged))
+
+    later_left, later_right = _version(405), _version(406)
+    advance = _split(merged, (later_left, later_right), generation=1)
+    with pytest.raises(HypothesisLineageContractError, match="active head|consumed"):
+        _replay((target, advance, reversal), initial_heads=_heads(left, right))
+
+    wrong = _version(407)
+    wrong_reversal = HypothesisLineageReceipt.reversal(
+        expected_generation=1,
+        target=target,
+        outputs=(wrong,),
+        relationship_proofs=(
+            _proof(wrong, (merged,), CanonicalOutcome.REL_CORRECTION_REVERSAL_OF),
+        ),
+    )
+    with pytest.raises(HypothesisLineageContractError, match="restore"):
+        _replay((target, wrong_reversal), initial_heads=_heads(left, right))
+
+
+def test_seen_output_consumed_reuse_and_self_edge_fail_closed() -> None:
+    left, right, merged = _version(500), _version(501), _version(502)
+    first = _consolidation((left, right), merged)
+    reuse = _split(left, (_version(503), _version(504)), generation=1)
+    with pytest.raises(HypothesisLineageContractError, match="consumed"):
+        _replay((first, reuse), initial_heads=_heads(left, right))
+
+    source, output = _version(505), _version(506)
+    seen = _split(source, (output, left))
+    with pytest.raises(HypothesisLineageContractError, match="seen|already active"):
+        _replay((seen,), initial_heads=_heads(source, left))
+
+    node = HypothesisLineageNodeBinding.from_version(left)
+    relation = first.relationships[0]
+    with pytest.raises(HypothesisLineageContractError, match="self edge"):
+        HypothesisLineageReceipt._build(
+            HypothesisLineageKind.CONSOLIDATION,
+            0,
+            tuple(
+                sorted(
+                    (node, HypothesisLineageNodeBinding.from_version(right)),
+                    key=lambda item: (
+                        item.hypothesis_id,
+                        item.version_id,
+                        item.version_digest,
+                    ),
+                )
+            ),
+            (node,),
+            (relation,),
+        )
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        b"[]",
+        b"true",
+        b"1.0",
+        b'{"x":9007199254740992}',
+        b'{"schema_version":"x","schema_version":"x"}',
+        b'{ "schema_version":"x"}',
+        b'{"schema_version":"\\ud800"}',
+        b'{"schema_version":"x","unknown":1}',
+    ],
+)
+def test_parser_rejects_noncanonical_or_unsafe_json(raw: bytes) -> None:
+    with pytest.raises(HypothesisLineageContractError):
+        HypothesisLineageReceipt.from_canonical_bytes(raw)
+
+
+def test_parser_unknown_nested_fields_and_derived_identity_tamper_fail_closed() -> None:
+    receipt = _consolidation((_version(600), _version(601)), _version(602))
+    value = json.loads(receipt.canonical_bytes)
+    value["inputs"][0]["unknown"] = True
+    with pytest.raises(HypothesisLineageContractError):
+        HypothesisLineageReceipt.from_canonical_bytes(canonical_json_bytes(value))
+    value = json.loads(receipt.canonical_bytes)
+    value["lineage_id"] = str(uuid.uuid4())
+    with pytest.raises(HypothesisLineageContractError, match="semantic identity"):
+        HypothesisLineageReceipt.from_canonical_bytes(canonical_json_bytes(value))
+
+
+def test_producer_type_impostor_uninitialised_cycle_oversize_and_depth_are_total() -> (
+    None
+):
+    from newsroom.increment6 import lineage as module
+
+    class VersionImpostor(EventHypothesisVersion):
+        pass
+
+    class TupleImpostor(tuple):
+        pass
+
+    with pytest.raises(HypothesisLineageContractError):
+        HypothesisLineageNodeBinding.from_version(object.__new__(VersionImpostor))
+    with pytest.raises(HypothesisLineageContractError):
+        replay_hypothesis_lineage(
+            TupleImpostor(),  # type: ignore[arg-type]
+            initial_heads=(),
+            versions=(),
+            relationship_proofs=(),
+        )
+    uninitialised = object.__new__(HypothesisLineageReceipt)
+    with pytest.raises(HypothesisLineageContractError):
+        _ = uninitialised.canonical_bytes
+    receipt = _consolidation((_version(700), _version(701)), _version(702))
+    cyclic: list[object] = []
+    cyclic.append(cyclic)
+    object.__setattr__(receipt, "inputs", cyclic)
+    with pytest.raises(HypothesisLineageContractError):
+        _ = receipt.canonical_bytes
+    with pytest.raises(HypothesisLineageContractError):
+        HypothesisLineageReceipt.from_canonical_bytes(
+            b"{" + b" " * module.MAX_LINEAGE_CANONICAL_BYTES + b"}"
+        )
+    deep: object = None
+    for _ in range(20):
+        deep = [deep]
+    with pytest.raises(HypothesisLineageContractError):
+        HypothesisLineageReceipt.from_canonical_bytes(
+            json.dumps({"x": deep}, separators=(",", ":")).encode()
+        )
+
+
+def test_relationship_binding_requires_exact_complete_public_receipt() -> None:
+    left, right = _version(800), _version(801)
+    complete, evidence = _decision(left, (right,), CanonicalOutcome.REL_SAME_STATE)
+    proof = HypothesisLineageRelationshipProof.from_assessment(complete, evidence)
+    binding = proof.binding
+    assert binding.assessment_digest == complete.canonical_digest
+    assert binding.outcome is complete.decision
+    assert binding.subject.version_id == left.version_id
+    assert binding.evidence[0].comparator_version_id == right.version_id
+    assert binding.evidence[0].classification is CanonicalOutcome.REL_SAME_STATE
+    third = _version(802)
+    receipt = _consolidation((right, third), left)
+    receipt_proof = _PROOFS[receipt.relationships[0].assessment_digest]
+    assert (
+        verify_hypothesis_lineage_receipt(
+            receipt,
+            versions=(right, third, left),
+            relationship_proofs=(receipt_proof,),
+            reversal_target=None,
+        ).kind
+        is HypothesisLineageKind.CONSOLIDATION
+    )
+    with pytest.raises(HypothesisLineageContractError, match="non-reversal"):
+        verify_hypothesis_lineage_receipt(
+            receipt,
+            versions=(right, third, left),
+            relationship_proofs=(receipt_proof,),
+            reversal_target=receipt,
+        )
+    incomplete = RelationshipAssessment(
+        AssessmentStatus.INCOMPLETE,
+        HypothesisVersionBinding.from_version(left),
+        ComparatorSetManifest(
+            AssessmentStatus.INCOMPLETE,
+            (HypothesisVersionBinding.from_version(right),),
+        ),
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    with pytest.raises(HypothesisLineageContractError, match="complete"):
+        HypothesisLineageRelationshipBinding.from_assessment(incomplete, evidence)
+    with pytest.raises(HypothesisLineageContractError):
+        HypothesisLineageRelationshipBinding.from_assessment(
+            object(),
+            evidence,  # type: ignore[arg-type]
+        )
+    with pytest.raises(HypothesisLineageContractError):
+        HypothesisLineageRelationshipProof()
+    changed = replace(evidence[0], same_state_score=79, related_distinct_score=60)
+    with pytest.raises(HypothesisLineageContractError, match="policy replay"):
+        HypothesisLineageRelationshipProof.from_assessment(complete, (changed,))
+
+
+def test_ordinary_exceptions_normalise_and_base_exceptions_survive() -> None:
+    from newsroom.increment6 import lineage as module
+
+    for exc in (RuntimeError(), KeyError(), AttributeError()):
+        with pytest.raises(HypothesisLineageContractError):
+            module._normalise(lambda exc=exc: (_ for _ in ()).throw(exc), "failed")
+    for exc_type in (KeyboardInterrupt, SystemExit):
+        with pytest.raises(exc_type):
+            module._normalise(
+                lambda exc_type=exc_type: (_ for _ in ()).throw(exc_type()), "failed"
+            )
+
+
+def test_v22_decision_subjects_are_unique() -> None:
+    receipt = _split(_version(900), (_version(901), _version(902)))
+    subjects = tuple(item.subject.version_id for item in receipt.relationships)
+    assert len(subjects) == len(set(subjects))
+
+
+def test_replay_rejects_forged_semantic_producers() -> None:
+    left, right, output = _version(910), _version(911), _version(912)
+    receipt = _consolidation((left, right), output)
+    forged_output = replace(receipt.outputs[0], version_digest=D2)
+    forged_relationships = tuple(
+        replace(item, subject=forged_output) for item in receipt.relationships
+    )
+    forged = replace(
+        receipt, outputs=(forged_output,), relationships=forged_relationships
+    )
+    with pytest.raises(HypothesisLineageContractError):
+        _replay((forged,), initial_heads=_heads(left, right))
+
+
+def test_structural_forged_output_assessment_evidence_and_endpoint_fail_replay() -> (
+    None
+):
+    left, right, output = _version(913), _version(914), _version(915)
+    receipt = _consolidation((left, right), output)
+    proof = _PROOFS[receipt.relationships[0].assessment_digest]
+    base = json.loads(receipt.canonical_bytes)
+
+    forged_values: list[dict[str, object]] = []
+    forged_output = json.loads(receipt.canonical_bytes)
+    forged_output["outputs"][0]["version_digest"] = D2
+    forged_output["relationships"][0]["subject"]["version_digest"] = D2
+    forged_values.append(forged_output)
+
+    forged_assessment = json.loads(receipt.canonical_bytes)
+    forged_assessment["relationships"][0]["assessment_digest"] = D2
+    forged_values.append(forged_assessment)
+
+    forged_evidence = json.loads(receipt.canonical_bytes)
+    forged_evidence["relationships"][0]["evidence"][0]["evidence_digest"] = D2
+    forged_values.append(forged_evidence)
+
+    forged_endpoints = base
+    evidence = forged_endpoints["relationships"][0]["evidence"]
+    evidence[0]["comparator_version_id"], evidence[1]["comparator_version_id"] = (
+        evidence[1]["comparator_version_id"],
+        evidence[0]["comparator_version_id"],
+    )
+    evidence.sort(key=lambda item: item["comparator_version_id"])
+    forged_values.append(forged_endpoints)
+
+    for value in forged_values:
+        parsed = HypothesisLineageReceipt.from_canonical_bytes(
+            canonical_json_bytes(value)
+        )
+        with pytest.raises(HypothesisLineageContractError):
+            replay_hypothesis_lineage(
+                (parsed,),
+                initial_heads=_heads(left, right),
+                versions=(left, right, output),
+                relationship_proofs=(proof,),
+            )
+
+
+def test_active_hypotheses_are_unique() -> None:
+    version = _version(920)
+    successor = _successor(version, 921)
+    with pytest.raises(HypothesisLineageContractError):
+        _replay((), initial_heads=_heads(version, successor))
+
+
+def test_partial_continuation_is_rejected() -> None:
+    with pytest.raises(HypothesisLineageContractError):
+        _replay(
+            (), initial_heads=(HypothesisLineageHead.from_version(_version(930), 1),)
+        )
+
+
+def test_uninitialised_assessment_proof_and_target_are_total() -> None:
+    assessment, evidence = _decision(
+        _version(940), (_version(942),), CanonicalOutcome.REL_SAME_STATE
+    )
+    assert assessment.status is AssessmentStatus.COMPLETE
+    with pytest.raises(HypothesisLineageContractError):
+        HypothesisLineageRelationshipBinding.from_assessment(
+            object.__new__(RelationshipAssessment), evidence
+        )
+    with pytest.raises(HypothesisLineageContractError):
+        _ = object.__new__(HypothesisLineageRelationshipProof).binding
+    with pytest.raises(HypothesisLineageContractError):
+        HypothesisLineageReceipt.reversal(
+            expected_generation=1,
+            target=object.__new__(HypothesisLineageReceipt),
+            outputs=(_version(941),),
+            relationship_proofs=(),
+        )
+
+
+def test_final_review_red_cross_binds_same_id_different_digest_comparators() -> None:
+    left, right, merged = _version(950), _version(951), _version(952)
+    changed_right = replace(right, proposed_summary="Changed comparator 951")
+    consolidation_proof = _proof(
+        merged, (left, changed_right), CanonicalOutcome.REL_SAME_STATE
+    )
+    consolidation = HypothesisLineageReceipt.consolidation(
+        expected_generation=0,
+        inputs=(left, right),
+        output=merged,
+        relationship_proofs=(consolidation_proof,),
+    )
+    with pytest.raises(HypothesisLineageContractError):
+        verify_hypothesis_lineage_receipt(
+            consolidation,
+            versions=(left, right, merged),
+            relationship_proofs=(consolidation_proof,),
+            reversal_target=None,
+        )
+
+    restored = (_successor(left, 953), _successor(right, 954))
+    changed_merged = replace(merged, proposed_summary="Changed comparator 952")
+    reversal_proofs = tuple(
+        _proof(
+            output,
+            (changed_merged,),
+            CanonicalOutcome.REL_CORRECTION_REVERSAL_OF,
+        )
+        for output in restored
+    )
+    reversal = HypothesisLineageReceipt.reversal(
+        expected_generation=1,
+        target=consolidation,
+        outputs=restored,
+        relationship_proofs=reversal_proofs,
+    )
+    with pytest.raises(HypothesisLineageContractError):
+        verify_hypothesis_lineage_receipt(
+            reversal,
+            versions=(merged, *restored),
+            relationship_proofs=reversal_proofs,
+            reversal_target=consolidation,
+        )
+
+
+def test_final_review_red_standalone_verifier_rejects_changed_reversal_target() -> None:
+    left, right, merged = _version(960), _version(961), _version(962)
+    target = _consolidation((left, right), merged)
+    restored = (_successor(left, 963), _successor(right, 964))
+    proofs = tuple(
+        _proof(output, (merged,), CanonicalOutcome.REL_CORRECTION_REVERSAL_OF)
+        for output in restored
+    )
+    reversal = HypothesisLineageReceipt.reversal(
+        expected_generation=1,
+        target=target,
+        outputs=restored,
+        relationship_proofs=proofs,
+    )
+    changed_target = HypothesisLineageTarget(target.lineage_id, D1)
+    forged = HypothesisLineageReceipt._build(
+        HypothesisLineageKind.REVERSAL,
+        reversal.expected_generation,
+        reversal.inputs,
+        reversal.outputs,
+        reversal.relationships,
+        changed_target,
+    )
+    assert forged.lineage_id != reversal.lineage_id
+    with pytest.raises(HypothesisLineageContractError):
+        verify_hypothesis_lineage_receipt(
+            forged,
+            versions=(merged, *restored),
+            relationship_proofs=proofs,
+            reversal_target=target,
+        )
+
+
+def test_final_parity_red_standalone_rejects_wrong_restoration_identities() -> None:
+    left, right, merged = _version(970), _version(971), _version(972)
+    target = _consolidation((left, right), merged)
+    wrong = _version(973)
+    proof = _proof(wrong, (merged,), CanonicalOutcome.REL_CORRECTION_REVERSAL_OF)
+    reversal = HypothesisLineageReceipt.reversal(
+        expected_generation=1,
+        target=target,
+        outputs=(wrong,),
+        relationship_proofs=(proof,),
+    )
+    with pytest.raises(HypothesisLineageContractError, match="restore"):
+        verify_hypothesis_lineage_receipt(
+            reversal,
+            versions=(merged, wrong),
+            relationship_proofs=(proof,),
+            reversal_target=target,
+        )


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-6d3-lineage-contract
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

Refs #365
Refs #382
Refs #395

## Scope

Phase 1 / 6D3a Tier-L adds the sole public `newsroom.increment6.lineage` contract and its focused public-interface test.

- one canonical `newsroom.increment6.hypothesis-lineage.v1` receipt covers consolidation, split and reversal through one deep interface
- typed node bindings consume exact canonical 6D1 `EventHypothesisVersion` producers
- one compact decision binding per unique subject consumes an exact COMPLETE 6D2 `RelationshipAssessment` plus its exact `ComparatorEvidence` tuple, reruns public D2 policy, and binds assessment, manifest, evidence-set, per-evidence digest, endpoints and classification
- deterministic UUIDv5 semantic identity excludes outputs and relationship basis, so byte-identical retries are idempotent while divergent retries fail closed
- required semantic verification rebinds every structural node and decision proof before the public full-rebuild-only reducer derives state
- replay keys active heads by Hypothesis identity, requires generation-zero exact roots, and enforces generations, consumption, unseen outputs, reversal targets, immutable history and bounded reconstructable edges
- strict canonical parsing remains explicitly untrusted and rejects duplicate or unknown keys, floats, unsafe integers, non-canonical bytes and structural or size excesses

## First-review correction closure

The bounded correction addresses the exact reviewed-head findings from `9d82b16502f436dae61e58f5b32a1581a9431090`:

1. **P1 — v22 compatibility:** replaced pair-per-assessment rows with one decision per unique subject. Consolidation uses one successor decision over all predecessors; split uses one decision per successor over source plus every other successor; reversal uses one decision per restoration over all superseded outputs. The 32-way split proves 32 unique subjects and 1,024 compact evidence entries under 1 MiB.
2. **P2 — semantic replay:** structural parser output must pass exact D1 Version and replayed D2 assessment/evidence producer verification inside the public reducer. Forged output, assessment, evidence and endpoint bindings parse structurally but fail replay.
3. **P2 — active view:** active heads are keyed by `hypothesis_id`; duplicate initial active hypotheses and unconsumed active-output collisions fail closed.
4. **P2 — continuation:** replay accepts only generation-zero roots and therefore cannot forget historical seen/consumed state through partial continuation.
5. **P2 — totality:** exact-but-uninitialised assessment, proof and reversal-target paths normalise ordinary exceptions to `HypothesisLineageContractError`; `BaseException` remains preserved.

Implementation correction is complete. The pre-rebase final substantive review reported 0 P1 / 0 material P2 and live unresolved review-thread count 0. The bounded exact-rebase delta review also reported 0 P1 / 0 material P2.

## Final delta correction closure

The final bounded correction addresses the two material P2 findings reviewed at `86d6c155e537022d3c3987db7ccce96e5e77f3c1` / `01814ff46899845ebeb747088e8c74bf3bed73d3`:

1. every exact D2 assessment-manifest and Comparator Evidence subject/comparator endpoint is now cross-bound by `hypothesis_id`, `version_id` and `version_digest` to the exact D1 receipt producer;
2. standalone reversal verification now requires the exact canonical non-reversal target receipt and binds target type, ID, digest and outputs, while non-reversal verification rejects a target. Full replay supplies only the exact earlier verified target.

Targeted RED reproduced both gaps: 2 failed, 28 deselected. Targeted GREEN is 2 passed, 28 deselected. Structural parsing remains explicitly untrusted, and the 32 decisions / 1,024 evidence / sub-1 MiB envelope is unchanged.

## Verifier-parity correction closure

The final verifier-parity material P2 reviewed at `01d8448231f30a0615711c0e532c11d4471c9d0f` / `0a715a6ec26dce9b38aafc3d65e1eddea544dad1` is closed in the implementation: standalone reversal verification now enforces the same one-to-one restoration of target input Hypothesis identities as full replay. The predicate moved to the mandatory verifier and the duplicate reducer copy was removed.

Targeted RED reproduced direct standalone acceptance: 1 failed, 30 deselected. Targeted GREEN: 1 passed, 30 deselected. No rule, schema, bound or effect surface changed.

## Phase boundary

This contract phase contains no migration, SQL/store, transaction, authority writer, current-view mutation, private v21/v22 import or downstream effect. Inputs and outputs are already-existing immutable 6D1 Versions. Compact decisions grant no authority; the later 6D3b persistence phase must resolve exact retained v22 assessment and evidence proof in its checked v23 transaction.

No Candidate, Evidence Intake, publication, egress, model/provider, external request or production effect is authorised.

Phase 1 passed its bounded exact-rebase delta review and may be marked ready. Merge waits only for the final exact-head workflow receipt. Keep #365 open: serial 6D3b persistence starts only from accepted Phase-1 main and after #395 is accepted.

## Exact source

- base / merge-base after the single dependency rebase: `main@61eacc0b11655b2cd2eef199d281bb34ea7fae77`
- initial RED: `uv run pytest -q newsroom/tests/test_increment6d3_lineage.py` — collection failed with `ModuleNotFoundError: No module named 'newsroom.increment6.lineage'`
- first-review correction RED: targeted five-regression run — 5 failed, 21 deselected; exposed duplicate v22 subjects, accepted forged producer, duplicate active Hypothesis, accepted partial continuation and raw `AttributeError`
- rebased exact GREEN head: `d5b1a0db8dc0d347a20bef0aba05138ee0dbe71e`
- rebased exact GREEN tree: `3299ee292f36e6cbae476a8f78087368a85a0dee`
- rebase patch proof: both source and focused-test Git blob IDs are byte-identical to reviewed head `68b9045ff0e7606ec166dd68cc9c8ec25cd135a3`; stable patch ID remains `bbad2522`
- production SHA-256: `d3bb1d672d8eea16f370eb9e27a4b133404a28e91e51e5ec88a94dfe03b8aef6` (`newsroom/increment6/lineage.py`, 1,445 lines)
- focused-test SHA-256: `4dd0f2679eddc3710b4be579bd2050268d94c1f41a27355e799adf9370a1d8fb`

## Verification

- `uv run pytest -q newsroom/tests/test_increment6d3_lineage.py` — 31 passed in 6.65s
- `uv run pytest -q newsroom/tests/test_increment6d1_hypotheses.py newsroom/tests/test_increment6d2_relationships.py newsroom/tests/test_increment6r_readiness.py` — 55 passed in 9.67s
- `uvx ruff format --check newsroom/increment6/lineage.py newsroom/tests/test_increment6d3_lineage.py` — clean
- `uvx ruff check newsroom/increment6/lineage.py newsroom/tests/test_increment6d3_lineage.py` — passed
- `uv run python -m compileall -q newsroom/increment6/lineage.py` — passed
- `uv lock --check` — passed
- `git diff --check` — passed
- bounded exact-rebase delta review — 0 P1 / 0 material P2; 0 review threads
- remote branch SHA verified as `d5b1a0db8dc0d347a20bef0aba05138ee0dbe71e`

