### PR TITLE
Complete retained relationship integrity port (#398)

### DIFF
--- a/newsroom/authority/_event_hypothesis_relationship_system.py
+++ b/newsroom/authority/_event_hypothesis_relationship_system.py
@@ -694,6 +694,15 @@ class _EventHypothesisRelationshipReadAuthority:
 
         return self.__read(value)
 
+    def verify_retained_integrity_in_transaction(self) -> None:
+        def verify() -> None:
+            _verify_relationship_reads_in_transaction(
+                self.__connection, self.__hypotheses, *self.__registries
+            )
+            _verify_relationship_event_coverage(self.__connection)
+
+        return self.__read(verify)
+
     def require_retained_receipt_in_transaction(
         self, assessment_digest: str
     ) -> RetainedRelationshipDecisionReceipt:

--- a/newsroom/increment6/relationships.py
+++ b/newsroom/increment6/relationships.py
@@ -861,6 +861,13 @@ class EventHypothesisRelationshipReadPort:
             )
         self.__authority = authority
 
+    def verify_retained_integrity_in_transaction(self) -> None:
+        return _normalise_exact(
+            self.__authority.verify_retained_integrity_in_transaction,
+            "retained relationship integrity transaction read failed",
+            type(None),
+        )
+
     def require_retained_receipt_in_transaction(
         self, assessment_digest: str
     ) -> RetainedRelationshipDecisionReceipt:

--- a/newsroom/tests/test_increment6d2_relationship_store.py
+++ b/newsroom/tests/test_increment6d2_relationship_store.py
@@ -539,6 +539,7 @@ def test_read_port_is_narrow_token_gated_and_requires_its_bound_transaction(
         if callable(value) and not name.startswith("_")
     }
     assert public_methods == {
+        "verify_retained_integrity_in_transaction",
         "require_retained_receipt_in_transaction",
         "require_retained_version_in_transaction",
         "require_current_version_in_transaction",
@@ -550,6 +551,8 @@ def test_read_port_is_narrow_token_gated_and_requires_its_bound_transaction(
         assert not hasattr(port, "history")
         assert not hasattr(port, "connection")
         assert not hasattr(port, "transaction")
+        with pytest.raises(RelationshipContractError, match="active checked"):
+            port.verify_retained_integrity_in_transaction()
         with pytest.raises(RelationshipContractError, match="active checked"):
             port.require_retained_receipt_in_transaction(
                 retained.canonical_digest
@@ -567,6 +570,8 @@ def test_read_port_is_narrow_token_gated_and_requires_its_bound_transaction(
         wrong.execute("BEGIN")
         try:
             with pytest.raises(RelationshipContractError, match="active checked"):
+                port.verify_retained_integrity_in_transaction()
+            with pytest.raises(RelationshipContractError, match="active checked"):
                 port.require_retained_receipt_in_transaction(
                     retained.canonical_digest
                 )
@@ -577,6 +582,7 @@ def test_read_port_is_narrow_token_gated_and_requires_its_bound_transaction(
 
         connection.execute("BEGIN IMMEDIATE")
         changes = connection.total_changes
+        assert port.verify_retained_integrity_in_transaction() is None
         receipt = port.require_retained_receipt_in_transaction(
             retained.canonical_digest
         )
@@ -630,6 +636,7 @@ def test_read_port_retained_reads_survive_version_advance_but_current_fails(
     try:
         connection.execute("BEGIN IMMEDIATE")
         changes = connection.total_changes
+        assert port.verify_retained_integrity_in_transaction() is None
         receipt = port.require_retained_receipt_in_transaction(
             retained.canonical_digest
         )
@@ -695,6 +702,8 @@ def test_read_port_rejects_self_consistent_retained_evidence_rewrite(
     try:
         checked.execute("BEGIN IMMEDIATE")
         changes = checked.total_changes
+        with pytest.raises(RelationshipContractError):
+            port.verify_retained_integrity_in_transaction()
         with pytest.raises(RelationshipContractError):
             port.require_retained_receipt_in_transaction(
                 tampered_assessment.canonical_digest


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: retained-relationship-integrity-port
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

## Scope

Adds the public token-gated retained-integrity verification read to the Event Hypothesis relationship read port. The private authority executes the existing complete retained relationship read and event-coverage verifiers inside the exact caller-owned active checked transaction.

## Exact state

```text
base: a3930e31c2aefc2d2ed8b0c724de3d3c7601f4ba
head: 89158e8d90249d3991a18a5d988eea8b1690cc03
tree: 74c86b73dc2988e932d8964dae9a22559a95031d
commits over base: 1
changed files:
- newsroom/increment6/relationships.py
- newsroom/authority/_event_hypothesis_relationship_system.py
- newsroom/tests/test_increment6d2_relationship_store.py
```

## Verification

- RED: focused read-port tests failed before implementation (`2 failed, 18 deselected`).
- GREEN: the same focused tests passed (`2 passed, 18 deselected`).
- Focused v22 relationship contract, migration and store tests plus D1 contract, migration and store compatibility, authority migration compatibility, and authority import-boundary tests: `151 passed in 227.31s`.
- Static gates: `python -m compileall -q` for the three changed files and `git diff --check` passed.
- No full-suite or #384 all-11 unchanged-lane run was performed.

## Non-effects

This read imposes no currentness requirement. It starts, commits and rolls back no transaction, exposes no raw connection, capability or mutation surface, and makes no migration, schema, checksum, opener or write-policy change.

Closes #398
Refs #399 #405 #382
