### PR TITLE
Complete measured D-wave admission successor (#415, #417)

### DIFF
--- a/.github/workflows/evidence.yml
+++ b/.github/workflows/evidence.yml
@@ -161,7 +161,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3]
+        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:

--- a/.sdlc/gates.toml
+++ b/.sdlc/gates.toml
@@ -1,11 +1,11 @@
 schema_version = "newsroom.sdlc.gates.v1"
-contract_version = "sdlc-v2.5"
+contract_version = "sdlc-v2.6"
 status = "accepted"
 owner = "fol2"
 canonical_language = "English"
 specification = "docs/specs/sdlc/high-performance-evidence-sdlc.md"
-acceptance_record = "docs/specs/sdlc/2026-08-10-sdlc-v2.5-core-sharding-amendment.md"
-issue = 98
+acceptance_record = "docs/specs/sdlc/2026-08-11-sdlc-v2.6-measured-core-budget-amendment.md"
+issue = 415
 
 [global]
 gate_command_timeout_seconds = 220
@@ -43,7 +43,7 @@ lane = "core"
 id = "core-deterministic"
 p50_target_seconds = 15
 p95_target_seconds = 35
-hard_timeout_seconds = 220
+hard_timeout_seconds = 330
 blocking = true
 lane = "core"
 
@@ -193,15 +193,17 @@ clustering = [
 
 [lanes.core]
 bootstrap_once = true
-shard_count = 4
+shard_count = 10
 partition = "sha256_node_id_balanced"
-workers_per_shard = 4
+workers_per_shard = 2
 distribution = "worksteal"
 max_worker_restart = 0
-per_shard_hard_timeout_seconds = 220
+per_shard_hard_timeout_seconds = 330
+per_shard_warning_seconds = 300
+critical_path_warning_seconds = 300
 reducer_single_canonical_receipt = true
 run_full_suite_when_p95_below_seconds = 35
-hard_timeout_seconds = 220
+hard_timeout_seconds = 330
 required = true
 
 [lanes.service]
@@ -228,6 +230,8 @@ hard_timeout_seconds = 20
 
 [test_strategy]
 full_suite_blocking_default = true
+individual_testcase_hard_timeout_seconds = 90
+individual_testcase_warning_seconds = 75
 full_suite_p95_threshold_seconds = 35
 warm_bootstrap_p95_threshold_seconds = 10
 selector_initial_mode = "observe"

--- a/docs/specs/sdlc/2026-08-10-sdlc-v2.5-core-sharding-amendment.md
+++ b/docs/specs/sdlc/2026-08-10-sdlc-v2.5-core-sharding-amendment.md
@@ -7,19 +7,27 @@ Predecessor: `sdlc-v2.4`
 
 ## Decision
 
-The deterministic core inventory is executed as four exact-head shards. The
+The deterministic core inventory is executed as six exact-head shards. The
 repository collects the complete sorted recursive `newsroom/tests/**/test_*.py` node-ID
 inventory, orders it by a stable SHA-256 key, and distributes it evenly across
-four shards. Callers cannot provide files, node IDs, exclusions, worker counts,
+six shards. Callers cannot provide files, node IDs, exclusions, worker counts,
 or scheduler options.
 
-Each shard retains four persistent pytest-xdist workers, one explicit
+Each shard retains two persistent pytest-xdist workers, one explicit
 `xdist.plugin`, `worksteal`, `--max-worker-restart=0`, isolated temporary state
 and an independent 220-second hard watchdog. That watchdog starts before node
 collection and covers collection, pytest, report processing and fragment
 finalisation. The producer verifies the tracked checkout immediately after
 collection and again after pytest/report finalisation, before publication; a
 later reducer checkout cannot substitute for either proof.
+
+The owner amended the fixed worker count from four to two on 2026-08-11 after
+exact-head D-wave evidence showed that four CPU- and SQLite-heavy workers on a
+bounded hosted runner inflated otherwise passing D3 cases beyond 60 seconds
+and left four shard lifecycles at 219.673--219.881 seconds. The six-shard
+assignment, complete JUnit universe, `worksteal` scheduler, zero worker restart
+policy and every 60/220-second enforcement boundary remain unchanged. This is
+a fixed repository topology; callers still cannot select worker count.
 
 Each canonical fragment binds the run, attempt, producer job, evaluated commit
 and tree, route, accepted contract, exact lockfile, Python/uv toolchain,
@@ -28,7 +36,7 @@ and summary, plus exact shard-lifecycle elapsed time, accepted timeout and typed
 result. The command specification itself binds the complete inventory and
 assigned node-ID digests; the child process recomputes both before pytest.
 
-Source integrity runs concurrently with the four shards. Its producer starts
+Source integrity runs concurrently with the six shards. Its producer starts
 the same immutable core-lane deadline before artifact preparation, binds a
 typed full-lifecycle record through durable fragment staging, and proves the
 tracked checkout after source execution and again at publication. A source
@@ -37,7 +45,7 @@ callback or finalisation step cannot publish a stale-tree or over-budget PASS.
 The `core` reducer
 rejects missing, extra, duplicate, non-canonical, tampered, wrong-head,
 wrong-tree, wrong-route, wrong-specification, wrong-inventory or wrong-report
-inputs. It proves the assigned and observed JUnit universes, merges the four
+inputs. It proves the assigned and observed JUnit universes, merges the six
 reports, and alone emits the existing canonical core lane artifact consumed by
 the decision. Its bound starts before fragment/source loading and inventory
 re-collection, is checked after every loading or collection boundary, and

--- a/docs/specs/sdlc/2026-08-11-sdlc-v2.5-ten-shard-capacity-amendment.md
+++ b/docs/specs/sdlc/2026-08-11-sdlc-v2.5-ten-shard-capacity-amendment.md
@@ -1,0 +1,59 @@
+# SDLC v2.5 ten-shard capacity owner amendment
+
+Status: accepted
+Owner: fol2
+Issue: #411
+Parent evidence defect: #407
+Predecessor: `docs/specs/sdlc/2026-08-10-sdlc-v2.5-core-sharding-amendment.md`
+
+## Decision
+
+The complete deterministic core inventory is executed as ten exact-head
+shards. The repository collects the complete sorted recursive
+`newsroom/tests/**/test_*.py` node-ID inventory, orders it by a stable SHA-256
+key and distributes it evenly across ten shards. Callers cannot provide files,
+node IDs, exclusions, shard counts, worker counts or scheduler options.
+
+Each shard retains two persistent pytest-xdist workers, one explicit
+`xdist.plugin`, `worksteal`, `--max-worker-restart=0`, isolated temporary state
+and an independent 220-second whole-lifecycle watchdog. The 60-second testcase
+boundary, complete JUnit universe, zero required skip policy, source and
+service routing, reducer semantics and decision policy remain unchanged.
+
+This capacity amendment follows exact-head run 31521937503. Its six-shard,
+two-worker topology assigned 551–552 nodes per shard. Five shards returned
+typed `BUDGET_EXCEEDED` outcomes at 219.770–219.921 seconds; the retained sixth
+fragment passed 551 tests with zero failures or errors and a 55.413-second
+maximum testcase. The canonical reducer correctly reported a 226.040-second
+critical path.
+
+Ten shards are the smallest fixed topology with credible non-marginal
+headroom: the same 3,307-node checkpoint inventory becomes 330–331 nodes per
+shard, about 40% less work. Eight shards would retain 413–414 nodes and risk a
+second marginal capacity iteration; twelve would add runner, bootstrap and
+artifact cost beyond the observed need. This decision does not authorise a new
+cache layer, probe splitting, timeout growth, exclusions or caller-selected
+capacity.
+
+Each canonical fragment continues to bind the run, attempt, producer job,
+evaluated commit and tree, route, accepted contract, exact lockfile, Python/uv
+toolchain, complete inventory, deterministic assignment, command
+specification, command run, JUnit report and whole-lifecycle result. The sole
+core reducer rejects missing, extra, duplicate, non-canonical, tampered or
+wrong-topology inputs, proves the exact JUnit union and emits the existing
+canonical core receipt.
+
+## Admission
+
+The topology is admitted only when one exact-head run produces ten PASS
+fragments, a complete and unique JUnit union with zero failures, errors and
+required skips, every testcase below 60 seconds, and both maximum shard
+lifecycle and core critical path below 190 seconds. A failed exact-head run is
+a hard stop; it does not authorise an unchanged rerun or another speculative
+cache or topology iteration.
+
+## Rollback
+
+One reviewed revert restores the predecessor six-shard topology and acceptance
+record. Contract, route, fragment and exact-tree identities prevent evidence
+crossing either topology boundary.

--- a/docs/specs/sdlc/2026-08-11-sdlc-v2.6-measured-core-budget-amendment.md
+++ b/docs/specs/sdlc/2026-08-11-sdlc-v2.6-measured-core-budget-amendment.md
@@ -1,0 +1,44 @@
+# SDLC v2.6 measured core budget owner amendment
+
+Status: accepted
+Owner: fol2
+Issue: #415
+Predecessor: `docs/specs/sdlc/2026-08-11-sdlc-v2.5-ten-shard-capacity-amendment.md`
+
+## Decision
+
+The complete deterministic core keeps the admitted topology of exactly ten
+SHA-256-balanced shards, two persistent pytest-xdist workers per shard,
+`worksteal`, and `--max-worker-restart=0`. No cache, D3 probe, test selection,
+product, migration, schema, routing, skip or admission semantic changes are
+authorised.
+
+Measured blocking boundaries are amended only for deterministic core work:
+
+- each individual testcase is accepted through 90 seconds;
+- each core shard command and complete shard lifecycle is accepted through 330
+  seconds;
+- the single core reducer and its complete critical path are accepted through
+  330 seconds;
+- authenticated service execution remains 220 seconds;
+- evidence finalisation remains 20 seconds.
+
+A testcase above 75 seconds and a core shard or core critical path above 300
+seconds remain warning-level performance debt. These warnings are retained in
+the accepted contract and specification; they do not change typed outcomes or
+blocking admission at or below the hard boundaries.
+
+## Evidence invariants
+
+The complete sorted inventory and exact JUnit union remain mandatory. Missing,
+extra, duplicate, non-canonical or tampered fragments fail closed. Required
+skips remain zero. Typed outcomes, reducer provenance, first-result
+immutability, producer conclusion propagation and truthful telemetry remain
+unchanged. The service lane is evaluated against its own 220-second budget and
+must not inherit the larger core ceiling.
+
+## Rollback
+
+One reviewed revert restores the v2.5 timing contract and acceptance record.
+Exact contract and evidence identities prevent evidence crossing the version
+boundary.

--- a/docs/specs/sdlc/high-performance-evidence-sdlc.md
+++ b/docs/specs/sdlc/high-performance-evidence-sdlc.md
@@ -1,15 +1,15 @@
 # High-performance evidence SDLC
 
 - Role: Normative target specification
-- Status: Accepted — amended by the owner on 2026-08-10
+- Status: Accepted — amended by the owner on 2026-08-11
 - Owner: fol2
 - Canonical language: English
 - Date: 2026-07-21
 - Specification ID: `SDLC-V2`
-- Contract version: `sdlc-v2.5`
+- Contract version: `sdlc-v2.6`
 - Related issue: #98
 - Related active product work: #96 / PR #97
-- Current owner amendment: `docs/specs/sdlc/2026-08-10-sdlc-v2.5-core-sharding-amendment.md`
+- Current owner amendment: `docs/specs/sdlc/2026-08-11-sdlc-v2.6-measured-core-budget-amendment.md`
 
 ## 1. Decision
 
@@ -17,14 +17,14 @@ Newsroom will replace increment-by-increment CI accumulation with an evidence-or
 
 A machine gate is a bounded decision over an exact change, environment and evidence contract. It either produces a reproducible typed decision inside its budget or fails closed. Its timeout does not grow whenever repository scope grows.
 
-The normal pull-request path has one always-reporting decision workflow with parallel source-integrity, four-way deterministic-core and conditional service work:
+The normal pull-request path has one always-reporting decision workflow with parallel source-integrity, ten-way deterministic-core and conditional service work:
 
-1. a core topology for routing, concurrent source integrity and four deterministic repository-test shards, followed by one canonical reducer;
+1. a core topology for routing, concurrent source integrity and ten deterministic repository-test shards, followed by one canonical reducer;
 2. a Neo4j service lane when the exact change affects the graph adapter, projection-authority integration, graph migrations, service compatibility, credentials, workflow service setup or qualifying GraphRAG behaviour.
 
 One decision-validated exact-head SDLC core receipt is the canonical complete deterministic evidence. Pull-request and merge-queue core/decision receipts are content-addressed, transport-verified evidence-only artifacts, not signed attestations. The isolated signed-closeout job remains limited to exact-main, service-required manual runs and supplies the Tier-M attestation. Fast CI and manually dispatched legacy diagnostics are compatibility signals only; Tier S adds only the affected lanes selected by the route. The change has one feature-complete stop and one review at that stop.
 
-The complete deterministic inventory remains blocking. Its stable node-ID inventory is divided into four complete, duplicate-free balanced shards because a single runner no longer fits the unchanged 220-second envelope. Test-impact analysis remains in observe mode and cannot replace this complete evidence until repository-specific shadow controls demonstrate that it preserves defect detection.
+The complete deterministic inventory remains blocking. Its stable node-ID inventory is divided into ten complete, duplicate-free balanced shards. The six-shard/two-worker D-wave checkpoint carried 551–552 nodes per shard and left five shards at 219.770–219.921 seconds with typed budget outcomes; ten shards reduce that fixed inventory to 330–331 nodes per shard without changing the complete evidence topology. The measured amendment sets the core testcase boundary to 90 seconds and the core shard/reducer critical-path boundary to 330 seconds; 75-second testcase and 300-second shard/critical-path warnings retain visible debt. Test-impact analysis remains in observe mode and cannot replace this complete evidence until repository-specific shadow controls demonstrate that it preserves defect detection.
 
 Deep mutation, fuzz, compatibility, flake, performance and recovery work runs as independent scientific shards outside the interactive path. Each shard has its own 220-second hard budget; a large experiment is many content-addressed shards, not one unbounded job.
 
@@ -137,13 +137,13 @@ A deterministic classification of changed paths and semantic surfaces that contr
 
 All gate and lane durations below start after runner allocation.
 
-The 2026-08-02 owner amendment doubles every `sdlc-v2.3` hard command, lane, shard and finalisation ceiling for all risk tiers. It does not double the p50/p95 performance targets, relax required evidence, reduce test coverage or alter risk routing. The unchanged targets continue to expose performance regression; the doubled values control only typed `BUDGET_EXCEEDED` enforcement. The watchdog retains a strict upper bound below 240 seconds.
+The 2026-08-02 owner amendment doubles every `sdlc-v2.3` hard command, lane, shard and finalisation ceiling for all risk tiers. It does not double the p50/p95 performance targets, relax required evidence, reduce test coverage or alter risk routing. The unchanged targets continue to expose performance regression; the doubled values control only typed `BUDGET_EXCEEDED` enforcement. The watchdog retains a strict upper bound below 240 seconds. The subsequent v2.6 measured-core amendment makes 330 seconds the sole core command/lane exception; the global non-core command and lane defaults remain 220 seconds, and service, merge, science and finalisation boundaries remain unchanged.
 
 | Gate | p50 | p95 | hard command timeout | Lane |
 |---|---:|---:|---:|---|
 | `route` | 1 s | 2 s | 20 s | core |
 | `source-integrity` | 3 s | 8 s | 60 s | core |
-| `core-deterministic` | 15 s | 35 s | 220 s | core |
+| `core-deterministic` | 15 s | 35 s | 330 s | core |
 | `service-neo4j` | 25 s | 50 s | 220 s | service |
 | `merge-exact` | 20 s | 50 s | 220 s | merge group |
 | each `science-*` shard | 20 s | 50 s | 220 s | science |
@@ -151,7 +151,7 @@ The 2026-08-02 owner amendment doubles every `sdlc-v2.3` hard command, lane, sha
 
 Aggregate execution rules:
 
-- core-lane repository-owned execution hard deadline: 220 seconds;
+- core-lane repository-owned execution hard deadline: 330 seconds;
 - core-lane execution is `max(source lifecycle, maximum shard lifecycle) +
   reducer lifecycle`, with source timed from pre-preparation, each shard timed
   from pre-collection and the reducer timed from pre-input-loading through
@@ -302,7 +302,7 @@ Shape:
 4. install pinned Python and pinned uv in each isolated exact-head job;
 5. restore an exact lock/toolchain-keyed cache;
 6. run `route`;
-7. run source integrity and four independently watched deterministic shards concurrently;
+7. run source integrity and ten independently watched deterministic shards concurrently;
 8. prove each shard producer's tracked tree after collection and again before
    fragment publication, and prove the source producer after execution and at
    publication;
@@ -390,7 +390,7 @@ Canonical output shape:
 ```json
 {
   "schema_version": "newsroom.sdlc.route.v1",
-  "contract_version": "sdlc-v2.5",
+  "contract_version": "sdlc-v2.6",
   "base_sha": "0000000000000000000000000000000000000000",
   "head_sha": "1111111111111111111111111111111111111111",
   "base_tree_sha": "2222222222222222222222222222222222222222",

--- a/newsroom/tests/authority_store_conformance.py
+++ b/newsroom/tests/authority_store_conformance.py
@@ -420,7 +420,34 @@ def _fresh_replay(adapter: AuthorityStoreAdapter) -> None:
     )
 
 
-def _fresh_reopen(adapter: AuthorityStoreAdapter) -> None:
+def _fresh_submission(adapter: AuthorityStoreAdapter) -> None:
+    command = _command()
+    _, handle = _new_handle(adapter)
+    before_history = handle.history()
+    _require(handle.observe(command.record_id) is None, "record existed before write")
+    expected = AuthorityValue.from_command(command)
+    _require(handle.submit(command) == expected, "fresh submission result differs")
+    after_fresh = _snapshot(handle, command.record_id)
+    _require(
+        len(after_fresh[1]) == len(before_history) + 1,
+        "fresh submission did not append once",
+    )
+
+
+def _exact_replay(adapter: AuthorityStoreAdapter) -> None:
+    command = _command()
+    _, handle = _new_handle(adapter)
+    expected = AuthorityValue.from_command(command)
+    handle.submit(command)
+    after_fresh = _snapshot(handle, command.record_id)
+    _require(handle.submit(command) == expected, "exact replay result differs")
+    _require(
+        _snapshot(handle, command.record_id) == after_fresh,
+        "exact replay changed state or append-only history",
+    )
+
+
+def _fresh_reopen_persistence(adapter: AuthorityStoreAdapter) -> None:
     command = _command()
     location, handle = _new_handle(adapter)
     expected = AuthorityValue.from_command(command)
@@ -437,10 +464,38 @@ def _fresh_reopen(adapter: AuthorityStoreAdapter) -> None:
         _snapshot(reopened, command.record_id) == snapshot,
         "reopen changed state or history",
     )
+
+
+def _fresh_reopen_digest(adapter: AuthorityStoreAdapter) -> None:
     _assert_tampers_rejected(adapter, (TamperKind.DIGEST,))
 
 
-def _representation(adapter: AuthorityStoreAdapter) -> None:
+def _fresh_reopen(adapter: AuthorityStoreAdapter) -> None:
+    _fresh_reopen_persistence(adapter)
+    _fresh_reopen_digest(adapter)
+
+
+_REPRESENTATION_TAMPERS = (
+    TamperKind.SCALAR,
+    TamperKind.CANONICAL,
+    TamperKind.IDENTITY,
+    TamperKind.LINKED_ROW,
+)
+_REQUEST_BINDING_FIELDS = ("actor", "request", "idempotency", "cas_predecessor")
+_HISTORICAL_TAMPERS = (
+    TamperKind.IDENTITY,
+    TamperKind.DIGEST,
+    TamperKind.PROVENANCE,
+)
+_CURRENT_USE_AUTHORITIES = ("authority", "policy")
+_TAMPER_REJECTION_TAMPERS = (
+    TamperKind.CANONICAL,
+    TamperKind.LINKED_ROW,
+    TamperKind.OFFLINE_REWRITE,
+)
+
+
+def _representation_retained(adapter: AuthorityStoreAdapter) -> None:
     command = _command()
     _, handle = _new_handle(adapter)
     handle.submit(command)
@@ -448,33 +503,40 @@ def _representation(adapter: AuthorityStoreAdapter) -> None:
         handle.observe(command.record_id) == StoredAuthorityState.from_command(command),
         "persisted representation differs",
     )
-    _assert_tampers_rejected(
-        adapter,
-        (
-            TamperKind.SCALAR,
-            TamperKind.CANONICAL,
-            TamperKind.IDENTITY,
-            TamperKind.LINKED_ROW,
-        ),
+
+
+def _representation_tamper(adapter: AuthorityStoreAdapter, kind: TamperKind) -> None:
+    _require(kind in _REPRESENTATION_TAMPERS, "unknown representation tamper probe")
+    _assert_tampers_rejected(adapter, (kind,))
+
+
+def _representation(adapter: AuthorityStoreAdapter) -> None:
+    _representation_retained(adapter)
+    for kind in _REPRESENTATION_TAMPERS:
+        _representation_tamper(adapter, kind)
+
+
+def _request_binding_field(adapter: AuthorityStoreAdapter, field_name: str) -> None:
+    _require(field_name in _REQUEST_BINDING_FIELDS, "unknown request binding probe")
+    command = _command()
+    _, handle = _new_handle(adapter)
+    handle.submit(command)
+    before = _snapshot(handle, command.record_id)
+    divergent = replace(command, **{field_name: f"different-{field_name}"})
+    _expect_exception(
+        BindingConflict,
+        lambda: handle.submit(divergent),
+        f"divergent {field_name} binding was accepted",
+    )
+    _require(
+        _snapshot(handle, command.record_id) == before,
+        f"divergent {field_name} changed state or history",
     )
 
 
 def _request_binding(adapter: AuthorityStoreAdapter) -> None:
-    command = _command()
-    for field_name in ("actor", "request", "idempotency", "cas_predecessor"):
-        _, handle = _new_handle(adapter)
-        handle.submit(command)
-        before = _snapshot(handle, command.record_id)
-        divergent = replace(command, **{field_name: f"different-{field_name}"})
-        _expect_exception(
-            BindingConflict,
-            lambda divergent=divergent, handle=handle: handle.submit(divergent),
-            f"divergent {field_name} binding was accepted",
-        )
-        _require(
-            _snapshot(handle, command.record_id) == before,
-            f"divergent {field_name} changed state or history",
-        )
+    for field_name in _REQUEST_BINDING_FIELDS:
+        _request_binding_field(adapter, field_name)
 
 
 def _lost_response(adapter: AuthorityStoreAdapter) -> None:
@@ -506,69 +568,128 @@ def _lost_response(adapter: AuthorityStoreAdapter) -> None:
     )
 
 
-def _historical(adapter: AuthorityStoreAdapter) -> None:
+def _historical_fixture(adapter: AuthorityStoreAdapter, kind: TamperKind):
+    _require(kind in _HISTORICAL_TAMPERS, "unknown historical tamper probe")
+    first = _command()
+    second = _command("record-2", "record-1", "beta")
+    location, handle = _new_handle(adapter)
+    handle.submit(first)
+    handle.submit(second)
+    handle.tamper(first.record_id, kind)
+    return first, location, handle
+
+
+def _historical_retained_operation(
+    adapter: AuthorityStoreAdapter, *, listing: bool
+) -> None:
     first = _command()
     second = _command("record-2", "record-1", "beta")
     expected = AuthorityValue.from_command(first)
-    for kind in (TamperKind.IDENTITY, TamperKind.DIGEST, TamperKind.PROVENANCE):
-        location, handle = _new_handle(adapter)
-        handle.submit(first)
-        handle.submit(second)
-        _require(handle.read(first.record_id) == expected, "historical load differs")
+    _, handle = _new_handle(adapter)
+    handle.submit(first)
+    handle.submit(second)
+    if listing:
         _require(
             expected in handle.list_history(),
             "historical list omitted retained value",
         )
-        handle.tamper(first.record_id, kind)
-        _expect_exception(
-            IntegrityViolation,
-            lambda handle=handle: handle.read(first.record_id),
-            f"fresh historical read accepted {kind.value} mutation",
-        )
-        _expect_exception(
-            IntegrityViolation,
-            handle.list_history,
-            f"fresh historical list accepted {kind.value} mutation",
-        )
+    else:
+        _require(handle.read(first.record_id) == expected, "historical load differs")
+
+
+def _historical_tamper_operation(
+    adapter: AuthorityStoreAdapter,
+    kind: TamperKind,
+    *,
+    reopened: bool,
+    listing: bool,
+) -> None:
+    first, location, handle = _historical_fixture(adapter, kind)
+    checked = handle
+    if reopened:
+        _expect_historical_corruption(handle, first, kind, False, listing)
         handle.close()
-        reopened = adapter.open_handle(location)
-        _require(reopened is not handle, "historical reopen returned original handle")
-        _expect_exception(
-            IntegrityViolation,
-            lambda reopened=reopened: reopened.read(first.record_id),
-            f"reopened historical read accepted {kind.value} mutation",
-        )
-        _expect_exception(
-            IntegrityViolation,
-            reopened.list_history,
-            f"reopened historical list accepted {kind.value} mutation",
-        )
+        checked = adapter.open_handle(location)
+        _require(checked is not handle, "historical reopen returned original handle")
+    _expect_historical_corruption(checked, first, kind, reopened, listing)
+
+
+def _expect_historical_corruption(
+    handle: AuthorityStoreHandle,
+    command: WriteCommand,
+    kind: TamperKind,
+    reopened: bool,
+    listing: bool,
+) -> None:
+    operation = (
+        handle.list_history if listing else lambda: handle.read(command.record_id)
+    )
+    phase = "reopened" if reopened else "fresh"
+    noun = "list" if listing else "read"
+    _expect_exception(
+        IntegrityViolation,
+        operation,
+        f"{phase} historical {noun} accepted {kind.value} mutation",
+    )
+
+
+def _historical_tamper(adapter: AuthorityStoreAdapter, kind: TamperKind) -> None:
+    first = _command()
+    second = _command("record-2", "record-1", "beta")
+    expected = AuthorityValue.from_command(first)
+    location, handle = _new_handle(adapter)
+    handle.submit(first)
+    handle.submit(second)
+    _require(handle.read(first.record_id) == expected, "historical load differs")
+    _require(
+        expected in handle.list_history(), "historical list omitted retained value"
+    )
+    handle.tamper(first.record_id, kind)
+    _expect_historical_corruption(handle, first, kind, False, False)
+    _expect_historical_corruption(handle, first, kind, False, True)
+    handle.close()
+    reopened = adapter.open_handle(location)
+    _require(reopened is not handle, "historical reopen returned original handle")
+    _expect_historical_corruption(reopened, first, kind, True, False)
+    _expect_historical_corruption(reopened, first, kind, True, True)
+
+
+def _historical(adapter: AuthorityStoreAdapter) -> None:
+    for kind in _HISTORICAL_TAMPERS:
+        _historical_tamper(adapter, kind)
+
+
+def _current_use_authority(adapter: AuthorityStoreAdapter, authority: str) -> None:
+    _require(authority in _CURRENT_USE_AUTHORITIES, "unknown current-use probe")
+    command = _command()
+    _, handle = _new_handle(adapter)
+    _seed_heads(handle, command)
+    handle.submit(command)
+    _require(
+        handle.current_use(command.record_id) == AuthorityValue.from_command(command),
+        "valid current-use read differs",
+    )
+    handle.set_upstream_head(authority, "changed")
+    _expect_exception(
+        IntegrityViolation,
+        lambda: handle.current_use(command.record_id),
+        f"changed {authority} head was accepted",
+    )
 
 
 def _current_use(adapter: AuthorityStoreAdapter) -> None:
-    command = _command()
-    for changed_authority, _ in command.required_upstream_heads:
-        _, handle = _new_handle(adapter)
-        _seed_heads(handle, command)
-        handle.submit(command)
-        _require(
-            handle.current_use(command.record_id)
-            == AuthorityValue.from_command(command),
-            "valid current-use read differs",
-        )
-        handle.set_upstream_head(changed_authority, "changed")
-        _expect_exception(
-            IntegrityViolation,
-            lambda handle=handle: handle.current_use(command.record_id),
-            f"changed {changed_authority} head was accepted",
-        )
+    for authority in _CURRENT_USE_AUTHORITIES:
+        _current_use_authority(adapter, authority)
+
+
+def _tamper_rejection_kind(adapter: AuthorityStoreAdapter, kind: TamperKind) -> None:
+    _require(kind in _TAMPER_REJECTION_TAMPERS, "unknown tamper rejection probe")
+    _assert_tampers_rejected(adapter, (kind,))
 
 
 def _tamper_rejection(adapter: AuthorityStoreAdapter) -> None:
-    _assert_tampers_rejected(
-        adapter,
-        (TamperKind.CANONICAL, TamperKind.LINKED_ROW, TamperKind.OFFLINE_REWRITE),
-    )
+    for kind in _TAMPER_REJECTION_TAMPERS:
+        _tamper_rejection_kind(adapter, kind)
 
 
 def _competing_writers(adapter: AuthorityStoreAdapter) -> None:
@@ -626,7 +747,7 @@ def _competing_writers(adapter: AuthorityStoreAdapter) -> None:
     )
 
 
-def _rollback(adapter: AuthorityStoreAdapter) -> None:
+def _rollback_sequence(adapter: AuthorityStoreAdapter) -> None:
     location, handle = _new_handle(adapter)
     before_history = handle.history()
     normal_command = _command("record-rollback-normal")
@@ -734,7 +855,71 @@ def _rollback(adapter: AuthorityStoreAdapter) -> None:
     )
 
 
-def _restart_migration(adapter: AuthorityStoreAdapter) -> None:
+def _rollback_kind(adapter: AuthorityStoreAdapter, *, abort: bool) -> None:
+    location, handle = _new_handle(adapter)
+    before_history = handle.history()
+    label = "abort" if abort else "normal"
+    command = _command(f"record-rollback-{label}")
+    invocations = 0
+    inspection_complete = False
+    sentinel = _RollbackInspectionAbort()
+
+    def operation(scope: RollbackScope) -> None:
+        nonlocal invocations, inspection_complete
+        invocations += 1
+        _require(invocations == 1, f"{label} rollback scope invoked callback twice")
+        scope.submit(command)
+        _require(
+            scope.observe(command.record_id)
+            == StoredAuthorityState.from_command(command),
+            f"{label} rollback scope cannot observe submitted state",
+        )
+        _require(
+            scope.history() == before_history + (AuthorityValue.from_command(command),),
+            f"{label} rollback scope history did not append exactly once",
+        )
+        inspection_complete = True
+        if abort:
+            raise sentinel
+
+    rethrown = False
+    try:
+        handle.rollback_scope(operation)
+    except Exception as exc:
+        if abort and exc is sentinel:
+            rethrown = True
+        elif isinstance(exc, _CaseFailed):
+            raise
+        else:
+            raise _CaseFailed(
+                f"{label} rollback scope raised {type(exc).__name__}"
+            ) from exc
+    _require(invocations == 1, f"{label} rollback scope skipped kernel callback")
+    _require(inspection_complete, f"{label} rollback scope swallowed inspection")
+    if abort:
+        _require(rethrown, "abort rollback scope swallowed kernel sentinel")
+    _require(
+        handle.observe(command.record_id) is None,
+        f"{label} rolled-back row remains visible on same handle",
+    )
+    _require(
+        handle.history() == before_history,
+        f"{label} rollback changed same-handle append-only history",
+    )
+    handle.close()
+    reopened = adapter.open_handle(location)
+    _require(reopened is not handle, "post-rollback reopen returned original handle")
+    _require(
+        reopened.observe(command.record_id) is None,
+        f"rolled-back row remains visible after reopen: {command.record_id}",
+    )
+    _require(
+        reopened.history() == before_history,
+        "rollback changed reopened append-only history",
+    )
+
+
+def _restart_or_migrate(adapter: AuthorityStoreAdapter, *, migrate: bool) -> None:
     command = _command()
     location, original = _new_handle(adapter)
     original.submit(command)
@@ -750,6 +935,8 @@ def _restart_migration(adapter: AuthorityStoreAdapter) -> None:
         _snapshot(restarted, command.record_id) == expected_snapshot,
         "restart changed state or history",
     )
+    if not migrate:
+        return
     restarted.close()
     migrated = adapter.open_handle(location, migrate=True)
     _require(migrated is not restarted, "migration returned prior handle")
@@ -762,6 +949,10 @@ def _restart_migration(adapter: AuthorityStoreAdapter) -> None:
     )
 
 
+def _restart_migration(adapter: AuthorityStoreAdapter) -> None:
+    _restart_or_migrate(adapter, migrate=True)
+
+
 _SCENARIOS = {
     CaseId.FRESH_REPLAY: _fresh_replay,
     CaseId.FRESH_REOPEN: _fresh_reopen,
@@ -772,7 +963,7 @@ _SCENARIOS = {
     CaseId.CURRENT_USE_REVALIDATION: _current_use,
     CaseId.TAMPER_REJECTION: _tamper_rejection,
     CaseId.COMPETING_WRITERS: _competing_writers,
-    CaseId.TRANSACTION_ROLLBACK: _rollback,
+    CaseId.TRANSACTION_ROLLBACK: _rollback_sequence,
     CaseId.RESTART_MIGRATION: _restart_migration,
 }
 

--- a/newsroom/tests/authority_store_conformance.py
+++ b/newsroom/tests/authority_store_conformance.py
@@ -535,8 +535,39 @@ def _request_binding_field(adapter: AuthorityStoreAdapter, field_name: str) -> N
 
 
 def _request_binding(adapter: AuthorityStoreAdapter) -> None:
+    command = _command()
+    record_id = command.record_id
+    location, baseline_handle = _new_handle(adapter)
+    try:
+        baseline = baseline_handle.submit(command)
+        initial = _snapshot(baseline_handle, record_id)
+    finally:
+        baseline_handle.close()
+    previous_handle = baseline_handle
     for field_name in _REQUEST_BINDING_FIELDS:
-        _request_binding_field(adapter, field_name)
+        handle = adapter.open_handle(location)
+        _require(handle is not previous_handle, "request binding reused prior handle")
+        try:
+            divergent = replace(command, **{field_name: f"different-{field_name}"})
+            _expect_exception(
+                BindingConflict,
+                lambda h=handle, c=divergent: h.submit(c),
+                f"divergent {field_name} was accepted",
+            )
+            _require(_snapshot(handle, record_id) == initial, "rejection mutated state")
+            _require(handle.submit(command) == baseline, "exact replay changed value")
+            _require(_snapshot(handle, record_id) == initial, "replay mutated state")
+        finally:
+            handle.close()
+        previous_handle = handle
+    reopened = adapter.open_handle(location)
+    _require(reopened is not previous_handle, "final reopen reused prior handle")
+    try:
+        _require(_snapshot(reopened, record_id) == initial, "final reopen differs")
+        _require(reopened.submit(command) == baseline, "final replay changed value")
+        _require(_snapshot(reopened, record_id) == initial, "final replay mutated")
+    finally:
+        reopened.close()
 
 
 def _lost_response(adapter: AuthorityStoreAdapter) -> None:

--- a/newsroom/tests/conftest.py
+++ b/newsroom/tests/conftest.py
@@ -1,1 +1,300 @@
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import os
+import pickle
+import re
+import stat
+import uuid
+from pathlib import Path
+
+import pytest
+
 collect_ignore_glob = ["_archive/*"]
+
+_D3_CACHE_FORMAT = "newsroom.d3-conformance-cache.v2"
+_D3_CACHE_CAPACITY = 6
+_D3_CACHE_TEMPLATE_KEYS = (
+    ("record-1",),
+    ("record-1", "record-2"),
+    ("record-1", "record-b"),
+    ("record-a", "record-b"),
+    ("record-rollback-normal", "record-rollback-abort"),
+)
+_D3_MODULE = "test_increment6d3_lineage_store.py"
+_RUN_UID = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}")
+
+
+def _validated_template_keys(
+    template_keys: object,
+) -> tuple[tuple[str, ...], ...]:
+    if not isinstance(template_keys, tuple) or not template_keys:
+        raise ValueError("d3 cache template subset")
+    if any(not isinstance(key, tuple) for key in template_keys):
+        raise ValueError("d3 cache template subset")
+    expected = tuple(key for key in _D3_CACHE_TEMPLATE_KEYS if key in template_keys)
+    if expected != template_keys or len(expected) != len(set(expected)):
+        raise ValueError("d3 cache template subset")
+    return expected
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def _validate_directory(path: Path, *, create: bool = False) -> None:
+    if create:
+        try:
+            path.mkdir(mode=0o700)
+        except FileExistsError:
+            pass
+    metadata = path.lstat()
+    if (
+        stat.S_ISLNK(metadata.st_mode)
+        or not stat.S_ISDIR(metadata.st_mode)
+        or metadata.st_uid != os.getuid()
+        or stat.S_IMODE(metadata.st_mode) != 0o700
+    ):
+        raise ValueError(f"unsafe d3 cache directory: {path.name}")
+
+
+def _validate_regular(path: Path, *, mode: int = 0o600) -> os.stat_result:
+    metadata = path.lstat()
+    if (
+        stat.S_ISLNK(metadata.st_mode)
+        or not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_uid != os.getuid()
+        or stat.S_IMODE(metadata.st_mode) != mode
+    ):
+        raise ValueError(f"unsafe d3 cache file: {path.name}")
+    return metadata
+
+
+def _fsync_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _artifact_tree(artifact: Path, *, normalise: bool) -> tuple[Path, ...]:
+    files: list[Path] = []
+    for path in sorted(artifact.rglob("*")):
+        metadata = path.lstat()
+        if stat.S_ISLNK(metadata.st_mode) or metadata.st_uid != os.getuid():
+            raise ValueError("unsafe d3 cache artifact")
+        if stat.S_ISDIR(metadata.st_mode):
+            if normalise:
+                path.chmod(0o700)
+            elif stat.S_IMODE(metadata.st_mode) != 0o700:
+                raise ValueError("unsafe d3 cache artifact directory")
+            continue
+        if not stat.S_ISREG(metadata.st_mode):
+            raise ValueError("unsupported d3 cache artifact")
+        if normalise:
+            path.chmod(0o600)
+        elif stat.S_IMODE(metadata.st_mode) != 0o600:
+            raise ValueError("unsafe d3 cache artifact file")
+        files.append(path)
+    return tuple(files)
+
+
+def _write_staged(path: Path, payload: bytes) -> None:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0)
+    descriptor = os.open(path, flags, 0o600)
+    try:
+        with os.fdopen(descriptor, "wb", closefd=False) as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+    finally:
+        os.close(descriptor)
+
+
+def _publish_d3_cache(
+    root: Path,
+    run_uid: str,
+    d3,
+    template_keys: tuple[tuple[str, ...], ...],
+) -> None:
+    token = uuid.uuid4().hex
+    artifact = root / f"artifact-{run_uid}-{token}"
+    artifact.mkdir(mode=0o700)
+    bundle = d3._prepare_shared_conformance_cache(artifact, template_keys)
+    artifact_files = _artifact_tree(artifact, normalise=True)
+
+    bundle_stage = root / f"bundle-{token}.stage"
+    bundle_path = root / "bundle.pickle"
+    _write_staged(bundle_stage, pickle.dumps(bundle, protocol=pickle.HIGHEST_PROTOCOL))
+    os.replace(bundle_stage, bundle_path)
+
+    file_paths = (*artifact_files, bundle_path)
+    files = [
+        {
+            "path": path.relative_to(root).as_posix(),
+            "sha256": _sha256(path),
+            "size": path.stat().st_size,
+        }
+        for path in sorted(file_paths)
+    ]
+    manifest = {
+        "capacity": _D3_CACHE_CAPACITY,
+        "files": files,
+        "format": _D3_CACHE_FORMAT,
+        "payload_root": artifact.name,
+        "template_keys": [list(key) for key in template_keys],
+    }
+    rendered = (
+        json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode() + b"\n"
+    )
+    manifest_stage = root / f"manifest-{token}.stage"
+    _write_staged(manifest_stage, rendered)
+    os.replace(manifest_stage, root / "manifest.json")
+    _fsync_directory(root)
+
+
+def _load_d3_cache(
+    root: Path, expected_template_keys: tuple[tuple[str, ...], ...]
+) -> object:
+    selected = _validated_template_keys(expected_template_keys)
+    manifest_path = root / "manifest.json"
+    _validate_regular(manifest_path)
+    raw = manifest_path.read_bytes()
+    manifest = json.loads(raw)
+    if not isinstance(manifest, dict) or raw != (
+        json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode() + b"\n"
+    ):
+        raise ValueError("non-canonical d3 cache manifest")
+    if set(manifest) != {
+        "capacity",
+        "files",
+        "format",
+        "payload_root",
+        "template_keys",
+    }:
+        raise ValueError("d3 cache manifest fields")
+    if (
+        manifest["format"] != _D3_CACHE_FORMAT
+        or manifest["capacity"] != _D3_CACHE_CAPACITY
+        or manifest["template_keys"] != [list(key) for key in selected]
+    ):
+        raise ValueError("d3 cache manifest contract")
+    payload_name = manifest["payload_root"]
+    if (
+        not isinstance(payload_name, str)
+        or not payload_name.startswith("artifact-")
+        or Path(payload_name).name != payload_name
+    ):
+        raise ValueError("d3 cache payload root")
+    artifact = root / payload_name
+    _validate_directory(artifact)
+    discovered = _artifact_tree(artifact, normalise=False)
+    expected_paths = {path.relative_to(root).as_posix() for path in discovered}
+    expected_paths.add("bundle.pickle")
+    entries = manifest["files"]
+    if not isinstance(entries, list) or len(entries) != len(expected_paths):
+        raise ValueError("d3 cache file inventory")
+    seen: set[str] = set()
+    for entry in entries:
+        if not isinstance(entry, dict) or set(entry) != {"path", "sha256", "size"}:
+            raise ValueError("d3 cache file entry")
+        relative = entry["path"]
+        if (
+            not isinstance(relative, str)
+            or relative not in expected_paths
+            or relative in seen
+        ):
+            raise ValueError("d3 cache file path")
+        seen.add(relative)
+        path = root / relative
+        metadata = _validate_regular(path)
+        if entry["size"] != metadata.st_size or entry["sha256"] != _sha256(path):
+            raise ValueError("d3 cache file digest")
+    if seen != expected_paths:
+        raise ValueError("d3 cache files incomplete")
+    return pickle.loads((root / "bundle.pickle").read_bytes())
+
+
+def _ensure_d3_cache(
+    root: Path,
+    run_uid: str,
+    d3,
+    *,
+    template_keys: tuple[tuple[str, ...], ...] = _D3_CACHE_TEMPLATE_KEYS,
+    hydrate_root: Path | None = None,
+) -> None:
+    selected = _validated_template_keys(template_keys)
+    if _RUN_UID.fullmatch(run_uid) is None:
+        raise ValueError("invalid d3 cache run uid")
+    _validate_directory(root, create=True)
+    lock_path = root / "producer.lock"
+    flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(lock_path, flags, 0o600)
+    try:
+        metadata = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_uid != os.getuid()
+            or stat.S_IMODE(metadata.st_mode) != 0o600
+        ):
+            raise ValueError("unsafe d3 cache lock")
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        if not (root / "manifest.json").exists():
+            _publish_d3_cache(root, run_uid, d3, selected)
+        bundle = _load_d3_cache(root, selected)
+    finally:
+        os.close(descriptor)
+    if hydrate_root is None:
+        d3._install_shared_conformance_cache(bundle, expected_template_keys=selected)
+    else:
+        d3._install_shared_conformance_cache(
+            bundle,
+            expected_template_keys=selected,
+            hydrate_root=hydrate_root,
+        )
+
+
+def _selected_for_d3_cache(config: pytest.Config) -> bool:
+    worker = getattr(config, "workerinput", None)
+    if not isinstance(worker, dict) or not str(worker.get("workerid", "")).startswith(
+        "gw"
+    ):
+        return False
+    return any(
+        _D3_MODULE in os.fspath(argument) for argument in config.invocation_params.args
+    )
+
+
+def pytest_sessionstart(session: pytest.Session) -> None:
+    config = session.config
+    if not _selected_for_d3_cache(config):
+        return
+    worker = config.workerinput
+    run_uid = worker.get("testrunuid")
+    if not isinstance(run_uid, str) or _RUN_UID.fullmatch(run_uid) is None:
+        raise pytest.UsageError("invalid xdist testrunuid for d3 cache")
+    basetemp = config._tmp_path_factory.getbasetemp()
+    common_root = basetemp.parent
+    from newsroom.tests import test_increment6d3_lineage_store as d3
+
+    try:
+        template_keys = d3._selected_shared_template_keys(
+            tuple(os.fspath(argument) for argument in config.invocation_params.args)
+        )
+        _ensure_d3_cache(
+            common_root / f"newsroom-d3-{run_uid}",
+            run_uid,
+            d3,
+            template_keys=template_keys,
+            hydrate_root=basetemp / "d3-hydrated",
+        )
+    except Exception as exc:
+        raise pytest.UsageError(f"d3 shared cache invalid: {exc}") from exc

--- a/newsroom/tests/graphiti_adapter_4d_migration_helpers.py
+++ b/newsroom/tests/graphiti_adapter_4d_migration_helpers.py
@@ -142,7 +142,6 @@ def drop_empty_v23_lineage_schema(connection: sqlite3.Connection) -> None:
 def drop_empty_v22_relationship_schema(connection: sqlite3.Connection) -> None:
     """Remove an exact, empty v22 relationship schema atomically."""
 
-    drop_empty_v23_lineage_schema(connection)
     savepoint = "checked_empty_v22_relationship_downgrade"
     relationship_table = "event_hypothesis_relationship_decisions"
     relationship_triggers = (
@@ -152,6 +151,7 @@ def drop_empty_v22_relationship_schema(connection: sqlite3.Connection) -> None:
     )
     connection.execute(f"SAVEPOINT {savepoint}")
     try:
+        drop_empty_v23_lineage_schema(connection)
         user_version = int(connection.execute("PRAGMA user_version").fetchone()[0])
         maximum_history_version = connection.execute(
             "SELECT MAX(version) FROM authority_migrations"

--- a/newsroom/tests/test_ci_workflow.py
+++ b/newsroom/tests/test_ci_workflow.py
@@ -139,7 +139,18 @@ def test_sdlc_workflow_retains_dynamic_complete_evidence_topology() -> None:
     )
     assert jobs["source"]["needs"] == ["route"]
     assert jobs["core_shard"]["needs"] == ["route"]
-    assert jobs["core_shard"]["strategy"]["matrix"]["shard"] == ["0", "1", "2", "3"]
+    assert jobs["core_shard"]["strategy"]["matrix"]["shard"] == [
+        "0",
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9",
+    ]
     assert jobs["core"]["needs"] == ["route", "source", "core_shard"]
     assert jobs["core"]["if"] == "always() && needs.route.result == 'success'"
     assert all(

--- a/newsroom/tests/test_increment6d2_relationship_store.py
+++ b/newsroom/tests/test_increment6d2_relationship_store.py
@@ -5,7 +5,7 @@ import os
 import sqlite3
 import uuid
 from collections.abc import Callable
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import ClassVar
 
@@ -21,14 +21,19 @@ from newsroom.authority.event_hypothesis_relationship_migrations import (
     EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION,
 )
 from newsroom.authority.migrations import (
+    EXPECTED_MIGRATION_HISTORY,
+    EXPECTED_SCHEMA_FINGERPRINT,
     SCHEMA_VERSION,
     apply_pending_migrations,
     prepare_pending_migration_backup,
+    schema_fingerprint,
 )
 from newsroom.authority.persistence import AuthoritySchemaError
 from newsroom.authority.types import UtcTimestamp
 from newsroom.checks.policy import merge_discovery_check_authority_registries
 from newsroom.discovery.policy import merge_discovery_signal_lead_registries
+from newsroom.increment5._retrieval_context_core import _evidence_digest
+from newsroom.increment5.retrieval_context import RetrievalContextJournal
 from newsroom.increment6.dispositions import ProposalDispositionStore
 from newsroom.increment6.outcomes import (
     CanonicalNextAction,
@@ -184,6 +189,19 @@ def _assessment(subject, comparator, outcome: str = "REL_UNCERTAIN", salt: int =
 _SEED_CACHE = None
 
 
+def _seed_cache_state(cache) -> tuple[int, int, int] | None:
+    return None if cache is None else (id(cache), len(cache), len(cache[3]))
+
+
+def _without_projection_evidence(receipt):
+    evidence = _evidence_digest(
+        (), receipt.authority_evidence, receipt.items, receipt.exclusions, receipt.no_match, receipt.truncated,
+    )
+    reason = "NONE" if receipt.reason is None else receipt.reason.value
+    identity = "|".join((receipt.request_digest, receipt.outcome.value, reason, evidence))
+    return replace(receipt, projection_evidence=(), context_id=str(uuid.uuid5(uuid.NAMESPACE_URL, identity)))
+
+
 def _seed_location(root: Path, *, subjects: int = 6):
     global _SEED_CACHE
     root.mkdir(mode=0o700)
@@ -205,11 +223,20 @@ def _seed_location(root: Path, *, subjects: int = 6):
             append,
         )
     inputs = branch_inputs.__wrapped__(root)
-    builder, _, _, _, _, request, receipt, _ = _retained_complete_context(
+    _, _, _, _, _, request, receipt, _ = _retained_complete_context(
         root, inputs, name="relationship-authority"
     )
+    receipt = _without_projection_evidence(receipt)
+    journal = RetrievalContextJournal(root / "context-relationship-slim.sqlite")
+    retained, replayed = (
+        journal.execute(idempotency_key=request.idempotency_key,
+                        request_digest=request.request_digest, producer=lambda _: receipt)
+        for _ in range(2)
+    )
+    assert retained.canonical_bytes == replayed.canonical_bytes == receipt.canonical_bytes
+    assert not receipt.projection_evidence and receipt.authority_evidence is not None and receipt.outcome.value == "COMPLETE" and len(receipt.items) == 1
     retrieval = RetrievalContextAuthority(
-        builder.journal.path, {request.request_digest: (request, receipt)}
+        journal.path, {request.request_digest: (request, receipt)}
     )
     decisions = []
     with open_discovery_system(database) as discovery:
@@ -363,6 +390,61 @@ def _seed_location(root: Path, *, subjects: int = 6):
         authorizer,
         upstream_advances,
     )
+
+
+@dataclass(frozen=True)
+class _AdapterSeedSnapshot:
+    database_bytes: bytes
+    seed_tail: tuple[object, ...]
+
+    def clone(self, root: Path):
+        root.mkdir(mode=0o700)
+        database = root / "relationship-authority.sqlite3"
+        database.touch(mode=0o600, exist_ok=False)
+        database.write_bytes(self.database_bytes)
+        return (self.seed_tail[0], database, *self.seed_tail[1:])
+
+
+def _assert_current_empty_relationship_store(connection: sqlite3.Connection) -> None:
+    assert connection.execute("PRAGMA user_version").fetchone() == (SCHEMA_VERSION,)
+    history = "SELECT version,name,checksum FROM authority_migrations ORDER BY version"
+    assert tuple(connection.execute(history)) == EXPECTED_MIGRATION_HISTORY
+    assert schema_fingerprint(connection) == EXPECTED_SCHEMA_FINGERPRINT
+    assert connection.execute("PRAGMA foreign_key_check").fetchall() == []
+    assert connection.execute(
+        "SELECT count(*) FROM event_hypothesis_relationship_decisions"
+    ).fetchone() == (0,)
+
+
+def _adapter_seed_snapshot(root: Path) -> _AdapterSeedSnapshot:
+    global _SEED_CACHE
+    global_cache = _SEED_CACHE
+    global_state = _seed_cache_state(global_cache)
+    _SEED_CACHE = None
+    try:
+        seed = _seed_location(root, subjects=1)
+        built = _SEED_CACHE
+        if built is None or _seed_cache_state(built)[1:] != (8, 1):
+            raise ValueError("relationship adapter seed snapshot shape")
+        connection = sqlite3.connect(seed[1], isolation_level=None)
+        try:
+            connection.execute("PRAGMA foreign_keys=ON")
+            prepare_pending_migration_backup(connection)
+            apply_pending_migrations(
+                connection, applied_at="2042-01-02T00:00:00.000000Z"
+            )
+            _assert_current_empty_relationship_store(connection)
+            connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        finally:
+            connection.close()
+        return _AdapterSeedSnapshot(
+            database_bytes=seed[1].read_bytes(),
+            seed_tail=(built[1], built[2], (built[3][0], built[2]), *built[4:]),
+        )
+    finally:
+        _SEED_CACHE = global_cache
+        if _seed_cache_state(_SEED_CACHE) != global_state:
+            raise AssertionError("global relationship seed cache changed")
 
 
 def _open_arguments(seed) -> dict[str, object]:
@@ -919,7 +1001,13 @@ def test_factory_lock_facade_and_self_consistent_rewrite_fail_closed(
 
 
 class _Location:
-    def __init__(self, seed) -> None:
+    def __init__(
+        self,
+        seed,
+        *,
+        subject_indices: tuple[int, ...] | None = None,
+        comparator_indices: tuple[int, ...] | None = None,
+    ) -> None:
         self.seed = seed
         ids = (
             "record-1",
@@ -929,8 +1017,12 @@ class _Location:
             "record-rollback-normal",
             "record-rollback-abort",
         )
-        self.subjects = dict(zip(ids, seed[3], strict=True))
-        self.subjects["record-b"] = self.subjects["record-a"]
+        subjects = seed[3] if subject_indices is None else tuple(seed[3][index] for index in subject_indices)
+        self.subjects = dict(zip(ids, subjects, strict=True))
+        if subject_indices is None:
+            self.subjects["record-b"] = self.subjects["record-a"]
+        comparators = (seed[2],) * len(ids) if comparator_indices is None else tuple(seed[3][index] for index in comparator_indices)
+        self.comparators = dict(zip(ids, comparators, strict=True))
 
 
 def _generic(
@@ -1009,7 +1101,11 @@ def _binding_assessment(location: _Location, command: WriteCommand):
     subject = HypothesisVersionBinding.from_version(
         location.subjects[command.record_id]
     )
-    comparator = HypothesisVersionBinding.from_version(location.seed[2])
+    comparator = HypothesisVersionBinding.from_version(
+        location.comparators[command.record_id]
+    )
+    if subject.version_id == comparator.version_id:
+        raise RelationshipContractError("conformance subject and comparator collide")
     evidence = ComparatorEvidence(
         subject,
         comparator,
@@ -1332,12 +1428,19 @@ class _Adapter:
     applicability: ClassVar = {
         case: Applicability.required() for case in CASE_INVENTORY
     }
+    _subject_indices = (0, 1, 0, 0, 0, 1)
+    _comparator_indices = (1, 0, 1, 1, 1, 0)
 
     def __init__(self, root: Path) -> None:
         self.root = root
+        self.seed_snapshot = _adapter_seed_snapshot(root / "capacity-2-seed")
 
     def create_location(self) -> _Location:
-        return _Location(_seed_location(self.root / str(uuid.uuid4())))
+        return _Location(
+            self.seed_snapshot.clone(self.root / str(uuid.uuid4())),
+            subject_indices=self._subject_indices,
+            comparator_indices=self._comparator_indices,
+        )
 
     def open_handle(self, location: _Location, *, migrate: bool = False) -> _Handle:
         if migrate:
@@ -1353,7 +1456,34 @@ class _Adapter:
 
 
 def test_real_store_passes_all_required_conformance_cases(tmp_path) -> None:
-    report = run_conformance(_Adapter(tmp_path))
+    global_cache = _SEED_CACHE
+    global_state = _seed_cache_state(global_cache)
+    if global_state is not None:
+        assert global_state[1:] == (8, 6)
+    adapter = _Adapter(tmp_path)
+    snapshot = adapter.seed_snapshot
+    first = adapter.create_location()
+    second = adapter.create_location()
+    assert adapter.seed_snapshot is snapshot
+    assert len(first.seed[3]) == len(second.seed[3]) == 2
+    assert first.seed[1] != second.seed[1]
+    assert first.seed[1].read_bytes() == second.seed[1].read_bytes()
+    assert {item.seed[1].stat().st_mode & 0o777 for item in (first, second)} == {0o600}
+    assert tuple(first.subjects.values()) == tuple(
+        first.seed[3][index] for index in (0, 1, 0, 0, 0, 1)
+    )
+    assert tuple(first.comparators.values()) == tuple(
+        first.seed[3][index] for index in (1, 0, 1, 1, 1, 0)
+    )
+    for record_id, subject in first.subjects.items():
+        assert subject.version_id != first.comparators[record_id].version_id
+    connection = sqlite3.connect(first.seed[1])
+    _assert_current_empty_relationship_store(connection)
+    connection.close()
+    assert _seed_cache_state(_SEED_CACHE) == global_state
+    report = run_conformance(adapter)
+    assert adapter.seed_snapshot is snapshot
+    assert _seed_cache_state(_SEED_CACHE) == global_state
     assert report.passed, repr(report.failures)
     assert tuple(item.case for item in report.outcomes) == CASE_INVENTORY
     assert all(item.status.value == "pass" for item in report.outcomes)
@@ -1470,7 +1600,12 @@ def test_migrate_flag_executes_real_v21_through_v22_to_current_path(
     adapter = _Adapter(tmp_path)
     location = adapter.create_location()
     connection = sqlite3.connect(location.seed[1])
+    _assert_current_empty_relationship_store(connection)
+    connection.close()
+    _downgrade_checked_v22_to_v21(location.seed[1])
+    connection = sqlite3.connect(location.seed[1])
     assert connection.execute("PRAGMA user_version").fetchone() == (21,)
+    assert connection.execute("PRAGMA foreign_key_check").fetchall() == []
     connection.close()
     sentinel = object()
     monkeypatch.setattr(
@@ -1479,15 +1614,12 @@ def test_migrate_flag_executes_real_v21_through_v22_to_current_path(
     )
     assert adapter.open_handle(location, migrate=True) is sentinel
     connection = sqlite3.connect(location.seed[1])
-    assert connection.execute("PRAGMA user_version").fetchone() == (SCHEMA_VERSION,)
+    _assert_current_empty_relationship_store(connection)
     migration = EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION
     assert connection.execute(
         "SELECT name,checksum FROM authority_migrations WHERE version=?",
         (migration.version,),
     ).fetchone() == (migration.name, migration.checksum)
-    assert connection.execute(
-        "SELECT count(*) FROM event_hypothesis_relationship_decisions"
-    ).fetchone() == (0,)
     connection.close()
 
 

--- a/newsroom/tests/test_increment6d3_lineage_store.py
+++ b/newsroom/tests/test_increment6d3_lineage_store.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import sqlite3
+from pathlib import Path
 
 import pytest
 
+import scripts.sdlc.workflow_lane as sdlc_lane
 from newsroom.authority.auth import StaticAuthorizer
 from newsroom.authority.persistence import AuthoritySchemaError
 from newsroom.increment6.lineage import (
@@ -20,6 +22,8 @@ from newsroom.increment6.relationships import (
 )
 from newsroom.tests import test_increment6d2_relationship_store as d2
 from newsroom.tests import test_increment6d3_lineage as d3
+
+REPO_ROOT = Path(__file__).parents[2]
 
 
 def _seed(tmp_path):
@@ -545,11 +549,23 @@ def test_reversal_target_retarget_fails_closed(tmp_path) -> None:
         merge_relationship_authority_registries,
     )
 
-    seed, args, _ = _seed(tmp_path)
+    cached_seed = d2._SEED_CACHE
+    d2._SEED_CACHE = None
+    try:
+        seed = d2._seed_location(tmp_path / "reversal-store", subjects=3)
+    finally:
+        d2._SEED_CACHE = cached_seed
+    args = d2._open_arguments(seed)
+    args["authorizer"] = _seed_authorizer()
+    commands, schemas = merge_relationship_authority_registries(
+        args["command_registry"], args["payload_schemas"]
+    )
+    commands, schemas = merge_lineage_authority_registries(commands, schemas)
+    checked_args = {**args, "command_registry": commands, "payload_schemas": schemas}
     source = seed[3][0]
     outputs = (seed[3][1], seed[3][2])
     split_proofs = []
-    relationship = open_event_hypothesis_relationship_authority(**args)
+    relationship = open_event_hypothesis_relationship_authority(**checked_args)
     try:
         for output in outputs:
             comparators = tuple(
@@ -577,53 +593,50 @@ def test_reversal_target_retarget_fails_closed(tmp_path) -> None:
         outputs=outputs,
         relationship_proofs=tuple(split_proofs),
     )
-    authority = open_event_hypothesis_lineage_authority(**args)
-    authority.retain(split.canonical_bytes, proof=seed[0][3])
-    authority.close()
-
-    connection = sqlite3.connect(seed[1], isolation_level=None)
-    upstream = d2.hypothesis_helpers._open((connection, *seed[0][1:]))
-    proposal, dispositions = seed[7]["authority"]
-    try:
-        restored = upstream.retain(
-            proposal,
-            dispositions,
-            proof=seed[0][3],
-            expected_target_version=source,
-        )
-    finally:
-        upstream.close()
-        connection.close()
-
-    commands, schemas = merge_relationship_authority_registries(
-        args["command_registry"], args["payload_schemas"]
-    )
-    commands, schemas = merge_lineage_authority_registries(commands, schemas)
-    checked_args = {**args, "command_registry": commands, "payload_schemas": schemas}
-    comparators = tuple(sorted(outputs, key=lambda item: item.version_id))
-    assessment, evidence = d3._decision(
-        restored, comparators, CanonicalOutcome.REL_CORRECTION_REVERSAL_OF
-    )
-    relationship = open_event_hypothesis_relationship_authority(**checked_args)
-    try:
-        relationship.retain(
-            assessment.canonical_bytes,
-            tuple(item.canonical_bytes for item in evidence),
-            proof=seed[0][3],
-        )
-    finally:
-        relationship.close()
-    reversal = HypothesisLineageReceipt.reversal(
-        expected_generation=1,
-        target=split,
-        outputs=(restored,),
-        relationship_proofs=(
-            HypothesisLineageRelationshipProof.from_assessment(assessment, evidence),
-        ),
-    )
     authority = open_event_hypothesis_lineage_authority(**checked_args)
-    authority.retain(reversal.canonical_bytes, proof=seed[0][3])
-    authority.close()
+    try:
+        authority.retain(split.canonical_bytes, proof=seed[0][3])
+
+        connection = sqlite3.connect(seed[1], isolation_level=None)
+        upstream = d2.hypothesis_helpers._open((connection, *seed[0][1:]))
+        proposal, dispositions = seed[7]["authority"]
+        try:
+            restored = upstream.retain(
+                proposal,
+                dispositions,
+                proof=seed[0][3],
+                expected_target_version=source,
+            )
+        finally:
+            upstream.close()
+            connection.close()
+
+        comparators = tuple(sorted(outputs, key=lambda item: item.version_id))
+        assessment, evidence = d3._decision(
+            restored, comparators, CanonicalOutcome.REL_CORRECTION_REVERSAL_OF
+        )
+        relationship = d2._open_unlocked_relationship_authority_for_test(**checked_args)
+        try:
+            relationship.retain(
+                assessment.canonical_bytes,
+                tuple(item.canonical_bytes for item in evidence),
+                proof=seed[0][3],
+            )
+        finally:
+            relationship.close()
+        reversal = HypothesisLineageReceipt.reversal(
+            expected_generation=1,
+            target=split,
+            outputs=(restored,),
+            relationship_proofs=(
+                HypothesisLineageRelationshipProof.from_assessment(
+                    assessment, evidence
+                ),
+            ),
+        )
+        authority.retain(reversal.canonical_bytes, proof=seed[0][3])
+    finally:
+        authority.close()
 
     connection = sqlite3.connect(seed[1], isolation_level=None)
     connection.execute("PRAGMA foreign_keys=OFF")
@@ -700,8 +713,13 @@ def test_second_public_writer_fails_closed_until_first_closes(tmp_path) -> None:
 # #384 adapter: command-field encodings live in retained D2 evidence and every
 # observable record/history value is reconstructed through a real v23 receipt.
 import json
+import os
+import subprocess
+import sys
 import uuid
-from dataclasses import replace
+from collections.abc import Callable
+from dataclasses import dataclass, replace
+from functools import partial
 from pathlib import Path
 from typing import ClassVar
 
@@ -712,7 +730,12 @@ from newsroom.increment6.relationships import (
     assess_relationships,
 )
 from newsroom.tests.authority_store_conformance import (
+    _CURRENT_USE_AUTHORITIES,
+    _HISTORICAL_TAMPERS,
+    _REPRESENTATION_TAMPERS,
+    _REQUEST_BINDING_FIELDS,
     _SCENARIOS,
+    _TAMPER_REJECTION_TAMPERS,
     CASE_INVENTORY,
     Applicability,
     AuthorityValue,
@@ -723,9 +746,84 @@ from newsroom.tests.authority_store_conformance import (
     StoredAuthorityState,
     TamperKind,
     WriteCommand,
+    _current_use_authority,
+    _exact_replay,
+    _fresh_reopen_digest,
+    _fresh_reopen_persistence,
+    _fresh_submission,
+    _historical_retained_operation,
+    _historical_tamper_operation,
+    _representation_retained,
+    _representation_tamper,
+    _request_binding_field,
+    _restart_or_migrate,
+    _rollback_kind,
+    _rollback_sequence,
+    _tamper_rejection_kind,
 )
 
 _CONFORMANCE_TEMPLATES: dict[tuple[str, ...], tuple[bytes, tuple]] = {}
+_CONFORMANCE_BASE_CAPACITY = 6
+_CONFORMANCE_BASE_SNAPSHOT: tuple[bytes, tuple] | None = None
+_XDIST_SHARED_CACHE_ACTIVE = False
+_SHARED_CONFORMANCE_TEMPLATE_KEYS = (
+    ("record-1",),
+    ("record-1", "record-2"),
+    ("record-1", "record-b"),
+    ("record-a", "record-b"),
+    ("record-rollback-normal", "record-rollback-abort"),
+)
+_CONFORMANCE_RECORDS_BY_CASE = {
+    CaseId.HISTORICAL_READ: ("record-1", "record-2"),
+    CaseId.COMPETING_WRITERS: ("record-a", "record-b"),
+    CaseId.TRANSACTION_ROLLBACK: (
+        "record-rollback-normal",
+        "record-rollback-abort",
+    ),
+    CaseId.TAMPER_REJECTION: ("record-1", "record-b"),
+}
+
+
+def _records_for_conformance_case(case: CaseId) -> tuple[str, ...]:
+    return _CONFORMANCE_RECORDS_BY_CASE.get(case, ("record-1",))
+
+
+def _validated_template_subset(
+    template_keys: object,
+) -> tuple[tuple[str, ...], ...]:
+    if not isinstance(template_keys, tuple) or not template_keys:
+        raise ValueError("d3 shared cache template subset")
+    if any(not isinstance(key, tuple) for key in template_keys):
+        raise ValueError("d3 shared cache template subset")
+    expected = tuple(
+        key for key in _SHARED_CONFORMANCE_TEMPLATE_KEYS if key in template_keys
+    )
+    if expected != template_keys or len(expected) != len(set(expected)):
+        raise ValueError("d3 shared cache template subset")
+    return expected
+
+
+def _clone_conformance_base(root: Path) -> tuple:
+    global _CONFORMANCE_BASE_SNAPSHOT
+    if _CONFORMANCE_BASE_SNAPSHOT is None:
+        d2._SEED_CACHE = None
+        build_root = root.parent / f"base-{uuid.uuid4()}"
+        seed = d2._seed_location(
+            build_root,
+            subjects=_CONFORMANCE_BASE_CAPACITY,
+        )
+        assert len(seed[3]) == _CONFORMANCE_BASE_CAPACITY
+        connection = sqlite3.connect(seed[1], isolation_level=None)
+        connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        connection.close()
+        _CONFORMANCE_BASE_SNAPSHOT = (seed[1].read_bytes(), seed)
+    payload, template_seed = _CONFORMANCE_BASE_SNAPSHOT
+    assert len(template_seed[3]) == _CONFORMANCE_BASE_CAPACITY
+    root.mkdir(mode=0o700)
+    database = root / "relationship-authority.sqlite3"
+    database.write_bytes(payload)
+    database.chmod(0o600)
+    return (template_seed[0], database, *template_seed[2:])
 
 
 class _ConformanceLocation:
@@ -766,6 +864,118 @@ def _seed_conformance_relationships(location: _ConformanceLocation) -> None:
             )
     finally:
         relationship.close()
+
+
+def _build_conformance_template(root: Path, records: tuple[str, ...]):
+    location = _ConformanceLocation(_clone_conformance_base(root), records)
+    _seed_conformance_relationships(location)
+    connection = sqlite3.connect(location.seed[1], isolation_level=None)
+    assert connection.execute(
+        "SELECT COUNT(*) FROM event_hypothesis_relationship_decisions"
+    ).fetchone() == (len(records),)
+    assert connection.execute(
+        "SELECT COUNT(*) FROM event_hypothesis_lineage"
+    ).fetchone() == (0,)
+    connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    connection.close()
+    return (location.seed[1].read_bytes(), location.seed)
+
+
+def _prepare_shared_conformance_cache(
+    artifact_root: Path,
+    template_keys: tuple[tuple[str, ...], ...],
+) -> dict[str, object]:
+    global _CONFORMANCE_BASE_SNAPSHOT
+    selected = _validated_template_subset(template_keys)
+    artifact_root.mkdir(mode=0o700, exist_ok=True)
+    d2._SEED_CACHE = None
+    _CONFORMANCE_BASE_SNAPSHOT = None
+    _CONFORMANCE_TEMPLATES.clear()
+    _clone_conformance_base(artifact_root / "base-clone")
+    for index, records in enumerate(selected):
+        _CONFORMANCE_TEMPLATES[records] = _build_conformance_template(
+            artifact_root / f"template-{index}", records
+        )
+    return {
+        "artifact_root": artifact_root,
+        "capacity": _CONFORMANCE_BASE_CAPACITY,
+        "template_keys": selected,
+        "d2_seed_cache": d2._SEED_CACHE,
+        "base_snapshot": _CONFORMANCE_BASE_SNAPSHOT,
+        "templates": dict(_CONFORMANCE_TEMPLATES),
+    }
+
+
+def _install_shared_conformance_cache(
+    bundle: object,
+    *,
+    expected_template_keys: tuple[tuple[str, ...], ...],
+    hydrate_root: Path | None = None,
+) -> None:
+    global _CONFORMANCE_BASE_SNAPSHOT, _XDIST_SHARED_CACHE_ACTIVE
+    selected = _validated_template_subset(expected_template_keys)
+    if not isinstance(bundle, dict):
+        raise TypeError("d3 shared cache bundle")
+    if set(bundle) != {
+        "artifact_root",
+        "base_snapshot",
+        "capacity",
+        "d2_seed_cache",
+        "template_keys",
+        "templates",
+    }:
+        raise ValueError("d3 shared cache bundle fields")
+    if bundle.get("capacity") != _CONFORMANCE_BASE_CAPACITY:
+        raise ValueError("d3 shared cache capacity")
+    if bundle.get("template_keys") != selected:
+        raise ValueError("d3 shared cache template keys")
+    seed_cache = bundle.get("d2_seed_cache")
+    base_snapshot = bundle.get("base_snapshot")
+    templates = bundle.get("templates")
+    artifact_root = bundle.get("artifact_root")
+    if not isinstance(artifact_root, Path) or not artifact_root.is_absolute():
+        raise ValueError("d3 shared cache artifact root")
+    if not isinstance(seed_cache, tuple) or len(seed_cache) != 8:
+        raise ValueError("d3 shared cache seed")
+    if len(seed_cache[3]) != _CONFORMANCE_BASE_CAPACITY:
+        raise ValueError("d3 shared cache seed capacity")
+    if not isinstance(base_snapshot, tuple) or len(base_snapshot) != 2:
+        raise ValueError("d3 shared cache base snapshot")
+    if len(base_snapshot[1][3]) != _CONFORMANCE_BASE_CAPACITY:
+        raise ValueError("d3 shared cache base capacity")
+    if not isinstance(templates, dict) or tuple(templates) != selected:
+        raise ValueError("d3 shared cache templates")
+    for records, template in templates.items():
+        if (
+            records not in selected
+            or not isinstance(template, tuple)
+            or len(template) != 2
+            or not isinstance(template[0], bytes)
+            or len(template[1][3]) != _CONFORMANCE_BASE_CAPACITY
+        ):
+            raise ValueError("d3 shared cache template")
+    seeds = (base_snapshot[1], *(template[1] for template in templates.values()))
+    paths = [seed[1] for seed in seeds]
+    retrieval = seed_cache[1][1]
+    paths.append(retrieval._path)
+    if any(
+        not isinstance(path, Path)
+        or not path.is_absolute()
+        or not path.is_relative_to(artifact_root)
+        for path in paths
+    ):
+        raise ValueError("d3 shared cache ancillary path")
+    if hydrate_root is not None:
+        hydrate_root.mkdir(mode=0o700)
+        hydrated_retrieval = hydrate_root / retrieval._path.name
+        hydrated_retrieval.write_bytes(retrieval._path.read_bytes())
+        hydrated_retrieval.chmod(0o600)
+        retrieval._path = hydrated_retrieval
+    d2._SEED_CACHE = seed_cache
+    _CONFORMANCE_BASE_SNAPSHOT = base_snapshot
+    _CONFORMANCE_TEMPLATES.clear()
+    _CONFORMANCE_TEMPLATES.update(templates)
+    _XDIST_SHARED_CACHE_ACTIVE = hydrate_root is not None
 
 
 def _conformance_domain(location: _ConformanceLocation, command: WriteCommand):
@@ -1144,6 +1354,17 @@ def _seed_authorizer():
     )
 
 
+def _conformance_template(root: Path, records: tuple[str, ...]) -> tuple[bytes, tuple]:
+    template = _CONFORMANCE_TEMPLATES.get(records)
+    if template is not None:
+        return template
+    if _XDIST_SHARED_CACHE_ACTIVE:
+        raise ValueError("xdist d3 shared cache template miss")
+    template = _build_conformance_template(root, records)
+    _CONFORMANCE_TEMPLATES[records] = template
+    return template
+
+
 class _LineageAdapter:
     name = "lineage-v23-real"
     applicability: ClassVar = {
@@ -1152,47 +1373,19 @@ class _LineageAdapter:
 
     def __init__(self, root: Path, case: CaseId) -> None:
         self.root = root
-        self.records = {
-            CaseId.HISTORICAL_READ: ("record-1", "record-2"),
-            CaseId.COMPETING_WRITERS: ("record-a", "record-b"),
-            CaseId.TRANSACTION_ROLLBACK: (
-                "record-rollback-normal",
-                "record-rollback-abort",
-            ),
-            CaseId.TAMPER_REJECTION: ("record-1", "record-b"),
-        }.get(case, ("record-1",))
+        self.records = _records_for_conformance_case(case)
 
     def create_location(self):
-        template = _CONFORMANCE_TEMPLATES.get(self.records)
-        if template is None:
-            d2._SEED_CACHE = None
-            subjects = len(self.records) + (4 if "record-2" in self.records else 2)
-            location = _ConformanceLocation(
-                d2._seed_location(self.root / str(uuid.uuid4()), subjects=subjects),
-                self.records,
-            )
-            _seed_conformance_relationships(location)
-            connection = sqlite3.connect(location.seed[1], isolation_level=None)
-            assert connection.execute(
-                "SELECT COUNT(*) FROM event_hypothesis_relationship_decisions"
-            ).fetchone() == (len(self.records),)
-            assert connection.execute(
-                "SELECT COUNT(*) FROM event_hypothesis_lineage"
-            ).fetchone() == (0,)
-            connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
-            connection.close()
-            template = (location.seed[1].read_bytes(), location.seed)
-            _CONFORMANCE_TEMPLATES[self.records] = template
-        else:
-            root = self.root / str(uuid.uuid4())
-            root.mkdir(mode=0o700)
-            database = root / "relationship-authority.sqlite3"
-            database.write_bytes(template[0])
-            database.chmod(0o600)
-            template_seed = template[1]
-            location = _ConformanceLocation(
-                (template_seed[0], database, *template_seed[2:]), self.records
-            )
+        template = _conformance_template(self.root / str(uuid.uuid4()), self.records)
+        root = self.root / str(uuid.uuid4())
+        root.mkdir(mode=0o700)
+        database = root / "relationship-authority.sqlite3"
+        database.write_bytes(template[0])
+        database.chmod(0o600)
+        template_seed = template[1]
+        location = _ConformanceLocation(
+            (template_seed[0], database, *template_seed[2:]), self.records
+        )
         return location
 
     def open_handle(self, location, *, migrate: bool = False):
@@ -1217,8 +1410,570 @@ class _LineageAdapter:
         return _ConformanceHandle(location)
 
 
-@pytest.mark.parametrize("case", CASE_INVENTORY, ids=lambda case: case.value)
-def test_real_v23_store_passes_required_conformance_case(tmp_path, case) -> None:
-    adapter = _LineageAdapter(tmp_path, case)
-    assert adapter.applicability[case] == Applicability.required()
-    _SCENARIOS[case](adapter)
+@dataclass(frozen=True)
+class _ConformanceProbe:
+    probe_id: str
+    case: CaseId
+    operation: Callable[[object], None]
+
+
+_CONFORMANCE_PROBES = (
+    _ConformanceProbe(
+        "fresh_replay-submission",
+        CaseId.FRESH_REPLAY,
+        _fresh_submission,
+    ),
+    _ConformanceProbe(
+        "fresh_replay-replay",
+        CaseId.FRESH_REPLAY,
+        _exact_replay,
+    ),
+    _ConformanceProbe(
+        "fresh_reopen-persistence",
+        CaseId.FRESH_REOPEN,
+        _fresh_reopen_persistence,
+    ),
+    _ConformanceProbe(
+        "fresh_reopen-digest",
+        CaseId.FRESH_REOPEN,
+        _fresh_reopen_digest,
+    ),
+    _ConformanceProbe(
+        "representation_binding-retained",
+        CaseId.REPRESENTATION_BINDING,
+        _representation_retained,
+    ),
+    *(
+        _ConformanceProbe(
+            f"representation_binding-{kind.value}",
+            CaseId.REPRESENTATION_BINDING,
+            partial(_representation_tamper, kind=kind),
+        )
+        for kind in _REPRESENTATION_TAMPERS
+    ),
+    *(
+        _ConformanceProbe(
+            f"request_binding-{field_name}",
+            CaseId.REQUEST_BINDING,
+            partial(_request_binding_field, field_name=field_name),
+        )
+        for field_name in _REQUEST_BINDING_FIELDS
+    ),
+    _ConformanceProbe(
+        CaseId.LOST_RESPONSE_REPLAY.value,
+        CaseId.LOST_RESPONSE_REPLAY,
+        _SCENARIOS[CaseId.LOST_RESPONSE_REPLAY],
+    ),
+    *(
+        _ConformanceProbe(
+            f"historical_read-{kind.value}-{phase}-{noun}",
+            CaseId.HISTORICAL_READ,
+            partial(
+                _historical_tamper_operation,
+                kind=kind,
+                reopened=reopened,
+                listing=listing,
+            ),
+        )
+        for kind in _HISTORICAL_TAMPERS
+        for phase, reopened in (("fresh", False), ("reopened", True))
+        for noun, listing in (
+            ("read", False),
+            ("list", True),
+        )
+    ),
+    *(
+        _ConformanceProbe(
+            f"historical_read-retained-{noun}",
+            CaseId.HISTORICAL_READ,
+            partial(_historical_retained_operation, listing=listing),
+        )
+        for noun, listing in (("read", False), ("list", True))
+    ),
+    *(
+        _ConformanceProbe(
+            f"current_use_revalidation-{authority}",
+            CaseId.CURRENT_USE_REVALIDATION,
+            partial(_current_use_authority, authority=authority),
+        )
+        for authority in _CURRENT_USE_AUTHORITIES
+    ),
+    *(
+        _ConformanceProbe(
+            f"tamper_rejection-{kind.value}",
+            CaseId.TAMPER_REJECTION,
+            partial(_tamper_rejection_kind, kind=kind),
+        )
+        for kind in _TAMPER_REJECTION_TAMPERS
+    ),
+    _ConformanceProbe(
+        CaseId.COMPETING_WRITERS.value,
+        CaseId.COMPETING_WRITERS,
+        _SCENARIOS[CaseId.COMPETING_WRITERS],
+    ),
+    *(
+        _ConformanceProbe(
+            f"transaction_rollback-{label}",
+            CaseId.TRANSACTION_ROLLBACK,
+            operation,
+        )
+        for label, operation in (
+            ("normal", partial(_rollback_kind, abort=False)),
+            ("abort", _rollback_sequence),
+        )
+    ),
+    _ConformanceProbe(
+        "restart_migration-restart",
+        CaseId.RESTART_MIGRATION,
+        partial(_restart_or_migrate, migrate=False),
+    ),
+    _ConformanceProbe(
+        "restart_migration-migrate",
+        CaseId.RESTART_MIGRATION,
+        partial(_restart_or_migrate, migrate=True),
+    ),
+)
+
+
+def _selected_shared_template_keys(
+    arguments: tuple[str, ...],
+) -> tuple[tuple[str, ...], ...]:
+    probe_function = "test_real_v23_store_passes_required_conformance_probe"
+    probes = {probe.probe_id: probe for probe in _CONFORMANCE_PROBES}
+    selected_cases: set[CaseId] = set()
+    conservative = False
+    saw_d3 = False
+    for argument in arguments:
+        if "test_increment6d3_lineage_store.py" not in argument:
+            continue
+        saw_d3 = True
+        tail = argument.split("test_increment6d3_lineage_store.py", 1)[1]
+        if not tail.startswith("::"):
+            conservative = True
+            continue
+        node = tail[2:]
+        if not node.startswith(probe_function):
+            continue
+        suffix = node[len(probe_function) :]
+        if not suffix:
+            conservative = True
+            continue
+        if not suffix.startswith("[") or not suffix.endswith("]"):
+            raise ValueError("unknown exact d3 conformance probe")
+        probe_id = suffix[1:-1]
+        probe = probes.get(probe_id)
+        if probe is None:
+            raise ValueError("unknown exact d3 conformance probe")
+        selected_cases.add(probe.case)
+    if not saw_d3:
+        raise ValueError("d3 conformance selection missing")
+    if conservative or not selected_cases:
+        return _SHARED_CONFORMANCE_TEMPLATE_KEYS
+    required = {_records_for_conformance_case(case) for case in selected_cases}
+    selected = tuple(
+        key for key in _SHARED_CONFORMANCE_TEMPLATE_KEYS if key in required
+    )
+    return _validated_template_subset(selected)
+
+
+_EXPECTED_PROBE_IDS = frozenset(
+    {
+        "fresh_replay-submission",
+        "fresh_replay-replay",
+        "fresh_reopen-persistence",
+        "fresh_reopen-digest",
+        "representation_binding-retained",
+        "representation_binding-scalar",
+        "representation_binding-canonical",
+        "representation_binding-identity",
+        "representation_binding-linked_row",
+        "request_binding-actor",
+        "request_binding-request",
+        "request_binding-idempotency",
+        "request_binding-cas_predecessor",
+        "lost_response_replay",
+        "historical_read-retained-read",
+        "historical_read-retained-list",
+        "historical_read-identity-fresh-read",
+        "historical_read-identity-fresh-list",
+        "historical_read-identity-reopened-read",
+        "historical_read-identity-reopened-list",
+        "historical_read-digest-fresh-read",
+        "historical_read-digest-fresh-list",
+        "historical_read-digest-reopened-read",
+        "historical_read-digest-reopened-list",
+        "historical_read-provenance-fresh-read",
+        "historical_read-provenance-fresh-list",
+        "historical_read-provenance-reopened-read",
+        "historical_read-provenance-reopened-list",
+        "current_use_revalidation-authority",
+        "current_use_revalidation-policy",
+        "tamper_rejection-canonical",
+        "tamper_rejection-linked_row",
+        "tamper_rejection-offline_rewrite",
+        "competing_writers",
+        "transaction_rollback-normal",
+        "transaction_rollback-abort",
+        "restart_migration-restart",
+        "restart_migration-migrate",
+    }
+)
+
+
+def test_real_v23_conformance_probe_inventory_is_exact_and_unique() -> None:
+    probe_ids = tuple(probe.probe_id for probe in _CONFORMANCE_PROBES)
+    assert len(probe_ids) == len(set(probe_ids))
+    assert frozenset(probe_ids) == _EXPECTED_PROBE_IDS
+    assert {probe.case for probe in _CONFORMANCE_PROBES} == set(CASE_INVENTORY)
+
+
+def test_real_v23_conformance_base_is_immutable_max_capacity(tmp_path) -> None:
+    first = _clone_conformance_base(tmp_path / "first")
+    assert _CONFORMANCE_BASE_SNAPSHOT is not None
+    payload, template_seed = _CONFORMANCE_BASE_SNAPSHOT
+    assert len(first[3]) == _CONFORMANCE_BASE_CAPACITY == 6
+    assert len(template_seed[3]) == _CONFORMANCE_BASE_CAPACITY
+
+    first[1].write_bytes(b"local clone mutation")
+    second = _clone_conformance_base(tmp_path / "second")
+    assert second[1] != first[1]
+    assert second[1].read_bytes() == payload
+    assert len(second[3]) == _CONFORMANCE_BASE_CAPACITY
+
+
+class _FakeSharedD3:
+    def __init__(self, marker: Path) -> None:
+        self.marker = marker
+        self.installed: list[object] = []
+
+    def _prepare_shared_conformance_cache(
+        self, artifact: Path, template_keys: tuple[tuple[str, ...], ...]
+    ) -> dict[str, object]:
+        with self.marker.open("ab") as stream:
+            stream.write(b"x")
+        ancillary = artifact / "context.sqlite"
+        ancillary.write_bytes(b"context")
+        return {"fake": 1, "template_keys": template_keys}
+
+    def _install_shared_conformance_cache(
+        self,
+        bundle: object,
+        *,
+        expected_template_keys: tuple[tuple[str, ...], ...],
+        hydrate_root: Path | None = None,
+    ) -> None:
+        assert bundle == {"fake": 1, "template_keys": expected_template_keys}
+        assert hydrate_root is None
+        self.installed.append(bundle)
+
+
+def test_d3_shared_cache_has_one_producer_across_four_processes(tmp_path) -> None:
+    root = tmp_path / "shared"
+    marker = tmp_path / "producers"
+    script = """
+from pathlib import Path
+import sys
+from newsroom.tests import conftest as cache
+
+class Fake:
+    def _prepare_shared_conformance_cache(self, artifact, template_keys):
+        with Path(sys.argv[3]).open("ab") as stream:
+            stream.write(b"x")
+        (artifact / "context.sqlite").write_bytes(b"context")
+        return {"fake": 1, "template_keys": template_keys}
+    def _install_shared_conformance_cache(self, bundle, *, expected_template_keys):
+        assert bundle == {"fake": 1, "template_keys": expected_template_keys}
+
+cache._ensure_d3_cache(Path(sys.argv[1]), sys.argv[2], Fake())
+"""
+    processes = [
+        subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                script,
+                os.fspath(root),
+                "run-shared",
+                os.fspath(marker),
+            ]
+        )
+        for _ in range(4)
+    ]
+    assert [process.wait(timeout=30) for process in processes] == [0, 0, 0, 0]
+    assert marker.read_bytes() == b"x"
+    assert len(tuple(root.glob("artifact-*"))) == 1
+
+
+def test_d3_shared_cache_run_uid_isolation_and_incomplete_stage_rebuild(
+    tmp_path,
+) -> None:
+    from newsroom.tests import conftest as cache
+
+    marker = tmp_path / "producers"
+    first_root = tmp_path / "run-one"
+    first_root.mkdir(mode=0o700)
+    partial = first_root / "bundle-incomplete.stage"
+    partial.write_bytes(b"partial")
+    partial.chmod(0o600)
+    cache._ensure_d3_cache(first_root, "run-one", _FakeSharedD3(marker))
+    second_root = tmp_path / "run-two"
+    cache._ensure_d3_cache(second_root, "run-two", _FakeSharedD3(marker))
+
+    assert marker.read_bytes() == b"xx"
+    assert (first_root / "manifest.json").is_file()
+    assert (second_root / "manifest.json").is_file()
+    assert first_root != second_root
+
+
+def test_ten_core_shard_probe_selections_derive_exact_template_subsets() -> None:
+    shard_probe_ids = (
+        (
+            "historical_read-digest-reopened-read",
+            "historical_read-identity-reopened-list",
+            "historical_read-retained-list",
+            "lost_response_replay",
+            "request_binding-actor",
+        ),
+        (
+            "historical_read-digest-reopened-list",
+            "historical_read-retained-read",
+        ),
+        (
+            "representation_binding-scalar",
+            "tamper_rejection-canonical",
+            "tamper_rejection-offline_rewrite",
+            "transaction_rollback-normal",
+        ),
+        (
+            "current_use_revalidation-authority",
+            "historical_read-provenance-reopened-read",
+        ),
+        (
+            "fresh_reopen-digest",
+            "historical_read-provenance-fresh-read",
+            "transaction_rollback-abort",
+        ),
+        (
+            "fresh_reopen-persistence",
+            "historical_read-identity-reopened-read",
+            "request_binding-request",
+        ),
+        (
+            "fresh_replay-submission",
+            "historical_read-identity-fresh-list",
+            "historical_read-provenance-fresh-list",
+            "historical_read-provenance-reopened-list",
+            "restart_migration-restart",
+        ),
+        (
+            "current_use_revalidation-policy",
+            "fresh_replay-replay",
+            "representation_binding-canonical",
+            "representation_binding-identity",
+            "representation_binding-retained",
+            "restart_migration-migrate",
+            "tamper_rejection-linked_row",
+        ),
+        (
+            "historical_read-digest-fresh-read",
+            "historical_read-identity-fresh-read",
+            "request_binding-cas_predecessor",
+        ),
+        (
+            "competing_writers",
+            "historical_read-digest-fresh-list",
+            "representation_binding-linked_row",
+            "request_binding-idempotency",
+        ),
+    )
+    prefix = (
+        "newsroom/tests/test_increment6d3_lineage_store.py::"
+        "test_real_v23_store_passes_required_conformance_probe"
+    )
+    actual_probe_ids = tuple(
+        tuple(
+            node_id[len(prefix) + 1 : -1]
+            for node_id in shard
+            if node_id.startswith(f"{prefix}[")
+        )
+        for shard in sdlc_lane._core_node_shards(
+            sdlc_lane._collect_core_node_ids(REPO_ROOT)
+        )
+    )
+    assert actual_probe_ids == shard_probe_ids
+    selected = tuple(
+        _selected_shared_template_keys(
+            tuple(f"{prefix}[{probe_id}]" for probe_id in probe_ids)
+        )
+        for probe_ids in shard_probe_ids
+    )
+    assert tuple(map(len, selected)) == (2, 1, 3, 2, 3, 2, 2, 2, 2, 3)
+    assert selected == (
+        (("record-1",), ("record-1", "record-2")),
+        (("record-1", "record-2"),),
+        (
+            ("record-1",),
+            ("record-1", "record-b"),
+            ("record-rollback-normal", "record-rollback-abort"),
+        ),
+        (("record-1",), ("record-1", "record-2")),
+        (
+            ("record-1",),
+            ("record-1", "record-2"),
+            ("record-rollback-normal", "record-rollback-abort"),
+        ),
+        (("record-1",), ("record-1", "record-2")),
+        (("record-1",), ("record-1", "record-2")),
+        (("record-1",), ("record-1", "record-b")),
+        (("record-1",), ("record-1", "record-2")),
+        (
+            ("record-1",),
+            ("record-1", "record-2"),
+            ("record-a", "record-b"),
+        ),
+    )
+
+
+def test_whole_module_selection_is_conservative_and_unknown_probe_fails() -> None:
+    module = "newsroom/tests/test_increment6d3_lineage_store.py"
+    assert _selected_shared_template_keys((module,)) == (
+        _SHARED_CONFORMANCE_TEMPLATE_KEYS
+    )
+    probe = "test_real_v23_store_passes_required_conformance_probe"
+    with pytest.raises(ValueError, match="unknown exact d3 conformance probe"):
+        _selected_shared_template_keys((f"{module}::{probe}[unknown-probe]",))
+
+
+@pytest.mark.parametrize(
+    "template_keys",
+    (
+        (),
+        (("record-1",), ("record-1",)),
+        (("record-1", "record-2"), ("record-1",)),
+        (("record-unknown",),),
+        (*_SHARED_CONFORMANCE_TEMPLATE_KEYS, ("record-unknown",)),
+    ),
+    ids=("missing", "duplicate", "reordered", "unknown", "superset"),
+)
+def test_d3_template_subset_contract_fails_closed(template_keys) -> None:
+    with pytest.raises(ValueError, match="d3 shared cache template subset"):
+        _validated_template_subset(template_keys)
+
+
+def test_expected_template_subset_mismatch_fails_before_unpickle(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from newsroom.tests import conftest as cache
+
+    root = tmp_path / "mismatch"
+    selected = (("record-1",),)
+    cache._ensure_d3_cache(
+        root,
+        "run-mismatch",
+        _FakeSharedD3(tmp_path / "producer-mismatch"),
+        template_keys=selected,
+    )
+    monkeypatch.setattr(
+        cache.pickle,
+        "loads",
+        lambda _: (_ for _ in ()).throw(AssertionError("unpickle called")),
+    )
+    with pytest.raises(ValueError, match="d3 cache manifest contract"):
+        cache._load_d3_cache(root, (("record-1", "record-2"),))
+
+
+def test_xdist_template_miss_fails_closed_and_serial_miss_builds(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = sys.modules[__name__]
+    records = ("record-1",)
+    monkeypatch.setattr(module, "_CONFORMANCE_TEMPLATES", {})
+    monkeypatch.setattr(module, "_XDIST_SHARED_CACHE_ACTIVE", True)
+    with pytest.raises(ValueError, match="xdist d3 shared cache template miss"):
+        _conformance_template(tmp_path / "xdist", records)
+
+    expected = (b"template", ("seed",))
+    monkeypatch.setattr(module, "_XDIST_SHARED_CACHE_ACTIVE", False)
+    monkeypatch.setattr(module, "_build_conformance_template", lambda *_: expected)
+    assert _conformance_template(tmp_path / "serial", records) == expected
+    assert _CONFORMANCE_TEMPLATES == {records: expected}
+
+
+@pytest.mark.parametrize(
+    "corruption", ("digest", "mode", "symlink", "capacity", "template")
+)
+def test_published_d3_shared_cache_corruption_fails_closed(
+    tmp_path, corruption: str
+) -> None:
+    from newsroom.tests import conftest as cache
+
+    root = tmp_path / corruption
+    marker = tmp_path / f"producer-{corruption}"
+    fake = _FakeSharedD3(marker)
+    cache._ensure_d3_cache(root, f"run-{corruption}", fake)
+    bundle = root / "bundle.pickle"
+    manifest_path = root / "manifest.json"
+    if corruption == "digest":
+        bundle.write_bytes(bundle.read_bytes() + b"tamper")
+    elif corruption == "mode":
+        bundle.chmod(0o644)
+    elif corruption == "symlink":
+        target = tmp_path / "symlink-target"
+        target.write_bytes(bundle.read_bytes())
+        target.chmod(0o600)
+        bundle.unlink()
+        bundle.symlink_to(target)
+    else:
+        manifest = json.loads(manifest_path.read_bytes())
+        if corruption == "capacity":
+            manifest["capacity"] = 5
+        else:
+            manifest["template_keys"] = [["record-corrupt"]]
+        manifest_path.write_bytes(
+            json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode() + b"\n"
+        )
+        manifest_path.chmod(0o600)
+    with pytest.raises(ValueError, match="d3 cache|unsafe d3 cache"):
+        cache._ensure_d3_cache(root, f"run-{corruption}", fake)
+    assert marker.read_bytes() == b"x"
+
+
+@pytest.mark.parametrize("corruption", ("capacity", "keys", "templates"))
+def test_d3_shared_bundle_contract_corruption_fails_closed(
+    tmp_path, corruption: str
+) -> None:
+    _clone_conformance_base(tmp_path / "base")
+    assert d2._SEED_CACHE is not None
+    assert _CONFORMANCE_BASE_SNAPSHOT is not None
+    template = _CONFORMANCE_BASE_SNAPSHOT
+    bundle = {
+        "artifact_root": tmp_path,
+        "capacity": _CONFORMANCE_BASE_CAPACITY,
+        "template_keys": _SHARED_CONFORMANCE_TEMPLATE_KEYS,
+        "d2_seed_cache": d2._SEED_CACHE,
+        "base_snapshot": _CONFORMANCE_BASE_SNAPSHOT,
+        "templates": {
+            records: template for records in _SHARED_CONFORMANCE_TEMPLATE_KEYS
+        },
+    }
+    if corruption == "capacity":
+        bundle["capacity"] = 5
+    elif corruption == "keys":
+        bundle["template_keys"] = (("record-corrupt",),)
+    else:
+        bundle["templates"] = {("record-corrupt",): template}
+    with pytest.raises(ValueError, match="d3 shared cache"):
+        _install_shared_conformance_cache(
+            bundle, expected_template_keys=_SHARED_CONFORMANCE_TEMPLATE_KEYS
+        )
+
+
+@pytest.mark.parametrize(
+    "probe",
+    _CONFORMANCE_PROBES,
+    ids=lambda probe: probe.probe_id,
+)
+def test_real_v23_store_passes_required_conformance_probe(tmp_path, probe) -> None:
+    adapter = _LineageAdapter(tmp_path, probe.case)
+    assert adapter.applicability[probe.case] == Applicability.required()
+    probe.operation(adapter)

--- a/newsroom/tests/test_increment6d3_lineage_store.py
+++ b/newsroom/tests/test_increment6d3_lineage_store.py
@@ -1725,116 +1725,70 @@ def test_d3_shared_cache_run_uid_isolation_and_incomplete_stage_rebuild(
     assert first_root != second_root
 
 
-def test_ten_core_shard_probe_selections_derive_exact_template_subsets() -> None:
-    shard_probe_ids = (
-        (
-            "historical_read-digest-reopened-read",
-            "historical_read-identity-reopened-list",
-            "historical_read-retained-list",
-            "lost_response_replay",
-            "request_binding-actor",
-        ),
-        (
-            "historical_read-digest-reopened-list",
-            "historical_read-retained-read",
-        ),
-        (
-            "representation_binding-scalar",
-            "tamper_rejection-canonical",
-            "tamper_rejection-offline_rewrite",
-            "transaction_rollback-normal",
-        ),
-        (
-            "current_use_revalidation-authority",
-            "historical_read-provenance-reopened-read",
-        ),
-        (
-            "fresh_reopen-digest",
-            "historical_read-provenance-fresh-read",
-            "transaction_rollback-abort",
-        ),
-        (
-            "fresh_reopen-persistence",
-            "historical_read-identity-reopened-read",
-            "request_binding-request",
-        ),
-        (
-            "fresh_replay-submission",
-            "historical_read-identity-fresh-list",
-            "historical_read-provenance-fresh-list",
-            "historical_read-provenance-reopened-list",
-            "restart_migration-restart",
-        ),
-        (
-            "current_use_revalidation-policy",
-            "fresh_replay-replay",
-            "representation_binding-canonical",
-            "representation_binding-identity",
-            "representation_binding-retained",
-            "restart_migration-migrate",
-            "tamper_rejection-linked_row",
-        ),
-        (
-            "historical_read-digest-fresh-read",
-            "historical_read-identity-fresh-read",
-            "request_binding-cas_predecessor",
-        ),
-        (
-            "competing_writers",
-            "historical_read-digest-fresh-list",
-            "representation_binding-linked_row",
-            "request_binding-idempotency",
-        ),
+def _bound_or_collected_core_inventory() -> tuple[str, ...]:
+    inventory_path = os.environ.get(sdlc_lane._CORE_NODE_INVENTORY_PATH_ENV)
+    inventory_digest = os.environ.get(sdlc_lane._CORE_NODE_INVENTORY_DIGEST_ENV)
+    if (inventory_path is None) != (inventory_digest is None):
+        raise ValueError("incomplete bound core inventory")
+    return (
+        sdlc_lane._collect_core_node_ids(REPO_ROOT)
+        if inventory_path is None
+        else sdlc_lane._load_core_node_inventory(
+            REPO_ROOT, inventory_path, inventory_digest
+        )
     )
+
+
+def test_ten_core_shard_probe_selections_derive_exact_template_subsets() -> None:
     prefix = (
         "newsroom/tests/test_increment6d3_lineage_store.py::"
         "test_real_v23_store_passes_required_conformance_probe"
     )
-    actual_probe_ids = tuple(
+    inventory = _bound_or_collected_core_inventory()
+    shards = sdlc_lane._core_node_shards(inventory)
+    probe_ids_by_shard = tuple(
         tuple(
             node_id[len(prefix) + 1 : -1]
             for node_id in shard
             if node_id.startswith(f"{prefix}[")
         )
-        for shard in sdlc_lane._core_node_shards(
-            sdlc_lane._collect_core_node_ids(REPO_ROOT)
+        for shard in shards
+    )
+    flattened = tuple(probe_id for shard in probe_ids_by_shard for probe_id in shard)
+    assert len(flattened) == len(set(flattened))
+    assert frozenset(flattened) == _EXPECTED_PROBE_IDS
+
+    probes = {probe.probe_id: probe for probe in _CONFORMANCE_PROBES}
+    records_by_case = {
+        CaseId.HISTORICAL_READ: ("record-1", "record-2"),
+        CaseId.COMPETING_WRITERS: ("record-a", "record-b"),
+        CaseId.TRANSACTION_ROLLBACK: (
+            "record-rollback-normal",
+            "record-rollback-abort",
+        ),
+        CaseId.TAMPER_REJECTION: ("record-1", "record-b"),
+    }
+    selected = tuple(_selected_shared_template_keys(tuple(shard)) for shard in shards)
+    expected = tuple(
+        tuple(
+            key
+            for key in _SHARED_CONFORMANCE_TEMPLATE_KEYS
+            if key
+            in {
+                records_by_case.get(probes[probe_id].case, ("record-1",))
+                for probe_id in probe_ids
+            }
         )
+        if probe_ids
+        else _SHARED_CONFORMANCE_TEMPLATE_KEYS
+        for probe_ids in probe_ids_by_shard
     )
-    assert actual_probe_ids == shard_probe_ids
-    selected = tuple(
-        _selected_shared_template_keys(
-            tuple(f"{prefix}[{probe_id}]" for probe_id in probe_ids)
-        )
-        for probe_ids in shard_probe_ids
-    )
-    assert tuple(map(len, selected)) == (2, 1, 3, 2, 3, 2, 2, 2, 2, 3)
-    assert selected == (
-        (("record-1",), ("record-1", "record-2")),
-        (("record-1", "record-2"),),
-        (
-            ("record-1",),
-            ("record-1", "record-b"),
-            ("record-rollback-normal", "record-rollback-abort"),
-        ),
-        (("record-1",), ("record-1", "record-2")),
-        (
-            ("record-1",),
-            ("record-1", "record-2"),
-            ("record-rollback-normal", "record-rollback-abort"),
-        ),
-        (("record-1",), ("record-1", "record-2")),
-        (("record-1",), ("record-1", "record-2")),
-        (("record-1",), ("record-1", "record-b")),
-        (("record-1",), ("record-1", "record-2")),
-        (
-            ("record-1",),
-            ("record-1", "record-2"),
-            ("record-a", "record-b"),
-        ),
-    )
+    assert selected == expected
 
 
-def test_whole_module_selection_is_conservative_and_unknown_probe_fails() -> None:
+def test_whole_module_selection_is_conservative_and_unknown_probe_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     module = "newsroom/tests/test_increment6d3_lineage_store.py"
     assert _selected_shared_template_keys((module,)) == (
         _SHARED_CONFORMANCE_TEMPLATE_KEYS
@@ -1842,6 +1796,14 @@ def test_whole_module_selection_is_conservative_and_unknown_probe_fails() -> Non
     probe = "test_real_v23_store_passes_required_conformance_probe"
     with pytest.raises(ValueError, match="unknown exact d3 conformance probe"):
         _selected_shared_template_keys((f"{module}::{probe}[unknown-probe]",))
+
+    monkeypatch.setenv(
+        sdlc_lane._CORE_NODE_INVENTORY_PATH_ENV,
+        os.fspath(tmp_path / "missing.json"),
+    )
+    monkeypatch.delenv(sdlc_lane._CORE_NODE_INVENTORY_DIGEST_ENV, raising=False)
+    with pytest.raises(ValueError, match="incomplete bound core inventory"):
+        _bound_or_collected_core_inventory()
 
 
 @pytest.mark.parametrize(

--- a/newsroom/tests/test_sdlc_contract.py
+++ b/newsroom/tests/test_sdlc_contract.py
@@ -4,7 +4,9 @@ from copy import deepcopy
 from pathlib import Path
 
 import pytest
+import yaml
 
+import scripts.sdlc.workflow_lane as lane_module
 from scripts.sdlc.contracts import (
     ContractError,
     load_contract,
@@ -18,25 +20,32 @@ REPO_ROOT = Path(__file__).parents[2]
 def test_accepted_contract_loads_and_references_exact_source_files() -> None:
     contract = load_contract(REPO_ROOT)
 
-    assert contract.contract_version == "sdlc-v2.5"
+    assert contract.contract_version == "sdlc-v2.6"
     assert contract.classifier_version == "sdlc-risk-v1"
     assert contract.data["status"] == "accepted"
     assert contract.source_path == REPO_ROOT / ".sdlc" / "gates.toml"
     assert contract.data["acceptance_record"] == (
-        "docs/specs/sdlc/2026-08-10-sdlc-v2.5-core-sharding-amendment.md"
+        "docs/specs/sdlc/2026-08-11-sdlc-v2.6-measured-core-budget-amendment.md"
     )
     assert contract.unknown_path_risk == "R3_EXTERNAL_SERVICE_SECURITY"
 
 
-def test_every_gate_lane_resolves_and_all_hard_timeouts_are_below_four_minutes() -> (
-    None
-):
+@pytest.mark.parametrize("version", ("sdlc-v2.5", "sdlc-v2.7"))
+def test_unaccepted_contract_version_fails_closed(version: str) -> None:
+    data = deepcopy(load_contract(REPO_ROOT).data)
+    data["contract_version"] = version
+
+    with pytest.raises(ContractError, match="contract version"):
+        validate_contract_data(data)
+
+
+def test_every_gate_lane_resolves_and_core_budget_is_below_six_minutes() -> None:
     contract = load_contract(REPO_ROOT)
     lanes = contract.data["lanes"]
 
     for gate in contract.data["gate"].values():
         assert gate["lane"] in lanes
-        assert 0 < gate["hard_timeout_seconds"] < 240
+        assert 0 < gate["hard_timeout_seconds"] < 360
     assert contract.data["global"] == {
         "gate_command_timeout_seconds": 220,
         "lane_execution_timeout_seconds": 220,
@@ -59,38 +68,120 @@ def test_every_gate_lane_resolves_and_all_hard_timeouts_are_below_four_minutes()
     } == {
         "route": 20,
         "source-integrity": 60,
-        "core-deterministic": 220,
+        "core-deterministic": 330,
         "service-neo4j": 220,
         "merge-exact": 220,
         "science-shard": 220,
         "evidence-finalize": 20,
     }
     assert lanes["decision"] == {"always_reports": True, "hard_timeout_seconds": 20}
-    assert lanes["core"]["hard_timeout_seconds"] == 220
+    assert lanes["core"]["hard_timeout_seconds"] == 330
     assert lanes["core"] == {
         "bootstrap_once": True,
-        "shard_count": 4,
+        "shard_count": 10,
         "partition": "sha256_node_id_balanced",
-        "workers_per_shard": 4,
+        "workers_per_shard": 2,
         "distribution": "worksteal",
         "max_worker_restart": 0,
-        "per_shard_hard_timeout_seconds": 220,
+        "per_shard_hard_timeout_seconds": 330,
+        "per_shard_warning_seconds": 300,
+        "critical_path_warning_seconds": 300,
         "reducer_single_canonical_receipt": True,
         "run_full_suite_when_p95_below_seconds": 35,
-        "hard_timeout_seconds": 220,
+        "hard_timeout_seconds": 330,
         "required": True,
     }
     assert lanes["service"]["hard_timeout_seconds"] == 220
     assert lanes["merge_group"]["hard_timeout_seconds"] == 220
     assert lanes["science"]["per_shard_hard_timeout_seconds"] == 220
+    assert contract.data["test_sizes"]["science"]["shard_hard_timeout_seconds"] == 220
+    assert (
+        contract.data["test_strategy"]["individual_testcase_hard_timeout_seconds"] == 90
+    )
+    assert contract.data["test_strategy"]["individual_testcase_warning_seconds"] == 75
+    workflow = yaml.safe_load(
+        (REPO_ROOT / ".github/workflows/evidence.yml").read_text(encoding="utf-8")
+    )
+    workflow_shards = workflow["jobs"]["core_shard"]["strategy"]["matrix"]["shard"]
+    assert workflow_shards == list(range(lanes["core"]["shard_count"]))
+    assert lanes["core"]["shard_count"] == lane_module._CORE_SHARD_COUNT
 
 
-def test_four_minute_ceiling_and_owner_multiplier_are_fail_closed() -> None:
+@pytest.mark.parametrize(
+    ("section", "field", "value"),
+    (
+        ("global", "gate_command_timeout_seconds", 219),
+        ("global", "gate_command_timeout_seconds", 221),
+        ("global", "lane_execution_timeout_seconds", 219),
+        ("global", "lane_execution_timeout_seconds", 221),
+        ("global", "finalization_timeout_seconds", 19),
+        ("global", "finalization_timeout_seconds", 21),
+        ("gate.core-deterministic", "hard_timeout_seconds", 329),
+        ("gate.core-deterministic", "hard_timeout_seconds", 331),
+        ("lanes.core", "per_shard_hard_timeout_seconds", 329),
+        ("lanes.core", "per_shard_hard_timeout_seconds", 331),
+        ("lanes.core", "hard_timeout_seconds", 329),
+        ("lanes.core", "hard_timeout_seconds", 331),
+        ("lanes.core", "per_shard_warning_seconds", 299),
+        ("lanes.core", "per_shard_warning_seconds", 301),
+        ("lanes.core", "critical_path_warning_seconds", 299),
+        ("lanes.core", "critical_path_warning_seconds", 301),
+        ("test_strategy", "individual_testcase_hard_timeout_seconds", 89),
+        ("test_strategy", "individual_testcase_hard_timeout_seconds", 91),
+        ("test_strategy", "individual_testcase_warning_seconds", 74),
+        ("test_strategy", "individual_testcase_warning_seconds", 76),
+        ("lanes.service", "hard_timeout_seconds", 219),
+        ("lanes.service", "hard_timeout_seconds", 221),
+        ("lanes.merge_group", "hard_timeout_seconds", 219),
+        ("lanes.merge_group", "hard_timeout_seconds", 221),
+        ("lanes.science", "per_shard_hard_timeout_seconds", 219),
+        ("lanes.science", "per_shard_hard_timeout_seconds", 221),
+        ("test_sizes.science", "shard_hard_timeout_seconds", 219),
+        ("test_sizes.science", "shard_hard_timeout_seconds", 221),
+        ("lanes.decision", "hard_timeout_seconds", 19),
+        ("lanes.decision", "hard_timeout_seconds", 21),
+    ),
+)
+def test_repository_timing_boundaries_are_caller_invariant(
+    section: str, field: str, value: int
+) -> None:
+    data = deepcopy(load_contract(REPO_ROOT).data)
+    table = data
+    for part in section.split("."):
+        table = table[part]
+    table[field] = value
+
+    with pytest.raises(ContractError):
+        validate_contract_data(data)
+
+
+@pytest.mark.parametrize("worker_count", (1, 3, 4))
+def test_unaccepted_core_worker_counts_fail_closed(worker_count: int) -> None:
+    contract = load_contract(REPO_ROOT)
+    data = deepcopy(contract.data)
+    data["lanes"]["core"]["workers_per_shard"] = worker_count
+
+    with pytest.raises(ContractError, match="accepted topology"):
+        validate_contract_data(data)
+
+
+def test_unaccepted_core_shard_counts_fail_closed() -> None:
+    contract = load_contract(REPO_ROOT)
+
+    for shard_count in (6, 8, 12):
+        data = deepcopy(contract.data)
+        data["lanes"]["core"]["shard_count"] = shard_count
+
+        with pytest.raises(ContractError, match="accepted topology"):
+            validate_contract_data(data)
+
+
+def test_fixed_core_ceiling_and_owner_multiplier_are_fail_closed() -> None:
     contract = load_contract(REPO_ROOT)
 
     oversized = deepcopy(contract.data)
-    oversized["gate"]["core-deterministic"]["hard_timeout_seconds"] = 240
-    with pytest.raises(ContractError, match="below 240"):
+    oversized["gate"]["core-deterministic"]["hard_timeout_seconds"] = 331
+    with pytest.raises(ContractError, match="below 331"):
         validate_contract_data(oversized)
 
     wrong_owner_multiplier = deepcopy(contract.data)
@@ -186,5 +277,5 @@ def test_contract_validation_cli_emits_a_small_typed_summary(
     output = capsys.readouterr().out
 
     assert '"status":"PASS"' in output
-    assert '"contract_version":"sdlc-v2.5"' in output
+    assert '"contract_version":"sdlc-v2.6"' in output
     assert "R4_RELEASE_OPERATIONAL" in output

--- a/newsroom/tests/test_sdlc_core_worker_capacity.py
+++ b/newsroom/tests/test_sdlc_core_worker_capacity.py
@@ -15,16 +15,17 @@ from scripts.sdlc.run_gate import GateRunResult
 from scripts.sdlc.workflow_lane import WorkflowLaneError
 
 REPO_ROOT = Path(__file__).parents[2]
+EXPECTED_CORE_SHARD_COUNT = 10
 
 
 def _contract_data() -> dict[str, object]:
     return {
-        "contract_version": "sdlc-v2.5",
+        "contract_version": "sdlc-v2.6",
         "status": "accepted",
         "lanes": {
             "core": {
-                "hard_timeout_seconds": 220,
-                "per_shard_hard_timeout_seconds": 220,
+                "hard_timeout_seconds": 330,
+                "per_shard_hard_timeout_seconds": 330,
             }
         },
     }
@@ -34,13 +35,13 @@ def _write_fragment_set(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     *,
-    directory_order: tuple[int, ...] = (0, 1, 2, 3),
+    directory_order: tuple[int, ...] = tuple(range(EXPECTED_CORE_SHARD_COUNT)),
 ) -> tuple[Path, object, object, dict[str, object]]:
     fragments = tmp_path / "fragments"
     fragments.mkdir(parents=True)
     contract = SimpleNamespace(
         repo_root=tmp_path,
-        contract_version="sdlc-v2.5",
+        contract_version="sdlc-v2.6",
         data=_contract_data(),
     )
     context = SimpleNamespace(
@@ -55,7 +56,9 @@ def _write_fragment_set(
         "head_tree_sha": context.evaluated_tree_sha,
         "clustering_required": False,
     }
-    files = tuple(f"newsroom/tests/test_{index}.py" for index in range(4))
+    files = tuple(
+        f"newsroom/tests/test_{index}.py" for index in range(EXPECTED_CORE_SHARD_COUNT)
+    )
     nodes = tuple(f"{path}::test_{index}" for index, path in enumerate(files))
     shards = lane_module._core_node_shards(nodes)
     spec = SimpleNamespace(
@@ -63,7 +66,7 @@ def _write_fragment_set(
         digest="sha256:" + "c" * 64,
     )
     binding = {
-        "contract_version": "sdlc-v2.5",
+        "contract_version": "sdlc-v2.6",
         "contract_digest": "sha256:" + "d" * 64,
         "lockfile_digest": "sha256:" + "e" * 64,
         "python_version": "3.12.11",
@@ -103,7 +106,7 @@ def _write_fragment_set(
             "evaluated_tree_sha": context.evaluated_tree_sha,
             "route_digest": lane_module.sha256_identity(route),
             "shard_index": shard_index,
-            "shard_count": 4,
+            "shard_count": EXPECTED_CORE_SHARD_COUNT,
             "file_inventory": list(files),
             "file_inventory_digest": lane_module.sha256_identity(list(files)),
             "node_inventory": list(nodes),
@@ -117,7 +120,7 @@ def _write_fragment_set(
             "shard_lifecycle": {
                 "schema_version": lane_module._CORE_SHARD_LIFECYCLE_SCHEMA,
                 "elapsed_ms": 200_000 + shard_index,
-                "timeout_ms": 220_000,
+                "timeout_ms": 330_000,
                 "result": "BUDGET_EXCEEDED",
             },
             "junit_summary": None,
@@ -177,7 +180,7 @@ def _patch_core_shard_execution(
 ) -> None:
     contract = SimpleNamespace(
         repo_root=tmp_path,
-        contract_version="sdlc-v2.5",
+        contract_version="sdlc-v2.6",
         data=_contract_data(),
     )
     context = SimpleNamespace(
@@ -192,7 +195,9 @@ def _patch_core_shard_execution(
         "head_tree_sha": context.evaluated_tree_sha,
         "clustering_required": False,
     }
-    files = tuple(f"newsroom/tests/test_{index}.py" for index in range(4))
+    files = tuple(
+        f"newsroom/tests/test_{index}.py" for index in range(EXPECTED_CORE_SHARD_COUNT)
+    )
     nodes = tuple(f"{path}::test_{index}" for index, path in enumerate(files))
     spec = SimpleNamespace(
         as_dict=lambda: {"schema_version": "test-command-spec"},
@@ -212,7 +217,7 @@ def _patch_core_shard_execution(
             result,
             reason,
             returncode,
-            219_950,
+            329_950,
             "",
             "",
             False,
@@ -232,14 +237,14 @@ def _patch_core_shard_execution(
     monkeypatch.setattr(
         lane_module,
         "start_lane_deadline",
-        lambda *_args: lane_module.LaneDeadline.start(220),
+        lambda *_args: lane_module.LaneDeadline.start(330),
     )
     monkeypatch.setattr(lane_module, "verify_tracked_checkout", lambda *_args: None)
     monkeypatch.setattr(
         lane_module,
         "_fragment_provenance",
         lambda **_kwargs: {
-            "contract_version": "sdlc-v2.5",
+            "contract_version": "sdlc-v2.6",
             "contract_digest": "sha256:" + "d" * 64,
             "lockfile_digest": "sha256:" + "e" * 64,
             "python_version": "3.12.11",
@@ -265,7 +270,7 @@ def _patch_source_execution(
 ) -> tuple[SimpleNamespace, dict[str, object]]:
     contract = SimpleNamespace(
         repo_root=tmp_path,
-        contract_version="sdlc-v2.5",
+        contract_version="sdlc-v2.6",
         data=_contract_data(),
     )
     context = SimpleNamespace(
@@ -309,14 +314,14 @@ def _patch_source_execution(
     monkeypatch.setattr(
         lane_module,
         "start_lane_deadline",
-        lambda *_args: lane_module.LaneDeadline.start(220),
+        lambda *_args: lane_module.LaneDeadline.start(330),
     )
     monkeypatch.setattr(lane_module, "verify_tracked_checkout", lambda *_args: None)
     monkeypatch.setattr(
         lane_module,
         "_fragment_provenance",
         lambda **_kwargs: {
-            "contract_version": "sdlc-v2.5",
+            "contract_version": "sdlc-v2.6",
             "contract_digest": "sha256:" + "d" * 64,
             "lockfile_digest": "sha256:" + "e" * 64,
             "python_version": "3.12.11",
@@ -370,6 +375,25 @@ def _passing_report() -> str:
     )
 
 
+def _junit_summary(
+    outcome: str = "PASS", *, required_skip_count: int = 0
+) -> dict[str, object]:
+    failed = outcome == "FAIL"
+    return {
+        "schema_version": "newsroom.sdlc.junit-summary.v1",
+        "outcome": outcome,
+        "reports": [{"path": "pytest.xml", "digest": "sha256:" + "d" * 64}],
+        "test_ids_digest": "sha256:" + "e" * 64,
+        "test_count": 1,
+        "failure_count": int(failed and not required_skip_count),
+        "error_count": 0,
+        "skip_count": required_skip_count,
+        "required_skip_count": required_skip_count,
+        "duration_ms": 1,
+        "first_failure_fingerprint": "sha256:" + "f" * 64 if failed else None,
+    }
+
+
 def _published_fragment(lifecycle_field: str, result: str) -> dict[str, object]:
     core = lifecycle_field == "shard_lifecycle"
     gate_id = "core-deterministic" if core else "source-integrity"
@@ -407,7 +431,7 @@ def _published_fragment(lifecycle_field: str, result: str) -> dict[str, object]:
                 else lane_module._SOURCE_LIFECYCLE_SCHEMA
             ),
             "elapsed_ms": 1,
-            "timeout_ms": 220_000,
+            "timeout_ms": 330_000,
             "result": result,
         },
     }
@@ -417,6 +441,8 @@ def _published_fragment(lifecycle_field: str, result: str) -> dict[str, object]:
     body.update(
         {key: None for key in fragment_keys - body.keys() - {"fragment_identity"}}
     )
+    if core and result in {"PASS", "FAIL"}:
+        body["junit_summary"] = _junit_summary(result)
     return {**body, "fragment_identity": lane_module._fragment_identity(body)}
 
 
@@ -454,7 +480,7 @@ def _run_reducer_fixture(
     monkeypatch: pytest.MonkeyPatch,
     *,
     source_elapsed_ms: int,
-    shard_elapsed_ms: tuple[int, int, int, int],
+    shard_elapsed_ms: tuple[int, int, int, int, int, int],
     reducer_elapsed_ms: int,
     load_elapsed_ms: int | None = None,
     output_elapsed_ms: int | None = None,
@@ -466,7 +492,7 @@ def _run_reducer_fixture(
         directory.mkdir(parents=True)
     contract = SimpleNamespace(
         repo_root=tmp_path,
-        contract_version="sdlc-v2.5",
+        contract_version="sdlc-v2.6",
         data=_contract_data(),
     )
     context = SimpleNamespace(
@@ -505,7 +531,7 @@ def _run_reducer_fixture(
         "source_lifecycle": {
             "schema_version": lane_module._SOURCE_LIFECYCLE_SCHEMA,
             "elapsed_ms": source_elapsed_ms,
-            "timeout_ms": 220_000,
+            "timeout_ms": 330_000,
             "result": "PASS",
         },
         "fragment_identity": "sha256:" + "8" * 64,
@@ -517,7 +543,7 @@ def _run_reducer_fixture(
                 "shard_lifecycle": {
                     "schema_version": lane_module._CORE_SHARD_LIFECYCLE_SCHEMA,
                     "elapsed_ms": elapsed,
-                    "timeout_ms": 220_000,
+                    "timeout_ms": 330_000,
                     "result": "PASS",
                 },
                 "junit_summary": None,
@@ -528,7 +554,7 @@ def _run_reducer_fixture(
         )
         for index, elapsed in enumerate(shard_elapsed_ms)
     )
-    deadline = lane_module.LaneDeadline.start(220)
+    deadline = lane_module.LaneDeadline.start(330)
     elapsed = {"value": reducer_elapsed_ms}
     order: list[str] = []
 
@@ -589,10 +615,10 @@ def _run_reducer_fixture(
     return json.loads(aggregate_path.read_text(encoding="utf-8")), order
 
 
-def test_core_lane_uses_four_persistent_worksteal_workers(
+def test_core_lane_uses_two_persistent_worksteal_workers(
     tmp_path: Path,
 ) -> None:
-    assert lane_module._CORE_WORKER_COUNT == 4
+    assert lane_module._CORE_WORKER_COUNT == 2
     assert lane_module._CORE_DISTRIBUTION == "worksteal"
 
     command = lane_module._core_worker_command(
@@ -601,7 +627,7 @@ def test_core_lane_uses_four_persistent_worksteal_workers(
     )
 
     worker_flag = command.index("-n")
-    assert command[worker_flag + 1] == "4"
+    assert command[worker_flag + 1] == "2"
     assert "--dist=worksteal" in command
     assert "--max-worker-restart=0" in command
     assert command.count("xdist.plugin") == 1
@@ -614,7 +640,7 @@ import importlib
 import scripts.sdlc.workflow_lane as lane
 reloaded = importlib.reload(lane)
 assert reloaded is lane
-assert reloaded._CORE_WORKER_COUNT == 4
+assert reloaded._CORE_WORKER_COUNT == 2
 assert reloaded._CORE_DISTRIBUTION == 'worksteal'
 assert reloaded._CORE_TESTS == ('newsroom/tests',)
 """
@@ -640,7 +666,7 @@ def test_core_node_partition_is_deterministic_complete_unique_and_balanced() -> 
     flattened = tuple(node for shard in first for node in shard)
 
     assert first == second
-    assert len(first) == 4
+    assert len(first) == EXPECTED_CORE_SHARD_COUNT
     assert tuple(sorted(flattened)) == tuple(sorted(nodes))
     assert len(flattened) == len(set(flattened))
     assert max(map(len, first)) - min(map(len, first)) == 1
@@ -719,7 +745,7 @@ def test_core_shard_command_has_fixed_scheduler_and_no_caller_file_surface(
     )
 
     assert command.count("xdist.plugin") == 1
-    assert command[command.index("-n") + 1] == "4"
+    assert command[command.index("-n") + 1] == "2"
     assert "--dist=worksteal" in command
     assert "--max-worker-restart=0" in command
     assert "newsroom/tests" not in command
@@ -746,7 +772,7 @@ def test_source_fragment_and_canonical_lane_use_the_same_portable_spec() -> None
 def test_core_shard_spec_binds_full_inventory_and_assigned_node_ids() -> None:
     contract = lane_module.load_contract(REPO_ROOT)
     inventory = tuple(
-        f"newsroom/tests/test_{index}.py::test_{index}" for index in range(8)
+        sorted(f"newsroom/tests/test_{index}.py::test_{index}" for index in range(18))
     )
     selected = lane_module._core_node_shards(inventory)[0]
 
@@ -771,7 +797,10 @@ def test_core_shard_spec_binds_full_inventory_and_assigned_node_ids() -> None:
 def test_core_shard_child_recomputes_bound_inventory_before_pytest(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    nodes = tuple(f"newsroom/tests/test_{index}.py::test_{index}" for index in range(4))
+    nodes = tuple(
+        f"newsroom/tests/test_{index}.py::test_{index}"
+        for index in range(EXPECTED_CORE_SHARD_COUNT)
+    )
     selected = lane_module._core_node_shards(nodes)[0]
     monkeypatch.setattr(
         lane_module, "_collect_core_node_ids", lambda _root, **_kwargs: nodes
@@ -792,11 +821,11 @@ def test_core_shard_child_recomputes_bound_inventory_before_pytest(
 @pytest.mark.parametrize(
     ("results", "expected"),
     [
-        (("PASS",) * 4, "PASS"),
-        (("FAIL", "PASS", "PASS", "PASS"), "FAIL"),
-        (("FAIL", "BUDGET_EXCEEDED", "PASS", "PASS"), "BUDGET_EXCEEDED"),
-        (("FAIL", "ENVIRONMENT_ERROR", "PASS", "PASS"), "ENVIRONMENT_ERROR"),
-        (("FAIL", "EVIDENCE_MISMATCH", "PASS", "PASS"), "EVIDENCE_MISMATCH"),
+        (("PASS",) * EXPECTED_CORE_SHARD_COUNT, "PASS"),
+        (("FAIL", *("PASS",) * 9), "FAIL"),
+        (("FAIL", "BUDGET_EXCEEDED", *("PASS",) * 8), "BUDGET_EXCEEDED"),
+        (("FAIL", "ENVIRONMENT_ERROR", *("PASS",) * 8), "ENVIRONMENT_ERROR"),
+        (("FAIL", "EVIDENCE_MISMATCH", *("PASS",) * 8), "EVIDENCE_MISMATCH"),
     ],
 )
 def test_core_reducer_preserves_typed_outcome_precedence(
@@ -808,11 +837,19 @@ def test_core_reducer_preserves_typed_outcome_precedence(
 @pytest.mark.parametrize(
     ("results", "junit_outcomes", "expected"),
     [
-        (("PASS",) * 4, ("PASS", "FAIL", "PASS", "PASS"), "FAIL"),
-        (("PASS", "FAIL", "PASS", "PASS"), ("PASS",) * 4, "FAIL"),
         (
-            ("PASS", "BUDGET_EXCEEDED", "PASS", "PASS"),
-            ("PASS", "FAIL", "PASS", "PASS"),
+            ("PASS",) * EXPECTED_CORE_SHARD_COUNT,
+            ("PASS", "FAIL", *("PASS",) * 8),
+            "FAIL",
+        ),
+        (
+            ("PASS", "FAIL", *("PASS",) * 8),
+            ("PASS",) * EXPECTED_CORE_SHARD_COUNT,
+            "FAIL",
+        ),
+        (
+            ("PASS", "BUDGET_EXCEEDED", *("PASS",) * 8),
+            ("PASS", "FAIL", *("PASS",) * 8),
             "BUDGET_EXCEEDED",
         ),
     ],
@@ -831,10 +868,10 @@ def test_core_reducer_preserves_required_skip_product_fail_and_timeout_precedenc
 @pytest.mark.parametrize(
     ("inner_result", "elapsed_ms", "expected"),
     [
-        ("PASS", 220_001, "BUDGET_EXCEEDED"),
-        ("FAIL", 220_001, "BUDGET_EXCEEDED"),
-        ("EVIDENCE_MISMATCH", 220_001, "EVIDENCE_MISMATCH"),
-        ("ENVIRONMENT_ERROR", 220_001, "ENVIRONMENT_ERROR"),
+        ("PASS", 330_001, "BUDGET_EXCEEDED"),
+        ("FAIL", 330_001, "BUDGET_EXCEEDED"),
+        ("EVIDENCE_MISMATCH", 330_001, "EVIDENCE_MISMATCH"),
+        ("ENVIRONMENT_ERROR", 330_001, "ENVIRONMENT_ERROR"),
     ],
 )
 def test_full_lifecycle_budget_preserves_typed_precedence(
@@ -844,7 +881,7 @@ def test_full_lifecycle_budget_preserves_typed_precedence(
         lane_module._lifecycle_result(
             inner_result,
             elapsed_ms=elapsed_ms,
-            timeout_ms=220_000,
+            timeout_ms=330_000,
         )
         == expected
     )
@@ -857,7 +894,18 @@ def test_reducer_uses_source_shard_critical_path_plus_sequential_elapsed(
         tmp_path,
         monkeypatch,
         source_elapsed_ms=60_000,
-        shard_elapsed_ms=(200_000, 180_000, 170_000, 160_000),
+        shard_elapsed_ms=(
+            200_000,
+            180_000,
+            170_000,
+            160_000,
+            150_000,
+            140_000,
+            130_000,
+            120_000,
+            110_000,
+            100_000,
+        ),
         reducer_elapsed_ms=19_000,
     )
 
@@ -871,6 +919,12 @@ def test_reducer_uses_source_shard_critical_path_plus_sequential_elapsed(
         180_000,
         170_000,
         160_000,
+        150_000,
+        140_000,
+        130_000,
+        120_000,
+        110_000,
+        100_000,
     ]
     assert accounting["reducer_lifecycle_ms"] == 19_000
     assert accounting["critical_path_ms"] == 219_000
@@ -879,15 +933,15 @@ def test_reducer_uses_source_shard_critical_path_plus_sequential_elapsed(
 @pytest.mark.parametrize(
     ("reducer_elapsed_ms", "expected"),
     [
-        (499, ("PASS", "PASS:core-deterministic:tests", 0, 219_999)),
-        (500, ("PASS", "PASS:core-deterministic:tests", 0, 220_000)),
+        (499, ("PASS", "PASS:core-deterministic:tests", 0, 329_999)),
+        (500, ("PASS", "PASS:core-deterministic:tests", 0, 330_000)),
         (
             501,
             (
                 "BUDGET_EXCEEDED",
                 "BUDGET_EXCEEDED:core-deterministic:tests",
                 124,
-                220_001,
+                330_001,
             ),
         ),
     ],
@@ -901,8 +955,8 @@ def test_reducer_critical_path_boundary_emits_valid_immutable_outcome(
     aggregate, _order = _run_reducer_fixture(
         tmp_path,
         monkeypatch,
-        source_elapsed_ms=219_500,
-        shard_elapsed_ms=(1, 1, 1, 1),
+        source_elapsed_ms=329_500,
+        shard_elapsed_ms=(1,) * EXPECTED_CORE_SHARD_COUNT,
         reducer_elapsed_ms=reducer_elapsed_ms,
     )
 
@@ -927,8 +981,8 @@ def test_slow_reducer_is_typed_budget_exceeded_from_before_input_loading(
             tmp_path,
             monkeypatch,
             source_elapsed_ms=1,
-            shard_elapsed_ms=(1, 1, 1, 1),
-            reducer_elapsed_ms=220_001,
+            shard_elapsed_ms=(1,) * EXPECTED_CORE_SHARD_COUNT,
+            reducer_elapsed_ms=330_001,
         )
 
     assert not (tmp_path / "output/core").exists()
@@ -945,9 +999,9 @@ def test_reducer_stops_after_a_load_crosses_its_deadline(
             tmp_path,
             monkeypatch,
             source_elapsed_ms=1,
-            shard_elapsed_ms=(1, 1, 1, 1),
+            shard_elapsed_ms=(1,) * EXPECTED_CORE_SHARD_COUNT,
             reducer_elapsed_ms=1,
-            load_elapsed_ms=220_001,
+            load_elapsed_ms=330_001,
         )
 
     assert not (tmp_path / "output/core").exists()
@@ -960,14 +1014,14 @@ def test_reducer_output_time_is_bound_and_cannot_publish_pass(
         tmp_path,
         monkeypatch,
         source_elapsed_ms=1,
-        shard_elapsed_ms=(1, 1, 1, 1),
-        reducer_elapsed_ms=219_999,
-        output_elapsed_ms=220_001,
+        shard_elapsed_ms=(1,) * EXPECTED_CORE_SHARD_COUNT,
+        reducer_elapsed_ms=329_999,
+        output_elapsed_ms=330_001,
     )
 
     assert aggregate["gate_run"]["result"] == "BUDGET_EXCEEDED"
     accounting = json.loads(aggregate["gate_run"]["stdout"])
-    assert accounting["reducer_lifecycle_ms"] == 220_001
+    assert accounting["reducer_lifecycle_ms"] == 330_001
     persisted = json.loads(
         (
             tmp_path / "output/core/gates/core-deterministic/tests/command-run.json"
@@ -1001,7 +1055,7 @@ def test_core_fragment_binds_contract_lock_toolchain_and_exact_inventory(
 ) -> None:
     contract = SimpleNamespace(
         repo_root=tmp_path,
-        contract_version="sdlc-v2.5",
+        contract_version="sdlc-v2.6",
         data=_contract_data(),
     )
     context = SimpleNamespace(
@@ -1016,7 +1070,9 @@ def test_core_fragment_binds_contract_lock_toolchain_and_exact_inventory(
         "head_tree_sha": context.evaluated_tree_sha,
         "clustering_required": False,
     }
-    files = tuple(f"newsroom/tests/test_{index}.py" for index in range(4))
+    files = tuple(
+        f"newsroom/tests/test_{index}.py" for index in range(EXPECTED_CORE_SHARD_COUNT)
+    )
     nodes = tuple(f"{path}::test_{index}" for index, path in enumerate(files))
     spec = SimpleNamespace(
         as_dict=lambda: {"schema_version": "test-command-spec"},
@@ -1030,7 +1086,7 @@ def test_core_fragment_binds_contract_lock_toolchain_and_exact_inventory(
             "BUDGET_EXCEEDED",
             "BUDGET_EXCEEDED:core-deterministic:tests",
             None,
-            219_950,
+            329_950,
             "",
             "",
             False,
@@ -1038,7 +1094,7 @@ def test_core_fragment_binds_contract_lock_toolchain_and_exact_inventory(
         ),
     )
     expected_binding = {
-        "contract_version": "sdlc-v2.5",
+        "contract_version": "sdlc-v2.6",
         "contract_digest": "sha256:" + "d" * 64,
         "lockfile_digest": "sha256:" + "e" * 64,
         "python_version": "3.12.11",
@@ -1059,7 +1115,7 @@ def test_core_fragment_binds_contract_lock_toolchain_and_exact_inventory(
     monkeypatch.setattr(
         lane_module,
         "start_lane_deadline",
-        lambda *_args: lane_module.LaneDeadline.start(220),
+        lambda *_args: lane_module.LaneDeadline.start(330),
     )
     monkeypatch.setattr(lane_module, "verify_tracked_checkout", lambda *_args: None)
     monkeypatch.setattr(lane_module, "_report_summary", lambda **_kwargs: None)
@@ -1084,7 +1140,7 @@ def test_core_fragment_binds_contract_lock_toolchain_and_exact_inventory(
     assert fragment["shard_lifecycle"] == {
         "schema_version": lane_module._CORE_SHARD_LIFECYCLE_SCHEMA,
         "elapsed_ms": fragment["shard_lifecycle"]["elapsed_ms"],
-        "timeout_ms": 220_000,
+        "timeout_ms": 330_000,
         "result": "BUDGET_EXCEEDED",
     }
     unsigned = dict(fragment)
@@ -1176,7 +1232,10 @@ def test_collection_time_tracked_mutation_prevents_fragment_publication(
         "head_tree_sha": context.evaluated_tree_sha,
         "clustering_required": False,
     }
-    nodes = tuple(f"newsroom/tests/test_{index}.py::test_{index}" for index in range(4))
+    nodes = tuple(
+        f"newsroom/tests/test_{index}.py::test_{index}"
+        for index in range(EXPECTED_CORE_SHARD_COUNT)
+    )
 
     def collect(_root: Path, **_kwargs: object) -> tuple[str, ...]:
         tracked.write_text("mutated during collection\n", encoding="utf-8")
@@ -1256,7 +1315,7 @@ def test_collection_subprocess_timeout_is_typed_and_publishes_no_fragment(
         result="PASS",
         report_payload=_passing_report(),
     )
-    deadline = lane_module.LaneDeadline.start(220)
+    deadline = lane_module.LaneDeadline.start(330)
     observed: list[float | None] = []
 
     def timeout(*args: object, **kwargs: object) -> object:
@@ -1278,7 +1337,7 @@ def test_collection_subprocess_timeout_is_typed_and_publishes_no_fragment(
             artifact_root="artifacts/core-fragment",
         )
 
-    assert observed and 0 < observed[0] <= 220
+    assert observed and 0 < observed[0] <= 330
     assert not (tmp_path / "artifacts/core-fragment/fragment.json").exists()
 
 
@@ -1291,7 +1350,7 @@ def test_slow_collection_is_charged_to_the_shard_lifecycle(
         result="PASS",
         report_payload=_passing_report(),
     )
-    deadline = lane_module.LaneDeadline.start(220)
+    deadline = lane_module.LaneDeadline.start(330)
     elapsed = {"value": 1}
     order: list[str] = []
     collect = lane_module._collect_core_node_ids
@@ -1304,7 +1363,7 @@ def test_slow_collection_is_charged_to_the_shard_lifecycle(
     def slow_collection(root: Path, **_kwargs: object) -> tuple[str, ...]:
         order.append("collect")
         result = collect(root)
-        elapsed["value"] = 220_001
+        elapsed["value"] = 330_001
         return result
 
     def observed_execute(**kwargs: object) -> CommandRun:
@@ -1344,12 +1403,12 @@ def test_fragment_finalisation_timeout_overrides_a_product_pass(
         result="PASS",
         report_payload=_passing_report(),
     )
-    elapsed = {"value": 219_999}
+    elapsed = {"value": 329_999}
     provenance = lane_module._fragment_provenance
 
     def slow_finalisation(**kwargs: object) -> dict[str, str]:
         value = provenance(**kwargs)
-        elapsed["value"] = 220_001
+        elapsed["value"] = 330_001
         return value
 
     monkeypatch.setattr(lane_module, "_fragment_provenance", slow_finalisation)
@@ -1367,8 +1426,8 @@ def test_fragment_finalisation_timeout_overrides_a_product_pass(
     assert fragment["command_run"]["gate_run"]["result"] == "PASS"
     assert fragment["shard_lifecycle"] == {
         "schema_version": lane_module._CORE_SHARD_LIFECYCLE_SCHEMA,
-        "elapsed_ms": 220_001,
-        "timeout_ms": 220_000,
+        "elapsed_ms": 330_001,
+        "timeout_ms": 330_000,
         "result": "BUDGET_EXCEEDED",
     }
     assert fragment["junit_summary"] is None
@@ -1384,13 +1443,13 @@ def test_fragment_durable_write_time_cannot_publish_a_pass(
         result="PASS",
         report_payload=_passing_report(),
     )
-    elapsed = {"value": 219_999}
+    elapsed = {"value": 329_999}
     private_write = lane_module._private_write
 
     def delayed_write(path: Path, value: object) -> None:
         private_write(path, value)
         if "fragment" in path.name:
-            elapsed["value"] = 220_001
+            elapsed["value"] = 330_001
 
     monkeypatch.setattr(lane_module, "_private_write", delayed_write)
     monkeypatch.setattr(
@@ -1457,7 +1516,7 @@ def test_source_lifecycle_starts_before_artifact_preparation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _patch_source_execution(tmp_path, monkeypatch)
-    deadline = lane_module.LaneDeadline.start(220)
+    deadline = lane_module.LaneDeadline.start(330)
     prepare = lane_module._prepare_artifact_root
     execute = lane_module._execute
     order: list[str] = []
@@ -1492,13 +1551,13 @@ def test_source_output_time_is_bound_and_cannot_publish_pass(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _patch_source_execution(tmp_path, monkeypatch)
-    elapsed = {"value": 219_999}
+    elapsed = {"value": 329_999}
     private_write = lane_module._private_write
 
     def delayed_write(path: Path, value: object) -> None:
         private_write(path, value)
         if "source-fragment" in path.name:
-            elapsed["value"] = 220_001
+            elapsed["value"] = 330_001
 
     monkeypatch.setattr(lane_module, "_private_write", delayed_write)
     monkeypatch.setattr(
@@ -1513,8 +1572,8 @@ def test_source_output_time_is_bound_and_cannot_publish_pass(
 
     assert fragment["source_lifecycle"] == {
         "schema_version": lane_module._SOURCE_LIFECYCLE_SCHEMA,
-        "elapsed_ms": 220_001,
-        "timeout_ms": 220_000,
+        "elapsed_ms": 330_001,
+        "timeout_ms": 330_000,
         "result": "BUDGET_EXCEEDED",
     }
     persisted = json.loads(
@@ -1622,6 +1681,86 @@ def test_published_fragment_result_determines_producer_cli_status(
     assert json.loads(capsys.readouterr().out) == fragment
 
 
+@pytest.mark.parametrize("required_skip_count", (0, 1))
+def test_core_cli_returns_failure_for_canonical_failing_junit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    required_skip_count: int,
+) -> None:
+    fragment = _published_fragment("shard_lifecycle", "PASS")
+    fragment["junit_summary"] = _junit_summary(
+        "FAIL", required_skip_count=required_skip_count
+    )
+    unsigned = dict(fragment)
+    unsigned.pop("fragment_identity")
+    fragment["fragment_identity"] = lane_module._fragment_identity(unsigned)
+    monkeypatch.setattr(
+        lane_module,
+        "load_contract",
+        lambda _root: SimpleNamespace(data=_contract_data()),
+    )
+    monkeypatch.setattr(lane_module, "execute_core_shard", lambda **_kwargs: fragment)
+
+    assert (
+        lane_module.main(
+            (
+                "execute-core-shard",
+                "--repo-root",
+                str(tmp_path),
+                "--route",
+                "route.json",
+                "--shard-index",
+                "0",
+                "--artifact-root",
+                "artifact",
+            )
+        )
+        == 1
+    )
+    assert json.loads(capsys.readouterr().out) == fragment
+
+
+@pytest.mark.parametrize("fault", ("missing", "malformed"))
+def test_core_cli_rejects_missing_or_malformed_junit_before_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    fault: str,
+) -> None:
+    fragment = _published_fragment("shard_lifecycle", "PASS")
+    fragment["junit_summary"] = None if fault == "missing" else {"outcome": "PASS"}
+    unsigned = dict(fragment)
+    unsigned.pop("fragment_identity")
+    fragment["fragment_identity"] = lane_module._fragment_identity(unsigned)
+    monkeypatch.setattr(
+        lane_module,
+        "load_contract",
+        lambda _root: SimpleNamespace(data=_contract_data()),
+    )
+    monkeypatch.setattr(lane_module, "execute_core_shard", lambda **_kwargs: fragment)
+
+    assert (
+        lane_module.main(
+            (
+                "execute-core-shard",
+                "--repo-root",
+                str(tmp_path),
+                "--route",
+                "route.json",
+                "--shard-index",
+                "0",
+                "--artifact-root",
+                "artifact",
+            )
+        )
+        == 2
+    )
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err.startswith("EVIDENCE_MISMATCH:workflow-lane:")
+
+
 @pytest.mark.parametrize(
     "fault",
     ("missing-required", "extra-field", "wrong-timeout", "result-mismatch"),
@@ -1693,7 +1832,7 @@ def test_core_cli_returns_budget_after_durable_fragment_publication(
         result="BUDGET_EXCEEDED",
         report_payload=None,
     )
-    monkeypatch.setattr(lane_module, "_deadline_elapsed_ms", lambda _deadline: 219_950)
+    monkeypatch.setattr(lane_module, "_deadline_elapsed_ms", lambda _deadline: 329_950)
 
     assert (
         lane_module.main(
@@ -1723,7 +1862,7 @@ def test_source_cli_returns_budget_after_durable_fragment_publication(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     _patch_source_execution(tmp_path, monkeypatch)
-    monkeypatch.setattr(lane_module, "_deadline_elapsed_ms", lambda _deadline: 220_001)
+    monkeypatch.setattr(lane_module, "_deadline_elapsed_ms", lambda _deadline: 330_001)
 
     assert (
         lane_module.main(
@@ -1772,7 +1911,7 @@ def test_fragment_loader_is_input_order_deterministic_and_validates_bindings(
     fragments, contract, context, route = _write_fragment_set(
         tmp_path,
         monkeypatch,
-        directory_order=(3, 2, 1, 0),
+        directory_order=tuple(reversed(range(EXPECTED_CORE_SHARD_COUNT))),
     )
 
     loaded = lane_module._load_core_fragments(
@@ -1783,11 +1922,8 @@ def test_fragment_loader_is_input_order_deterministic_and_validates_bindings(
         route=route,
     )
 
-    assert tuple(fragment["shard_index"] for fragment, _report in loaded) == (
-        0,
-        1,
-        2,
-        3,
+    assert tuple(fragment["shard_index"] for fragment, _report in loaded) == tuple(
+        range(EXPECTED_CORE_SHARD_COUNT)
     )
 
 
@@ -1821,8 +1957,8 @@ def test_fragment_loader_is_input_order_deterministic_and_validates_bindings(
             "shard_lifecycle",
             {
                 "schema_version": "newsroom.sdlc.core-shard-lifecycle.v1",
-                "elapsed_ms": 220_001,
-                "timeout_ms": 220_000,
+                "elapsed_ms": 330_001,
+                "timeout_ms": 330_000,
                 "result": "PASS",
             },
             "core_fragment_lifecycle",
@@ -1946,7 +2082,7 @@ def test_reducer_rejects_self_consistent_junit_outside_assigned_union(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     fragments, contract, context, route = _write_fragment_set(tmp_path, monkeypatch)
-    for index in range(4):
+    for index in range(EXPECTED_CORE_SHARD_COUNT):
         path = fragments / f"input-{index}" / "fragment.json"
         _rewrite_fragment_as_pass(path)
         _write_bound_junit(path)
@@ -1974,7 +2110,7 @@ def test_reducer_rejects_self_consistent_junit_outside_assigned_union(
         "source_lifecycle": {
             "schema_version": lane_module._SOURCE_LIFECYCLE_SCHEMA,
             "elapsed_ms": 1,
-            "timeout_ms": 220_000,
+            "timeout_ms": 330_000,
             "result": "PASS",
         },
     }
@@ -1989,7 +2125,7 @@ def test_reducer_rejects_self_consistent_junit_outside_assigned_union(
     monkeypatch.setattr(
         lane_module,
         "start_lane_deadline",
-        lambda *_args: lane_module.LaneDeadline.start(220),
+        lambda *_args: lane_module.LaneDeadline.start(330),
     )
     monkeypatch.setattr(
         lane_module,
@@ -2048,7 +2184,7 @@ def test_reducer_validates_available_junit_when_another_shard_timed_out(
     monkeypatch.setattr(
         lane_module,
         "start_lane_deadline",
-        lambda *_args: lane_module.LaneDeadline.start(220),
+        lambda *_args: lane_module.LaneDeadline.start(330),
     )
     monkeypatch.setattr(
         lane_module,
@@ -2063,7 +2199,7 @@ def test_reducer_validates_available_junit_when_another_shard_timed_out(
             "source_lifecycle": {
                 "schema_version": lane_module._SOURCE_LIFECYCLE_SCHEMA,
                 "elapsed_ms": 1,
-                "timeout_ms": 220_000,
+                "timeout_ms": 330_000,
                 "result": "PASS",
             },
             "fragment_identity": "sha256:" + "8" * 64,
@@ -2118,9 +2254,9 @@ def test_fragment_loader_rejects_duplicate_and_noncanonical_fragments(
 
 def test_reducer_rejects_missing_or_extra_fragment_count() -> None:
     with pytest.raises(WorkflowLaneError, match="core_fragment_count"):
-        lane_module._reduced_core_outcome(("PASS",) * 3)
+        lane_module._reduced_core_outcome(("PASS",) * 9)
     with pytest.raises(WorkflowLaneError, match="core_fragment_count"):
-        lane_module._reduced_core_outcome(("PASS",) * 5)
+        lane_module._reduced_core_outcome(("PASS",) * 11)
 
 
 def test_fragment_loader_rejects_missing_and_extra_artifact_inputs(
@@ -2128,24 +2264,28 @@ def test_fragment_loader_rejects_missing_and_extra_artifact_inputs(
 ) -> None:
     fragments = tmp_path / "fragments"
     fragments.mkdir()
-    for index in range(4):
+    for index in range(EXPECTED_CORE_SHARD_COUNT):
         directory = fragments / f"shard-{index}"
         directory.mkdir()
         (directory / "fragment.json").write_text("{}\n", encoding="utf-8")
     monkeypatch.setattr(
         lane_module,
         "_core_test_files",
-        lambda _root: tuple(f"newsroom/tests/test_{index}.py" for index in range(4)),
+        lambda _root: tuple(
+            f"newsroom/tests/test_{index}.py"
+            for index in range(EXPECTED_CORE_SHARD_COUNT)
+        ),
     )
     monkeypatch.setattr(
         lane_module,
         "_collect_core_node_ids",
         lambda _root, **_kwargs: tuple(
-            f"newsroom/tests/test_{index}.py::test_{index}" for index in range(4)
+            f"newsroom/tests/test_{index}.py::test_{index}"
+            for index in range(EXPECTED_CORE_SHARD_COUNT)
         ),
     )
 
-    (fragments / "shard-3" / "fragment.json").unlink()
+    (fragments / "shard-9" / "fragment.json").unlink()
     with pytest.raises(WorkflowLaneError, match="core_fragment_count"):
         lane_module._load_core_fragments(
             root=tmp_path,
@@ -2155,7 +2295,7 @@ def test_fragment_loader_rejects_missing_and_extra_artifact_inputs(
             route={},
         )
 
-    (fragments / "shard-3" / "fragment.json").write_text("{}\n", encoding="utf-8")
+    (fragments / "shard-9" / "fragment.json").write_text("{}\n", encoding="utf-8")
     (fragments / "unexpected").write_text("extra", encoding="utf-8")
     with pytest.raises(WorkflowLaneError, match="core_fragment_count"):
         lane_module._load_core_fragments(

--- a/newsroom/tests/test_sdlc_core_worker_capacity.py
+++ b/newsroom/tests/test_sdlc_core_worker_capacity.py
@@ -802,20 +802,84 @@ def test_core_shard_child_recomputes_bound_inventory_before_pytest(
         for index in range(EXPECTED_CORE_SHARD_COUNT)
     )
     selected = lane_module._core_node_shards(nodes)[0]
-    monkeypatch.setattr(
-        lane_module, "_collect_core_node_ids", lambda _root, **_kwargs: nodes
-    )
+    report = tmp_path / "pytest.xml"
+    inventory_path = tmp_path / "node-inventory.json"
+    lane_module._private_write(inventory_path, list(nodes))
+    observed: dict[str, object] = {}
 
-    with pytest.raises(WorkflowLaneError, match="core_shard_inventory"):
+    def no_recollection(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("bound inventory must not be recollected")
+
+    def run(*args: object, **kwargs: object) -> object:
+        observed["command"] = args[0]
+        observed["environment"] = kwargs["env"]
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(lane_module, "_collect_core_node_ids", no_recollection)
+    monkeypatch.setattr(
+        lane_module,
+        "_core_test_files",
+        lambda _root: tuple(node.split("::")[0] for node in nodes),
+    )
+    monkeypatch.setattr(lane_module.subprocess, "run", run)
+    monkeypatch.setenv(lane_module._CORE_NODE_INVENTORY_PATH_ENV, "ambient-path")
+    monkeypatch.setenv(lane_module._CORE_NODE_INVENTORY_DIGEST_ENV, "ambient-digest")
+
+    assert (
         lane_module.core_shard_tests(
             repo_root=tmp_path,
-            report=tmp_path / "pytest.xml",
+            report=report,
             basetemp=tmp_path / "pytest-temp",
             shard_index=0,
-            node_inventory_digest="sha256:" + "0" * 64,
+            node_inventory_digest=lane_module.sha256_identity(list(nodes)),
             selected_node_ids_digest=lane_module.sha256_identity(list(selected)),
             clustering=False,
         )
+        == 0
+    )
+    environment = observed["environment"]
+    assert isinstance(environment, dict)
+    assert environment[lane_module._CORE_NODE_INVENTORY_PATH_ENV] == str(inventory_path)
+    assert environment[lane_module._CORE_NODE_INVENTORY_DIGEST_ENV] == (
+        lane_module.sha256_identity(list(nodes))
+    )
+    assert len(observed) == 2
+
+    for corruption in ("digest", "selected", "noncanonical", "mode", "symlink"):
+        if inventory_path.exists() or inventory_path.is_symlink():
+            inventory_path.unlink()
+        inventory_path.write_bytes(
+            lane_module.canonical_json_bytes(list(nodes)) + b"\n"
+        )
+        inventory_path.chmod(0o600)
+        if corruption == "noncanonical":
+            inventory_path.write_bytes(inventory_path.read_bytes() + b" ")
+        elif corruption == "mode":
+            inventory_path.chmod(0o644)
+        elif corruption == "symlink":
+            target = tmp_path / "inventory-target.json"
+            target.write_bytes(inventory_path.read_bytes())
+            target.chmod(0o600)
+            inventory_path.unlink()
+            inventory_path.symlink_to(target)
+        with pytest.raises(WorkflowLaneError, match="core_shard_inventory"):
+            lane_module.core_shard_tests(
+                repo_root=tmp_path,
+                report=report,
+                basetemp=tmp_path / "pytest-temp",
+                shard_index=0,
+                node_inventory_digest=(
+                    "sha256:" + "0" * 64
+                    if corruption == "digest"
+                    else lane_module.sha256_identity(list(nodes))
+                ),
+                selected_node_ids_digest=(
+                    "sha256:" + "1" * 64
+                    if corruption == "selected"
+                    else lane_module.sha256_identity(list(selected))
+                ),
+                clustering=False,
+            )
 
 
 @pytest.mark.parametrize(
@@ -1146,6 +1210,7 @@ def test_core_fragment_binds_contract_lock_toolchain_and_exact_inventory(
     unsigned = dict(fragment)
     identity = unsigned.pop("fragment_identity")
     assert identity == lane_module._fragment_identity(unsigned)
+    assert not (tmp_path / "artifacts/core-fragment/node-inventory.json").exists()
 
 
 def test_fragment_provenance_hashes_exact_contract_and_lockfile_bytes() -> None:
@@ -1256,6 +1321,7 @@ def test_collection_time_tracked_mutation_prevents_fragment_publication(
         )
 
     assert not (tmp_path / "artifacts/core-fragment/fragment.json").exists()
+    assert not (tmp_path / "artifacts/core-fragment/node-inventory.json").exists()
 
 
 def test_test_time_tracked_mutation_prevents_fragment_publication(
@@ -1303,6 +1369,7 @@ def test_test_time_tracked_mutation_prevents_fragment_publication(
         )
 
     assert not (tmp_path / "artifacts/core-fragment/fragment.json").exists()
+    assert not (tmp_path / "artifacts/core-fragment/node-inventory.json").exists()
 
 
 def test_collection_subprocess_timeout_is_typed_and_publishes_no_fragment(

--- a/newsroom/tests/test_sdlc_evidence.py
+++ b/newsroom/tests/test_sdlc_evidence.py
@@ -56,6 +56,8 @@ def _copy_contract(root: Path) -> None:
         "docs/specs/sdlc/2026-07-30-sdlc-v2.3-owner-budget-amendment.md",
         "docs/specs/sdlc/2026-08-02-sdlc-v2.4-owner-budget-amendment.md",
         "docs/specs/sdlc/2026-08-10-sdlc-v2.5-core-sharding-amendment.md",
+        "docs/specs/sdlc/2026-08-11-sdlc-v2.5-ten-shard-capacity-amendment.md",
+        "docs/specs/sdlc/2026-08-11-sdlc-v2.6-measured-core-budget-amendment.md",
     )
     for relative in paths:
         target = root / relative

--- a/newsroom/tests/test_sdlc_evidence_workflow.py
+++ b/newsroom/tests/test_sdlc_evidence_workflow.py
@@ -134,7 +134,7 @@ def test_job_graph_is_exact_and_decision_always_reports() -> None:
     assert jobs["core"]["if"] == "always() && needs.route.result == 'success'"
     assert jobs["core_shard"]["strategy"] == {
         "fail-fast": "false",
-        "matrix": {"shard": ["0", "1", "2", "3"]},
+        "matrix": {"shard": ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]},
     }
     assert jobs["service"]["if"] == (
         "needs.route.result == 'success' && "

--- a/newsroom/tests/test_sdlc_junit_evidence.py
+++ b/newsroom/tests/test_sdlc_junit_evidence.py
@@ -173,7 +173,16 @@ def test_normalized_duplicate_report_path_is_rejected(tmp_path: Path) -> None:
         summarize_junit(tmp_path, ("results.xml", "./results.xml"))
 
 
-@pytest.mark.parametrize("duration", ["-1", "NaN", "Infinity", "60.001", "1e999999"])
+def test_testcase_at_ninety_second_boundary_is_accepted(tmp_path: Path) -> None:
+    _write(tmp_path, "results.xml", _suite(_case("boundary", time="90")))
+
+    summary = summarize_junit(tmp_path, ("results.xml",))
+
+    assert summary.test_count == 1
+    assert summary.duration_ms == 90_000
+
+
+@pytest.mark.parametrize("duration", ["-1", "NaN", "Infinity", "90.001", "1e999999"])
 def test_invalid_or_oversized_duration_is_rejected(
     tmp_path: Path,
     duration: str,

--- a/newsroom/tests/test_sdlc_shadow_decision.py
+++ b/newsroom/tests/test_sdlc_shadow_decision.py
@@ -323,6 +323,36 @@ def test_concurrent_core_gates_use_critical_path_not_duration_sum(
     assert decision.totals.execution_max_ms == 200_000
 
 
+def test_core_and_service_use_their_own_execution_budgets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    route = _route("R3_EXTERNAL_SERVICE_SECURITY")
+    core = _lane(
+        "core",
+        route,
+        gates=(_gate("core-deterministic", "tests", execution_ms=330_000),),
+    )
+    service = _lane(
+        "service",
+        route,
+        gates=(_gate("service-neo4j", "tests", execution_ms=220_001),),
+    )
+    _patch_lane_validator(monkeypatch, core, service)
+
+    decision = aggregate_shadow_decision(
+        context=_context(),
+        event=_event(),
+        core=core,  # type: ignore[arg-type]
+        service=service,  # type: ignore[arg-type]
+        contract=_contract(),
+    )
+
+    assert decision.result == "BUDGET_EXCEEDED"
+    assert decision.first_failure is not None
+    assert decision.first_failure.lane_id == "service"
+    assert decision.first_failure.phase == "execution"
+
+
 def test_service_is_required_exactly_when_route_requires_it(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -445,7 +475,7 @@ def test_gate_failure_required_skip_and_budget_precedence(
         route,
         gates=(
             _gate("source-integrity", "source", result="FAIL"),
-            _gate("core-deterministic", "tests", execution_ms=221_000),
+            _gate("core-deterministic", "tests", execution_ms=331_000),
         ),
     )
     _patch_lane_validator(monkeypatch, over_budget)

--- a/newsroom/tests/test_sdlc_shadow_lane.py
+++ b/newsroom/tests/test_sdlc_shadow_lane.py
@@ -42,7 +42,7 @@ class _Metadata:
 
 @dataclass(frozen=True)
 class _Route:
-    contract_version: str = "sdlc-v2.5"
+    contract_version: str = "sdlc-v2.6"
     risk_classifier_version: str = "sdlc-risk-v1"
     risk_tier: str = "R1_LOCAL_CODE"
     service_required: bool = False
@@ -146,9 +146,79 @@ def _core_matrix_jobs() -> list[dict[str, object]]:
             "run_attempt": RUN_ATTEMPT,
             "status": "completed",
             "conclusion": "success",
-            "completed_at": f"2026-07-22T12:00:0{index + 1}Z",
+            "completed_at": f"2026-07-22T12:00:{index + 1:02d}Z",
         }
-        for index in range(4)
+        for index in range(10)
+    ]
+
+
+def _completed_job(
+    name: str,
+    *,
+    completed_at: str,
+    started_at: str = "2026-07-22T12:00:00.000Z",
+    steps: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
+    return {
+        "id": 800 + len(name),
+        "name": name,
+        "run_id": RUN_ID,
+        "run_attempt": RUN_ATTEMPT,
+        "status": "completed",
+        "conclusion": "success",
+        "started_at": started_at,
+        "completed_at": completed_at,
+        "steps": steps or [],
+    }
+
+
+def _stuck_completed_job(
+    name: str,
+    *,
+    completed_at: str,
+    started_at: str = "2026-07-22T12:00:00.000Z",
+    steps: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
+    completed_steps = list(steps or [])
+    completed_steps.append(
+        {
+            "name": "Complete job",
+            "status": "completed",
+            "conclusion": "success",
+            "started_at": completed_at,
+            "completed_at": completed_at,
+        }
+    )
+    job = _completed_job(
+        name,
+        completed_at=completed_at,
+        started_at=started_at,
+        steps=completed_steps,
+    )
+    job.update(status="in_progress", conclusion=None, completed_at=None)
+    return job
+
+
+def _producer_steps(
+    bootstrap_name: str,
+    *,
+    bootstrap_at: str,
+) -> list[dict[str, object]]:
+    return [
+        {
+            "name": bootstrap_name,
+            "status": "completed",
+            "conclusion": "success",
+            "started_at": "2026-07-22T12:00:06.000Z",
+            "completed_at": bootstrap_at,
+        },
+        {
+            "name": "Finalize evidence",
+            "status": "completed",
+            "conclusion": "success",
+            "started_at": "2026-07-22T12:00:40.000Z",
+            "completed_at": "2026-07-22T12:00:41.000Z",
+        },
     ]
 
 
@@ -182,13 +252,13 @@ def _github_core_jobs(
             "run_attempt": RUN_ATTEMPT,
             "status": "completed",
             "conclusion": "success",
-            "started_at": "2026-07-22T12:00:06Z",
+            "started_at": "2026-07-22T12:00:10Z",
             "completed_at": "2026-07-22T12:00:42Z",
             "steps": [
                 {
                     "name": "Sync locked environment",
                     "status": "completed",
-                    "completed_at": "2026-07-22T12:00:10Z",
+                    "completed_at": "2026-07-22T12:00:11Z",
                 },
                 {
                     "name": "Finalize evidence",
@@ -311,7 +381,7 @@ def test_verify_shadow_lane_composes_replay_telemetry_and_receipt(
         "run_attempt": RUN_ATTEMPT,
         "status": "completed",
         "conclusion": "success",
-        "completed_at": "2026-07-22T12:00:04Z",
+        "completed_at": "2026-07-22T12:00:10Z",
     }
     assert calls["measure"][1]["job_name"] == "core"  # type: ignore[index]
     assert calls["measure"][1]["ready_after_job_names"] == (  # type: ignore[index]
@@ -414,7 +484,7 @@ def test_core_telemetry_rejects_noncanonical_matrix_dependencies(
     elif fault == "duplicate":
         jobs.append(dict(jobs[0]))
     elif fault == "extra":
-        jobs.append({**jobs[0], "name": "core-shard-4"})
+        jobs.append({**jobs[0], "name": "core-shard-10"})
     elif fault == "wrong-run":
         jobs[0]["run_id"] = RUN_ID + 1
     elif fault == "wrong-attempt":
@@ -501,6 +571,267 @@ def test_service_lane_uses_exact_service_policy(
     assert calls["measure"]["ready_after_job_names"] == ("route",)  # type: ignore[index]
     assert calls["measure"]["bootstrap_end_step"] == "Wait for authenticated Neo4j"  # type: ignore[index]
     assert calls["verify"]["expected_job_id"] == "service"  # type: ignore[index]
+
+
+def test_service_telemetry_normalises_exact_stuck_completed_producer_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipt = _Receipt(
+        _Metadata(name=ARTIFACT_NAME.replace("-core-", "-service-")),
+        route=_Route(
+            risk_tier="R3_EXTERNAL_SERVICE_SECURITY",
+            service_required=True,
+        ),
+        producer_job_id="service",
+        gate_decisions=(_GateDecision("service-neo4j", "tests"),),
+    )
+    replay = _replay(artifact_name=receipt.metadata.name)
+    service = _stuck_completed_job(
+        "service",
+        started_at="2026-07-22T12:00:05.000Z",
+        completed_at="2026-07-22T12:00:42.000Z",
+        steps=_producer_steps(
+            "Wait for authenticated Neo4j",
+            bootstrap_at="2026-07-22T12:00:10.000Z",
+        ),
+    )
+    jobs = {
+        "jobs": [
+            _completed_job("route", completed_at="2026-07-22T12:00:04.000Z"),
+            service,
+        ]
+    }
+    transport = SimpleNamespace(
+        replay=replay,
+        run={"event": "pull_request", "created_at": "2026-07-22T12:00:00.000Z"},
+        jobs=jobs,
+        metadata={},
+        artifact_root=tmp_path / "artifact",
+        archive_path=tmp_path / "artifact.zip",
+    )
+    monkeypatch.setattr(lane_module, "load_verified_transport", lambda _root: transport)
+    monkeypatch.setattr(lane_module, "verify_artifact", lambda **_kwargs: receipt)
+    _patch_receipt_validator(monkeypatch, receipt)
+
+    record = verify_shadow_lane(
+        repo_root=tmp_path,
+        bundle_root=tmp_path / "bundle",
+        lane_id="service",
+        decision_context=SimpleNamespace(job_id="decision"),  # type: ignore[arg-type]
+        contract=SimpleNamespace(repo_root=tmp_path),  # type: ignore[arg-type]
+    )
+
+    assert record.telemetry.job_conclusion == "success"
+    assert record.telemetry.job_completed_at == "2026-07-22T12:00:42.000Z"
+    assert service["status"] == "in_progress"
+    assert service["completed_at"] is None
+
+
+def test_core_ready_after_normalises_exact_stuck_dependencies_and_shard_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipt = _Receipt(_Metadata())
+    replay = _replay()
+    shards = [
+        _completed_job(
+            f"core-shard-{index}",
+            completed_at=f"2026-07-22T12:00:{index + 4:02d}.000Z",
+        )
+        for index in range(10)
+    ]
+    shards[9] = _stuck_completed_job(
+        "core-shard-9",
+        completed_at="2026-07-22T12:00:15.000Z",
+        steps=[
+            {
+                "name": "Run shard",
+                "status": "completed",
+                "conclusion": "success",
+                "started_at": "2026-07-22T12:00:04.000Z",
+                "completed_at": "2026-07-22T12:00:08.000Z",
+            }
+        ],
+    )
+    core = _stuck_completed_job(
+        "core",
+        started_at="2026-07-22T12:00:16.000Z",
+        completed_at="2026-07-22T12:00:42.000Z",
+        steps=_producer_steps(
+            "Sync locked environment",
+            bootstrap_at="2026-07-22T12:00:20.000Z",
+        ),
+    )
+    route = _stuck_completed_job(
+        "route",
+        completed_at="2026-07-22T12:00:03.000Z",
+    )
+    source = _stuck_completed_job(
+        "source",
+        completed_at="2026-07-22T12:00:02.000Z",
+    )
+    jobs = {
+        "jobs": [
+            route,
+            source,
+            *shards,
+            core,
+        ]
+    }
+    transport = SimpleNamespace(
+        replay=replay,
+        run={"event": "pull_request", "created_at": "2026-07-22T12:00:00.000Z"},
+        jobs=jobs,
+        metadata={},
+        artifact_root=tmp_path / "artifact",
+        archive_path=tmp_path / "artifact.zip",
+    )
+    monkeypatch.setattr(lane_module, "load_verified_transport", lambda _root: transport)
+    monkeypatch.setattr(lane_module, "verify_artifact", lambda **_kwargs: receipt)
+    _patch_receipt_validator(monkeypatch, receipt)
+
+    record = verify_shadow_lane(
+        repo_root=tmp_path,
+        bundle_root=tmp_path / "bundle",
+        lane_id="core",
+        decision_context=SimpleNamespace(job_id="decision"),  # type: ignore[arg-type]
+        contract=SimpleNamespace(repo_root=tmp_path),  # type: ignore[arg-type]
+    )
+
+    assert record.telemetry.ready_at == "2026-07-22T12:00:15.000Z"
+    assert record.telemetry.job_completed_at == "2026-07-22T12:00:42.000Z"
+    assert shards[9]["status"] == "in_progress"
+    assert shards[9]["completed_at"] is None
+    assert core["status"] == "in_progress"
+    assert core["completed_at"] is None
+    assert route["status"] == "in_progress"
+    assert route["completed_at"] is None
+    assert source["status"] == "in_progress"
+    assert source["completed_at"] is None
+
+
+@pytest.mark.parametrize(
+    "fault",
+    [
+        "empty",
+        "missing-complete",
+        "duplicate-complete",
+        "pending",
+        "failed",
+        "complete-skipped",
+        "missing-conclusion",
+        "bad-completed-at",
+        "duplicate-step",
+        "non-mapping-step",
+        "trailing-step",
+        "complete-before-maximum",
+    ],
+)
+def test_stuck_job_normalisation_rejects_malformed_or_non_success_snapshots(
+    fault: str,
+) -> None:
+    job = _stuck_completed_job(
+        "service",
+        completed_at="2026-07-22T12:00:42.000Z",
+        steps=[
+            {
+                "name": "Finalize evidence",
+                "status": "completed",
+                "conclusion": "success",
+                "completed_at": "2026-07-22T12:00:41.000Z",
+            }
+        ],
+    )
+    steps = job["steps"]
+    assert isinstance(steps, list)
+    if fault == "empty":
+        steps.clear()
+    elif fault == "missing-complete":
+        steps.pop()
+    elif fault == "duplicate-complete":
+        steps.append(dict(steps[-1]))
+    elif fault == "pending":
+        steps[0]["status"] = "in_progress"
+    elif fault == "failed":
+        steps[0]["conclusion"] = "failure"
+    elif fault == "complete-skipped":
+        steps[-1]["conclusion"] = "skipped"
+    elif fault == "missing-conclusion":
+        steps[0].pop("conclusion")
+    elif fault == "bad-completed-at":
+        steps[0]["completed_at"] = None
+    elif fault == "duplicate-step":
+        steps.append(dict(steps[0]))
+    elif fault == "non-mapping-step":
+        steps.append("not-a-step")
+    elif fault == "trailing-step":
+        steps.append(
+            {
+                "name": "Post Complete job",
+                "status": "completed",
+                "conclusion": "success",
+                "completed_at": "2026-07-22T12:00:43.000Z",
+            }
+        )
+    else:
+        steps[0]["completed_at"] = "2026-07-22T12:00:43.000Z"
+
+    with pytest.raises(WorkflowEvidenceError, match="stale_job"):
+        lane_module._normalise_stale_completed_jobs(
+            {"jobs": [job]},
+            job_names=frozenset({"service"}),
+        )
+
+
+@pytest.mark.parametrize(
+    ("status", "conclusion", "completed_at"),
+    [
+        ("queued", None, None),
+        ("in_progress", "success", None),
+        ("in_progress", None, "2026-07-22T12:00:42.000Z"),
+        ("completed", None, None),
+    ],
+)
+def test_job_normalisation_does_not_reinterpret_any_other_top_level_state(
+    status: str,
+    conclusion: str | None,
+    completed_at: str | None,
+) -> None:
+    job = _stuck_completed_job(
+        "service",
+        completed_at="2026-07-22T12:00:42.000Z",
+    )
+    job.update(
+        status=status,
+        conclusion=conclusion,
+        completed_at=completed_at,
+    )
+
+    normalised = lane_module._normalise_stale_completed_jobs(
+        {"jobs": [job]},
+        job_names=frozenset({"service"}),
+    )
+
+    assert normalised == {"jobs": [job]}
+
+
+@pytest.mark.parametrize("missing", ["conclusion", "completed_at"])
+def test_job_normalisation_requires_the_complete_top_level_stale_triple(
+    missing: str,
+) -> None:
+    job = _stuck_completed_job(
+        "service",
+        completed_at="2026-07-22T12:00:42.000Z",
+    )
+    job.pop(missing)
+
+    normalised = lane_module._normalise_stale_completed_jobs(
+        {"jobs": [job]},
+        job_names=frozenset({"service"}),
+    )
+
+    assert normalised == {"jobs": [job]}
 
 
 @pytest.mark.parametrize(

--- a/newsroom/tests/test_sdlc_watchdog.py
+++ b/newsroom/tests/test_sdlc_watchdog.py
@@ -232,23 +232,36 @@ def test_environment_error_does_not_echo_command_or_exception_message() -> None:
 
 def test_deadline_and_configured_budget_cannot_be_raised() -> None:
     contract = load_contract(REPO_ROOT)
-    assert start_lane_deadline(contract, "route").timeout_ms == 220_000
+    assert start_lane_deadline(contract, "route").timeout_ms == 330_000
+    assert LaneDeadline.start(330).timeout_ms == 330_000
+    assert (
+        _run_gate_command(
+            gate_id="core-deterministic",
+            phase="boundary",
+            argv=("/usr/bin/true",),
+            deadline=LaneDeadline.start(330),
+            command_timeout_seconds=330,
+            termination_grace_seconds=0.1,
+        ).result
+        == "PASS"
+    )
 
-    with pytest.raises(GateRunError, match="below 240"):
-        LaneDeadline(0, 240_000)
+    with pytest.raises(GateRunError, match="at most 330"):
+        LaneDeadline(0, 330_001)
     with pytest.raises(GateRunError, match="accepted lane timeout"):
         run_configured_gate(
             contract=contract,
-            gate_id="route",
+            gate_id="service-neo4j",
             phase="oversized",
             argv=_python("pass"),
-            deadline=LaneDeadline.start(239),
+            deadline=LaneDeadline.start(330),
         )
 
 
 def test_invalid_budget_identifier_and_output_limit_are_rejected() -> None:
-    with pytest.raises(GateRunError, match="below 240"):
-        LaneDeadline.start(240)
+    for timeout in (330.001, 330.5, 330.999):
+        with pytest.raises(GateRunError, match="at most 330"):
+            LaneDeadline.start(timeout)
     with pytest.raises(GateRunError, match="unsupported characters"):
         _run_gate_command(
             gate_id="bad:gate",
@@ -265,6 +278,19 @@ def test_invalid_budget_identifier_and_output_limit_are_rejected() -> None:
             deadline=LaneDeadline.start(2),
             command_timeout_seconds=1,
             output_limit_bytes=1_048_577,
+        )
+
+
+@pytest.mark.parametrize("timeout", (330.001, 330.5, 330.999))
+def test_command_timeout_cannot_exceed_exact_core_maximum(timeout: float) -> None:
+    with pytest.raises(GateRunError, match="at most 330"):
+        _run_gate_command(
+            gate_id="core-deterministic",
+            phase="unit",
+            argv=("/usr/bin/true",),
+            deadline=LaneDeadline.start(330),
+            command_timeout_seconds=timeout,
+            termination_grace_seconds=0.1,
         )
     with pytest.raises(GateRunError, match="five seconds"):
         _run_gate_command(

--- a/newsroom/tests/test_sdlc_workflow_lane.py
+++ b/newsroom/tests/test_sdlc_workflow_lane.py
@@ -476,7 +476,7 @@ def test_core_worker_command_is_pinned_persistent_and_file_scoped(
         basetemp=basetemp,
     )
 
-    assert lane_module._CORE_WORKER_COUNT == 4
+    assert lane_module._CORE_WORKER_COUNT == 2
     assert lane_module._CORE_DISTRIBUTION == "worksteal"
     assert command[:13] == (
         sys.executable,
@@ -489,7 +489,7 @@ def test_core_worker_command_is_pinned_persistent_and_file_scoped(
         "-p",
         "xdist.plugin",
         "-n",
-        "4",
+        "2",
         "--dist=worksteal",
         "--max-worker-restart=0",
     )

--- a/scripts/sdlc/contracts.py
+++ b/scripts/sdlc/contracts.py
@@ -31,7 +31,7 @@ _REQUIRED_RISKS = (
     "R4_RELEASE_OPERATIONAL",
 )
 _INTERACTIVE_LANES = frozenset({"core", "service", "merge_group"})
-_MAX_HARD_TIMEOUT_SECONDS = 240
+_MAX_HARD_TIMEOUT_SECONDS = 331
 
 
 def _mapping(value: object, name: str) -> Mapping[str, Any]:
@@ -140,11 +140,8 @@ def validate_contract_data(
         raise ContractError("unsupported SDLC contract schema")
     if data.get("status") != "accepted":
         raise ContractError("SDLC contract is not accepted")
-    if (
-        not isinstance(data.get("contract_version"), str)
-        or not data["contract_version"]
-    ):
-        raise ContractError("contract_version is required")
+    if data.get("contract_version") != "sdlc-v2.6":
+        raise ContractError("accepted contract version must be sdlc-v2.6")
 
     global_config = _mapping(data.get("global"), "global")
     command_limit = _positive_int(
@@ -162,6 +159,8 @@ def validate_contract_data(
         "global.finalization_timeout_seconds",
         below=_MAX_HARD_TIMEOUT_SECONDS,
     )
+    if (command_limit, lane_limit, finalization_limit) != (220, 220, 20):
+        raise ContractError("global timing differs from the accepted measured budget")
     if global_config.get("required_decision_always_reports") is not True:
         raise ContractError("the required decision must always report")
     if global_config.get("rerun_can_overwrite_required_result") is not False:
@@ -195,8 +194,22 @@ def validate_contract_data(
             f"gate.{gate_name}.hard_timeout_seconds",
             below=_MAX_HARD_TIMEOUT_SECONDS,
         )
-        if timeout > command_limit:
+        if timeout > command_limit and gate_name != "core-deterministic":
             raise ContractError(f"gate.{gate_name} exceeds the global command timeout")
+    accepted_gate_timeouts = {
+        "route": 20,
+        "source-integrity": 60,
+        "core-deterministic": 330,
+        "service-neo4j": 220,
+        "merge-exact": 220,
+        "science-shard": 220,
+        "evidence-finalize": 20,
+    }
+    if {
+        name: _mapping(value, f"gate.{name}").get("hard_timeout_seconds")
+        for name, value in gates.items()
+    } != accepted_gate_timeouts:
+        raise ContractError("gate timing differs from the accepted measured budget")
 
     for lane_name in _INTERACTIVE_LANES:
         lane = _mapping(lanes.get(lane_name), f"lanes.{lane_name}")
@@ -205,13 +218,13 @@ def validate_contract_data(
             f"lanes.{lane_name}.hard_timeout_seconds",
             below=_MAX_HARD_TIMEOUT_SECONDS,
         )
-        if timeout > lane_limit:
+        if timeout > lane_limit and lane_name != "core":
             raise ContractError(f"lanes.{lane_name} exceeds the aggregate lane timeout")
     core = _mapping(lanes.get("core"), "lanes.core")
     if (
-        core.get("shard_count") != 4
+        core.get("shard_count") != 10
         or core.get("partition") != "sha256_node_id_balanced"
-        or core.get("workers_per_shard") != 4
+        or core.get("workers_per_shard") != 2
         or core.get("distribution") != "worksteal"
         or core.get("max_worker_restart") != 0
         or core.get("reducer_single_canonical_receipt") is not True
@@ -224,20 +237,40 @@ def validate_contract_data(
         "lanes.core.per_shard_hard_timeout_seconds",
         below=_MAX_HARD_TIMEOUT_SECONDS,
     )
-    if shard_timeout != command_limit:
-        raise ContractError("lanes.core shard timeout differs from the command timeout")
+    if shard_timeout != 330 or core.get("hard_timeout_seconds") != 330:
+        raise ContractError("lanes.core timeout differs from the accepted core budget")
+    for field in ("per_shard_warning_seconds", "critical_path_warning_seconds"):
+        warning = _positive_int(core.get(field), f"lanes.core.{field}")
+        if warning != 300 or warning >= shard_timeout:
+            raise ContractError(f"lanes.core.{field} differs from the accepted warning")
     science = _mapping(lanes.get("science"), "lanes.science")
-    _positive_int(
+    science_timeout = _positive_int(
         science.get("per_shard_hard_timeout_seconds"),
         "lanes.science.per_shard_hard_timeout_seconds",
         below=_MAX_HARD_TIMEOUT_SECONDS,
     )
+    if (
+        _mapping(lanes.get("service"), "lanes.service").get("hard_timeout_seconds")
+        != 220
+        or _mapping(lanes.get("merge_group"), "lanes.merge_group").get(
+            "hard_timeout_seconds"
+        )
+        != 220
+        or science_timeout != 220
+    ):
+        raise ContractError(
+            "non-core lane timing differs from the accepted measured budget"
+        )
     decision = _mapping(lanes.get("decision"), "lanes.decision")
     decision_timeout = _positive_int(
         decision.get("hard_timeout_seconds"),
         "lanes.decision.hard_timeout_seconds",
         below=_MAX_HARD_TIMEOUT_SECONDS,
     )
+    if decision_timeout != 20:
+        raise ContractError(
+            "lanes.decision timing differs from the accepted measured budget"
+        )
     if decision.get("always_reports") is not True:
         raise ContractError("lanes.decision must always report")
     if decision_timeout > finalization_limit:
@@ -288,6 +321,28 @@ def validate_contract_data(
             )
 
     strategy = _mapping(data.get("test_strategy"), "test_strategy")
+    testcase_limit = _positive_int(
+        strategy.get("individual_testcase_hard_timeout_seconds"),
+        "test_strategy.individual_testcase_hard_timeout_seconds",
+    )
+    testcase_warning = _positive_int(
+        strategy.get("individual_testcase_warning_seconds"),
+        "test_strategy.individual_testcase_warning_seconds",
+    )
+    if (
+        testcase_limit != 90
+        or testcase_warning != 75
+        or testcase_warning >= testcase_limit
+    ):
+        raise ContractError(
+            "test_strategy testcase timing differs from the accepted budget"
+        )
+    test_sizes = _mapping(data.get("test_sizes"), "test_sizes")
+    science_size = _mapping(test_sizes.get("science"), "test_sizes.science")
+    if science_size.get("shard_hard_timeout_seconds") != 220:
+        raise ContractError(
+            "test_sizes.science timing differs from the accepted measured budget"
+        )
     owner = _mapping(data.get("owner_decisions"), "owner_decisions")
     review = _mapping(data.get("change_review"), "change_review")
     if owner.get("review_net_executable_lines_trigger") != review.get(

--- a/scripts/sdlc/junit_evidence.py
+++ b/scripts/sdlc/junit_evidence.py
@@ -18,7 +18,7 @@ SCHEMA_VERSION = "newsroom.sdlc.junit-summary.v1"
 _MAX_REPORTS = 32
 _MAX_REPORT_BYTES = 16 * 1024 * 1024
 _MAX_TESTS = 100_000
-_MAX_TEST_SECONDS = Decimal("60")
+_MAX_TEST_SECONDS = Decimal("90")
 _MAX_FIELD_CHARS = 262_144
 _ANSI = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 

--- a/scripts/sdlc/run_gate.py
+++ b/scripts/sdlc/run_gate.py
@@ -20,7 +20,7 @@ SCHEMA_VERSION = "newsroom.sdlc.gate-run.v1"
 _SECRET_NAME = re.compile(r"(?:AUTH|CREDENTIAL|KEY|PASSWORD|SECRET|TOKEN)", re.IGNORECASE)
 _SAFE_ID = re.compile(r"[A-Za-z0-9_.*-]{1,128}")
 _MAX_OUTPUT_BYTES = 1_048_576
-_MAX_TIMEOUT_SECONDS = 240
+_MAX_TIMEOUT_SECONDS = 330
 _SCHEDULER_MARGIN_SECONDS = 0.05
 
 
@@ -43,9 +43,9 @@ class LaneDeadline:
         if (
             isinstance(self.timeout_ms, bool)
             or not isinstance(self.timeout_ms, int)
-            or not 0 < self.timeout_ms < _MAX_TIMEOUT_SECONDS * 1000
+            or not 0 < self.timeout_ms <= _MAX_TIMEOUT_SECONDS * 1000
         ):
-            raise GateRunError("lane timeout must be positive and below 240 seconds")
+            raise GateRunError("lane timeout must be positive and at most 330 seconds")
 
     @classmethod
     def start(cls, timeout_seconds: float) -> "LaneDeadline":
@@ -131,8 +131,8 @@ def _timeout_seconds(value: object, name: str) -> float:
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise GateRunError(f"{name} must be numeric")
     timeout = float(value)
-    if timeout <= 0 or timeout >= _MAX_TIMEOUT_SECONDS:
-        raise GateRunError(f"{name} must be positive and below 240 seconds")
+    if timeout <= 0 or timeout > _MAX_TIMEOUT_SECONDS:
+        raise GateRunError(f"{name} must be positive and at most 330 seconds")
     return timeout
 
 

--- a/scripts/sdlc/shadow_decision.py
+++ b/scripts/sdlc/shadow_decision.py
@@ -294,9 +294,11 @@ def _result(value: object, code: str) -> str:
     return result
 
 
-def _contract_limits(contract: SdlcContract) -> tuple[int, int]:
+def _contract_limits(contract: SdlcContract, lane_id: str) -> tuple[int, int]:
     global_value = _mapping(contract.data.get("global"), "contract_global")
-    lane = global_value.get("lane_execution_timeout_seconds")
+    lanes = _mapping(contract.data.get("lanes"), "contract_lanes")
+    lane_value = _mapping(lanes.get(lane_id), "contract_lane")
+    lane = lane_value.get("hard_timeout_seconds")
     finalize = global_value.get("finalization_timeout_seconds")
     if (
         isinstance(lane, bool)
@@ -476,9 +478,9 @@ def _gate_failure(lane: ShadowLaneRecord) -> FailureSummary | None:
 def _derive_result(
     lanes: tuple[ShadowLaneRecord, ...], *, contract: SdlcContract
 ) -> tuple[str, str, FailureSummary | None]:
-    lane_budget_ms, finalize_budget_ms = _contract_limits(contract)
     failures = [failure for lane in lanes if (failure := _gate_failure(lane))]
     for lane in lanes:
+        lane_budget_ms, finalize_budget_ms = _contract_limits(contract, lane.lane_id)
         if lane.telemetry.job_conclusion != "success":
             failures.append(
                 _failure(

--- a/scripts/sdlc/shadow_lane.py
+++ b/scripts/sdlc/shadow_lane.py
@@ -33,13 +33,15 @@ from .workflow_event import (
 
 SCHEMA_VERSION = "newsroom.sdlc.shadow-lane.v1"
 POLICY_VERSION = "sdlc-shadow-lane-v1"
-CONTRACT_VERSION = "sdlc-v2.5"
+CONTRACT_VERSION = "sdlc-v2.6"
 CLASSIFIER_VERSION = "sdlc-risk-v1"
 _SERVICE_RISKS = frozenset({"R3_EXTERNAL_SERVICE_SECURITY", "R4_RELEASE_OPERATIONAL"})
 _OWNER_RISKS = frozenset({"R4_RELEASE_OPERATIONAL"})
 _SAFE_ID = re.compile(r"[A-Za-z0-9_.-]{1,128}")
 _SHA256 = re.compile(r"sha256:[0-9a-f]{64}")
 _TIMESTAMP = re.compile(r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[^\x00-\x1f\x7f]{1,48}Z")
+_SUCCESSFUL_STEP_CONCLUSIONS = frozenset({"success", "skipped", "neutral"})
+_CORE_SHARD_NAMES = tuple(f"core-shard-{index}" for index in range(10))
 _RECORD_KEYS = frozenset(
     {
         "schema_version",
@@ -333,9 +335,9 @@ def _telemetry_jobs(
         and isinstance(job.get("name"), str)
         and str(job["name"]).startswith("core-shard-")
     ]
-    expected = {f"core-shard-{index}" for index in range(4)}
+    expected = set(_CORE_SHARD_NAMES)
     if (
-        len(matrix) != 4
+        len(matrix) != len(_CORE_SHARD_NAMES)
         or {job["name"] for job in matrix} != expected
         or any(job.get("name") == "core_shard" for job in jobs if isinstance(job, dict))
         or any(
@@ -408,6 +410,76 @@ def _verify_core_dependency_results(
         raise ShadowLaneError("producer_result")
 
 
+def _normalise_stale_completed_jobs(
+    value: object,
+    *,
+    job_names: frozenset[str],
+) -> object:
+    jobs = value.get("jobs") if isinstance(value, dict) else None
+    if not isinstance(jobs, list):
+        return value
+    normalised: list[object] = []
+    for raw_job in jobs:
+        if not isinstance(raw_job, dict) or raw_job.get("name") not in job_names:
+            normalised.append(raw_job)
+            continue
+        if not {"status", "conclusion", "completed_at"}.issubset(raw_job) or (
+            raw_job.get("status"),
+            raw_job.get("conclusion"),
+            raw_job.get("completed_at"),
+        ) != ("in_progress", None, None):
+            normalised.append(raw_job)
+            continue
+        steps = raw_job.get("steps")
+        if not isinstance(steps, list) or not steps:
+            raise WorkflowEvidenceError("stale_job_steps")
+        completed_steps: list[tuple[str, datetime]] = []
+        seen_names: set[str] = set()
+        complete_job_count = 0
+        complete_job_completed: datetime | None = None
+        for raw_step in steps:
+            if not isinstance(raw_step, dict):
+                raise WorkflowEvidenceError("stale_job_step")
+            name = _text(raw_step.get("name"), "stale_job_step_name", maximum=256)
+            if name in seen_names:
+                raise WorkflowEvidenceError("stale_job_step_duplicate")
+            seen_names.add(name)
+            if raw_step.get("status") != "completed":
+                raise WorkflowEvidenceError("stale_job_step_incomplete")
+            conclusion = raw_step.get("conclusion")
+            if conclusion not in _SUCCESSFUL_STEP_CONCLUSIONS:
+                raise WorkflowEvidenceError("stale_job_step_conclusion")
+            completed_steps.append(
+                _workflow_timestamp(
+                    raw_step.get("completed_at"),
+                    "stale_job_step_completed_at",
+                )
+            )
+            if name == "Complete job":
+                complete_job_count += 1
+                if conclusion != "success":
+                    raise WorkflowEvidenceError("stale_job_complete_conclusion")
+                complete_job_completed = completed_steps[-1][1]
+        if complete_job_count != 1:
+            raise WorkflowEvidenceError("stale_job_complete_step")
+        latest_step = max(completed_steps, key=lambda item: item[1])
+        if (
+            not isinstance(steps[-1], dict)
+            or steps[-1].get("name") != "Complete job"
+            or complete_job_completed != latest_step[1]
+        ):
+            raise WorkflowEvidenceError("stale_job_complete_order")
+        normalised.append(
+            {
+                **raw_job,
+                "status": "completed",
+                "conclusion": "success",
+                "completed_at": latest_step[0],
+            }
+        )
+    return {**value, "jobs": normalised}
+
+
 def verify_shadow_lane(
     *,
     repo_root: str | Path,
@@ -430,8 +502,18 @@ def verify_shadow_lane(
     run_event = _event_name(run.get("event"))
     run_created_at = _timestamp(run.get("created_at"))
     try:
-        jobs = _telemetry_jobs(
+        normalised_jobs = _normalise_stale_completed_jobs(
             transport.jobs,
+            job_names=frozenset(
+                {
+                    policy.producer_job_id,
+                    *policy.ready_after_jobs,
+                    *_CORE_SHARD_NAMES,
+                }
+            ),
+        )
+        jobs = _telemetry_jobs(
+            normalised_jobs,
             policy=policy,
             run_id=transport.replay.run_id,
             run_attempt=transport.replay.run_attempt,

--- a/scripts/sdlc/workflow_lane.py
+++ b/scripts/sdlc/workflow_lane.py
@@ -6,6 +6,7 @@ import json
 import os
 import platform
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -118,6 +119,9 @@ _SERVICE_CONFIGURATION = {
 _CORE_TESTS = ("newsroom/tests",)
 _CORE_WORKER_COUNT = 2
 _CORE_SHARD_COUNT = 10
+_CORE_NODE_INVENTORY_FILE = "node-inventory.json"
+_CORE_NODE_INVENTORY_PATH_ENV = "NEWSROOM_SDLC_CORE_NODE_INVENTORY_PATH"
+_CORE_NODE_INVENTORY_DIGEST_ENV = "NEWSROOM_SDLC_CORE_NODE_INVENTORY_DIGEST"
 _CORE_DISTRIBUTION = "worksteal"
 _CORE_FRAGMENT_SCHEMA = "newsroom.sdlc.core-shard-fragment.v1"
 _CORE_SHARD_LIFECYCLE_SCHEMA = "newsroom.sdlc.core-shard-lifecycle.v1"
@@ -1015,6 +1019,58 @@ def _collect_core_node_ids(
     return values
 
 
+def _core_node_inventory_path(report: Path) -> Path:
+    return report.with_name(_CORE_NODE_INVENTORY_FILE)
+
+
+def _load_core_node_inventory(
+    root: Path, value: str | Path, expected_digest: object
+) -> tuple[str, ...]:
+    try:
+        candidate = Path(value)
+        absolute = candidate if candidate.is_absolute() else root / candidate
+        metadata = os.lstat(absolute)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_uid != os.getuid()
+            or stat.S_IMODE(metadata.st_mode) != 0o600
+        ):
+            raise WorkflowLaneError("core_shard_inventory")
+        loaded = _load_json(root, value)
+        if type(loaded) is not list or any(type(item) is not str for item in loaded):
+            raise WorkflowLaneError("core_shard_inventory")
+        inventory = tuple(loaded)
+        files = frozenset(_core_test_files(root))
+        if (
+            not inventory
+            or inventory != tuple(sorted(inventory))
+            or len(inventory) != len(set(inventory))
+            or any(node_id.split("::", 1)[0] not in files for node_id in inventory)
+            or expected_digest != sha256_identity(list(inventory))
+        ):
+            raise WorkflowLaneError("core_shard_inventory")
+    except (OSError, WorkflowLaneError) as exc:
+        if str(exc) == "core_shard_inventory":
+            raise
+        raise WorkflowLaneError("core_shard_inventory") from exc
+    return inventory
+
+
+def _remove_core_node_inventory(path: Path) -> None:
+    try:
+        metadata = path.lstat()
+        safe = (
+            stat.S_ISREG(metadata.st_mode)
+            and metadata.st_uid == os.getuid()
+            and stat.S_IMODE(metadata.st_mode) == 0o600
+        )
+        path.unlink()
+    except OSError as exc:
+        raise WorkflowLaneError("core_shard_inventory_cleanup") from exc
+    if not safe or path.exists() or path.is_symlink():
+        raise WorkflowLaneError("core_shard_inventory_cleanup")
+
+
 def _core_node_shards(node_ids: Sequence[str]) -> tuple[tuple[str, ...], ...]:
     inventory = tuple(sorted(node_ids))
     if not inventory or len(inventory) != len(set(inventory)):
@@ -1442,11 +1498,16 @@ def execute_core_shard(
         basetemp=basetemp,
         clustering=bool(route["clustering_required"]),
     )
-    run = _execute(
-        contract=contract,
-        spec=spec,
-        deadline=deadline,
-    )
+    inventory_path = _core_node_inventory_path(report)
+    _private_write(inventory_path, list(inventory))
+    try:
+        run = _execute(
+            contract=contract,
+            spec=spec,
+            deadline=deadline,
+        )
+    finally:
+        _remove_core_node_inventory(inventory_path)
     shutil.rmtree(basetemp, ignore_errors=True)
     summary = _core_fragment_report_summary(
         repo_root=root,
@@ -2207,7 +2268,8 @@ def core_shard_tests(
         or not basetemp_path.is_relative_to(root)
     ):
         raise WorkflowLaneError("core_shard_command")
-    inventory = _collect_core_node_ids(root)
+    inventory_path = _core_node_inventory_path(report_path)
+    inventory = _load_core_node_inventory(root, inventory_path, node_inventory_digest)
     selected = _core_node_shards(inventory)[shard_index]
     if node_inventory_digest != sha256_identity(
         list(inventory)
@@ -2218,8 +2280,13 @@ def core_shard_tests(
         basetemp=basetemp_path,
         test_files=selected,
     )
+    environment = {
+        **os.environ,
+        _CORE_NODE_INVENTORY_PATH_ENV: os.fspath(inventory_path),
+        _CORE_NODE_INVENTORY_DIGEST_ENV: node_inventory_digest,
+    }
     try:
-        completed = subprocess.run(command, cwd=root, check=False)
+        completed = subprocess.run(command, cwd=root, check=False, env=environment)
     except OSError as exc:
         raise WorkflowLaneError("core_worker_process") from exc
     if completed.returncode or not clustering or shard_index != 0:

--- a/scripts/sdlc/workflow_lane.py
+++ b/scripts/sdlc/workflow_lane.py
@@ -39,6 +39,7 @@ from .command_spec import (
 from .contracts import ContractError, SdlcContract, load_contract
 from .emit_evidence import (
     EvidenceError,
+    _validate_junit,
     _validate_route,
     build_gate_evidence,
     canonical_json_bytes,
@@ -115,8 +116,8 @@ _SERVICE_CONFIGURATION = {
     "NEWSROOM_NEO4J_URI": "bolt://localhost:7687",
 }
 _CORE_TESTS = ("newsroom/tests",)
-_CORE_WORKER_COUNT = 4
-_CORE_SHARD_COUNT = 4
+_CORE_WORKER_COUNT = 2
+_CORE_SHARD_COUNT = 10
 _CORE_DISTRIBUTION = "worksteal"
 _CORE_FRAGMENT_SCHEMA = "newsroom.sdlc.core-shard-fragment.v1"
 _CORE_SHARD_LIFECYCLE_SCHEMA = "newsroom.sdlc.core-shard-lifecycle.v1"
@@ -1270,6 +1271,18 @@ def _producer_exit_status(
         error="producer_fragment_lifecycle",
     )
     result = str(validated["result"])
+    if fragment_schema == _CORE_FRAGMENT_SCHEMA:
+        try:
+            junit = _validate_junit(fragment.get("junit_summary"))
+        except EvidenceError as exc:
+            raise WorkflowLaneError("producer_fragment_junit") from exc
+        if result in {"PASS", "FAIL"}:
+            if junit is None:
+                raise WorkflowLaneError("producer_fragment_junit_required")
+        elif junit is not None:
+            raise WorkflowLaneError("producer_fragment_junit_unexpected")
+        if result == "PASS" and junit is not None and junit["outcome"] == "FAIL":
+            return 1
     if result == "PASS":
         return 0
     if result == "BUDGET_EXCEEDED":


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: sdlc-v2-6-capacity-successor
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

Closes #415
Closes #417
Refs #383
Refs #411
Refs #412
Refs #413
Refs #416

## Scope

Carries the frozen functional candidate from PR #416 onto accepted `main@b32a96523406f2d15c240617c2c675490cceecd3`, then applies one bounded changed-head correction for the classified shard-0 capacity failures.

- exact head: `f1fc518a6cda1dcd490f7aa46bead871bd4ac273`
- exact tree: `79ebd559c1815eb676558e4030a754984a26b8f5`
- frozen predecessor: `f98e61f9465dd3783151e4b8a61c26d165d57edf`
- correction delta: 5 files, 379 insertions, 120 deletions, 499 changed lines
- production delta is limited to `scripts/sdlc/workflow_lane.py`
- no product, authority, migration, schema, topology, worker, scheduler, timeout, budget, cache-layer, D3 probe or test-selection change

PR #416 remains the unchanged frozen failed DRAFT checkpoint. PR #412 remains untouched at `21ea675ab6295340699dc9992489bb8d66e69814`.

## Exact failures and diagnosis

The frozen run [31534224072](https://github.com/fol2/newsroom/actions/runs/31534224072) retained a canonical shard-0 `BUDGET_EXCEEDED` fragment after 336/337 terminal progress symbols. The exact failed-progress node was the D3 meta-test that pinned obsolete literal shard groups after the test inventory changed. The historical artifact contained no JUnit or node-start ledger, so its unfinished node is not fabricated from incomplete evidence.

The first successor run [31540737971](https://github.com/fol2/newsroom/actions/runs/31540737971) completed all 337 shard-0 JUnit cases but correctly rejected the fragment because `test_real_store_passes_all_required_conformance_cases` took `130.021s`, above the unchanged `90s` hard limit. The second changed-head run [31543613413](https://github.com/fol2/newsroom/actions/runs/31543613413) again completed exact 337-case JUnit with zero failures/errors and four optional skips, but the same D2 node remained `96.096s`. Each exact failure was classified once; neither head was rerun unchanged.

The D2 fixture was repeating v21-to-current migration for every conformance location. The changed head removes only that fixture rework: one adapter-local current-v23 capacity-1 snapshot supplies two exact reciprocal subject/comparator Versions, and each case still receives a fresh database.

## Correction

### Exact inventory handoff

- the outer core-shard producer remains the sole collector;
- it writes one run-scoped, canonical, owner-bound `0600` inventory beside the transient report;
- the child reloads and revalidates exact inventory and selected-node digests instead of collecting again;
- missing, partial, stale, noncanonical, duplicate, unsorted, wrong-mode, symlinked or out-of-topology inventory fails closed;
- the inventory is deleted in `finally` before fragment publication on every exit path;
- the D3 meta-test consumes the bound inventory in canonical execution and retains standalone fallback only when both binding variables are absent;
- probe coverage is proved exact-once against an independent case-to-template invariant, without literal shard assignments.

### D2 hard-cap correction

- the adapter owns one immutable current-v23 capacity-1 snapshot and clones a fresh `0600` database per location;
- the configured subject and existing comparator form two distinct exact Versions;
- independent literal oracles pin subject mapping `(0,1,0,0,0,1)` and reciprocal comparator mapping `(1,0,1,1,1,0)`;
- record-1/record-2 and rollback subjects remain distinct; record-a/record-b retain same-subject competition;
- snapshot construction verifies exact migration history, schema fingerprint, FK integrity, zero relationship rows, and checkpoints WAL before reading bytes;
- the D3 capacity-6 global cache is restored by exact object identity and shape on success and exception;
- the D2 fixture retains a slim typed COMPLETE receipt through its own public immutable `RetrievalContextJournal`, then exact-replays the retained bytes before all Work Item bindings; only optional projection evidence is empty, while the hydrated item, authority evidence and exact content identities remain;
- the existing migration node explicitly downgrades an empty current clone to v21, then proves the real v21-through-v22-to-current path;
- all 11 required `CASE_INVENTORY` cases, ordering, assertions and the existing test node remain unchanged.

### Request-binding conformance

The generic request-binding case now submits its baseline once to one retained location. Each actor/request/idempotency/CAS mutation uses a fresh handle, proves exact `BindingConflict`, unchanged durable state/history, and exact replay; a final reopen proves no hidden poison. The four granular D3 probes and their IDs remain unchanged.

No timeout, JUnit rule or semantic assertion was relaxed.

## TDD and focused evidence

- RED inventory/mapping correction: 4 focused failures before implementation
- RED D2 adapter: `1 failed in 3.02s`, proving the old adapter used the full seed
- canonical Linux first-successor RED: D2 `130.021s`, fragment rejected as `invalid_test_duration`
- changed-head D2 all-11: `1 passed`, maximum local call `28.81s`
- complete D2 store file: `24 passed`; all-11 call `27.44s`
- generic authority conformance harness: `51 passed`
- dedicated real migration node: `1 passed`, call `1.23s`
- four request-binding mutation sensitivities: `4 passed / 35 deselected`
- workflow/capacity/contract/shadow/Fast-CI focused lane at the inventory-handoff checkpoint: `232 passed`
- inventory: `3365`, digest `sha256:c1985af76fe339e99dae649de2b73bd1d5f39b04f59d80544a185fadda2f0d6b`
- shard 0: `337`, digest `sha256:9476e84bb9b03e3b5a45de87e04c9672bb6edb2f34b2f5a713524df13bab0ef7`
- `uv lock --check`, Ruff, py_compile and `git diff --check`: PASS
- final independent substantive delta review at exact working tree: **0 P1 / 0 material P2**
- unresolved review threads at publication: 0

## Source integrity

- `scripts/sdlc/workflow_lane.py`: `sha256:32407e330aebc2cf0cc1e302dc1032f584cf10a149259215dec77b85ff0a65e3`
- `newsroom/tests/test_sdlc_core_worker_capacity.py`: `sha256:5e46cdd6c47a9246d128d1fa18bbf22fe4fcde1c7f2915ce847839643fab5a64`
- `newsroom/tests/test_increment6d3_lineage_store.py`: `sha256:97ac2ba1245db85353a55540a7aa9870a89b665ccc46942c583e2bae4d0cf06a`
- `newsroom/tests/test_increment6d2_relationship_store.py`: `sha256:b3bb99894a7c494b4d82cc1d4eca4808b6ea25be522c7e939139582c9c61bae2`
- `newsroom/tests/authority_store_conformance.py`: `sha256:2eb2d8495d381c0a3372a9e75340cda984bb2472f9f51ff4f0d7552a40f36478`

## Admission

The changed head is the bounded correction to the classified first-successor failure. Push-triggered permanent workflows were the sole new canonical admission; no complete manual SDLC run was triggered and no head was rerun unchanged.

Automatic run [31546107301](https://github.com/fol2/newsroom/actions/runs/31546107301) passed at exact head/tree:

- route, source, service, all ten core shards, reducer and decision: **PASS**;
- exact JUnit union: `3365` tests, `0` failures, `0` errors, `41` optional skips, `0` required skips;
- slowest testcase: D2 all-11 `76.297s`, below the unchanged `90s` hard cap;
- critical path: `229948ms`, below `330000ms`; reducer lifecycle `7366ms`;
- shard lifecycles: `222582,132573,153580,188316,91546,202069,173195,154874,195057,196433ms`;
- core evidence identity: `sha256:80ea20a2c9ff388ecf118cab9003c626e8ebcab8c1b65f5339505e52f684d3d5`;
- final decision identity: `sha256:d186804683f1ddb75a6fbc043f97f2a2f098cfc2f32e341266d0a2ea3e1213f1`.

The exact-head canonical admission and final bounded review are green; merge may proceed only after a final live zero-thread/check/state guard.


