### PR TITLE
Close the v22 backup transaction boundary

### DIFF
--- a/newsroom/authority/event_hypothesis_relationship_migrations.py
+++ b/newsroom/authority/event_hypothesis_relationship_migrations.py
@@ -146,6 +146,8 @@ def prepare_event_hypothesis_relationship_backup(
         "INSERT INTO event_hypothesis_relationship_backup_gate VALUES(?,?,?)",
         (str(backup_path), backup_digest, logical_digest),
     )
+    if connection.in_transaction:
+        connection.commit()
     return EventHypothesisRelationshipBackupReceipt(
         backup_path, digest_path, backup_digest, logical_digest
     )

--- a/newsroom/tests/test_increment6d2_relationship_migrations.py
+++ b/newsroom/tests/test_increment6d2_relationship_migrations.py
@@ -130,6 +130,27 @@ def test_exact_v21_backup_upgrade_and_injected_rollback(
     assert connection.execute("PRAGMA user_version").fetchone() == (22,)
 
 
+def test_standard_sqlite_connection_v22_backup_gate_closes_implicit_transaction(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "standard-connection.sqlite3"
+    initial = _fresh(database)
+    _downgrade_to_v21(initial)
+    initial.close()
+
+    connection = sqlite3.connect(database)
+    try:
+        backup, _ = event_hypothesis_relationship_backup_paths(database)
+        prepare_event_hypothesis_relationship_backup(connection, backup)
+        assert connection.in_transaction is False
+
+        apply_pending_migrations(connection, applied_at="2042-01-01T00:00:01.000000Z")
+
+        assert connection.execute("PRAGMA user_version").fetchone() == (22,)
+    finally:
+        connection.close()
+
+
 def test_v21_backup_required_and_v23_fails_closed(tmp_path: Path) -> None:
     connection = _fresh(tmp_path / "authority.sqlite3")
     _downgrade_to_v21(connection)


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-6d2-v22-backup-transaction
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

Refs #364 #393

## Scope

Bounded production correction for the v22 backup-preflight transaction boundary.

- Base: `8240b6136d77646681f69cd679e470b1acf9287f`
- Head: `78eb4aed0046cb89c48dc7c0a5b630b44e0a2a66`
- Tree: `37b7491bc32377d523985b38e5382117893d95b2`
- Changed files: 1 allocated migration helper and 1 focused migration test
- Migration helper SHA-256: `sha256:44fd311cb3a73f775f96119be14a69dfecaf2a6f6def011298b0c038b73fe140`

The TEMP v22 backup-gate receipt now commits an implicit default-SQLite transaction before the central migrator opens its exclusive migration transaction. This exactly matches the accepted v17-v21 backup helpers. Migration statements, checksum, schema fingerprint and authority semantics are unchanged.

## Evidence

### RED

The new default-connection regression failed before the production correction:

`test_standard_sqlite_connection_v22_backup_gate_closes_implicit_transaction` -> `connection.in_transaction is True` after preflight. Continuing the real migration failed at `BEGIN EXCLUSIVE` with `OperationalError: cannot start a transaction within a transaction`.

### GREEN

- v22 migration tests, v21 migration compatibility and real v21-to-v22 store path: **17 passed**.
- Ruff format/check on both changed files: passed.
- targeted compileall, `uv lock --check` and `git diff --check`: passed.
- worktree clean; local and remote head must remain exact.

This PR does not close #364. After it lands, draft PR #393 will rebase once, remove its temporary autocommit workaround and prove the retained v13-v20 fixtures against corrected main.
