### PR TITLE
Add authority migration compatibility harness

### DIFF
--- a/docs/operations/authority-migration-compatibility.md
+++ b/docs/operations/authority-migration-compatibility.md
@@ -1,0 +1,152 @@
+# Authority migration compatibility harness
+
+## Purpose
+
+`newsroom/tests/authority_migration_compatibility.py` is the canonical test-only
+builder and inspector for retained empty SQLite authority schemas from v13
+through the production `SCHEMA_VERSION` (v22 at this release).
+It gives a future checked migration one stable way to prove that its exact
+predecessors still upgrade. It does not add a production migration, change a
+schema statement, recalculate a production checksum, or replace the existing
+Graphiti downgrade helpers.
+
+The harness builds old schemas forwards from the production SQL statement
+tuples. It never creates a predecessor by deleting objects from the current
+schema. Migration selection is by each record's declared `version` and `name`,
+never by a relative list-tail offset.
+
+## Authority and fail-closed gates
+
+At import, the harness binds every record in
+`newsroom.authority.migrations.MIGRATIONS` to its named authoritative
+`*_MIGRATION_STATEMENTS` tuple. Both the registry and
+`EXPECTED_MIGRATION_HISTORY` must equal the independent literal
+`PINNED_MIGRATION_HISTORY` for every version from v1 through current. The
+harness also recomputes each authoritative statement-tuple digest and requires
+the corresponding literal checksum. The registry must be unique, consecutive
+and complete. Missing, extra or drifted records and statement bindings fail
+closed. A new checked migration must append its literal full-history record.
+
+`build_exact_prefix(path, version)` requires a new file path and supports the
+range from explicit `RETAINED_MIN_VERSION = 13` through the current production
+schema version. It applies only migrations v1 through the requested
+named version, inserts their checked history, sets `PRAGMA user_version`, and
+commits everything in one exclusive transaction. A statement failure rolls the
+entire empty build back.
+
+`inspect_exact_prefix(path)` opens the database read-only and compares all of:
+
+- the exact `PRAGMA user_version`;
+- ordered migration versions, names and checksums, with no missing or extra row;
+- the canonical full-history fingerprint rendered in the release matrix;
+- the production normalised schema fingerprint as an additional compatibility
+  signal;
+- the complete ordered `sqlite_master` inventory with exact storage types:
+  `type`, `name` and `tbl_name` must be built-in strings while `sql` must be a
+  built-in string or `NULL`, including SQLite automatic indexes, and its
+  canonical fingerprint (`NULL` remains JSON `null`);
+- `PRAGMA foreign_key_check`, which must return no row; and
+- `PRAGMA quick_check`, which must return exactly `ok`.
+
+Changing migration history or leaking a table, view, trigger or index therefore
+fails even when `user_version` was left unchanged. Versions outside the retained
+range, including a newer schema, are rejected before an exact-cell comparison.
+Raw SQL identity is intentionally not whitespace-normalised: normalising inside
+a quoted SQLite error literal can hide a contract change. Likewise, an automatic
+index whose catalog `sql` is changed from `NULL` to empty text is different even
+when SQLite `quick_check` remains `ok`.
+
+## API for the next migration
+
+The intended v23 test flow is:
+
+```python
+database = tmp_path / "exact-v22.sqlite3"
+before = build_exact_prefix(database, 22)
+
+connection = sqlite3.connect(database)
+connection.execute("PRAGMA foreign_keys=ON")
+prepare_default_connection_backup(connection)
+apply_pending_migrations(connection, applied_at=APPLIED_AT)
+connection.close()
+
+# The v23 change should inspect against its own new current-schema contract.
+assert before.version == 22
+```
+
+Available typed helpers are:
+
+- `migration_for_version(version)` and `history_through(version)` for explicit
+  named lookup;
+- `build_exact_prefix(path, version)` for a fresh file-backed empty prefix;
+- `inspect_exact_prefix(path, expected_version=...)` for exact retained-schema
+  validation;
+- `prepare_default_connection_backup(connection)` for the durable v16-v21
+  backup gate on a normal `sqlite3.connect(...)` connection;
+- `canonical_cell(version)` for deterministic history, schema and inventory
+  identity; and
+- `render_compatibility_matrix()` for stable review pins.
+
+The exported `CURRENT_VERSION`, `PREDECESSOR_VERSION`, `NEWER_VERSION`,
+`UPGRADE_PREDECESSOR_VERSIONS` and `BACKUP_PREDECESSOR_VERSIONS` derive
+behavioural boundaries from production `SCHEMA_VERSION` and the retained
+minimum. `statement_symbol_for_version(CURRENT_VERSION)` identifies the current
+authoritative SQL tuple for generic injected-failure proof. Only literal release
+history, name/checksum and matrix pins require a manual append for a new version.
+
+`statement_executor` on `build_exact_prefix` is an injection seam for atomic
+failure tests only. Production execution should use the default.
+
+## Backup and transaction invariant
+
+Exact v16-v21 upgrades require the existing production backup gate. Open the
+database with normal `sqlite3.connect(path)` transaction behaviour, enable
+foreign keys, and ensure that no transaction is active before calling
+`prepare_default_connection_backup`. The helper delegates to the production
+backup implementation and verifies that backup preparation did not open a
+transaction. `BEGIN EXCLUSIVE` must remain immediately available before the
+upgrade.
+
+For a multihop older upgrade, production retains one exact predecessor and one
+SHA-256 sidecar at each destructive boundary:
+
+```text
+DATABASE.pre-v17.sqlite3          # exact v16
+DATABASE.pre-v18.sqlite3          # exact v17
+DATABASE.pre-v19.sqlite3          # exact v18
+DATABASE.pre-v20.sqlite3          # exact v19
+DATABASE.pre-v21.sqlite3          # exact v20
+DATABASE.pre-v22.sqlite3          # exact v21
+```
+
+Each `.sha256` receipt contains the production `sha256:`-prefixed digest. The
+focused proof reopens every backup through the same exact inspector.
+
+The canonical restore rehearsal closes every connection after a successful
+v21-to-v22 upgrade, proves the retained backup and digest, replaces the primary
+file from that backup, and inspects it as exact v21. It then prepares the
+retained gate again, re-upgrades, and inspects exact v22. This proves the empty
+canonical schema rollback/restore path rather than only backup creation.
+
+## Verification
+
+Run the focused contract first:
+
+```bash
+uv run pytest -q newsroom/tests/test_authority_migration_compatibility.py
+```
+
+It pins deterministic cells from v13 through current, direct-v22/current
+equivalence, every v13-v21 upgrade, multihop receipts, default-connection backup
+behaviour, rollback after an injected migration failure, successful restore and
+re-upgrade, inspector and production-migrator newer-version rejection without
+byte changes, history tampering, leaked schema objects, quoted-literal
+whitespace drift, catalog `NULL`/empty-text drift and the rendered matrix. A
+future schema version must append its explicit full-history record, release
+name/checksum and matrix row to the focused pins; the helper range itself
+follows `SCHEMA_VERSION` without a hard-coded maximum.
+
+Then run the retained v17-v22 migration selections required by the change under
+review. Do not treat the harness as production readiness on its own: it covers
+empty canonical schemas. Data-bearing migration and restore rehearsal,
+concurrency, crash recovery and application reopen proof remain separate gates.

--- a/newsroom/tests/authority_migration_compatibility.py
+++ b/newsroom/tests/authority_migration_compatibility.py
@@ -1,0 +1,552 @@
+"""Canonical retained-schema fixtures for authority migration compatibility tests.
+
+This module deliberately builds old schemas forwards from the production SQL
+registry.  It does not infer predecessors by removing objects from a newer
+schema and it never addresses migration history relative to the list tail.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+from collections.abc import Callable
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Protocol
+
+from newsroom.authority import migrations as authority_migrations
+from newsroom.authority.canonical import digest_canonical
+
+RETAINED_MIN_VERSION = 13
+CURRENT_VERSION = authority_migrations.SCHEMA_VERSION
+PREDECESSOR_VERSION = CURRENT_VERSION - 1
+NEWER_VERSION = CURRENT_VERSION + 1
+RETAINED_VERSIONS = tuple(range(RETAINED_MIN_VERSION, CURRENT_VERSION + 1))
+UPGRADE_PREDECESSOR_VERSIONS = RETAINED_VERSIONS[:-1]
+BACKUP_PREDECESSOR_VERSIONS = tuple(
+    version
+    for version in UPGRADE_PREDECESSOR_VERSIONS
+    if version >= authority_migrations.GRAPHITI_ADAPTER_SCHEMA_VERSION
+)
+FIXTURE_APPLIED_AT = "1970-01-01T00:00:00.000000Z"
+
+
+class MigrationCompatibilityError(AssertionError):
+    """The migration registry or a retained SQLite prefix is not exact."""
+
+
+class MigrationLike(Protocol):
+    version: int
+    name: str
+    checksum: str
+
+
+StatementExecutor = Callable[[sqlite3.Connection, int, int, str], None]
+ObjectRow = tuple[str, str, str, str | None]
+HistoryRow = tuple[int, str, str]
+
+# Independent release pins. A checked migration must append its literal record.
+PINNED_MIGRATION_HISTORY: tuple[HistoryRow, ...] = (
+    (
+        1,
+        "authority_event_foundation_v1",
+        "sha256:2b50772c37bb426ccac46f84efc254cdb0e8124103b9af0d44dffbccf84b14ee",
+    ),
+    (
+        2,
+        "governed_object_authority_v2",
+        "sha256:e64a85069c061c03d85889524c92f9707f23a8abe417c31875fbbbadcad465b1",
+    ),
+    (
+        3,
+        "projection_authority_v3",
+        "sha256:ddcc7020aff2e1ec449bab190b1e22767e6c4c78db27f24ca3ee3638c548b6af",
+    ),
+    (
+        4,
+        "projection_generation_promotion_v4",
+        "sha256:eddebadf6bfb4a315d0be9525e7af245f75fea6043a88c35b84356d4bd7b8194",
+    ),
+    (
+        5,
+        "integrated_foundation_proof_v5",
+        "sha256:dd3c0f05beadbcdb0dc98c06549120825a793b6e6083454b9604d8d10c336a35",
+    ),
+    (
+        6,
+        "governed_relation_authority_v6",
+        "sha256:5417391a9d2d2da2fa2ed860ad64164865d4433c319c96e63359d4dff736c36b",
+    ),
+    (
+        7,
+        "complete_projection_authority_v7",
+        "sha256:fb0bf5a42912a761ba2c228c0da518baedc42c19aea94b347f87990d4d807615",
+    ),
+    (
+        8,
+        "hybrid_retrieval_authority_v8",
+        "sha256:8c73b3b0a73b4e61b56b4017b514704c1c3517e5bb93dce7d0d16b50d329643f",
+    ),
+    (
+        9,
+        "complete_fixture_candidate_authority_v9",
+        "sha256:cfb90b0e8432a8edc2c4edddfc71bd0e9b0b25edc712e23835b6d2bdcdec17b1",
+    ),
+    (
+        10,
+        "source_registry_authority_v10",
+        "sha256:332856936e220c4c39124dffb6132638be22c6da899ccb46f600aa1f21ddbd17",
+    ),
+    (
+        11,
+        "check_transition_authority_v11",
+        "sha256:8f0ae515f90058c21d985f51543a2a57578091114c4785aee1aeaca8ed2f2a34",
+    ),
+    (
+        12,
+        "discovery_signal_lead_authority_v12",
+        "sha256:4cba2fc7309516a9344b3a0fa12bb4f5c3506ce9ae57e6677ec2cbf0119e03c4",
+    ),
+    (
+        13,
+        "extraction_run_authority_v13",
+        "sha256:c3e5ae627dda1c04bebc50952786413d977bd399e67b7f5b87452794f08f49ab",
+    ),
+    (
+        14,
+        "entity_resolution_authority_v14",
+        "sha256:546e81c2419ecb895a1eea7f9c9556931a3e8ad85efe61e878b2fcc25ad72ee9",
+    ),
+    (
+        15,
+        "editorial_relation_authority_v15",
+        "sha256:946a697524cd1ce84546208c21948ec29c59df79410c5eafef196c344f2d8587",
+    ),
+    (
+        16,
+        "graphiti_proposal_adapter_v16",
+        "sha256:ffd44aa70e65e7a2c69a48b3b652160ccc33285d9282c7eed202d206133ba991",
+    ),
+    (
+        17,
+        "evaluation_handoff_authority_v17",
+        "sha256:c15b3a3fc90833048938b591291d16f59ee1f36b54a6d72dbd04b63877682e7f",
+    ),
+    (
+        18,
+        "triage_work_item_authority_v18",
+        "sha256:f815499c103fed95fbff0c25528331b2483b7c01687f8742394faa92a538bb88",
+    ),
+    (
+        19,
+        "triage_proposal_disposition_authority_v19",
+        "sha256:d5f9702d359836e3b564ba1cadbad27e5fc17ba79e5155e2b34382ec30681177",
+    ),
+    (
+        20,
+        "triage_execution_authority_v20",
+        "sha256:6eb04f981f650bbb4956f148d11f1656bcd2b7c510117db96602dd9d83ab9bd3",
+    ),
+    (
+        21,
+        "event_hypothesis_authority_v21",
+        "sha256:42009475669a475af8e3e24bbcd02e6fcd9fbb71a800e18d83624e34e79e5e21",
+    ),
+    (
+        22,
+        "event_hypothesis_relationship_authority_v22",
+        "sha256:e59eb222a95e2901ccaae29ce1b9e8eded797306e9796718a6d2c4fa505a6636",
+    ),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CompatibilityCell:
+    """Deterministic identity and integrity results for one retained schema."""
+
+    version: int
+    migration_name: str
+    migration_checksum: str
+    history: tuple[HistoryRow, ...]
+    history_fingerprint: str
+    schema_fingerprint: str
+    object_inventory: tuple[ObjectRow, ...]
+    object_fingerprint: str
+    foreign_key_check: tuple[tuple[object, ...], ...]
+    quick_check: tuple[str, ...]
+
+    @property
+    def object_count(self) -> int:
+        return len(self.object_inventory)
+
+
+def _catalog_text(value: object, *, column: str) -> str:
+    if type(value) is not str:
+        raise MigrationCompatibilityError(
+            f"sqlite_master.{column} must be an exact string"
+        )
+    return value
+
+
+def _catalog_sql(value: object) -> str | None:
+    if value is None:
+        return None
+    return _catalog_text(value, column="sql")
+
+
+def _catalog_row(row: tuple[object, ...] | sqlite3.Row) -> ObjectRow:
+    return (
+        _catalog_text(row[0], column="type"),
+        _catalog_text(row[1], column="name"),
+        _catalog_text(row[2], column="tbl_name"),
+        _catalog_sql(row[3]),
+    )
+
+
+def _record_tuple(record: MigrationLike) -> HistoryRow:
+    return int(record.version), str(record.name), str(record.checksum)
+
+
+def _require_exact_int(value: object, *, label: str) -> int:
+    if type(value) is not int:
+        raise MigrationCompatibilityError(f"{label} must be an exact integer")
+    return value
+
+
+def _discover_statement_bindings() -> dict[str, tuple[str, tuple[str, ...]]]:
+    """Bind each named migration record to its authoritative statement tuple."""
+    bindings: dict[str, tuple[str, tuple[str, ...]]] = {}
+    namespace = vars(authority_migrations)
+    for symbol, candidate in namespace.items():
+        if symbol == "MIGRATION":
+            statement_symbol = "MIGRATION_STATEMENTS"
+        elif symbol.endswith("_MIGRATION"):
+            statement_symbol = f"{symbol}_STATEMENTS"
+        else:
+            continue
+        statements = namespace.get(statement_symbol)
+        if statements is None or not all(
+            hasattr(candidate, field) for field in ("version", "name", "checksum")
+        ):
+            continue
+        if not isinstance(statements, tuple) or not all(
+            isinstance(statement, str) for statement in statements
+        ):
+            raise MigrationCompatibilityError(
+                f"{statement_symbol} is not an immutable SQL statement tuple"
+            )
+        migration_name = str(candidate.name)
+        binding = (statement_symbol, statements)
+        existing = bindings.setdefault(migration_name, binding)
+        if existing != binding:
+            raise MigrationCompatibilityError(
+                f"multiple statement tuples claim migration {migration_name}"
+            )
+    return bindings
+
+
+def _checked_registry() -> tuple[MigrationLike, ...]:
+    records = tuple(authority_migrations.MIGRATIONS)
+    record_history = tuple(_record_tuple(record) for record in records)
+    expected_history = tuple(authority_migrations.EXPECTED_MIGRATION_HISTORY)
+    if record_history != PINNED_MIGRATION_HISTORY:
+        raise MigrationCompatibilityError(
+            "MIGRATIONS differ from independent literal release pins"
+        )
+    if expected_history != PINNED_MIGRATION_HISTORY:
+        raise MigrationCompatibilityError(
+            "EXPECTED_MIGRATION_HISTORY differs from independent literal release pins"
+        )
+    versions = tuple(record[0] for record in record_history)
+    if versions != tuple(range(1, authority_migrations.SCHEMA_VERSION + 1)):
+        raise MigrationCompatibilityError(
+            "authority migration registry is not complete and consecutive"
+        )
+    names = tuple(record[1] for record in record_history)
+    if len(names) != len(set(names)):
+        raise MigrationCompatibilityError("authority migration names are not unique")
+    bindings = _discover_statement_bindings()
+    statement_names = set(bindings)
+    if statement_names != set(names):
+        missing = sorted(set(names) - statement_names)
+        extra = sorted(statement_names - set(names))
+        raise MigrationCompatibilityError(
+            f"statement registry differs: missing={missing!r}, extra={extra!r}"
+        )
+    for version, name, checksum in PINNED_MIGRATION_HISTORY:
+        statements = bindings[name][1]
+        actual_checksum = digest_canonical(
+            {"version": version, "name": name, "statements": list(statements)}
+        )
+        if actual_checksum != checksum:
+            raise MigrationCompatibilityError(
+                f"authoritative statements differ from literal release pin for v{version}"
+            )
+    return records
+
+
+MIGRATION_REGISTRY = _checked_registry()
+STATEMENT_BINDINGS_BY_NAME = _discover_statement_bindings()
+STATEMENTS_BY_NAME = {
+    name: binding[1] for name, binding in STATEMENT_BINDINGS_BY_NAME.items()
+}
+
+
+def migration_for_version(version: int) -> MigrationLike:
+    """Return a migration by its declared version, not by a tail offset."""
+    version = _require_exact_int(version, label="migration version")
+    matches = [record for record in MIGRATION_REGISTRY if record.version == version]
+    if len(matches) != 1:
+        raise MigrationCompatibilityError(
+            f"expected one named migration for version {version}, found {len(matches)}"
+        )
+    return matches[0]
+
+
+def history_through(version: int) -> tuple[HistoryRow, ...]:
+    """Return the complete ordered history ending at the named version."""
+    migration_for_version(version)
+    history = tuple(
+        _record_tuple(record)
+        for record in MIGRATION_REGISTRY
+        if record.version <= version
+    )
+    if not history or history[-1][0] != version:
+        raise MigrationCompatibilityError(f"history does not end at version {version}")
+    return history
+
+
+def statements_for_version(version: int) -> tuple[str, ...]:
+    record = migration_for_version(version)
+    try:
+        return STATEMENTS_BY_NAME[record.name]
+    except KeyError as exc:  # pragma: no cover - guarded at module import
+        raise MigrationCompatibilityError(
+            f"no SQL statements are bound to {record.name}"
+        ) from exc
+
+
+def statement_symbol_for_version(version: int) -> str:
+    """Return the authoritative module symbol for a named migration version."""
+    record = migration_for_version(version)
+    return STATEMENT_BINDINGS_BY_NAME[record.name][0]
+
+
+def _execute_statement(
+    connection: sqlite3.Connection, version: int, index: int, statement: str
+) -> None:
+    del version, index
+    connection.execute(statement)
+
+
+def build_exact_prefix(
+    database: str | Path,
+    version: int,
+    *,
+    statement_executor: StatementExecutor = _execute_statement,
+) -> CompatibilityCell:
+    """Create a fresh file-backed exact empty schema prefix in one transaction."""
+    version = _require_exact_int(version, label="fixture version")
+    if version not in RETAINED_VERSIONS:
+        raise MigrationCompatibilityError(
+            f"retained fixture version must be one of {RETAINED_VERSIONS}"
+        )
+    path = Path(database)
+    if path.exists():
+        raise MigrationCompatibilityError(f"fixture database already exists: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    connection = sqlite3.connect(path, isolation_level=None)
+    try:
+        connection.execute("PRAGMA foreign_keys=ON")
+        connection.execute("BEGIN EXCLUSIVE")
+        for record in MIGRATION_REGISTRY:
+            if record.version > version:
+                break
+            for index, statement in enumerate(statements_for_version(record.version)):
+                statement_executor(connection, record.version, index, statement)
+            connection.execute(
+                "INSERT INTO authority_migrations(version,name,checksum,applied_at) "
+                "VALUES(?,?,?,?)",
+                (*_record_tuple(record), FIXTURE_APPLIED_AT),
+            )
+        connection.execute(f"PRAGMA user_version={version}")
+        connection.execute("COMMIT")
+        cell = _snapshot(connection, version)
+        if cell.history != history_through(version):
+            raise MigrationCompatibilityError(
+                f"constructed schema v{version} has incomplete migration history"
+            )
+        if cell.foreign_key_check or cell.quick_check != ("ok",):
+            raise MigrationCompatibilityError(
+                f"constructed schema v{version} failed SQLite integrity checks"
+            )
+        return cell
+    except Exception:
+        if connection.in_transaction:
+            connection.execute("ROLLBACK")
+        raise
+    finally:
+        connection.close()
+
+
+def _snapshot(connection: sqlite3.Connection, version: int) -> CompatibilityCell:
+    record = migration_for_version(version)
+    history = tuple(
+        (int(row[0]), str(row[1]), str(row[2]))
+        for row in connection.execute(
+            "SELECT version,name,checksum FROM authority_migrations ORDER BY version"
+        )
+    )
+    inventory = tuple(
+        _catalog_row(row)
+        for row in connection.execute(
+            "SELECT type,name,tbl_name,sql FROM sqlite_master ORDER BY type,name,tbl_name"
+        )
+    )
+    foreign_keys = tuple(
+        tuple(row) for row in connection.execute("PRAGMA foreign_key_check")
+    )
+    quick_check = tuple(str(row[0]) for row in connection.execute("PRAGMA quick_check"))
+    return CompatibilityCell(
+        version=version,
+        migration_name=str(record.name),
+        migration_checksum=str(record.checksum),
+        history=history,
+        history_fingerprint=digest_canonical([list(row) for row in history]),
+        schema_fingerprint=authority_migrations.schema_fingerprint(connection),
+        object_inventory=inventory,
+        object_fingerprint=digest_canonical([list(row) for row in inventory]),
+        foreign_key_check=foreign_keys,
+        quick_check=quick_check,
+    )
+
+
+@lru_cache(maxsize=len(RETAINED_VERSIONS))
+def canonical_cell(version: int) -> CompatibilityCell:
+    """Derive the immutable expected cell from a separate fresh file fixture."""
+    version = _require_exact_int(version, label="canonical version")
+    if version not in RETAINED_VERSIONS:
+        raise MigrationCompatibilityError(f"unsupported retained version {version}")
+    with tempfile.TemporaryDirectory(prefix=f"authority-v{version}-") as directory:
+        path = Path(directory) / "canonical.sqlite3"
+        build_exact_prefix(path, version)
+        connection = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+        try:
+            return _snapshot(connection, version)
+        finally:
+            connection.close()
+
+
+def inspect_exact_prefix(
+    database: str | Path, *, expected_version: int | None = None
+) -> CompatibilityCell:
+    """Inspect and reject any non-canonical history, object, or integrity result."""
+    path = Path(database)
+    if not path.is_file():
+        raise MigrationCompatibilityError(f"fixture database is not a file: {path}")
+    connection = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    try:
+        version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+        if expected_version is not None:
+            expected_version = _require_exact_int(
+                expected_version, label="expected version"
+            )
+        if expected_version is not None and version != expected_version:
+            raise MigrationCompatibilityError(
+                f"schema version {version} differs from expected {expected_version}"
+            )
+        if version not in RETAINED_VERSIONS:
+            raise MigrationCompatibilityError(
+                f"schema version {version} is outside retained versions"
+            )
+        actual = _snapshot(connection, version)
+    except sqlite3.DatabaseError as exc:
+        raise MigrationCompatibilityError(f"database inspection failed: {exc}") from exc
+    finally:
+        connection.close()
+
+    expected = canonical_cell(version)
+    differences: list[str] = []
+    if actual.history != expected.history:
+        differences.append("migration history")
+    if actual.history_fingerprint != expected.history_fingerprint:
+        differences.append("migration history fingerprint")
+    if actual.schema_fingerprint != expected.schema_fingerprint:
+        differences.append("schema fingerprint")
+    if actual.object_inventory != expected.object_inventory:
+        differences.append("sqlite_master inventory")
+    if actual.object_fingerprint != expected.object_fingerprint:
+        differences.append("sqlite_master fingerprint")
+    if actual.foreign_key_check:
+        differences.append("foreign_key_check")
+    if actual.quick_check != ("ok",):
+        differences.append("quick_check")
+    if differences:
+        raise MigrationCompatibilityError(
+            f"schema v{version} is not exact: {', '.join(differences)}"
+        )
+    return actual
+
+
+def prepare_default_connection_backup(connection: sqlite3.Connection) -> object:
+    """Prepare a v16-v21 backup without changing default transaction behaviour."""
+    if connection.isolation_level is None:
+        raise MigrationCompatibilityError(
+            "backup proof requires a normal sqlite3.connect default connection"
+        )
+    if connection.in_transaction:
+        raise MigrationCompatibilityError("backup requires no active transaction")
+    receipt = authority_migrations.prepare_pending_migration_backup(connection)
+    if receipt is None:
+        version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+        raise MigrationCompatibilityError(
+            f"schema v{version} has no retained backup boundary"
+        )
+    if connection.in_transaction:
+        raise MigrationCompatibilityError("backup preparation opened a transaction")
+    return receipt
+
+
+def render_compatibility_matrix(
+    cells: tuple[CompatibilityCell, ...] | None = None,
+) -> str:
+    """Render stable, reviewable pins without volatile file-system details."""
+    selected = cells or tuple(canonical_cell(version) for version in RETAINED_VERSIONS)
+    header = (
+        "version | migration | objects | history fingerprint | "
+        "schema fingerprint | object fingerprint"
+    )
+    divider = "--- | --- | ---: | --- | --- | ---"
+    rows = [
+        f"v{cell.version} | {cell.migration_name} | {cell.object_count} | "
+        f"{cell.history_fingerprint} | {cell.schema_fingerprint} | "
+        f"{cell.object_fingerprint}"
+        for cell in selected
+    ]
+    return "\n".join((header, divider, *rows)) + "\n"
+
+
+__all__ = [
+    "BACKUP_PREDECESSOR_VERSIONS",
+    "CURRENT_VERSION",
+    "FIXTURE_APPLIED_AT",
+    "MIGRATION_REGISTRY",
+    "NEWER_VERSION",
+    "PINNED_MIGRATION_HISTORY",
+    "PREDECESSOR_VERSION",
+    "RETAINED_MIN_VERSION",
+    "RETAINED_VERSIONS",
+    "UPGRADE_PREDECESSOR_VERSIONS",
+    "CompatibilityCell",
+    "MigrationCompatibilityError",
+    "build_exact_prefix",
+    "canonical_cell",
+    "history_through",
+    "inspect_exact_prefix",
+    "migration_for_version",
+    "prepare_default_connection_backup",
+    "render_compatibility_matrix",
+    "statement_symbol_for_version",
+    "statements_for_version",
+]

--- a/newsroom/tests/test_authority_migration_compatibility.py
+++ b/newsroom/tests/test_authority_migration_compatibility.py
@@ -1,0 +1,526 @@
+from __future__ import annotations
+
+import hashlib
+import shutil
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from newsroom.authority import migrations as authority_migrations
+from newsroom.authority.canonical import digest_canonical
+from newsroom.tests.authority_migration_compatibility import (
+    BACKUP_PREDECESSOR_VERSIONS,
+    CURRENT_VERSION,
+    MIGRATION_REGISTRY,
+    NEWER_VERSION,
+    PINNED_MIGRATION_HISTORY,
+    PREDECESSOR_VERSION,
+    RETAINED_MIN_VERSION,
+    RETAINED_VERSIONS,
+    UPGRADE_PREDECESSOR_VERSIONS,
+    MigrationCompatibilityError,
+    build_exact_prefix,
+    canonical_cell,
+    history_through,
+    inspect_exact_prefix,
+    migration_for_version,
+    prepare_default_connection_backup,
+    render_compatibility_matrix,
+    statement_symbol_for_version,
+    statements_for_version,
+)
+
+_EXPECTED_NAMES = {
+    13: "extraction_run_authority_v13",
+    14: "entity_resolution_authority_v14",
+    15: "editorial_relation_authority_v15",
+    16: "graphiti_proposal_adapter_v16",
+    17: "evaluation_handoff_authority_v17",
+    18: "triage_work_item_authority_v18",
+    19: "triage_proposal_disposition_authority_v19",
+    20: "triage_execution_authority_v20",
+    21: "event_hypothesis_authority_v21",
+    22: "event_hypothesis_relationship_authority_v22",
+}
+_EXPECTED_CHECKSUMS = {
+    13: "sha256:c3e5ae627dda1c04bebc50952786413d977bd399e67b7f5b87452794f08f49ab",
+    14: "sha256:546e81c2419ecb895a1eea7f9c9556931a3e8ad85efe61e878b2fcc25ad72ee9",
+    15: "sha256:946a697524cd1ce84546208c21948ec29c59df79410c5eafef196c344f2d8587",
+    16: "sha256:ffd44aa70e65e7a2c69a48b3b652160ccc33285d9282c7eed202d206133ba991",
+    17: "sha256:c15b3a3fc90833048938b591291d16f59ee1f36b54a6d72dbd04b63877682e7f",
+    18: "sha256:f815499c103fed95fbff0c25528331b2483b7c01687f8742394faa92a538bb88",
+    19: "sha256:d5f9702d359836e3b564ba1cadbad27e5fc17ba79e5155e2b34382ec30681177",
+    20: "sha256:6eb04f981f650bbb4956f148d11f1656bcd2b7c510117db96602dd9d83ab9bd3",
+    21: "sha256:42009475669a475af8e3e24bbcd02e6fcd9fbb71a800e18d83624e34e79e5e21",
+    22: "sha256:e59eb222a95e2901ccaae29ce1b9e8eded797306e9796718a6d2c4fa505a6636",
+}
+
+_EXPECTED_MATRIX = """version | migration | objects | history fingerprint | schema fingerprint | object fingerprint
+--- | --- | ---: | --- | --- | ---
+v13 | extraction_run_authority_v13 | 720 | sha256:415a157b19c4ba351c0a257c06d215c081e9348bc846aedfecb2441a4120687e | sha256:62eb9596a324b75a3ec96cc0db6e182217fa30fc6b64fd5b801cf784dfdea9b4 | sha256:ee51d8754920b8dd818a39d464c59106ff55e0024d341dfdfc17b51e45dd66a5
+v14 | entity_resolution_authority_v14 | 879 | sha256:5134c423d25fb1f1b3d19974a1fcbc6f8c35966618c35f825552430f48a8aec3 | sha256:47a0421affa099c11cc478220c26d8ce6164cb621057fe9760f410c7dcea8233 | sha256:d52ca75ac8207b3a3abde1a7cd55e6e006e2c62f5b1160b9544d3ba165f4be1c
+v15 | editorial_relation_authority_v15 | 985 | sha256:ef45c22301c6c68c81e8fe0327a73623e78ec405474da042ed4868d527a9acda | sha256:5b113904c4ab06452f792078b32bee1752640bb821dc98fc3fdeeb747274efca | sha256:115ee7a7fc0632bf1cf5afa4ac133a120b103f523837e955d4a3c7e0f6ad0c1f
+v16 | graphiti_proposal_adapter_v16 | 1068 | sha256:f6368810467de4600769e7213d2aeb9e29bf17fe2988968f4df60d4905ce0cbc | sha256:b5a6d2afc78838cdeb648e7cd34b66452f2e0a0f7dab4773dd17a4cc28e3b5d8 | sha256:6a25ce2721c07b6e90f44e81e1b396a8ef5c89f8f53890121af74cea736a040f
+v17 | evaluation_handoff_authority_v17 | 1085 | sha256:0966aacc7bee4d80486f701e3c4a525f1df0a98a6e122f18a7bc1433bddac7a8 | sha256:aaa9544bc6f90dce5831452cffb227967175901e4f7b085e17056ac4194109f5 | sha256:6cff28a00ceb9864c1df97e7fabfc98bf2c25c0793cfdab3afc112482c5e1a7d
+v18 | triage_work_item_authority_v18 | 1108 | sha256:7813e4ac4a260c5601b4632fc0aeb020064f9ad9e2edc0700871ad10980aad34 | sha256:7a33005d06998ffd7c438e352ffce2c2c4da008deaa2b0d1171fe3f7599798ea | sha256:08108c0e68585b6236aa4622b46612cc4a5da1265dd5be4865b319dbc2126ca5
+v19 | triage_proposal_disposition_authority_v19 | 1123 | sha256:b117a350a73c136444a9a30398618614d6883fc40cdc734fde36303ba5168965 | sha256:542bd9c351094cf4d56905fa92aa042924b5dab877cc04374a097c48fe6b6003 | sha256:082f473aabb994e1941436adacbaa5ede7944349eb2a599c27b784e6be056d5d
+v20 | triage_execution_authority_v20 | 1147 | sha256:01aaf90aef4a4e7e5d7946ab944af3d7a19481f8213162cb337f75f0afdf8274 | sha256:36a7c9910775ede9c29113a43e08bba261a5a98c4fab5225dd2cae9448689389 | sha256:60cf06c18f743984c14464793ac579f524c3ef56766441cc6f0bc0aa04fc5d6c
+v21 | event_hypothesis_authority_v21 | 1170 | sha256:7404a1b6ffb14aacff8d3e9bb1ddff7f751287100003bfa268d55722c4e34ab0 | sha256:d314d06118a25f8a32a0f9d8acb1af5383abd6b30be682cb5f65943ae15c213f | sha256:d5c9fe7ac19900901f4ccb64545bf9defca4db9e6d82de7e71bb66f9c8d9aaff
+v22 | event_hypothesis_relationship_authority_v22 | 1179 | sha256:69acb590abbd8cbb3e6acdad8e6a0c0f31e13e1ed0a718098b64d545c343c1ed | sha256:2118fa893fb7fd2911bbde3056b79b1d0e26ccd6903e1c4228616f342898eaad | sha256:117392ff7fd1160034ec0792ab9f0d94e3a4643dc6fc280b44855ac67efff77a
+"""
+
+
+def _upgrade_to_current(database: Path, starting_version: int) -> None:
+    connection = sqlite3.connect(database)
+    try:
+        connection.execute("PRAGMA foreign_keys=ON")
+        if starting_version in BACKUP_PREDECESSOR_VERSIONS:
+            prepare_default_connection_backup(connection)
+        authority_migrations.apply_pending_migrations(
+            connection, applied_at="1970-01-02T00:00:00.000000Z"
+        )
+    finally:
+        connection.close()
+
+
+def test_registry_history_and_statement_pins_are_complete_and_named() -> None:
+    assert CURRENT_VERSION == authority_migrations.SCHEMA_VERSION
+    assert PREDECESSOR_VERSION == CURRENT_VERSION - 1
+    assert NEWER_VERSION == CURRENT_VERSION + 1
+    assert UPGRADE_PREDECESSOR_VERSIONS == RETAINED_VERSIONS[:-1]
+    assert BACKUP_PREDECESSOR_VERSIONS[-1] == PREDECESSOR_VERSION
+    assert tuple(authority_migrations.EXPECTED_MIGRATION_HISTORY) == (
+        PINNED_MIGRATION_HISTORY
+    )
+    assert RETAINED_MIN_VERSION == 13
+    assert RETAINED_VERSIONS == tuple(_EXPECTED_NAMES)
+    assert tuple(record.version for record in MIGRATION_REGISTRY) == tuple(
+        range(1, CURRENT_VERSION + 1)
+    )
+    assert (
+        tuple(
+            (record.version, record.name, record.checksum)
+            for record in MIGRATION_REGISTRY
+        )
+        == authority_migrations.EXPECTED_MIGRATION_HISTORY
+    )
+
+    for version, name, checksum in PINNED_MIGRATION_HISTORY:
+        record = migration_for_version(version)
+        assert (record.name, record.checksum) == (name, checksum)
+        assert history_through(version)[-1] == (
+            record.version,
+            record.name,
+            record.checksum,
+        )
+        assert (
+            digest_canonical(
+                {
+                    "version": record.version,
+                    "name": record.name,
+                    "statements": list(statements_for_version(version)),
+                }
+            )
+            == record.checksum
+        )
+
+    for version, expected_name in _EXPECTED_NAMES.items():
+        record = migration_for_version(version)
+        assert record.name == expected_name
+        assert record.checksum == _EXPECTED_CHECKSUMS[version]
+
+    with pytest.raises(MigrationCompatibilityError, match="found 0"):
+        migration_for_version(NEWER_VERSION)
+    with pytest.raises(MigrationCompatibilityError, match="exact integer"):
+        migration_for_version(True)
+
+
+@pytest.mark.parametrize("version", RETAINED_VERSIONS)
+def test_exact_prefix_cells_are_deterministic(tmp_path: Path, version: int) -> None:
+    database = tmp_path / f"v{version}.sqlite3"
+    built = build_exact_prefix(database, version)
+    inspected = inspect_exact_prefix(database, expected_version=version)
+
+    assert built == inspected == canonical_cell(version)
+    assert inspected.history == history_through(version)
+    assert inspected.foreign_key_check == ()
+    assert inspected.quick_check == ("ok",)
+
+
+def test_fresh_current_migrator_equals_direct_exact_current_prefix(
+    tmp_path: Path,
+) -> None:
+    direct_path = tmp_path / f"direct-v{CURRENT_VERSION}.sqlite3"
+    fresh_path = tmp_path / "fresh-current.sqlite3"
+    direct = build_exact_prefix(direct_path, CURRENT_VERSION)
+
+    connection = sqlite3.connect(fresh_path)
+    try:
+        connection.execute("PRAGMA foreign_keys=ON")
+        authority_migrations.apply_pending_migrations(
+            connection, applied_at="1970-01-01T00:00:00.000000Z"
+        )
+    finally:
+        connection.close()
+
+    assert inspect_exact_prefix(fresh_path, expected_version=CURRENT_VERSION) == direct
+
+
+@pytest.mark.parametrize("predecessor", UPGRADE_PREDECESSOR_VERSIONS)
+def test_exact_predecessors_upgrade_to_current(
+    tmp_path: Path, predecessor: int
+) -> None:
+    database = tmp_path / f"upgrade-v{predecessor}.sqlite3"
+    build_exact_prefix(database, predecessor)
+    _upgrade_to_current(database, predecessor)
+    assert inspect_exact_prefix(
+        database, expected_version=CURRENT_VERSION
+    ) == canonical_cell(CURRENT_VERSION)
+
+
+def test_multihop_upgrade_retains_each_exact_backup_and_digest(tmp_path: Path) -> None:
+    database = tmp_path / "multihop.sqlite3"
+    build_exact_prefix(database, RETAINED_MIN_VERSION)
+    _upgrade_to_current(database, RETAINED_MIN_VERSION)
+
+    for predecessor in BACKUP_PREDECESSOR_VERSIONS:
+        successor = predecessor + 1
+        backup = database.with_name(database.name + f".pre-v{successor}.sqlite3")
+        digest = backup.with_name(backup.name + ".sha256")
+        assert inspect_exact_prefix(
+            backup, expected_version=predecessor
+        ) == canonical_cell(predecessor)
+        assert digest.read_text(encoding="ascii") == (
+            "sha256:" + hashlib.sha256(backup.read_bytes()).hexdigest() + "\n"
+        )
+
+
+@pytest.mark.parametrize("predecessor", BACKUP_PREDECESSOR_VERSIONS)
+def test_default_connection_backup_leaves_exclusive_upgrade_available(
+    tmp_path: Path, predecessor: int
+) -> None:
+    database = tmp_path / f"default-v{predecessor}.sqlite3"
+    build_exact_prefix(database, predecessor)
+
+    connection = sqlite3.connect(database)
+    try:
+        assert connection.isolation_level == ""
+        receipt = prepare_default_connection_backup(connection)
+        assert Path(receipt.backup_path).is_file()
+        assert not connection.in_transaction
+        connection.execute("BEGIN EXCLUSIVE")
+        connection.execute("ROLLBACK")
+        authority_migrations.apply_pending_migrations(
+            connection, applied_at="1970-01-02T00:00:00.000000Z"
+        )
+    finally:
+        connection.close()
+
+    inspect_exact_prefix(database, expected_version=CURRENT_VERSION)
+
+
+def test_failed_upgrade_rolls_back_to_exact_predecessor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    database = tmp_path / f"rollback-v{PREDECESSOR_VERSION}.sqlite3"
+    before = build_exact_prefix(database, PREDECESSOR_VERSION)
+    statement_symbol = statement_symbol_for_version(CURRENT_VERSION)
+    statements = getattr(authority_migrations, statement_symbol)
+    monkeypatch.setattr(
+        authority_migrations,
+        statement_symbol,
+        statements + ("CREATE TABLE injected_then_fail(value TEXT)", "INVALID SQL"),
+    )
+
+    connection = sqlite3.connect(database)
+    try:
+        connection.execute("PRAGMA foreign_keys=ON")
+        prepare_default_connection_backup(connection)
+        with pytest.raises(sqlite3.DatabaseError):
+            authority_migrations.apply_pending_migrations(
+                connection, applied_at="1970-01-02T00:00:00.000000Z"
+            )
+        assert not connection.in_transaction
+    finally:
+        connection.close()
+
+    assert (
+        inspect_exact_prefix(database, expected_version=PREDECESSOR_VERSION) == before
+    )
+
+
+def test_successful_upgrade_can_restore_exact_backup_then_reupgrade(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / f"restore-v{PREDECESSOR_VERSION}.sqlite3"
+    exact_predecessor = build_exact_prefix(database, PREDECESSOR_VERSION)
+
+    connection = sqlite3.connect(database)
+    try:
+        connection.execute("PRAGMA foreign_keys=ON")
+        receipt = prepare_default_connection_backup(connection)
+        authority_migrations.apply_pending_migrations(
+            connection, applied_at="1970-01-02T00:00:00.000000Z"
+        )
+    finally:
+        connection.close()
+
+    backup = Path(receipt.backup_path)
+    digest = Path(receipt.digest_path)
+    assert inspect_exact_prefix(
+        database, expected_version=CURRENT_VERSION
+    ) == canonical_cell(CURRENT_VERSION)
+    assert (
+        inspect_exact_prefix(backup, expected_version=PREDECESSOR_VERSION)
+        == exact_predecessor
+    )
+    assert digest.read_text(encoding="ascii") == (
+        "sha256:" + hashlib.sha256(backup.read_bytes()).hexdigest() + "\n"
+    )
+
+    database.unlink()
+    shutil.copy2(backup, database)
+    assert (
+        inspect_exact_prefix(database, expected_version=PREDECESSOR_VERSION)
+        == exact_predecessor
+    )
+
+    _upgrade_to_current(database, PREDECESSOR_VERSION)
+    assert inspect_exact_prefix(
+        database, expected_version=CURRENT_VERSION
+    ) == canonical_cell(CURRENT_VERSION)
+
+
+def test_exact_builder_statement_failure_rolls_back_atomically(tmp_path: Path) -> None:
+    database = tmp_path / "builder-failure.sqlite3"
+    failure_version = BACKUP_PREDECESSOR_VERSIONS[2]
+
+    def fail_at_v18(
+        connection: sqlite3.Connection, version: int, index: int, statement: str
+    ) -> None:
+        if version == failure_version and index == 0:
+            raise sqlite3.OperationalError("injected statement failure")
+        connection.execute(statement)
+
+    with pytest.raises(sqlite3.OperationalError, match="injected"):
+        build_exact_prefix(database, failure_version, statement_executor=fail_at_v18)
+
+    connection = sqlite3.connect(database)
+    try:
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 0
+        assert (
+            connection.execute("SELECT type,name FROM sqlite_master").fetchall() == []
+        )
+    finally:
+        connection.close()
+
+
+def test_newer_schema_is_rejected_before_inventory_inspection(tmp_path: Path) -> None:
+    database = tmp_path / "newer.sqlite3"
+    build_exact_prefix(database, CURRENT_VERSION)
+    connection = sqlite3.connect(database)
+    try:
+        connection.execute(f"PRAGMA user_version={NEWER_VERSION}")
+    finally:
+        connection.close()
+
+    with pytest.raises(MigrationCompatibilityError, match="outside retained"):
+        inspect_exact_prefix(database)
+
+
+def test_production_migrator_rejects_newer_without_changing_database(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / f"central-newer-v{NEWER_VERSION}.sqlite3"
+    build_exact_prefix(database, CURRENT_VERSION)
+    connection = sqlite3.connect(database)
+    try:
+        connection.execute(f"PRAGMA user_version={NEWER_VERSION}")
+    finally:
+        connection.close()
+
+    before_bytes = database.read_bytes()
+    connection = sqlite3.connect(database)
+    try:
+        before_version = connection.execute("PRAGMA user_version").fetchone()[0]
+        before_history = connection.execute(
+            "SELECT version,name,checksum FROM authority_migrations ORDER BY version"
+        ).fetchall()
+        before_inventory = connection.execute(
+            "SELECT type,name,tbl_name,sql FROM sqlite_master "
+            "ORDER BY type,name,tbl_name"
+        ).fetchall()
+        with pytest.raises(sqlite3.DatabaseError, match="newer than supported"):
+            authority_migrations.apply_pending_migrations(
+                connection, applied_at="1970-01-02T00:00:00.000000Z"
+            )
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == before_version
+        assert (
+            connection.execute(
+                "SELECT version,name,checksum FROM authority_migrations ORDER BY version"
+            ).fetchall()
+            == before_history
+        )
+        assert (
+            connection.execute(
+                "SELECT type,name,tbl_name,sql FROM sqlite_master "
+                "ORDER BY type,name,tbl_name"
+            ).fetchall()
+            == before_inventory
+        )
+    finally:
+        connection.close()
+
+    assert database.read_bytes() == before_bytes
+
+
+@pytest.mark.parametrize("tamper", ("checksum", "missing", "extra"))
+def test_history_tamper_is_rejected(tmp_path: Path, tamper: str) -> None:
+    database = tmp_path / f"history-{tamper}.sqlite3"
+    build_exact_prefix(database, CURRENT_VERSION)
+    connection = sqlite3.connect(database)
+    try:
+        if tamper == "checksum":
+            connection.execute("DROP TRIGGER immutable_authority_migrations_update")
+            connection.execute(
+                "UPDATE authority_migrations SET checksum='sha256:tampered' "
+                f"WHERE version={BACKUP_PREDECESSOR_VERSIONS[2]}"
+            )
+        elif tamper == "missing":
+            connection.execute("DROP TRIGGER immutable_authority_migrations_delete")
+            connection.execute(
+                "DELETE FROM authority_migrations WHERE version=?",
+                (BACKUP_PREDECESSOR_VERSIONS[2],),
+            )
+        else:
+            connection.execute(
+                "INSERT INTO authority_migrations VALUES(999,'extra','extra','now')"
+            )
+        connection.commit()
+    finally:
+        connection.close()
+
+    with pytest.raises(MigrationCompatibilityError, match="migration history"):
+        inspect_exact_prefix(database, expected_version=CURRENT_VERSION)
+
+
+@pytest.mark.parametrize("object_type", ("table", "trigger", "index"))
+def test_sqlite_master_object_leaks_are_rejected(
+    tmp_path: Path, object_type: str
+) -> None:
+    database = tmp_path / f"leak-{object_type}.sqlite3"
+    build_exact_prefix(database, CURRENT_VERSION)
+    statements = {
+        "table": "CREATE TABLE leaked_table(value TEXT)",
+        "trigger": (
+            "CREATE TRIGGER leaked_trigger AFTER INSERT ON authority_migrations "
+            "BEGIN SELECT 1; END"
+        ),
+        "index": "CREATE INDEX leaked_index ON authority_migrations(applied_at)",
+    }
+    connection = sqlite3.connect(database)
+    try:
+        connection.execute(statements[object_type])
+    finally:
+        connection.close()
+
+    with pytest.raises(MigrationCompatibilityError, match="sqlite_master inventory"):
+        inspect_exact_prefix(database, expected_version=CURRENT_VERSION)
+
+
+def test_missing_sqlite_master_object_is_rejected(tmp_path: Path) -> None:
+    database = tmp_path / "missing-index.sqlite3"
+    build_exact_prefix(database, CURRENT_VERSION)
+    connection = sqlite3.connect(database)
+    try:
+        row = connection.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='index' AND sql IS NOT NULL ORDER BY name LIMIT 1"
+        ).fetchone()
+        assert row is not None
+        index_name = str(row[0]).replace('"', '""')
+        connection.execute(f'DROP INDEX "{index_name}"')
+    finally:
+        connection.close()
+
+    with pytest.raises(MigrationCompatibilityError, match="sqlite_master inventory"):
+        inspect_exact_prefix(database, expected_version=CURRENT_VERSION)
+
+
+def test_quoted_literal_whitespace_drift_bypasses_normalised_fingerprint_only(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "quoted-literal-space.sqlite3"
+    build_exact_prefix(database, CURRENT_VERSION)
+    connection = sqlite3.connect(database)
+    try:
+        production_fingerprint = authority_migrations.schema_fingerprint(connection)
+        row = connection.execute(
+            "SELECT sql FROM sqlite_master "
+            "WHERE type='trigger' AND name='immutable_authority_migrations_update'"
+        ).fetchone()
+        assert row is not None
+        original_sql = str(row[0])
+        changed_sql = original_sql.replace(
+            "immutable migration history", "immutable  migration history", 1
+        )
+        assert changed_sql != original_sql
+        connection.execute("DROP TRIGGER immutable_authority_migrations_update")
+        connection.execute(changed_sql)
+        connection.commit()
+        assert (
+            authority_migrations.schema_fingerprint(connection)
+            == production_fingerprint
+        )
+    finally:
+        connection.close()
+
+    with pytest.raises(MigrationCompatibilityError, match="sqlite_master inventory"):
+        inspect_exact_prefix(database, expected_version=CURRENT_VERSION)
+
+
+def test_automatic_index_null_sql_changed_to_empty_text_is_rejected(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "automatic-index-empty-sql.sqlite3"
+    build_exact_prefix(database, CURRENT_VERSION)
+    connection = sqlite3.connect(database)
+    try:
+        row = connection.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='index' AND name LIKE 'sqlite_autoindex_%' "
+            "AND sql IS NULL ORDER BY name LIMIT 1"
+        ).fetchone()
+        assert row is not None
+        connection.execute("PRAGMA writable_schema=ON")
+        try:
+            connection.execute(
+                "UPDATE sqlite_master SET sql='' WHERE type='index' AND name=?",
+                (str(row[0]),),
+            )
+            connection.commit()
+        finally:
+            connection.execute("PRAGMA writable_schema=OFF")
+    finally:
+        connection.close()
+
+    reopened = sqlite3.connect(database)
+    try:
+        assert reopened.execute("PRAGMA writable_schema").fetchone()[0] == 0
+        assert reopened.execute("PRAGMA quick_check").fetchone()[0] == "ok"
+        assert (
+            reopened.execute(
+                "SELECT typeof(sql) FROM sqlite_master WHERE name=?", (str(row[0]),)
+            ).fetchone()[0]
+            == "text"
+        )
+    finally:
+        reopened.close()
+
+    with pytest.raises(MigrationCompatibilityError, match="sqlite_master inventory"):
+        inspect_exact_prefix(database, expected_version=CURRENT_VERSION)
+
+
+def test_matrix_render_is_stable_and_pinned() -> None:
+    assert render_compatibility_matrix() == _EXPECTED_MATRIX


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: authority-migration-compatibility
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

Refs #395
Refs #382
Refs #365

## Scope

Adds the repository-owned, tests-only compatibility harness required before Increment 6D3 v23 persistence:

- `newsroom/tests/authority_migration_compatibility.py` — canonical exact-prefix builder and inspector
- `newsroom/tests/test_authority_migration_compatibility.py` — retained v13-v22 matrix and sensitivities
- `docs/operations/authority-migration-compatibility.md` — usage and evidence boundary

No production module, migration statement, schema allocation, checksum, fingerprint, authority behavior or runtime effect changes.

## Contract

- binds every ordered production migration record to its named authoritative SQL statement tuple and exact expected history
- uses explicit version lookup; no negative or moving list-tail offsets
- builds each retained empty file-backed predecessor forwards in one exclusive transaction
- verifies exact user version, history/checksums, production schema fingerprint, complete `sqlite_master` inventory/fingerprint, foreign keys and quick check
- rejects missing/extra history, checksum tamper, newer schema, and leaked or missing tables/triggers/indexes
- proves v13-v21 upgrades, v16-v21 default-connection backup transaction behavior, multihop backups and sidecars, atomic failure rollback, exact restore and re-upgrade
- derives its retained upper bound from production `SCHEMA_VERSION`; a future migration must add explicit name/checksum/matrix pins

The harness intentionally covers canonical empty schemas. Data-bearing migration/restore, concurrency, crash recovery and application reopen remain atom-specific gates.

## Exact revision

- base / merge-base: `main@aeb640ae149d84437dd751b4020810ce58654b9f`
- head: `79595e65f627d5f243c352d7e9cc1b5cba5ff5a8`
- tree: `28193aa9ba46f05c89d33ae8c0c23261c82590ab`
- one product commit; three new files; 1,230 insertions
- helper: 552 lines (below 1,500-line bound)
- helper SHA-256: `72f9dc90fef5909c9389cb9583da29d7cdb0f25d4c46b73f0a940651d5508b9f`
- focused-test SHA-256: `488e4a2e1eb75c2f1b15971cfe440d6baaee0a2640b2f87228660dfc1af1e102`
- documentation SHA-256: `74a77bb42e5accdda89afb9a2b92c90a09595f195847b15aa96831f702c5090b`

## TDD and verification

- RED: focused collection failed with `ModuleNotFoundError` before the helper existed
- focused harness: `43 passed`
- retained v17-v22 migration selection: `56 passed`
- Ruff check and format check: passed
- targeted compileall: passed
- `uv lock --check`: passed
- staged diff check: passed
- local/tracking/remote head exact; worktree clean

## First-review correction closure

The single bounded correction batch closes all four material P2 findings from reviewed head `e0dd3d1f3398ae724feae862da75131d19a80d66`:

1. independently pins every v1-current `(version, name, checksum)`, recomputes every authoritative statement-tuple checksum, and includes the exact full-history fingerprint in the release matrix;
2. preserves raw `sqlite_master.sql` identity and rejects a quoted-trigger-literal whitespace change that collides under the production normalised fingerprint;
3. exports dynamic current/predecessor/newer, upgrade-predecessor and backup-predecessor boundaries and uses them for every behavioural path, including a dynamically resolved current statement symbol;
4. proves the production central migrator rejects a file-backed newer schema without changing bytes, version, history or objects.

Targeted RED began with missing boundary exports; GREEN is 43 focused tests. Retained v17-v22 compatibility remains 56 passed. No production file changed.

## Final exact-catalog correction

The final delta finding is closed: exact `sqlite_master` inventory now preserves SQL as built-in `str | None`, retains SQL `NULL` as JSON `null`, and rejects non-exact storage types rather than coercing them. A writable-schema regression changes one automatic-index SQL value from `NULL` to empty TEXT while `quick_check` remains `ok`; exact inspection rejects it. Targeted GREEN is 1 passed and the focused suite is 43 passed.

## Review state

Final substantive delta review reported 0 P1 / 0 material P2 with 0 review threads. The PR may be marked ready; merge waits for the ready-state lifecycle receipt. Exact-head SDLC run 31437948575 passed CI, source, all four shards and the core reducer, while decision classified only `BUDGET_EXCEEDED`; under #382 this full-inventory capacity signal is deferred to #383 and is not an atom blocker.




