### PR TITLE
Retain SDLC v2.6 performance warnings (#415)

### DIFF
--- a/newsroom/tests/test_sdlc_core_worker_capacity.py
+++ b/newsroom/tests/test_sdlc_core_worker_capacity.py
@@ -26,8 +26,11 @@ def _contract_data() -> dict[str, object]:
             "core": {
                 "hard_timeout_seconds": 330,
                 "per_shard_hard_timeout_seconds": 330,
+                "per_shard_warning_seconds": 300,
+                "critical_path_warning_seconds": 300,
             }
         },
+        "test_strategy": {"individual_testcase_warning_seconds": 75},
     }
 
 
@@ -177,6 +180,7 @@ def _patch_core_shard_execution(
     *,
     result: str,
     report_payload: str | None,
+    execution_ms: int = 329_950,
 ) -> None:
     contract = SimpleNamespace(
         repo_root=tmp_path,
@@ -217,7 +221,7 @@ def _patch_core_shard_execution(
             result,
             reason,
             returncode,
-            329_950,
+            execution_ms,
             "",
             "",
             False,
@@ -483,7 +487,7 @@ def _run_reducer_fixture(
     shard_elapsed_ms: tuple[int, int, int, int, int, int],
     reducer_elapsed_ms: int,
     load_elapsed_ms: int | None = None,
-    output_elapsed_ms: int | None = None,
+    output_elapsed_ms: int | tuple[int, ...] | None = None,
 ) -> tuple[dict[str, object], list[str]]:
     fragments_root = tmp_path / "fragments"
     source_root = tmp_path / "source"
@@ -594,11 +598,16 @@ def _run_reducer_fixture(
     monkeypatch.setattr(lane_module, "verify_tracked_checkout", lambda *_args: None)
     if output_elapsed_ms is not None:
         private_write = lane_module._private_write
+        output_times = iter(
+            output_elapsed_ms
+            if isinstance(output_elapsed_ms, tuple)
+            else (output_elapsed_ms,)
+        )
 
         def delayed_output(path: Path, value: object) -> None:
             private_write(path, value)
             if "core-deterministic" in path.parts and path.name == "command-run.json":
-                elapsed["value"] = output_elapsed_ms
+                elapsed["value"] = next(output_times, elapsed["value"])
 
         monkeypatch.setattr(lane_module, "_private_write", delayed_output)
 
@@ -1094,6 +1103,135 @@ def test_reducer_output_time_is_bound_and_cannot_publish_pass(
     assert persisted["gate_run"]["result"] == "BUDGET_EXCEEDED"
 
 
+def test_core_warning_debt_is_retained_without_changing_canonical_pass(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    aggregate, _order = _run_reducer_fixture(
+        tmp_path,
+        monkeypatch,
+        source_elapsed_ms=1,
+        shard_elapsed_ms=(300_001,) + (1,) * (EXPECTED_CORE_SHARD_COUNT - 1),
+        reducer_elapsed_ms=1,
+    )
+
+    assert aggregate["gate_run"]["result"] == "PASS"
+    assert aggregate["gate_run"]["returncode"] == 0
+    warnings = json.loads(aggregate["gate_run"]["stdout"])["warnings"]
+    assert warnings["warning_count"] == 2
+    assert warnings["testcase"]["count"] == 0
+    assert warnings["shard_lifecycle"]["max_subject"] == "core-shard-00"
+    assert warnings["critical_path"]["max_duration_ms"] == 300_002
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err.splitlines() == [
+        "::warning title=SDLC core shard lifecycle warning::1 shard exceeded 300s; max core-shard-00=300001ms",
+        "::warning title=SDLC core critical path warning::critical path exceeded 300s; observed 300002ms",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("source_ms", "reducer_ms", "output_times", "expected"),
+    [
+        (1, 299_999, 300_000, ("PASS", 0, 300_001)),
+        (1, 299_999, (300_000, 330_001), ("BUDGET_EXCEEDED", 124, 330_002)),
+        (100_000, 199_999, (200_001, 250_001), ("BUDGET_EXCEEDED", 124, 350_001)),
+    ],
+)
+def test_core_publication_rebinds_warning_and_subsequent_hard_crossing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    source_ms: int,
+    reducer_ms: int,
+    output_times: int | tuple[int, ...],
+    expected: tuple[str, int, int],
+) -> None:
+    aggregate, _order = _run_reducer_fixture(
+        tmp_path,
+        monkeypatch,
+        source_elapsed_ms=source_ms,
+        shard_elapsed_ms=(1,) * EXPECTED_CORE_SHARD_COUNT,
+        reducer_elapsed_ms=reducer_ms,
+        output_elapsed_ms=output_times,
+    )
+
+    gate_run = aggregate["gate_run"]
+    assert (
+        gate_run["result"],
+        gate_run["returncode"],
+        gate_run["execution_ms"],
+    ) == expected
+    assert json.loads(gate_run["stdout"])["warnings"]["critical_path"]["count"] == (1)
+
+
+def test_core_warning_thresholds_are_strict_and_consumed_from_contract(
+    tmp_path: Path,
+) -> None:
+    report = tmp_path / "reports/pytest.xml"
+    report.parent.mkdir()
+    long_id = "x" * 200_000
+    long_decimal = "75." + ("0" * 50_000) + "1"
+    payload = (
+        '<testsuite><testcase classname="suite" name="at" time="75" />'
+        f'<testcase classname="{long_id}" name="over" time="{long_decimal}" /></testsuite>'
+    )
+    original = tmp_path / "shard.xml"
+    original.write_text(payload, encoding="utf-8")
+    report.write_text(payload, encoding="utf-8")
+    debt = lane_module._core_testcase_warning_debt(report, 75)
+    original.write_text('<testcase time="90.001" />', encoding="utf-8")
+
+    warnings = lane_module._core_warning_summary(
+        contract=SimpleNamespace(data=_contract_data()),
+        lifecycles=[{"elapsed_ms": 300_000}] * EXPECTED_CORE_SHARD_COUNT,
+        testcase_debt=debt,
+        critical_path_ms=300_000,
+    )
+
+    assert warnings["warning_count"] == warnings["testcase"]["count"] == 1
+    expected_subject = (
+        "sha256:" + lane_module.hashlib.sha256(f"{long_id}::over".encode()).hexdigest()
+    )
+    assert warnings["testcase"]["max_subject"] == expected_subject
+    assert warnings["testcase"]["max_duration_ms"] == 75_001
+    assert len(lane_module.canonical_json_bytes(warnings)) < 1024 * 1024
+
+
+@pytest.mark.parametrize("fault", ["missing_threshold", "malformed_junit", "hard_cap"])
+def test_core_warning_evidence_fails_closed(tmp_path: Path, fault: str) -> None:
+    data = _contract_data()
+    report = tmp_path / "pytest.xml"
+    report.write_text("<testsuite>", encoding="utf-8")
+    if fault == "missing_threshold":
+        del data["test_strategy"]
+        report.write_text(
+            '<testsuite><testcase classname="suite" name="test" /></testsuite>',
+            encoding="utf-8",
+        )
+    elif fault == "hard_cap":
+        report.write_text(
+            '<testsuite><testcase classname="suite" name="test" time="90.001" /></testsuite>',
+            encoding="utf-8",
+        )
+
+    with pytest.raises(WorkflowLaneError, match="core_warning_evidence"):
+        if fault == "missing_threshold":
+            lane_module._core_warning_summary(
+                contract=SimpleNamespace(data=data),
+                lifecycles=[{"elapsed_ms": 1}] * EXPECTED_CORE_SHARD_COUNT,
+                testcase_debt=(0, None, None),
+                critical_path_ms=1,
+            )
+        else:
+            lane_module._core_testcase_warning_debt(report, 75)
+
+
+def test_github_warning_output_is_deterministic_and_escaped() -> None:
+    warning = lane_module._github_warning(
+        title="title%,:\n", message="message%\r\nnext"
+    )
+    assert warning == "::warning title=title%25%2C%3A%0A::message%25%0D%0Anext"
+
+
 def test_core_fragment_identity_is_canonical_and_tamper_evident() -> None:
     body = {
         "schema_version": lane_module._CORE_FRAGMENT_SCHEMA,
@@ -1499,6 +1637,64 @@ def test_fragment_finalisation_timeout_overrides_a_product_pass(
     }
     assert fragment["junit_summary"] is None
     assert fragment["report_digest"] is None
+
+
+@pytest.mark.parametrize(
+    ("command_result", "rebind_ms", "expected"),
+    [
+        ("PASS", 300_001, ("PASS", 0, True)),
+        ("PASS", 330_001, ("BUDGET_EXCEEDED", 124, False)),
+        ("ENVIRONMENT_ERROR", 300_001, ("ENVIRONMENT_ERROR", 1, False)),
+    ],
+)
+def test_core_fragment_rebinds_warning_crossed_during_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    command_result: str,
+    rebind_ms: int,
+    expected: tuple[str, int, bool],
+) -> None:
+    _patch_core_shard_execution(
+        tmp_path,
+        monkeypatch,
+        result=command_result,
+        report_payload=_passing_report(),
+        execution_ms=299_000,
+    )
+    checked_write = lane_module._checked_fragment_write
+    published = iter((300_001, rebind_ms))
+
+    def crossing_write(*args: object) -> int:
+        checked_write(*args)  # type: ignore[arg-type]
+        return 300_000 if args[-1] else next(published, rebind_ms)
+
+    monkeypatch.setattr(lane_module, "_checked_fragment_write", crossing_write)
+    fragment = lane_module.execute_core_shard(
+        repo_root=tmp_path,
+        route_path="route.json",
+        shard_index=0,
+        artifact_root="artifacts/core-fragment",
+    )
+
+    result, returncode, report_retained = expected
+    assert fragment["shard_lifecycle"]["elapsed_ms"] == rebind_ms
+    assert fragment["shard_lifecycle"]["result"] == result
+    assert (
+        lane_module._producer_exit_status(
+            fragment,
+            fragment_schema=lane_module._CORE_FRAGMENT_SCHEMA,
+            lifecycle_field="shard_lifecycle",
+            lifecycle_schema=lane_module._CORE_SHARD_LIFECYCLE_SCHEMA,
+            gate_id="core-deterministic",
+            phase="tests",
+            fragment_keys=lane_module._CORE_FRAGMENT_KEYS,
+            expected_timeout_ms=330_000,
+        )
+        == returncode
+    )
+    assert (fragment["junit_summary"] is not None) is report_retained
+    assert (fragment["report_digest"] is not None) is report_retained
+    assert (tmp_path / "artifacts/core-fragment/pytest.xml").exists() is report_retained
 
 
 def test_fragment_durable_write_time_cannot_publish_a_pass(

--- a/scripts/sdlc/workflow_lane.py
+++ b/scripts/sdlc/workflow_lane.py
@@ -15,6 +15,7 @@ import xml.etree.ElementTree as ET
 from collections.abc import Callable, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
+from decimal import ROUND_CEILING, localcontext
 from pathlib import Path
 
 from .artifact_envelope import (
@@ -49,7 +50,17 @@ from .emit_evidence import (
     sha256_identity,
     verify_tracked_checkout,
 )
-from .junit_evidence import JUnitEvidenceError, JUnitSummary, summarize_junit
+from .junit_evidence import (
+    JUnitEvidenceError,
+    JUnitSummary,
+    summarize_junit,
+)
+from .junit_evidence import (
+    _case_id as _junit_case_id,
+)
+from .junit_evidence import (
+    _duration_seconds as _junit_duration_seconds,
+)
 from .run_gate import (
     GateRunError,
     GateRunResult,
@@ -1376,7 +1387,13 @@ def _publish_lifecycle_fragment(
     deadline: LaneDeadline,
     head_sha: str,
     on_budget: Callable[[], None] | None = None,
+    warning_ms: int | None = None,
 ) -> dict[str, object]:
+    if warning_ms is not None and (
+        not _valid_elapsed_ms(warning_ms) or warning_ms >= deadline.timeout_ms
+    ):
+        raise WorkflowLaneError("core_lifecycle_warning")
+
     def bind(elapsed_ms: int) -> dict[str, object]:
         body[field] = _shard_lifecycle(
             command_result=command_result,
@@ -1402,6 +1419,16 @@ def _publish_lifecycle_fragment(
             on_budget()
         fragment = bind(published_ms)
         write(fragment)
+    elif warning_ms is not None and elapsed_ms <= warning_ms < published_ms:
+        path.unlink()
+        fragment = bind(published_ms)
+        rebound_ms = write(fragment)
+        if rebound_ms > deadline.timeout_ms:
+            path.unlink()
+            if on_budget is not None:
+                on_budget()
+            fragment = bind(rebound_ms)
+            write(fragment)
     return fragment
 
 
@@ -1563,6 +1590,9 @@ def execute_core_shard(
         deadline=deadline,
         head_sha=str(route["head_sha"]),
         on_budget=discard_report,
+        warning_ms=int(
+            contract.data["lanes"]["core"]["per_shard_warning_seconds"] * 1000
+        ),
     )
 
 
@@ -1863,6 +1893,148 @@ def _junit_case_ids(report: Path) -> frozenset[str]:
     return frozenset(values)
 
 
+def _github_warning(*, title: str, message: str) -> str:
+    def escape(value: str, *, property_value: bool = False) -> str:
+        escaped = value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+        if property_value:
+            escaped = escaped.replace(":", "%3A").replace(",", "%2C")
+        return escaped
+
+    return f"::warning title={escape(title, property_value=True)}::{escape(message)}"
+
+
+def _core_warning_thresholds(contract: SdlcContract) -> tuple[int, int, int]:
+    try:
+        core = contract.data["lanes"]["core"]
+        thresholds = (
+            contract.data["test_strategy"]["individual_testcase_warning_seconds"],
+            core["per_shard_warning_seconds"],
+            core["critical_path_warning_seconds"],
+        )
+        if any(type(item) is not int or item <= 0 for item in thresholds):
+            raise ValueError
+        return thresholds
+    except (KeyError, TypeError, ValueError) as exc:
+        raise WorkflowLaneError("core_warning_evidence") from exc
+
+
+def _core_testcase_warning_debt(
+    report: Path | None, threshold: int
+) -> tuple[int, str | None, int | None]:
+    if report is None:
+        return 0, None, None
+    try:
+        document = ET.parse(report).getroot()
+        cases: dict[str, object] = {}
+        for case in document.iter():
+            if _xml_local_name(case.tag) != "testcase":
+                continue
+            subject = _junit_case_id(case)
+            if subject in cases:
+                raise JUnitEvidenceError("duplicate_testcase")
+            cases[subject] = _junit_duration_seconds(case)
+        slow = [
+            (subject, duration)
+            for subject, duration in cases.items()
+            if duration > threshold
+        ]
+    except (JUnitEvidenceError, OSError, ET.ParseError) as exc:
+        raise WorkflowLaneError("core_warning_evidence") from exc
+    maximum = min(slow, key=lambda item: (-item[1], item[0])) if slow else None
+    if maximum is None:
+        return 0, None, None
+    subject, duration = maximum
+    if len(subject) > 256:
+        subject = "sha256:" + hashlib.sha256(subject.encode("utf-8")).hexdigest()
+    with localcontext() as context:
+        context.prec = max(28, len(duration.as_tuple().digits) + 3)
+        milliseconds = int((duration * 1000).to_integral_value(rounding=ROUND_CEILING))
+    return len(slow), subject, milliseconds
+
+
+def _core_warning_summary(
+    *,
+    contract: SdlcContract,
+    lifecycles: Sequence[Mapping[str, object]],
+    testcase_debt: tuple[int, str | None, int | None],
+    critical_path_ms: int,
+) -> dict[str, object]:
+    try:
+        testcase_threshold, shard_threshold, critical_threshold = (
+            _core_warning_thresholds(contract)
+        )
+        if len(lifecycles) != _CORE_SHARD_COUNT or not _valid_elapsed_ms(
+            critical_path_ms
+        ):
+            raise ValueError
+        shard_values = tuple(item["elapsed_ms"] for item in lifecycles)
+        if not all(_valid_elapsed_ms(item) for item in shard_values):
+            raise ValueError
+        testcase_count, max_testcase, max_testcase_ms = testcase_debt
+        if testcase_count < 0 or (testcase_count == 0) != (max_testcase is None):
+            raise ValueError
+    except (TypeError, ValueError) as exc:
+        raise WorkflowLaneError("core_warning_evidence") from exc
+
+    slow_shards = [
+        (f"core-shard-{index:02d}", elapsed)
+        for index, elapsed in enumerate(shard_values)
+        if elapsed > shard_threshold * 1000
+    ]
+    max_shard = (
+        min(slow_shards, key=lambda item: (-item[1], item[0])) if slow_shards else None
+    )
+    critical_count = int(critical_path_ms > critical_threshold * 1000)
+    return {
+        "schema_version": "newsroom.sdlc.core-warning-summary.v1",
+        "warning_count": testcase_count + len(slow_shards) + critical_count,
+        "testcase": {
+            "count": testcase_count,
+            "threshold_seconds": testcase_threshold,
+            "max_subject": max_testcase,
+            "max_duration_ms": max_testcase_ms,
+        },
+        "shard_lifecycle": {
+            "count": len(slow_shards),
+            "threshold_seconds": shard_threshold,
+            "max_subject": None if max_shard is None else max_shard[0],
+            "max_duration_ms": None if max_shard is None else max_shard[1],
+        },
+        "critical_path": {
+            "count": critical_count,
+            "threshold_seconds": critical_threshold,
+            "max_subject": "core-deterministic" if critical_count else None,
+            "max_duration_ms": critical_path_ms if critical_count else None,
+        },
+    }
+
+
+def _emit_core_warnings(summary: Mapping[str, object]) -> None:
+    testcase = summary["testcase"]
+    shard = summary["shard_lifecycle"]
+    critical = summary["critical_path"]
+    annotations = (
+        (
+            testcase,
+            "SDLC core testcase warning",
+            f"{testcase['count']} testcase(s) exceeded {testcase['threshold_seconds']}s; max {testcase['max_subject']}={testcase['max_duration_ms']}ms",
+        ),
+        (
+            shard,
+            "SDLC core shard lifecycle warning",
+            f"{shard['count']} shard exceeded {shard['threshold_seconds']}s; max {shard['max_subject']}={shard['max_duration_ms']}ms",
+        ),
+        (
+            critical,
+            "SDLC core critical path warning",
+            f"critical path exceeded {critical['threshold_seconds']}s; observed {critical['max_duration_ms']}ms",
+        ),
+    )
+    for details, title, message in annotations:
+        if details["count"]:
+            print(_github_warning(title=title, message=message), file=sys.stderr)
+
+
 def _junit_id_for_node(node_id: str) -> str:
     unparameterised, bracket, parameters = node_id.partition("[")
     parts = unparameterised.split("::")
@@ -1973,6 +2145,7 @@ def reduce_core_lane(
         reports_available = all(
             value["junit_summary"] is not None for value, _ in fragments
         )
+        merged_report: Path | None = None
         for value, report in fragments:
             if value["junit_summary"] is None:
                 continue
@@ -1983,10 +2156,10 @@ def reduce_core_lane(
                 raise WorkflowLaneError("core_fragment_report_inventory")
             _require_deadline(reducer_deadline, "reducer")
         if reports_available:
-            report = reports / "pytest.xml"
+            merged_report = reports / "pytest.xml"
             _merge_junit_reports(
                 root=root,
-                report=report,
+                report=merged_report,
                 shard_reports=[item[1] for item in fragments],
                 expected_count=_CORE_SHARD_COUNT,
                 identity="core",
@@ -1997,8 +2170,12 @@ def reduce_core_lane(
                 for item in _collect_core_node_ids(root, deadline=reducer_deadline)
             )
             _require_deadline(reducer_deadline, "reducer")
-            if _junit_case_ids(report) != expected_all:
+            if _junit_case_ids(merged_report) != expected_all:
                 raise WorkflowLaneError("core_reduced_report_inventory")
+        testcase_threshold, _shard_threshold, _critical_threshold = (
+            _core_warning_thresholds(contract)
+        )
+        testcase_debt = _core_testcase_warning_debt(merged_report, testcase_threshold)
         reduced_outcome = _reduced_core_outcome(
             results,
             summaries=[value["junit_summary"] for value, _report in fragments],
@@ -2037,6 +2214,12 @@ def reduce_core_lane(
                 "shard_lifecycle_ms": shard_ms,
                 "reducer_lifecycle_ms": elapsed_ms,
                 "critical_path_ms": critical_path_ms,
+                "warnings": _core_warning_summary(
+                    contract=contract,
+                    lifecycles=lifecycles,
+                    testcase_debt=testcase_debt,
+                    critical_path_ms=critical_path_ms,
+                ),
             }
             return CommandRun(
                 expected_digest,
@@ -2066,10 +2249,23 @@ def reduce_core_lane(
         staged_ms = publish(aggregate, True)
         aggregate = build(staged_ms, reduced_outcome)
         published_ms = publish(aggregate)
-        if aggregate.gate_run.result in {"PASS", "FAIL"} and published_ms > timeout_ms:
+        for _transition in range(2):
+            rebound = build(published_ms, reduced_outcome)
+            current_warning = json.loads(aggregate.gate_run.stdout)["warnings"][
+                "critical_path"
+            ]["count"]
+            rebound_warning = json.loads(rebound.gate_run.stdout)["warnings"][
+                "critical_path"
+            ]["count"]
+            if (aggregate.gate_run.result, current_warning) == (
+                rebound.gate_run.result,
+                rebound_warning,
+            ):
+                break
             command_path.unlink()
-            aggregate = build(published_ms, reduced_outcome)
-            publish(aggregate)
+            aggregate = rebound
+            published_ms = publish(aggregate)
+        _emit_core_warnings(json.loads(aggregate.gate_run.stdout)["warnings"])
         complete = True
         return LaneExecutionOutput(
             "core",


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: sdlc-v2-6-warning-observability
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

Closes #415
Refs #383
Refs #418

## Scope

Closes the one valid late post-merge review finding on PR #418 without changing the admitted v2.6 topology, budgets, typed outcomes, product tests, product code, migrations or authority surfaces.

- base: `906ba8c1a2c13dcd2914982590ee4ec7d16f09a9`
- exact head: `b5ea495bda7e45d3c8e2611be3c4e7d5bc7e8c57`
- exact tree: `48439ce70b7f36be6d535920e4455cd007d533ff`
- delta: 2 files, 402 insertions, 10 deletions
- review finding: https://github.com/fol2/newsroom/pull/418#discussion_r3762477448

## Correction

The validated v2.6 warning thresholds are now consumed by the canonical core reducer:

- testcase duration strictly above 75 seconds;
- complete core shard lifecycle strictly above 300 seconds;
- complete core critical path strictly above 300 seconds.

Warnings remain non-blocking below the unchanged hard 90/330-second boundaries. Canonical PASS remains PASS with return code 0. Warning debt is retained as bounded canonical data inside the existing core `command-run.json` accounting stdout and emitted as escaped GitHub warning annotations on stderr.

The reducer derives testcase debt exactly once from the final merged JUnit using the existing canonical testcase identity and hard-duration parser. Long Decimal spellings become fixed ceil-millisecond values; long subjects become deterministic SHA-256 identities. Original shard reports are not reopened during publication rebinds.

Shard and reducer publication use bounded monotonic rebinds so durable output crossing 300 seconds gains a warning and a later crossing of the full 330-second critical path becomes canonical `BUDGET_EXCEEDED`/124. Typed exceptional outcomes retain precedence while still recording warning-level elapsed time.

No fragment, JUnit, decision or evidence schema changes. Historical command-run stdout remains valid because the accounting payload is an opaque canonical field to existing validators.

## TDD and evidence

- RED warning selection: 4 failures before implementation
- focused warning selection after all review deltas: 12 passed
- complete core capacity + JUnit evidence: 109 passed
- workflow/capacity/JUnit/contract/lane/decision focused closure: 213 passed
- Fast-CI compatibility smoke: 115 passed
- `uv lock --check`: PASS
- changed-file Ruff check/format: PASS
- `py_compile`: PASS
- `git diff --check`: PASS
- exact committed-head source-integrity check from base: PASS
- independent substantive final review: **0 P1 / 0 material P2**

Review corrections included:

- final merged JUnit provenance and hard-90 reuse;
- fixed-size warning payloads;
- producer exceptional warning rebound;
- full critical-path rather than reducer-only hard crossing;
- warning-rebind publication subsequently crossing the hard boundary;
- canonical JSON stdout kept clean while annotations use stderr.

## Source integrity

- `scripts/sdlc/workflow_lane.py`: `sha256:fa6fdc0bbfb76df0a30a7ffefc333bcc8aa3a3ce3a94dd287762cc353866f460`
- `newsroom/tests/test_sdlc_core_worker_capacity.py`: `sha256:9750c109633f68c338be2902a93273e9651a449b9df084a5676a33d89cb722a7`

## Admission

No complete manual SDLC admission is triggered by this PR. Permanent pull-request workflows are the sole changed-head admission. Merge remains guarded on:

- exact head/tree;
- all required checks complete and green;
- canonical warning accounting present in exact artifacts;
- zero unresolved review threads;
- final live state guard.

After guarded merge, #383 must refresh its exact-main wave closeout once on the new tree before #400 can activate.
