### PR TITLE
Add Candidate identity and admission contracts (#400)

### DIFF
--- a/newsroom/increment6/candidates.py
+++ b/newsroom/increment6/candidates.py
@@ -12,6 +12,7 @@ from newsroom.authority.canonical import (
     digest_bytes,
 )
 from newsroom.discovery.record_models import DiscoverySignal, GateDecision, NewsLead
+from newsroom.discovery.types import GateOutcome
 from newsroom.increment6.collision import (
     CandidateUseOperation,
     CollisionEligibilityOutcome,
@@ -128,7 +129,10 @@ class _CanonicalFields:
 
     @classmethod
     def from_value(cls, value: object) -> Self:
-        return cls(**_exact(value, set(cls.__dataclass_fields__), cls.__name__))  # type: ignore[arg-type]
+        return _normalise(
+            lambda: cls(**_exact(value, set(cls.__dataclass_fields__), cls.__name__)),  # type: ignore[arg-type]
+            f"{cls.__name__} replay failed",
+        )
 
 
 def _normalise[T](operation: object, message: str) -> T:
@@ -317,6 +321,7 @@ class CandidateLeadSignalBinding(_NoEffect, _CanonicalFields):
     coverage_basis: str
     incomplete: bool
 
+    @_total("invalid Lead/Signal binding")
     def __post_init__(self) -> None:
         _valid(type(self) is CandidateLeadSignalBinding)
         for name in ("lead_id", "signal_id", "lead_event_id", "signal_event_id"):
@@ -351,6 +356,7 @@ class CandidateGoverningStateBinding(_NoEffect, _CanonicalFields):
     admission_ruleset: str
     declared_versions: str
 
+    @_total("invalid governing-state binding")
     def __post_init__(self) -> None:
         if type(self) is not CandidateGoverningStateBinding:
             raise _Error("governing-state binding must be exact")
@@ -363,6 +369,7 @@ class CandidateGoverningState(_NoEffect):
     status: CandidateGoverningStateStatus
     binding: CandidateGoverningStateBinding | None
 
+    @_total("invalid governing state")
     def __post_init__(self) -> None:
         if type(self.status) is not CandidateGoverningStateStatus or (
             self.status is CandidateGoverningStateStatus.COMPLETE
@@ -409,6 +416,7 @@ class CandidateGoverningManifest(_NoEffect):
     governing_state_binding: CandidateGoverningStateBinding
     incomplete: bool
 
+    @_total("invalid governing manifest")
     def __post_init__(self) -> None:
         _valid(type(self) is CandidateGoverningManifest)
         digests = _MANIFEST_DIGESTS.split()
@@ -448,6 +456,13 @@ class CandidateGoverningManifest(_NoEffect):
             _uuid(comparator[0], "relationship_comparator_hypothesis_id")
             _uuid(comparator[1], "relationship_comparator_version_id")
             _digest(comparator[2], "relationship_comparator_version_digest")
+        no_comparator = all(item is None for item in comparator)
+        _valid(
+            no_comparator
+            if self.relationship_status is not AssessmentStatus.COMPLETE
+            or self.relationship_outcome is CanonicalOutcome.REL_NO_ADEQUATE_PRIOR_MATCH
+            else not no_comparator
+        )
         _valid(type(self.lineage_generation) is int and self.lineage_generation >= 0)
         _token(self.collision_namespace, "collision_namespace")
         _valid(type(self.governing_state_binding) is CandidateGoverningStateBinding)
@@ -455,16 +470,20 @@ class CandidateGoverningManifest(_NoEffect):
         optional = set(_OPTIONAL_TUPLES.split())
         for name in tuple_fields:
             values = getattr(self, name)
+            exact = type(values) is tuple and all(
+                type(value) is str and value for value in values
+            )
             ordered = (
-                len(set(values)) == len(values)
-                if name == "lineage_history_digests"
-                else values == tuple(sorted(set(values)))
+                (
+                    len(set(values)) == len(values)
+                    if name == "lineage_history_digests"
+                    else values == tuple(sorted(set(values)))
+                )
+                if exact
+                else False
             )
             _require(
-                type(values) is tuple
-                and all(type(value) is str and value for value in values)
-                and (bool(values) or name in optional)
-                and ordered,
+                exact and (bool(values) or name in optional) and ordered,
                 f"invalid {name}",
             )
         for name in digests[1:3] + tuple_fields[:3]:
@@ -601,6 +620,7 @@ class StoryCandidate(_NoEffect, _CanonicalFields):
     authority_event_id: str
     semantic_scope_digest: str
 
+    @_total("invalid Story Candidate")
     def __post_init__(self) -> None:
         _valid(type(self) is StoryCandidate)
         for name in (
@@ -616,6 +636,10 @@ class StoryCandidate(_NoEffect, _CanonicalFields):
         return _document_bytes(
             STORY_CANDIDATE, self.canonical_value(), "Story Candidate"
         )
+
+    @property
+    def canonical_digest(self) -> str:
+        return _hash(self.canonical_bytes)
 
     @classmethod
     def from_canonical_bytes(cls, raw: bytes) -> Self:
@@ -635,6 +659,7 @@ class StoryCandidateVersion(_NoEffect, _CanonicalFields):
     committed_admission_decision_id: str
     governing_manifest: CandidateGoverningManifest
 
+    @_total("invalid Candidate Version")
     def __post_init__(self) -> None:
         _valid(type(self) is StoryCandidateVersion)
         for name in ("candidate_id", "version_id", "committed_admission_decision_id"):
@@ -695,6 +720,7 @@ class CandidateDistinctScopeProof(_NoEffect, _CanonicalFields):
     comparator_semantic_scope_digest: str
     context_digest: str
 
+    @_total("invalid distinct-scope proof")
     def __post_init__(self) -> None:
         if type(self) is not CandidateDistinctScopeProof:
             raise _Error("distinct-scope proof must be exact")
@@ -716,6 +742,7 @@ class CandidateAdmissionRequest(_NoEffect, _CanonicalFields):
     expected_governing_state_digest: str
     distinct_scope_proof_digest: str | None
 
+    @_total("invalid Candidate Admission request")
     def __post_init__(self) -> None:
         _valid(type(self) is CandidateAdmissionRequest)
         _uuid(self.request_id, "request_id")
@@ -1051,6 +1078,11 @@ def build_candidate_governing_manifest(
             if (
                 str(gate.request.signal_id) != signal_id
                 or gate.request.coverage != lead.request.coverage
+                or gate.request.outcome is not GateOutcome.PROMOTED_TO_LEAD
+                or gate.request.evaluated_definition_version_id
+                != signal.request.definition_version_id
+                or gate.request.evaluated_definition_version_id
+                != lead.request.definition_version_id
             ):
                 raise _Error("promoting Gate differs from Lead lineage")
             # Shared source lineage is exact only when the Lead retains the Signal's source identities.
@@ -1306,6 +1338,8 @@ def _validate_relationship_route(version, assessment) -> None:
         "D1 relationship",
     )
     if assessment.status is not AssessmentStatus.COMPLETE:
+        if assessment.comparator is not None:
+            raise _Error("invalid Candidate contract")
         return
     if assessment.decision is not expected:
         raise _Error("invalid Candidate contract")
@@ -1323,6 +1357,10 @@ def _validate_relationship_route(version, assessment) -> None:
         version.target_version_id,
         version.target_version_digest,
     )
+    if (expected is CanonicalOutcome.REL_NO_ADEQUATE_PRIOR_MATCH) != (
+        comparator is None
+    ):
+        raise _Error("invalid Candidate contract")
     if comparator != (None if target == (None, None, None) else target):
         raise _Error("invalid Candidate contract")
 
@@ -1343,7 +1381,7 @@ def build_candidate_distinct_scope_proof(
         pb, cb = p.request.binding, c.request.binding
         context = lambda item: _attrs(item, _CONTEXT.split())
 
-        def collision_matches(manifest, decision):
+        def historical_collision_matches(manifest, decision):
             return _attrs(
                 manifest,
                 "collision_request_digest collision_decision_digest collision_namespace collision_key_digest hypothesis_id hypothesis_version_id hypothesis_version_digest",
@@ -1358,8 +1396,11 @@ def build_candidate_distinct_scope_proof(
 
         _valid(
             not (
-                not collision_matches(proposed_manifest, p)
-                or not collision_matches(v.governing_manifest, c)
+                not historical_collision_matches(proposed_manifest, p)
+                or _attrs(
+                    v.governing_manifest, "collision_namespace collision_key_digest"
+                )
+                != _attrs(cb, "collision_namespace collision_key_digest")
                 or proposed_manifest.relationship_outcome
                 is not CanonicalOutcome.REL_NO_ADEQUATE_PRIOR_MATCH
                 or p.outcome is not CollisionEligibilityOutcome.ELIGIBLE
@@ -1385,6 +1426,7 @@ def build_candidate_distinct_scope_proof(
                     == v.governing_manifest.semantic_scope_digest
                 )
                 or (context(pb) != context(cb))
+                or p.trusted_context.context_digest != c.trusted_context.context_digest
             )
         )
         return CandidateDistinctScopeProof(
@@ -1394,7 +1436,7 @@ def build_candidate_distinct_scope_proof(
             v.version_id,
             v.canonical_digest,
             v.governing_manifest.semantic_scope_digest,
-            _project(context(pb)),
+            p.trusted_context.context_digest,
         )
 
     return _normalise(build, "distinct-scope proof failed closed")
@@ -1428,6 +1470,8 @@ def evaluate_candidate_admission(
             or (binding.subject_id != m.hypothesis_id)
             or (binding.subject_version_id != m.hypothesis_version_id)
             or (binding.subject_version_digest != m.hypothesis_version_digest)
+            or (binding.collision_namespace != m.collision_namespace)
+            or (binding.collision_key_digest != m.collision_key_digest)
         )
     )
     current = () if v is None else (v.candidate_id, v.version_id, v.canonical_digest)

--- a/newsroom/increment6/candidates.py
+++ b/newsroom/increment6/candidates.py
@@ -1,0 +1,1500 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Self
+
+from newsroom.authority.canonical import (
+    MAX_SAFE_INTEGER,
+    canonical_json_bytes,
+    digest_bytes,
+)
+from newsroom.discovery.record_models import DiscoverySignal, GateDecision, NewsLead
+from newsroom.increment6.collision import (
+    CandidateUseOperation,
+    CollisionEligibilityOutcome,
+    CollisionState,
+    CurrentCollisionEligibilityDecision,
+)
+from newsroom.increment6.dispositions import ProposalDisposition
+from newsroom.increment6.hypotheses import EventHypothesisVersion
+from newsroom.increment6.lineage import (
+    HypothesisLineageHead,
+    HypothesisLineageReceipt,
+    HypothesisLineageRelationshipProof,
+    replay_hypothesis_lineage,
+)
+from newsroom.increment6.outcomes import CanonicalOutcome
+from newsroom.increment6.proposals import CandidateManifestKind
+from newsroom.increment6.relationships import (
+    AssessmentStatus,
+    RelationshipAssessment,
+    RetainedRelationshipDecisionReceipt,
+)
+
+_json, _hash = canonical_json_bytes, digest_bytes
+
+
+STORY_CANDIDATE = "newsroom.increment6.story-candidate.v1"
+STORY_CANDIDATE_VERSION = "newsroom.increment6.story-candidate-version.v1"
+CANDIDATE_ADMISSION = "newsroom.increment6.candidate-admission.v1"
+CANDIDATE_CURRENT_VERSION = "EXACT_RETAINED_MAX_ORDINAL_HEAD"
+MAX_CANDIDATE_CANONICAL_BYTES = 16_777_216
+_UUID = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z"
+)
+_DIGEST = re.compile(r"sha256:[0-9a-f]{64}\Z")
+_TOKEN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:\-]{0,255}\Z")
+_MANIFEST_DIGESTS = "semantic_scope_digest hypothesis_version_digest relationship_assessment_digest collision_request_digest collision_decision_digest collision_key_digest"
+_MANIFEST_TUPLES = "lineage_history_digests disposition_digests candidate_manifest_digests likely_new_information reader_utility_bases uncertainties evidence_objectives governing_versions missing_context retrieval_incompleteness lead_incompleteness_warnings signal_operational_finding_ids"
+_OPTIONAL_TUPLES = "lineage_history_digests missing_context retrieval_incompleteness lead_incompleteness_warnings signal_operational_finding_ids"
+_DISPOSITION_FIELDS = "proposal_id proposal_content_identity proposal_canonical_digest work_item_id work_item_version_id work_item_version_digest retrieval_context_id retrieval_context_digest"
+_SOURCE_FIELDS = "definition_id definition_version_id item_id revision_id representation_id occurrence_id transition_id"
+_POLICIES = "signal_admission_policy gate_policy duplicate_policy newness_policy time_validity_policy exclusion_policy"
+_CONTEXT = "collision_namespace generation_id query_valid_time serving_time authority_watermark"
+_NO_EFFECTS = "authorises_authority authorises_persistence authorises_external_effect authorises_publication authorises_evidence authorises_egress production_activation_authorised candidate_effect_performed creates_candidate creates_version mutates_current_version"
+_PUBLIC = "STORY_CANDIDATE,STORY_CANDIDATE_VERSION,CANDIDATE_ADMISSION,CANDIDATE_CURRENT_VERSION,CandidateContractError,CandidateAdmissionOutcome,CandidateAdmissionReason,CandidateLeadSignalBinding,CandidateGoverningStateStatus,CandidateGoverningStateBinding,CandidateGoverningState,CandidateGoverningManifest,StoryCandidate,StoryCandidateVersion,CandidateDistinctScopeProof,CandidateAdmissionRequest,CandidateAdmission,build_candidate_governing_manifest,build_candidate_distinct_scope_proof,evaluate_candidate_admission,validate_candidate_first_version,validate_candidate_version_successor"
+_CANDIDATE_ROUTES = {
+    "NEW_EVENT_CANDIDATE": CandidateManifestKind.NEW_EVENT,
+    "DEVELOPMENT_CANDIDATE": CandidateManifestKind.DEVELOPMENT,
+    "CORRECTION_CANDIDATE": CandidateManifestKind.CORRECTION,
+}
+_ADMISSIBLE_RELATIONSHIP = {
+    "NEW_EVENT": CanonicalOutcome.REL_NO_ADEQUATE_PRIOR_MATCH,
+    "DEVELOPMENT": CanonicalOutcome.REL_DEVELOPMENT_OF,
+    "CORRECTION": CanonicalOutcome.REL_CORRECTION_REVERSAL_OF,
+}
+
+
+class CandidateContractError(ValueError):
+    pass
+
+
+_Error = CandidateContractError
+
+
+def _string_enum(name: str, values: str):
+    return StrEnum(name, {value: value for value in values.split()})
+
+
+CandidateAdmissionOutcome = _string_enum(
+    "CandidateAdmissionOutcome",
+    "ADMISSIBLE DUPLICATE_EQUIVALENT DISTINCT INCOMPLETE STALE BLOCKED",
+)
+CandidateAdmissionReason = _string_enum(
+    "CandidateAdmissionReason",
+    "NEW_CANDIDATE_PRE_EFFECT SUCCESSOR_VERSION_PRE_EFFECT EXACT_MANIFEST_REPLAY RELATED_DISTINCT_PRE_EFFECT GOVERNING_EVIDENCE_INCOMPLETE COLLISION_AUTHORITY_UNAVAILABLE COLLISION_AUTHORITY_STALE CANDIDATE_CAS_STALE COLLISION_OPERATION_CAS_DIFFERS COLLISION_AUTHORITY_BLOCKED GOVERNING_STATE_STALE GOVERNING_STATE_BLOCKED",
+)
+
+
+_REASON_OUTCOME = {
+    CandidateAdmissionReason.NEW_CANDIDATE_PRE_EFFECT: CandidateAdmissionOutcome.ADMISSIBLE,
+    CandidateAdmissionReason.SUCCESSOR_VERSION_PRE_EFFECT: CandidateAdmissionOutcome.ADMISSIBLE,
+    CandidateAdmissionReason.EXACT_MANIFEST_REPLAY: CandidateAdmissionOutcome.DUPLICATE_EQUIVALENT,
+    CandidateAdmissionReason.RELATED_DISTINCT_PRE_EFFECT: CandidateAdmissionOutcome.DISTINCT,
+    CandidateAdmissionReason.GOVERNING_EVIDENCE_INCOMPLETE: CandidateAdmissionOutcome.INCOMPLETE,
+    CandidateAdmissionReason.COLLISION_AUTHORITY_UNAVAILABLE: CandidateAdmissionOutcome.INCOMPLETE,
+    CandidateAdmissionReason.COLLISION_AUTHORITY_STALE: CandidateAdmissionOutcome.STALE,
+    CandidateAdmissionReason.CANDIDATE_CAS_STALE: CandidateAdmissionOutcome.STALE,
+    CandidateAdmissionReason.GOVERNING_STATE_STALE: CandidateAdmissionOutcome.STALE,
+    CandidateAdmissionReason.COLLISION_OPERATION_CAS_DIFFERS: CandidateAdmissionOutcome.BLOCKED,
+    CandidateAdmissionReason.COLLISION_AUTHORITY_BLOCKED: CandidateAdmissionOutcome.BLOCKED,
+    CandidateAdmissionReason.GOVERNING_STATE_BLOCKED: CandidateAdmissionOutcome.BLOCKED,
+}
+
+
+def _reason_matches(outcome, reason):
+    return _REASON_OUTCOME.get(reason) is outcome
+
+
+class _NoEffect:
+    authority = authority_effect = candidate_effect = "NONE"
+    for _name in _NO_EFFECTS.split():
+        locals()[_name] = False
+
+
+class _CanonicalFields:
+    def canonical_value(self) -> dict[str, object]:
+        return _normalise(
+            lambda: {name: getattr(self, name) for name in self.__dataclass_fields__},
+            "contract cannot be canonicalised",
+        )
+
+    @property
+    def canonical_digest(self) -> str:
+        return _hash(_json(self.canonical_value()))
+
+    @classmethod
+    def from_value(cls, value: object) -> Self:
+        return cls(**_exact(value, set(cls.__dataclass_fields__), cls.__name__))  # type: ignore[arg-type]
+
+
+def _normalise[T](operation: object, message: str) -> T:
+    try:
+        return operation()  # type: ignore[operator,no-any-return]
+    except CandidateContractError:
+        raise
+    except Exception as exc:
+        raise _Error(message) from exc
+
+
+def _cap(raw: bytes, field: str) -> bytes:
+    _require(
+        len(raw) <= MAX_CANDIDATE_CANONICAL_BYTES,
+        f"{field} exceeds canonical byte bound",
+    )
+    _decode(raw)
+    return raw
+
+
+def _total(message: str):
+    return lambda function: (
+        lambda *args, **kwargs: _normalise(lambda: function(*args, **kwargs), message)
+    )
+
+
+def _require(condition: object, message: str) -> None:
+    if not condition:
+        raise _Error(message)
+
+
+def _valid(condition):
+    _require(condition, "invalid Candidate contract")
+
+
+def _same_fields(left: object, right: object, fields: tuple[str, ...]) -> bool:
+    return all(getattr(left, name) == getattr(right, name) for name in fields)
+
+
+def _attrs(value, fields):
+    fields = fields.split() if type(fields) is str else fields
+    return tuple(getattr(value, field) for field in fields)
+
+
+def _exact_tuple(value: object, kind: type, field: str, *, required=False):
+    _require(
+        type(value) is tuple
+        and (not required or bool(value))
+        and all(type(item) is kind for item in value),
+        f"{field} producers must be exact",
+    )
+    return value
+
+
+def _all_or_none(values: tuple[object, ...], field: str) -> bool:
+    _require(
+        all(item is None for item in values)
+        or all(item is not None for item in values),
+        f"{field} binding is partial",
+    )
+    return values[0] is not None
+
+
+def _canonical_bytes(value: object, field: str) -> bytes:
+    return _cap(
+        _normalise(lambda: _json(value), f"{field} cannot be canonicalised"),
+        field,
+    )
+
+
+def _decode_document(raw: bytes, schema: str, fields: set[str], field: str):
+    value = _exact(_decode(raw), {"schema_version", *fields}, field)
+    _require(value.pop("schema_version") == schema, f"{field} schema is unsupported")
+    return value
+
+
+def _document_bytes(schema: str, value: dict, field: str) -> bytes:
+    return _canonical_bytes({"schema_version": schema, **value}, field)
+
+
+def _pattern(value: object, field: str, pattern, label: str) -> str:
+    _require(
+        type(value) is str and pattern.fullmatch(value) is not None,
+        f"{field} must be {label}",
+    )
+    return value
+
+
+def _uuid(value: object, field: str) -> str:
+    return _pattern(value, field, _UUID, "a canonical UUID")
+
+
+def _digest(value: object, field: str) -> str:
+    return _pattern(value, field, _DIGEST, "a canonical SHA-256 digest")
+
+
+def _token(value: object, field: str) -> str:
+    return _pattern(value, field, _TOKEN, "bounded canonical text")
+
+
+def _enum(kind, value: object, field: str):
+    return _normalise(lambda: kind(value), f"{field} is unsupported")
+
+
+def _ordinal(value: object, field: str = "ordinal") -> int:
+    if type(value) is not int or not 1 <= value <= MAX_SAFE_INTEGER:
+        raise _Error(f"{field} must be an exact positive integer")
+    return value
+
+
+def _exact(value: object, fields: set[str], field: str) -> dict[str, object]:
+    if type(value) is not dict:
+        raise _Error(f"{field} fields are not exact")
+    try:
+        if set(value) != fields:
+            raise _Error(f"{field} fields are not exact")
+    except CandidateContractError:
+        raise
+    except Exception as exc:
+        raise _Error(f"{field} fields are not exact") from exc
+    return value
+
+
+def _decode(raw: bytes) -> dict[str, object]:
+    _valid(
+        type(raw) is bytes and bool(raw) and (len(raw) <= MAX_CANDIDATE_CANONICAL_BYTES)
+    )
+
+    def unique(pairs):
+        value = {}
+        for key, child in pairs:
+            _require(key not in value, f"duplicate object name: {key}")
+            value[key] = child
+        return value
+
+    def integer(text):
+        _valid(len(text.lstrip("-")) <= 16)
+        value = int(text)
+        _valid(-MAX_SAFE_INTEGER <= value <= MAX_SAFE_INTEGER)
+        return value
+
+    def unsupported(_):
+        raise _Error("unsupported number")
+
+    try:
+        value = json.loads(
+            raw.decode(),
+            object_pairs_hook=unique,
+            parse_int=integer,
+            parse_float=unsupported,
+            parse_constant=unsupported,
+        )
+    except CandidateContractError:
+        raise
+    except Exception as exc:
+        raise _Error("canonical input is invalid UTF-8 JSON") from exc
+    pending, nodes = [(value, 1)], 0
+    while pending:
+        item, depth = pending.pop()
+        nodes += 1
+        _require(
+            depth <= 24 and nodes <= 32768, "canonical input exceeds structural bounds"
+        )
+        if type(item) in (dict, list):
+            children = item.values() if type(item) is dict else item
+            pending.extend((child, depth + 1) for child in children)
+        else:
+            _valid(type(item) in (str, int, bool, type(None)))
+    _valid(type(value) is dict)
+    _valid(
+        _normalise(lambda: _json(value), "canonical input cannot be normalised") == raw
+    )
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateLeadSignalBinding(_NoEffect, _CanonicalFields):
+    lead_id: str
+    lead_digest: str
+    signal_id: str
+    signal_digest: str
+    lead_event_id: str
+    lead_aggregate_version: int
+    signal_event_id: str
+    signal_aggregate_version: int
+    coverage_basis: str
+    incomplete: bool
+
+    def __post_init__(self) -> None:
+        _valid(type(self) is CandidateLeadSignalBinding)
+        for name in ("lead_id", "signal_id", "lead_event_id", "signal_event_id"):
+            _uuid(getattr(self, name), name)
+        for name in ("lead_digest", "signal_digest"):
+            _digest(getattr(self, name), name)
+        for name in ("lead_aggregate_version", "signal_aggregate_version"):
+            _ordinal(getattr(self, name), name)
+        _valid(type(self.coverage_basis) is str and bool(self.coverage_basis))
+        raw = _normalise(
+            lambda: self.coverage_basis.encode(),
+            "invalid Candidate contract",
+        )
+        _valid(_json(_decode(raw)) == raw)
+        _valid(type(self.incomplete) is bool)
+
+
+CandidateGoverningStateStatus = _string_enum(
+    "CandidateGoverningStateStatus", "COMPLETE INCOMPLETE UNAVAILABLE BLOCKED"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateGoverningStateBinding(_NoEffect, _CanonicalFields):
+    coverage: str
+    policy: str
+    rights: str
+    source: str
+    triage: str
+    retrieval: str
+    event_lineage: str
+    admission_ruleset: str
+    declared_versions: str
+
+    def __post_init__(self) -> None:
+        if type(self) is not CandidateGoverningStateBinding:
+            raise _Error("governing-state binding must be exact")
+        for name in self.__dataclass_fields__:
+            _digest(getattr(self, name), name)
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateGoverningState(_NoEffect):
+    status: CandidateGoverningStateStatus
+    binding: CandidateGoverningStateBinding | None
+
+    def __post_init__(self) -> None:
+        if type(self.status) is not CandidateGoverningStateStatus or (
+            self.status is CandidateGoverningStateStatus.COMPLETE
+        ) != (type(self.binding) is CandidateGoverningStateBinding):
+            raise _Error("governing-state status and binding differ")
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateGoverningManifest(_NoEffect):
+    semantic_scope_digest: str
+    candidate_kind: CandidateManifestKind
+    hypothesis_id: str
+    hypothesis_version_id: str
+    hypothesis_version_digest: str
+    proposed_summary: str
+    hypothesis_status: str
+    relationship_status: AssessmentStatus
+    relationship_outcome: CanonicalOutcome | None
+    relationship_assessment_digest: str
+    relationship_comparator_hypothesis_id: str | None
+    relationship_comparator_version_id: str | None
+    relationship_comparator_version_digest: str | None
+    lineage_generation: int
+    lineage_history_digests: tuple[str, ...]
+    disposition_digests: tuple[str, ...]
+    candidate_manifest_digests: tuple[str, ...]
+    lead_signal_bindings: tuple[CandidateLeadSignalBinding, ...]
+    proposed_geography: str
+    proposed_category: str
+    urgency: str
+    likely_new_information: tuple[str, ...]
+    reader_utility_bases: tuple[str, ...]
+    uncertainties: tuple[str, ...]
+    evidence_objectives: tuple[str, ...]
+    governing_versions: tuple[str, ...]
+    missing_context: tuple[str, ...]
+    retrieval_incompleteness: tuple[str, ...]
+    lead_incompleteness_warnings: tuple[str, ...]
+    signal_operational_finding_ids: tuple[str, ...]
+    collision_request_digest: str
+    collision_decision_digest: str
+    collision_namespace: str
+    collision_key_digest: str
+    governing_state_binding: CandidateGoverningStateBinding
+    incomplete: bool
+
+    def __post_init__(self) -> None:
+        _valid(type(self) is CandidateGoverningManifest)
+        digests = _MANIFEST_DIGESTS.split()
+        for name in digests:
+            _digest(getattr(self, name), name)
+        _uuid(self.hypothesis_id, "hypothesis_id")
+        _uuid(self.hypothesis_version_id, "hypothesis_version_id")
+        _valid(
+            type(self.proposed_summary) is str
+            and self.proposed_summary == self.proposed_summary.strip()
+            and bool(self.proposed_summary)
+        )
+        _token(self.hypothesis_status, "hypothesis_status")
+        _valid(self.hypothesis_status == "UNVERIFIED_DISCOVERY_HYPOTHESIS")
+        _valid(
+            type(self.candidate_kind) is CandidateManifestKind
+            and type(self.relationship_status) is AssessmentStatus
+        )
+        _valid(
+            self.relationship_outcome is None
+            or type(self.relationship_outcome) is CanonicalOutcome
+        )
+        _valid(
+            (self.relationship_status is AssessmentStatus.COMPLETE)
+            == (self.relationship_outcome is not None)
+        )
+        comparator = (
+            self.relationship_comparator_hypothesis_id,
+            self.relationship_comparator_version_id,
+            self.relationship_comparator_version_digest,
+        )
+        _valid(
+            all(item is None for item in comparator)
+            or all(item is not None for item in comparator)
+        )
+        if comparator[0] is not None:
+            _uuid(comparator[0], "relationship_comparator_hypothesis_id")
+            _uuid(comparator[1], "relationship_comparator_version_id")
+            _digest(comparator[2], "relationship_comparator_version_digest")
+        _valid(type(self.lineage_generation) is int and self.lineage_generation >= 0)
+        _token(self.collision_namespace, "collision_namespace")
+        _valid(type(self.governing_state_binding) is CandidateGoverningStateBinding)
+        tuple_fields = _MANIFEST_TUPLES.split()
+        optional = set(_OPTIONAL_TUPLES.split())
+        for name in tuple_fields:
+            values = getattr(self, name)
+            ordered = (
+                len(set(values)) == len(values)
+                if name == "lineage_history_digests"
+                else values == tuple(sorted(set(values)))
+            )
+            _require(
+                type(values) is tuple
+                and all(type(value) is str and value for value in values)
+                and (bool(values) or name in optional)
+                and ordered,
+                f"invalid {name}",
+            )
+        for name in digests[1:3] + tuple_fields[:3]:
+            for value in (
+                getattr(self, name, ())
+                if name in tuple_fields
+                else (getattr(self, name),)
+            ):
+                _digest(value, name)
+        for value in self.signal_operational_finding_ids:
+            _uuid(value, "signal_operational_finding_id")
+        for name in ("proposed_geography", "proposed_category", "urgency"):
+            _token(getattr(self, name), name)
+        _valid(
+            type(self.lead_signal_bindings) is tuple
+            and all(
+                type(item) is CandidateLeadSignalBinding
+                for item in self.lead_signal_bindings
+            )
+        )
+        lead_ids = _normalise(
+            lambda: tuple(item.lead_id for item in self.lead_signal_bindings),
+            "Lead/Signal bindings cannot be validated",
+        )
+        _valid(bool(lead_ids) and lead_ids == tuple(sorted(set(lead_ids))))
+        _require(
+            type(self.incomplete) is bool
+            and self.incomplete
+            == (
+                self.relationship_status is not AssessmentStatus.COMPLETE
+                or any(item.incomplete for item in self.lead_signal_bindings)
+            ),
+            "manifest incompleteness differs from Lead/Signal lineage",
+        )
+        expected_scope = _project(
+            {
+                "collision_namespace": self.collision_namespace,
+                "collision_key_digest": self.collision_key_digest,
+                "hypothesis_id": self.hypothesis_id,
+            }
+        )
+        _valid(self.semantic_scope_digest == expected_scope)
+        _ = self.canonical_bytes
+
+    def canonical_value(self) -> dict[str, object]:
+        def render():
+            value = {name: getattr(self, name) for name in self.__dataclass_fields__}
+            for name in (
+                "candidate_kind",
+                "relationship_status",
+                "relationship_outcome",
+            ):
+                item = value[name]
+                value[name] = None if item is None else item.value
+            value["lead_signal_bindings"] = [
+                item.canonical_value() for item in self.lead_signal_bindings
+            ]
+            value["governing_state_binding"] = (
+                self.governing_state_binding.canonical_value()
+            )
+            value.update(
+                (name, list(item))
+                for name, item in tuple(value.items())
+                if type(item) is tuple
+            )
+            return value
+
+        return _normalise(render, "governing manifest cannot be canonicalised")
+
+    def version_material_value(self) -> dict[str, object]:
+        value = self.canonical_value()
+        for name in ("collision_request_digest", "collision_decision_digest"):
+            value.pop(name)
+        return value
+
+    @property
+    def version_material_digest(self) -> str:
+        return _project(
+            {
+                "schema_version": "newsroom.increment6.candidate-version-material.v1",
+                "manifest": self.version_material_value(),
+            }
+        )
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return _canonical_bytes(self.canonical_value(), "governing manifest")
+
+    @property
+    def canonical_digest(self) -> str:
+        return _hash(self.canonical_bytes)
+
+    @classmethod
+    def from_value(cls, value: object) -> Self:
+        item = _exact(value, set(cls.__dataclass_fields__), "governing manifest")
+        copied = dict(item)
+        for name, kind in (
+            ("candidate_kind", CandidateManifestKind),
+            ("relationship_status", AssessmentStatus),
+        ):
+            copied[name] = _enum(kind, item[name], name)
+        copied["relationship_outcome"] = (
+            None
+            if item["relationship_outcome"] is None
+            else _enum(
+                CanonicalOutcome, item["relationship_outcome"], "relationship_outcome"
+            )
+        )
+        copied["lead_signal_bindings"] = tuple(
+            CandidateLeadSignalBinding.from_value(child)
+            for child in _tuple_input(
+                item["lead_signal_bindings"], "lead_signal_bindings"
+            )
+        )
+        copied["governing_state_binding"] = CandidateGoverningStateBinding.from_value(
+            item["governing_state_binding"]
+        )
+        arrays = _MANIFEST_TUPLES.split()
+        for name in arrays:
+            copied[name] = _tuple_input(item[name], name)
+        return cls(**copied)  # type: ignore[arg-type]
+
+
+def _tuple_input(value: object, field: str) -> tuple[object, ...]:
+    if type(value) is not list:
+        raise _Error(f"{field} must be a canonical array")
+    return tuple(value)
+
+
+@dataclass(frozen=True, slots=True)
+class StoryCandidate(_NoEffect, _CanonicalFields):
+    candidate_id: str
+    committed_admission_decision_id: str
+    authority_event_id: str
+    semantic_scope_digest: str
+
+    def __post_init__(self) -> None:
+        _valid(type(self) is StoryCandidate)
+        for name in (
+            "candidate_id",
+            "committed_admission_decision_id",
+            "authority_event_id",
+        ):
+            _uuid(getattr(self, name), name)
+        _digest(self.semantic_scope_digest, "semantic_scope_digest")
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return _document_bytes(
+            STORY_CANDIDATE, self.canonical_value(), "Story Candidate"
+        )
+
+    @classmethod
+    def from_canonical_bytes(cls, raw: bytes) -> Self:
+        root = _decode_document(
+            raw, STORY_CANDIDATE, set(cls.__dataclass_fields__), "Story Candidate"
+        )
+        return _normalise(lambda: cls(**root), "Story Candidate replay failed")  # type: ignore[arg-type]
+
+
+@dataclass(frozen=True, slots=True)
+class StoryCandidateVersion(_NoEffect, _CanonicalFields):
+    version_id: str
+    candidate_id: str
+    ordinal: int
+    previous_version_id: str | None
+    previous_version_digest: str | None
+    committed_admission_decision_id: str
+    governing_manifest: CandidateGoverningManifest
+
+    def __post_init__(self) -> None:
+        _valid(type(self) is StoryCandidateVersion)
+        for name in ("candidate_id", "version_id", "committed_admission_decision_id"):
+            _uuid(getattr(self, name), name)
+        ordinal = _ordinal(self.ordinal)
+        predecessor = _all_or_none(
+            (self.previous_version_id, self.previous_version_digest),
+            "Candidate Version predecessor",
+        )
+        _valid((ordinal == 1) != predecessor)
+        if predecessor:
+            _uuid(self.previous_version_id, "previous_version_id")
+            _digest(self.previous_version_digest, "previous_version_digest")
+        if type(self.governing_manifest) is not CandidateGoverningManifest:
+            raise _Error("Candidate Version manifest must be exact")
+        _ = self.governing_manifest.canonical_digest
+        _ = self.canonical_bytes
+
+    @property
+    def canonical_value(self) -> dict[str, object]:
+        value = _CanonicalFields.canonical_value(self)
+        value["governing_manifest"] = self.governing_manifest.canonical_value()
+        return value
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return _document_bytes(
+            STORY_CANDIDATE_VERSION,
+            {"version": self.canonical_value},
+            "Candidate Version",
+        )
+
+    @property
+    def canonical_digest(self) -> str:
+        return _hash(self.canonical_bytes)
+
+    @classmethod
+    def from_canonical_bytes(cls, raw: bytes) -> Self:
+        root = _decode_document(
+            raw, STORY_CANDIDATE_VERSION, {"version"}, "Candidate Version"
+        )
+        item = _exact(
+            root["version"], set(cls.__dataclass_fields__), "Candidate Version"
+        )
+        item["governing_manifest"] = CandidateGoverningManifest.from_value(
+            item["governing_manifest"]
+        )
+        return _normalise(lambda: cls(**item), "Candidate Version replay failed")  # type: ignore[arg-type]
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateDistinctScopeProof(_NoEffect, _CanonicalFields):
+    proposed_collision_digest: str
+    comparator_collision_digest: str
+    comparator_candidate_id: str
+    comparator_version_id: str
+    comparator_version_digest: str
+    comparator_semantic_scope_digest: str
+    context_digest: str
+
+    def __post_init__(self) -> None:
+        if type(self) is not CandidateDistinctScopeProof:
+            raise _Error("distinct-scope proof must be exact")
+        for name in self.__dataclass_fields__:
+            validator = _uuid if name.endswith("_id") else _digest
+            validator(getattr(self, name), name)
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateAdmissionRequest(_NoEffect, _CanonicalFields):
+    request_id: str
+    actor_identity_digest: str
+    idempotency_key: str
+    expected_current_version_id: str | None
+    expected_current_version_digest: str | None
+    expected_current_ordinal: int
+    semantic_scope_digest: str
+    collision_request_digest: str
+    expected_governing_state_digest: str
+    distinct_scope_proof_digest: str | None
+
+    def __post_init__(self) -> None:
+        _valid(type(self) is CandidateAdmissionRequest)
+        _uuid(self.request_id, "request_id")
+        _token(self.idempotency_key, "idempotency_key")
+        for name in (
+            "actor_identity_digest",
+            "semantic_scope_digest",
+            "collision_request_digest",
+            "expected_governing_state_digest",
+        ):
+            _digest(getattr(self, name), name)
+        if self.distinct_scope_proof_digest is not None:
+            _digest(self.distinct_scope_proof_digest, "distinct_scope_proof_digest")
+        _valid(
+            type(self.expected_current_ordinal) is int
+            and self.expected_current_ordinal >= 0
+        )
+        has_current = _all_or_none(
+            (self.expected_current_version_id, self.expected_current_version_digest),
+            "admission CAS",
+        )
+        _valid((self.expected_current_ordinal == 0) != has_current)
+        if has_current:
+            _uuid(self.expected_current_version_id, "expected_current_version_id")
+            _digest(
+                self.expected_current_version_digest, "expected_current_version_digest"
+            )
+        _ = self.canonical_bytes
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return _canonical_bytes(self.canonical_value(), "admission request")
+
+    @property
+    def canonical_digest(self) -> str:
+        return _hash(self.canonical_bytes)
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateAdmission(_NoEffect):
+    request: CandidateAdmissionRequest
+    governing_manifest: CandidateGoverningManifest
+    outcome: CandidateAdmissionOutcome
+    reason: CandidateAdmissionReason
+    current_candidate_id: str | None
+    current_candidate_version_id: str | None
+    current_candidate_version_digest: str | None
+    distinct_scope_proof: CandidateDistinctScopeProof | None = None
+
+    @_total("Candidate Admission cannot be validated")
+    def __post_init__(self) -> None:
+        q, m, outcome, reason = (
+            self.request,
+            self.governing_manifest,
+            self.outcome,
+            self.reason,
+        )
+        R = CandidateAdmissionReason
+        _valid(
+            type(self) is CandidateAdmission and type(q) is CandidateAdmissionRequest
+        )
+        _valid(
+            type(m) is CandidateGoverningManifest
+            and type(outcome) is CandidateAdmissionOutcome
+        )
+        _ = m.canonical_digest
+        _require(
+            type(reason) is CandidateAdmissionReason
+            and _reason_matches(outcome, reason),
+            "admission outcome and reason differ",
+        )
+        proof = self.distinct_scope_proof
+        _require(
+            (type(proof) is CandidateDistinctScopeProof)
+            == (reason is R.RELATED_DISTINCT_PRE_EFFECT)
+            and (
+                proof is None or q.distinct_scope_proof_digest == proof.canonical_digest
+            ),
+            "distinct result and proof differ",
+        )
+        current = (
+            self.current_candidate_id,
+            self.current_candidate_version_id,
+            self.current_candidate_version_digest,
+        )
+        has_current = _all_or_none(current, "current Candidate")
+        if has_current:
+            _uuid(current[0], "current_candidate_id")
+            _uuid(current[1], "current_candidate_version_id")
+            _digest(current[2], "current_candidate_version_digest")
+        new = reason in {R.NEW_CANDIDATE_PRE_EFFECT, R.RELATED_DISTINCT_PRE_EFFECT}
+        retained = reason in {R.SUCCESSOR_VERSION_PRE_EFFECT, R.EXACT_MANIFEST_REPLAY}
+        _valid(not new or (q.expected_current_ordinal == 0 and (not has_current)))
+        _require(
+            not retained or has_current,
+            "admission result requires an exact current Candidate binding",
+        )
+        _valid(
+            not retained
+            or (q.expected_current_version_id, q.expected_current_version_digest)
+            == current[1:]
+        )
+        _valid(
+            not (
+                reason is R.CANDIDATE_CAS_STALE
+                and (not has_current)
+                and (q.expected_current_ordinal == 0)
+            )
+        )
+        _valid(
+            q.semantic_scope_digest == m.semantic_scope_digest
+            and q.collision_request_digest == m.collision_request_digest
+            and (
+                reason is R.GOVERNING_STATE_STALE
+                or q.expected_governing_state_digest
+                == m.governing_state_binding.canonical_digest
+            )
+        )
+        _ = self.canonical_bytes
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        value = {name: getattr(self, name) for name in self.__dataclass_fields__}
+        for name in ("request", "governing_manifest", "distinct_scope_proof"):
+            item = value[name]
+            value[name] = None if item is None else item.canonical_value()
+        value.update(
+            schema_version=CANDIDATE_ADMISSION,
+            authority="NONE",
+            candidate_effect="NONE",
+        )
+        value["outcome"], value["reason"] = self.outcome.value, self.reason.value
+        return _canonical_bytes(value, "Candidate Admission")
+
+    @property
+    def canonical_digest(self) -> str:
+        return _hash(self.canonical_bytes)
+
+    @classmethod
+    def from_canonical_bytes(cls, raw: bytes) -> Self:
+        root = _exact(
+            _decode(raw),
+            {
+                "schema_version",
+                "authority",
+                "candidate_effect",
+                *cls.__dataclass_fields__,
+            },
+            "Candidate Admission",
+        )
+        if (
+            root.pop("schema_version") != CANDIDATE_ADMISSION
+            or root.pop("authority") != "NONE"
+            or root.pop("candidate_effect") != "NONE"
+        ):
+            raise _Error("invalid Candidate contract")
+        root["request"] = CandidateAdmissionRequest.from_value(root["request"])
+        root["governing_manifest"] = CandidateGoverningManifest.from_value(
+            root["governing_manifest"]
+        )
+        root["outcome"] = _enum(
+            CandidateAdmissionOutcome, root["outcome"], "admission outcome"
+        )
+        root["reason"] = _enum(
+            CandidateAdmissionReason, root["reason"], "admission reason"
+        )
+        root["distinct_scope_proof"] = (
+            None
+            if root["distinct_scope_proof"] is None
+            else CandidateDistinctScopeProof.from_value(root["distinct_scope_proof"])
+        )
+        return _normalise(lambda: cls(**root), "Candidate Admission replay failed")  # type: ignore[arg-type]
+
+
+def build_candidate_governing_manifest(
+    *,
+    hypothesis_version: EventHypothesisVersion,
+    lineage_receipts: tuple[HypothesisLineageReceipt, ...],
+    lineage_initial_heads: tuple[HypothesisLineageHead, ...],
+    lineage_versions: tuple[EventHypothesisVersion, ...],
+    lineage_relationship_proofs: tuple[HypothesisLineageRelationshipProof, ...],
+    dispositions: tuple[ProposalDisposition, ...],
+    leads: tuple[NewsLead, ...],
+    signals: tuple[DiscoverySignal, ...],
+    gates: tuple[GateDecision, ...],
+    relationship: RelationshipAssessment | RetainedRelationshipDecisionReceipt,
+    collision: CurrentCollisionEligibilityDecision,
+) -> CandidateGoverningManifest:
+    def build() -> CandidateGoverningManifest:
+        version = hypothesis_version
+        if type(version) is not EventHypothesisVersion:
+            raise _Error("Hypothesis producer must be exact")
+        lineage = replay_hypothesis_lineage(
+            lineage_receipts,
+            initial_heads=lineage_initial_heads,
+            versions=lineage_versions,
+            relationship_proofs=lineage_relationship_proofs,
+        )
+        _exact_tuple(dispositions, ProposalDisposition, "disposition", required=True)
+        _exact_tuple(leads, NewsLead, "Lead")
+        _exact_tuple(signals, DiscoverySignal, "Signal")
+        _exact_tuple(gates, GateDecision, "Gate")
+        if type(collision) is not CurrentCollisionEligibilityDecision:
+            raise _Error("collision producer must be exact")
+        if type(relationship) is RetainedRelationshipDecisionReceipt:
+            assessment = relationship.assessment
+        elif type(relationship) is RelationshipAssessment:
+            assessment = relationship
+            if assessment.status is AssessmentStatus.COMPLETE:
+                raise _Error("invalid Candidate contract")
+        else:
+            raise _Error("relationship producer must be exact")
+        if (
+            assessment.subject.hypothesis_id != version.hypothesis_id
+            or assessment.subject.version_id != version.version_id
+            or assessment.subject.version_digest != version.canonical_digest
+        ):
+            raise _Error("invalid Candidate contract")
+        heads = [
+            head
+            for head in lineage.active_heads
+            if head.node.version_id == version.version_id
+            and head.node.version_digest == version.canonical_digest
+            and head.node.hypothesis_id == version.hypothesis_id
+        ]
+        if len(heads) != 1:
+            raise _Error("Hypothesis Version is not one exact current lineage head")
+        if heads[0].generation > 0 and (
+            not any(
+                binding.assessment_digest == assessment.canonical_digest
+                for receipt in lineage.history
+                for binding in receipt.relationships
+            )
+        ):
+            raise _Error("invalid Candidate contract")
+        source_by_disposition = {
+            item.disposition_id: item for item in version.source_bindings
+        }
+        if set(source_by_disposition) != {item.disposition_id for item in dispositions}:
+            raise _Error("invalid Candidate contract")
+        lead_by_id = {str(item.request.lead_id): item for item in leads}
+        signal_by_id = {str(item.request.signal_id): item for item in signals}
+        gate_by_id = {str(item.request.decision_id): item for item in gates}
+        if (
+            len(lead_by_id) != len(leads)
+            or len(signal_by_id) != len(signals)
+            or len(gate_by_id) != len(gates)
+        ):
+            raise _Error("Lead or Signal producers are duplicated")
+        bindings: list[CandidateLeadSignalBinding] = []
+        manifests = []
+        for disposition in dispositions:
+            route = disposition.route.value
+            manifest = disposition.route_binding.candidate_manifest
+            if (
+                route not in _CANDIDATE_ROUTES
+                or manifest is None
+                or manifest.manifest_kind is not _CANDIDATE_ROUTES[route]
+            ):
+                raise _Error("invalid Candidate contract")
+            source = source_by_disposition[disposition.disposition_id]
+            source_projection = (
+                _hash(disposition.canonical_bytes),
+                disposition.finding_set_digest,
+                disposition.route_binding_digest,
+                disposition.lead_head.decision_lead_id,
+                disposition.lead_head.decision_lead_digest,
+                disposition.lead_head.current_disposition_head_id,
+                disposition.lead_head.current_disposition_head_digest,
+            )
+            if tuple(source.canonical_value().values()) != (
+                disposition.disposition_id,
+                *source_projection,
+            ):
+                raise _Error("invalid Candidate contract")
+            proposal_hypothesis = disposition.route_binding.hypothesis
+            route_fields = (
+                ("proposal_local_id", "proposal_local_id"),
+                ("summary", "proposed_summary"),
+                ("relationship_kind", "proposed_relationship"),
+                ("target_hypothesis_id", "proposed_target_hypothesis_id"),
+            )
+            if (
+                proposal_hypothesis is None
+                or not _same_fields(
+                    disposition, version, tuple(_DISPOSITION_FIELDS.split())
+                )
+                or (
+                    not all(
+                        (
+                            getattr(proposal_hypothesis, left)
+                            == getattr(version, right)
+                            for left, right in route_fields
+                        )
+                    )
+                )
+            ):
+                raise _Error("invalid Candidate contract")
+            manifests.append(manifest)
+        kinds = {manifest.manifest_kind for manifest in manifests}
+        if len(kinds) != 1:
+            raise _Error("invalid Candidate contract")
+        candidate_kind = kinds.pop()
+        _validate_relationship_route(version, assessment)
+        contributing = {
+            lead for manifest in manifests for lead in manifest.contributing_lead_ids
+        }
+        if contributing != set(lead_by_id):
+            raise _Error("invalid Candidate contract")
+        _validate_contributing_dispositions(contributing, dispositions)
+        if set(signal_by_id) != {str(lead.request.signal_id) for lead in leads}:
+            raise _Error("Signals differ from exact contributing Lead lineage")
+        if set(gate_by_id) != {
+            str(lead.request.promoting_gate_decision_id) for lead in leads
+        }:
+            raise _Error("Gates differ from exact promoting lineage")
+        for lead_id in sorted(contributing):
+            lead = lead_by_id[lead_id]
+            source = next(
+                item
+                for item in version.source_bindings
+                if item.decision_lead_id == lead_id
+            )
+            if source.decision_lead_digest != lead.canonical_digest:
+                raise _Error(
+                    "disposition Lead digest differs from exact supplied News Lead"
+                )
+            signal_id = str(lead.request.signal_id)
+            signal = signal_by_id.get(signal_id)
+            if signal is None:
+                raise _Error("invalid Candidate contract")
+            gate = gate_by_id[str(lead.request.promoting_gate_decision_id)]
+            if (
+                str(gate.request.signal_id) != signal_id
+                or gate.request.coverage != lead.request.coverage
+            ):
+                raise _Error("promoting Gate differs from Lead lineage")
+            # Shared source lineage is exact only when the Lead retains the Signal's source identities.
+            for field in _SOURCE_FIELDS.split():
+                if getattr(lead.request, field) != getattr(signal.request, field):
+                    raise _Error("Lead and Signal source lineage differ")
+            bindings.append(
+                CandidateLeadSignalBinding(
+                    lead_id,
+                    lead.canonical_digest,
+                    signal_id,
+                    signal.canonical_digest,
+                    str(lead.event_id),
+                    lead.aggregate_version,
+                    str(signal.event_id),
+                    signal.aggregate_version,
+                    _json(lead.request.coverage.canonical_value()).decode("utf-8"),
+                    bool(lead.request.incompleteness_warnings)
+                    or signal.request.incomplete,
+                )
+            )
+        binding = collision.request.binding
+        if (
+            binding.subject_id != version.hypothesis_id
+            or binding.subject_version_id != version.version_id
+            or binding.subject_version_digest != version.canonical_digest
+        ):
+            raise _Error("invalid Candidate contract")
+        state_binding = _derive_governing_state(
+            gates, leads, signals, dispositions, version, assessment, lineage
+        )
+        comparator = assessment.comparator
+        comparator_values = (
+            (None, None, None)
+            if comparator is None
+            else (
+                comparator.hypothesis_id,
+                comparator.version_id,
+                comparator.version_digest,
+            )
+        )
+        return CandidateGoverningManifest(
+            _project(
+                {
+                    "collision_namespace": binding.collision_namespace,
+                    "collision_key_digest": binding.collision_key_digest,
+                    "hypothesis_id": version.hypothesis_id,
+                }
+            ),
+            candidate_kind,
+            version.hypothesis_id,
+            version.version_id,
+            version.canonical_digest,
+            version.proposed_summary,
+            "UNVERIFIED_DISCOVERY_HYPOTHESIS",
+            assessment.status,
+            assessment.decision,
+            assessment.canonical_digest,
+            *comparator_values,
+            heads[0].generation,
+            tuple(item.canonical_digest for item in lineage.history),
+            tuple(sorted(_hash(item.canonical_bytes) for item in dispositions)),
+            tuple(sorted({_hash(_json(item.canonical_value())) for item in manifests})),
+            tuple(bindings),
+            *(
+                _one(manifests, field)
+                for field in ("proposed_geography", "proposed_category", "urgency")
+            ),
+            tuple(sorted({item.likely_new_information for item in manifests})),
+            tuple(sorted({item.reader_utility_basis for item in manifests})),
+            *(
+                _union(manifests, lambda item, field=field: getattr(item, field))
+                for field in (
+                    "uncertainties",
+                    "evidence_objectives",
+                    "governing_versions",
+                )
+            ),
+            *(
+                _union(
+                    dispositions,
+                    lambda item, field=field: getattr(item.route_binding, field),
+                )
+                for field in ("missing_context", "retrieval_incompleteness")
+            ),
+            _union(leads, lambda item: item.request.incompleteness_warnings),
+            _union(
+                signals,
+                lambda item: tuple(
+                    str(value) for value in item.request.operational_finding_ids
+                ),
+            ),
+            collision.request.request_digest,
+            _hash(collision.canonical_bytes),
+            binding.collision_namespace,
+            binding.collision_key_digest,
+            state_binding,
+            assessment.status is not AssessmentStatus.COMPLETE
+            or any(item.incomplete for item in bindings),
+        )
+
+    return _normalise(build, "invalid Candidate contract")
+
+
+@_total("Candidate Version succession failed closed")
+def validate_candidate_version_successor(
+    previous: StoryCandidateVersion,
+    proposed: StoryCandidateVersion,
+) -> StoryCandidateVersion:
+    p, q = previous, proposed
+    _valid(type(p) is type(q) is StoryCandidateVersion)
+    actual = (
+        q.candidate_id,
+        q.governing_manifest.semantic_scope_digest,
+        *_attrs(q, "ordinal previous_version_id previous_version_digest"),
+    )
+    expected = (
+        p.candidate_id,
+        p.governing_manifest.semantic_scope_digest,
+        p.ordinal + 1,
+        p.version_id,
+        p.canonical_digest,
+    )
+    _require(
+        actual == expected, "Candidate Version is not the exact contiguous successor"
+    )
+    _valid(q.version_id not in {p.version_id, q.previous_version_id})
+    _require(
+        q.committed_admission_decision_id != p.committed_admission_decision_id,
+        "Candidate Version successor requires a new committed admission decision",
+    )
+    _require(
+        q.governing_manifest.version_material_digest
+        != p.governing_manifest.version_material_digest,
+        "equivalent manifest replay cannot create a successor",
+    )
+    return q
+
+
+@_total("invalid Candidate contract")
+def validate_candidate_first_version(
+    candidate: StoryCandidate,
+    version: StoryCandidateVersion,
+) -> StoryCandidateVersion:
+    c, v = candidate, version
+    _valid(type(c) is StoryCandidate and type(v) is StoryCandidateVersion)
+    actual = (
+        *_attrs(v, "candidate_id committed_admission_decision_id"),
+        v.governing_manifest.semantic_scope_digest,
+        *_attrs(v, "ordinal previous_version_id previous_version_digest"),
+    )
+    expected = (
+        c.candidate_id,
+        c.committed_admission_decision_id,
+        c.semantic_scope_digest,
+        1,
+        None,
+        None,
+    )
+    _require(
+        actual == expected,
+        "first Candidate Version differs from committed Candidate admission",
+    )
+    return v
+
+
+def _one(items: list[object], field: str) -> str:
+    values = {getattr(item, field) for item in items}
+    if len(values) != 1:
+        raise _Error(f"Candidate manifests disagree on {field}")
+    return values.pop()
+
+
+def _union(items: object, values: object) -> tuple[str, ...]:
+    return tuple(sorted({value for item in items for value in values(item)}))  # type: ignore[operator,union-attr]
+
+
+def _validate_contributing_dispositions(
+    contributing: set[str], dispositions: tuple[ProposalDisposition, ...]
+) -> None:
+    decision_leads = {
+        disposition.lead_head.decision_lead_id for disposition in dispositions
+    }
+    if decision_leads != contributing or len(decision_leads) != len(dispositions):
+        raise _Error("every contributing Lead requires one exact disposition source")
+
+
+def _project(value: object) -> str:
+    return _hash(_json(value))
+
+
+def _derive_governing_state(
+    gates, leads, signals, dispositions, version, assessment, lineage
+):
+    gates = tuple(sorted(gates, key=lambda item: str(item.request.decision_id)))
+    leads = tuple(sorted(leads, key=lambda item: str(item.request.lead_id)))
+    signals = tuple(sorted(signals, key=lambda item: str(item.request.signal_id)))
+    dispositions = tuple(sorted(dispositions, key=lambda item: item.disposition_id))
+    values = tuple(
+        [item.request.canonical_value() for item in group]
+        for group in (gates, leads, signals)
+    )
+    gate_values, lead_values, signal_values = values
+    policies = _POLICIES.split()
+    projections = (
+        [
+            [item["coverage"] for item in gate_values],
+            [item["coverage"] for item in lead_values],
+        ],
+        [
+            [[item[key] for key in policies] for item in gate_values],
+            [item["lead_policy"] for item in lead_values],
+            [item["admission_policy"] for item in signal_values],
+        ],
+        [
+            [
+                item["rights_decision_id"],
+                item["rights_policy_version"],
+                item["basis"]["rights_current"],
+            ]
+            for item in gate_values
+        ],
+        [
+            [item.canonical_digest for item in group]
+            for group in (signals, leads, gates)
+        ],
+        [_hash(item.canonical_bytes) for item in dispositions],
+        [
+            [item.retrieval_context_id, item.retrieval_context_digest]
+            for item in dispositions
+        ],
+        [
+            version.canonical_digest,
+            assessment.canonical_digest,
+            [item.canonical_digest for item in lineage.history],
+        ],
+        [CANDIDATE_ADMISSION, CANDIDATE_CURRENT_VERSION],
+        sorted(
+            {
+                value
+                for item in dispositions
+                for value in item.route_binding.candidate_manifest.governing_versions
+            }
+        ),
+    )
+    return CandidateGoverningStateBinding(*map(_project, projections))
+
+
+def _validate_relationship_route(version, assessment) -> None:
+    expected = _enum(
+        CanonicalOutcome,
+        f"REL_{version.proposed_relationship.value}",
+        "D1 relationship",
+    )
+    if assessment.status is not AssessmentStatus.COMPLETE:
+        return
+    if assessment.decision is not expected:
+        raise _Error("invalid Candidate contract")
+    comparator = (
+        None
+        if assessment.comparator is None
+        else (
+            assessment.comparator.hypothesis_id,
+            assessment.comparator.version_id,
+            assessment.comparator.version_digest,
+        )
+    )
+    target = (
+        version.proposed_target_hypothesis_id,
+        version.target_version_id,
+        version.target_version_digest,
+    )
+    if comparator != (None if target == (None, None, None) else target):
+        raise _Error("invalid Candidate contract")
+
+
+def build_candidate_distinct_scope_proof(
+    *,
+    proposed_manifest: CandidateGoverningManifest,
+    proposed_collision: CurrentCollisionEligibilityDecision,
+    comparator_collision: CurrentCollisionEligibilityDecision,
+    comparator_version: StoryCandidateVersion,
+) -> CandidateDistinctScopeProof:
+    def build() -> CandidateDistinctScopeProof:
+        p, c, v = proposed_collision, comparator_collision, comparator_version
+        _valid(
+            all(type(item) is CurrentCollisionEligibilityDecision for item in (p, c))
+            and type(v) is StoryCandidateVersion
+        )
+        pb, cb = p.request.binding, c.request.binding
+        context = lambda item: _attrs(item, _CONTEXT.split())
+
+        def collision_matches(manifest, decision):
+            return _attrs(
+                manifest,
+                "collision_request_digest collision_decision_digest collision_namespace collision_key_digest hypothesis_id hypothesis_version_id hypothesis_version_digest",
+            ) == (
+                decision.request.request_digest,
+                _hash(decision.canonical_bytes),
+                *_attrs(
+                    decision.request.binding,
+                    "collision_namespace collision_key_digest subject_id subject_version_id subject_version_digest",
+                ),
+            )
+
+        _valid(
+            not (
+                not collision_matches(proposed_manifest, p)
+                or not collision_matches(v.governing_manifest, c)
+                or proposed_manifest.relationship_outcome
+                is not CanonicalOutcome.REL_NO_ADEQUATE_PRIOR_MATCH
+                or p.outcome is not CollisionEligibilityOutcome.ELIGIBLE
+                or pb.operation is not CandidateUseOperation.ADMIT_NEW_CANDIDATE
+                or (p.collision_state is not CollisionState.UNOCCUPIED)
+                or (c.outcome is not CollisionEligibilityOutcome.ELIGIBLE)
+                or (cb.operation is not CandidateUseOperation.USE_CURRENT_CANDIDATE)
+                or (c.collision_state is not CollisionState.OCCUPIED)
+                or (cb.expected_candidate_id != v.candidate_id)
+                or (c.observed_candidate_id != v.candidate_id)
+                or (
+                    (cb.subject_id, cb.subject_version_id, cb.subject_version_digest)
+                    != (
+                        v.governing_manifest.hypothesis_id,
+                        v.governing_manifest.hypothesis_version_id,
+                        v.governing_manifest.hypothesis_version_digest,
+                    )
+                )
+                or (pb.collision_key_digest == cb.collision_key_digest)
+                or (pb.subject_id == cb.subject_id)
+                or (
+                    proposed_manifest.semantic_scope_digest
+                    == v.governing_manifest.semantic_scope_digest
+                )
+                or (context(pb) != context(cb))
+            )
+        )
+        return CandidateDistinctScopeProof(
+            _hash(p.canonical_bytes),
+            _hash(c.canonical_bytes),
+            v.candidate_id,
+            v.version_id,
+            v.canonical_digest,
+            v.governing_manifest.semantic_scope_digest,
+            _project(context(pb)),
+        )
+
+    return _normalise(build, "distinct-scope proof failed closed")
+
+
+@_total("invalid Candidate contract")
+def evaluate_candidate_admission(
+    *,
+    request: CandidateAdmissionRequest,
+    manifest: CandidateGoverningManifest,
+    collision: CurrentCollisionEligibilityDecision,
+    current_version: StoryCandidateVersion | None,
+    governing_state: CandidateGoverningState,
+    comparator_collision: CurrentCollisionEligibilityDecision | None = None,
+    comparator_version: StoryCandidateVersion | None = None,
+) -> CandidateAdmission:
+    r, m, c, v, state = request, manifest, collision, current_version, governing_state
+    _valid(
+        type(r) is CandidateAdmissionRequest and type(m) is CandidateGoverningManifest
+    )
+    _valid(type(c) is CurrentCollisionEligibilityDecision)
+    _valid(v is None or type(v) is StoryCandidateVersion)
+    _valid(type(state) is CandidateGoverningState)
+    binding = c.request.binding
+    _valid(
+        not (
+            r.semantic_scope_digest != m.semantic_scope_digest
+            or r.collision_request_digest != c.request.request_digest
+            or m.collision_request_digest != c.request.request_digest
+            or (m.collision_decision_digest != _hash(c.canonical_bytes))
+            or (binding.subject_id != m.hypothesis_id)
+            or (binding.subject_version_id != m.hypothesis_version_id)
+            or (binding.subject_version_digest != m.hypothesis_version_digest)
+        )
+    )
+    current = () if v is None else (v.candidate_id, v.version_id, v.canonical_digest)
+
+    def result(outcome, reason, proof=None):
+        return CandidateAdmission(
+            r, m, outcome, reason, *(current or (None, None, None)), proof
+        )
+
+    O, R = CandidateAdmissionOutcome, CandidateAdmissionReason
+    if v is None and r.expected_current_ordinal != 0:
+        return result(O.STALE, R.CANDIDATE_CAS_STALE)
+    if v is not None and (
+        r.expected_current_ordinal != v.ordinal
+        or r.expected_current_version_id != v.version_id
+        or r.expected_current_version_digest != v.canonical_digest
+    ):
+        return result(O.STALE, R.CANDIDATE_CAS_STALE)
+    if state.status in {
+        CandidateGoverningStateStatus.UNAVAILABLE,
+        CandidateGoverningStateStatus.INCOMPLETE,
+    }:
+        return result(O.INCOMPLETE, R.GOVERNING_EVIDENCE_INCOMPLETE)
+    if state.status is CandidateGoverningStateStatus.BLOCKED:
+        return result(O.BLOCKED, R.GOVERNING_STATE_BLOCKED)
+    if (
+        state.binding != m.governing_state_binding
+        or r.expected_governing_state_digest
+        != m.governing_state_binding.canonical_digest
+    ):
+        return result(O.STALE, R.GOVERNING_STATE_STALE)
+    if c.outcome is CollisionEligibilityOutcome.UNAVAILABLE:
+        return result(O.INCOMPLETE, R.COLLISION_AUTHORITY_UNAVAILABLE)
+    if m.incomplete or c.outcome is CollisionEligibilityOutcome.INCOMPLETE:
+        return result(O.INCOMPLETE, R.GOVERNING_EVIDENCE_INCOMPLETE)
+    if c.outcome is CollisionEligibilityOutcome.STALE:
+        return result(O.STALE, R.COLLISION_AUTHORITY_STALE)
+    if (
+        c.outcome is not CollisionEligibilityOutcome.ELIGIBLE
+        or m.relationship_outcome is not _ADMISSIBLE_RELATIONSHIP[m.candidate_kind]
+    ):
+        return result(O.BLOCKED, R.COLLISION_AUTHORITY_BLOCKED)
+    if binding.operation is CandidateUseOperation.ADMIT_NEW_CANDIDATE and v is None:
+        if r.distinct_scope_proof_digest is None:
+            return result(O.ADMISSIBLE, R.NEW_CANDIDATE_PRE_EFFECT)
+        proof = build_candidate_distinct_scope_proof(
+            proposed_manifest=m,
+            proposed_collision=c,
+            comparator_collision=comparator_collision,
+            comparator_version=comparator_version,
+        )
+        _valid(proof.canonical_digest == r.distinct_scope_proof_digest)
+        return result(O.DISTINCT, R.RELATED_DISTINCT_PRE_EFFECT, proof)
+    if (
+        binding.operation is not CandidateUseOperation.USE_CURRENT_CANDIDATE
+        or v is None
+    ):
+        return result(O.BLOCKED, R.COLLISION_OPERATION_CAS_DIFFERS)
+    if (
+        v.governing_manifest.semantic_scope_digest != m.semantic_scope_digest
+        or binding.expected_candidate_id != v.candidate_id
+        or c.observed_candidate_id != v.candidate_id
+    ):
+        return result(O.BLOCKED, R.COLLISION_OPERATION_CAS_DIFFERS)
+    if v.governing_manifest.version_material_digest == m.version_material_digest:
+        return result(O.DUPLICATE_EQUIVALENT, R.EXACT_MANIFEST_REPLAY)
+    return result(O.ADMISSIBLE, R.SUCCESSOR_VERSION_PRE_EFFECT)
+
+
+__all__ = tuple(_PUBLIC.split(","))

--- a/newsroom/tests/test_increment6e2_candidates.py
+++ b/newsroom/tests/test_increment6e2_candidates.py
@@ -1,0 +1,1501 @@
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import replace
+
+import pytest
+
+from newsroom.authority.canonical import canonical_json_bytes, digest_bytes
+from newsroom.authority.types import EventId
+from newsroom.discovery.record_models import DiscoverySignal, GateDecision, NewsLead
+from newsroom.increment6 import candidates as candidates_module
+from newsroom.increment6.candidates import (
+    CANDIDATE_ADMISSION,
+    CANDIDATE_CURRENT_VERSION,
+    STORY_CANDIDATE,
+    STORY_CANDIDATE_VERSION,
+    CandidateAdmission,
+    CandidateAdmissionOutcome,
+    CandidateAdmissionReason,
+    CandidateAdmissionRequest,
+    CandidateContractError,
+    CandidateGoverningManifest,
+    CandidateGoverningState,
+    CandidateGoverningStateBinding,
+    CandidateGoverningStateStatus,
+    CandidateLeadSignalBinding,
+    StoryCandidate,
+    StoryCandidateVersion,
+    build_candidate_distinct_scope_proof,
+    build_candidate_governing_manifest,
+    evaluate_candidate_admission,
+    validate_candidate_first_version,
+    validate_candidate_version_successor,
+)
+from newsroom.increment6.collision import (
+    CandidateUseCollisionBinding,
+    CandidateUseOperation,
+    CollisionEligibilityOutcome,
+    CollisionEligibilityReason,
+    CollisionState,
+    CurrentCollisionEligibilityRequest,
+)
+from newsroom.increment6.hypotheses import (
+    EventHypothesis,
+    EventHypothesisVersion,
+    HypothesisSourceBinding,
+)
+from newsroom.increment6.lineage import (
+    HypothesisLineageHead,
+    HypothesisLineageReceipt,
+)
+from newsroom.increment6.outcomes import CanonicalOutcome
+from newsroom.increment6.proposals import CandidateManifestKind
+from newsroom.increment6.relationships import (
+    AssessmentStatus,
+    RetainedRelationshipDecisionReceipt,
+)
+from newsroom.tests.discovery_3d_authority_helpers import exact_admission_request
+from newsroom.tests.test_increment6a2_work_items import _id
+from newsroom.tests.test_increment6c2_dispositions import _persisted_disposition_store
+from newsroom.tests.test_increment6d3_lineage import (
+    _consolidation,
+    _heads,
+    _proof,
+    _replay,
+    _split,
+    _successor,
+    _version,
+)
+from newsroom.tests.test_increment6d3_lineage import (
+    _decision as _relationship_decision,
+)
+from newsroom.tests.test_increment6e1_collision import _decide, _occupied_evidence
+
+D = "sha256:" + "1" * 64
+HYPOTHESIS_ID = "11111111-1111-4111-8111-111111111111"
+VERSION_ID = "22222222-2222-4222-8222-222222222222"
+
+
+def _manifest(collision, *, incomplete: bool = False) -> CandidateGoverningManifest:
+    binding = collision.request.binding
+    scope = digest_bytes(
+        canonical_json_bytes(
+            {
+                "collision_namespace": binding.collision_namespace,
+                "collision_key_digest": binding.collision_key_digest,
+                "hypothesis_id": HYPOTHESIS_ID,
+            }
+        )
+    )
+    return CandidateGoverningManifest(
+        semantic_scope_digest=scope,
+        candidate_kind=CandidateManifestKind.NEW_EVENT,
+        hypothesis_id=HYPOTHESIS_ID,
+        hypothesis_version_id=VERSION_ID,
+        hypothesis_version_digest=D,
+        proposed_summary="Unverified discovery hypothesis",
+        hypothesis_status="UNVERIFIED_DISCOVERY_HYPOTHESIS",
+        relationship_status=AssessmentStatus.COMPLETE,
+        relationship_outcome=CanonicalOutcome.REL_NO_ADEQUATE_PRIOR_MATCH,
+        relationship_assessment_digest=D,
+        relationship_comparator_hypothesis_id=None,
+        relationship_comparator_version_id=None,
+        relationship_comparator_version_digest=None,
+        lineage_generation=2,
+        lineage_history_digests=(D,),
+        disposition_digests=(D,),
+        candidate_manifest_digests=(D,),
+        lead_signal_bindings=(
+            CandidateLeadSignalBinding(
+                "33333333-3333-4333-8333-333333333333",
+                D,
+                "44444444-4444-4444-8444-444444444444",
+                D,
+                "99999999-9999-4999-8999-999999999999",
+                1,
+                "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+                1,
+                '{"obligation_id":"news","responsibility":"PRIMARY"}',
+                incomplete,
+            ),
+        ),
+        proposed_geography="GB",
+        proposed_category="UK_NEWS",
+        urgency="ROUTINE",
+        likely_new_information=("Material change",),
+        reader_utility_bases=("Reader utility",),
+        uncertainties=("Unverified",),
+        evidence_objectives=("Confirm",),
+        governing_versions=("candidate-policy-v1",),
+        missing_context=(),
+        retrieval_incompleteness=(),
+        lead_incompleteness_warnings=(),
+        signal_operational_finding_ids=(),
+        collision_request_digest=collision.request.request_digest,
+        collision_decision_digest=digest_bytes(collision.canonical_bytes),
+        collision_namespace=binding.collision_namespace,
+        collision_key_digest=binding.collision_key_digest,
+        governing_state_binding=CandidateGoverningStateBinding(*((D,) * 9)),
+        incomplete=incomplete,
+    )
+
+
+def _eligible_current(tmp_path, candidate_id: str):
+    requirement, evidence = _occupied_evidence(tmp_path)
+    original = requirement.binding
+    binding = CandidateUseCollisionBinding(
+        subject_id=HYPOTHESIS_ID,
+        subject_version_id=VERSION_ID,
+        subject_version_digest=D,
+        operation=CandidateUseOperation.USE_CURRENT_CANDIDATE,
+        expected_candidate_id=candidate_id,
+        collision_namespace=original.collision_namespace,
+        collision_key_digest=original.collision_key_digest,
+        generation_id=original.generation_id,
+        query_valid_time=original.query_valid_time,
+        serving_time=original.serving_time,
+        authority_watermark=original.authority_watermark,
+    )
+    request = CurrentCollisionEligibilityRequest(
+        binding, requirement.named_request_digest
+    )
+    original_decision = _decide(request=requirement, evidence=evidence)
+    return replace(
+        original_decision, request=request, observed_candidate_id=candidate_id
+    )
+
+
+def _request(
+    manifest: CandidateGoverningManifest, current: StoryCandidateVersion | None
+) -> CandidateAdmissionRequest:
+    return CandidateAdmissionRequest(
+        request_id="55555555-5555-4555-8555-555555555555",
+        actor_identity_digest=D,
+        idempotency_key="candidate-request:001",
+        expected_current_version_id=None if current is None else current.version_id,
+        expected_current_version_digest=None
+        if current is None
+        else current.canonical_digest,
+        expected_current_ordinal=0 if current is None else current.ordinal,
+        semantic_scope_digest=manifest.semantic_scope_digest,
+        collision_request_digest=manifest.collision_request_digest,
+        expected_governing_state_digest=manifest.governing_state_binding.canonical_digest,
+        distinct_scope_proof_digest=None,
+    )
+
+
+def _current_state(manifest: CandidateGoverningManifest) -> CandidateGoverningState:
+    return CandidateGoverningState(
+        CandidateGoverningStateStatus.COMPLETE, manifest.governing_state_binding
+    )
+
+
+def _lineage_args(version: EventHypothesisVersion) -> dict[str, object]:
+    return {
+        "lineage_receipts": (),
+        "lineage_initial_heads": (HypothesisLineageHead.from_version(version),),
+        "lineage_versions": (version,),
+        "lineage_relationship_proofs": (),
+    }
+
+
+def test_candidate_contract_names_are_exact() -> None:
+    assert STORY_CANDIDATE == "newsroom.increment6.story-candidate.v1"
+    assert STORY_CANDIDATE_VERSION == "newsroom.increment6.story-candidate-version.v1"
+    assert CANDIDATE_ADMISSION == "newsroom.increment6.candidate-admission.v1"
+    assert CANDIDATE_CURRENT_VERSION == "EXACT_RETAINED_MAX_ORDINAL_HEAD"
+    assert "proposed_summary" in CandidateGoverningManifest.__dataclass_fields__
+    assert "hypothesis_status" in CandidateGoverningManifest.__dataclass_fields__
+
+
+def test_only_committed_admission_can_create_candidate_identity_and_version() -> None:
+    candidate = StoryCandidate(
+        "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        "66666666-6666-4666-8666-666666666666",
+        "77777777-7777-4777-8777-777777777777",
+        D,
+    )
+    assert StoryCandidate.from_canonical_bytes(candidate.canonical_bytes) == candidate
+    assert not hasattr(StoryCandidate, "allocate")
+    assert not hasattr(StoryCandidate, "from_committed_admission")
+    assert candidate.creates_candidate is False
+
+    class Child(StoryCandidate):
+        pass
+
+    with pytest.raises(CandidateContractError):
+        Child(
+            candidate.candidate_id,
+            candidate.committed_admission_decision_id,
+            candidate.authority_event_id,
+            candidate.semantic_scope_digest,
+        )
+
+
+def test_version_replay_deduplicates_and_changed_manifest_is_contiguous(
+    tmp_path,
+) -> None:
+    provisional = StoryCandidate(
+        "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        "66666666-6666-4666-8666-666666666666",
+        "77777777-7777-4777-8777-777777777777",
+        D,
+    )
+    collision = _eligible_current(tmp_path, provisional.candidate_id)
+    manifest = _manifest(collision)
+    candidate = replace(
+        provisional, semantic_scope_digest=manifest.semantic_scope_digest
+    )
+    first = StoryCandidateVersion(
+        "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+        candidate.candidate_id,
+        1,
+        None,
+        None,
+        candidate.committed_admission_decision_id,
+        manifest,
+    )
+    assert StoryCandidateVersion.from_canonical_bytes(first.canonical_bytes) == first
+    assert validate_candidate_first_version(candidate, first) == first
+    changed = replace(manifest, governing_versions=("candidate-policy-v2",))
+    with pytest.raises(CandidateContractError, match="equivalent manifest"):
+        validate_candidate_version_successor(
+            first,
+            replace(
+                first,
+                version_id="dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+                ordinal=2,
+                previous_version_id=first.version_id,
+                previous_version_digest=first.canonical_digest,
+                committed_admission_decision_id="88888888-8888-4888-8888-888888888888",
+            ),
+        )
+    second = StoryCandidateVersion(
+        "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+        candidate.candidate_id,
+        2,
+        first.version_id,
+        first.canonical_digest,
+        "88888888-8888-4888-8888-888888888888",
+        changed,
+    )
+    assert validate_candidate_version_successor(first, second) == second
+    false_scope = replace(
+        changed,
+        hypothesis_id="eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+        semantic_scope_digest=digest_bytes(
+            canonical_json_bytes(
+                {
+                    "collision_namespace": changed.collision_namespace,
+                    "collision_key_digest": changed.collision_key_digest,
+                    "hypothesis_id": "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+                }
+            )
+        ),
+    )
+    with pytest.raises(CandidateContractError, match="contiguous successor"):
+        validate_candidate_version_successor(
+            first, replace(second, governing_manifest=false_scope)
+        )
+    with pytest.raises(CandidateContractError, match="new committed"):
+        validate_candidate_version_successor(
+            first,
+            replace(
+                second,
+                committed_admission_decision_id=first.committed_admission_decision_id,
+            ),
+        )
+    with pytest.raises(CandidateContractError):
+        validate_candidate_version_successor(
+            first, replace(second, version_id=first.version_id)
+        )
+    assert second.ordinal == 2
+    assert (second.previous_version_id, second.previous_version_digest) == (
+        first.version_id,
+        first.canonical_digest,
+    )
+
+
+def test_pure_duplicate_decision_has_no_new_candidate_or_version_identity(
+    tmp_path,
+) -> None:
+    provisional = StoryCandidate(
+        "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        "66666666-6666-4666-8666-666666666666",
+        "77777777-7777-4777-8777-777777777777",
+        D,
+    )
+    collision = _eligible_current(tmp_path, provisional.candidate_id)
+    manifest = _manifest(collision)
+    candidate = replace(
+        provisional, semantic_scope_digest=manifest.semantic_scope_digest
+    )
+    current = StoryCandidateVersion(
+        "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+        candidate.candidate_id,
+        1,
+        None,
+        None,
+        candidate.committed_admission_decision_id,
+        manifest,
+    )
+    decision = evaluate_candidate_admission(
+        request=_request(manifest, current),
+        manifest=manifest,
+        collision=collision,
+        current_version=current,
+        governing_state=_current_state(manifest),
+    )
+    assert decision.outcome is CandidateAdmissionOutcome.DUPLICATE_EQUIVALENT
+    assert decision.reason is CandidateAdmissionReason.EXACT_MANIFEST_REPLAY
+    assert CandidateAdmission.from_canonical_bytes(decision.canonical_bytes) == decision
+    assert decision.authority == decision.candidate_effect == "NONE"
+    assert decision.candidate_effect_performed is decision.creates_candidate is False
+    document = json.loads(decision.canonical_bytes)
+    assert document["current_candidate_id"] == current.candidate_id
+    assert "candidate_version_id" not in document
+    assert "committed_admission_decision_id" not in document
+
+
+def test_admissible_new_intent_contains_no_candidate_or_version_identity(
+    tmp_path,
+) -> None:
+    candidate_id = StoryCandidate(
+        "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        "66666666-6666-4666-8666-666666666666",
+        "77777777-7777-4777-8777-777777777777",
+        D,
+    ).candidate_id
+    current = _eligible_current(tmp_path, candidate_id)
+    old = current.request.binding
+    binding = replace(
+        old,
+        operation=CandidateUseOperation.ADMIT_NEW_CANDIDATE,
+        expected_candidate_id=None,
+    )
+    collision = replace(
+        current,
+        request=CurrentCollisionEligibilityRequest(
+            binding, current.request.named_request_digest
+        ),
+        reason=CollisionEligibilityReason.CURRENT_SLOT_UNOCCUPIED,
+        collision_state=CollisionState.UNOCCUPIED,
+        observed_candidate_id=None,
+    )
+    manifest = _manifest(collision)
+    decision = evaluate_candidate_admission(
+        request=_request(manifest, None),
+        manifest=manifest,
+        collision=collision,
+        current_version=None,
+        governing_state=_current_state(manifest),
+    )
+    assert decision.outcome is CandidateAdmissionOutcome.ADMISSIBLE
+    assert decision.current_candidate_id is None
+    assert decision.current_candidate_version_id is None
+    assert decision.current_candidate_version_digest is None
+    document = json.loads(decision.canonical_bytes)
+    assert "committed_admission_decision_id" not in document
+    assert "candidate_version_id" not in document
+
+
+def test_incomplete_and_stale_are_typed_while_mismatched_binding_fails_closed(
+    tmp_path,
+) -> None:
+    provisional = StoryCandidate(
+        "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        "66666666-6666-4666-8666-666666666666",
+        "77777777-7777-4777-8777-777777777777",
+        D,
+    )
+    collision = _eligible_current(tmp_path, provisional.candidate_id)
+    manifest = _manifest(collision, incomplete=True)
+    candidate = replace(
+        provisional, semantic_scope_digest=manifest.semantic_scope_digest
+    )
+    current = StoryCandidateVersion(
+        "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+        candidate.candidate_id,
+        1,
+        None,
+        None,
+        candidate.committed_admission_decision_id,
+        manifest,
+    )
+    decision = evaluate_candidate_admission(
+        request=_request(manifest, current),
+        manifest=manifest,
+        collision=collision,
+        current_version=current,
+        governing_state=_current_state(manifest),
+    )
+    assert decision.outcome is CandidateAdmissionOutcome.INCOMPLETE
+    stale = replace(_request(manifest, current), expected_current_ordinal=2)
+    stale_decision = evaluate_candidate_admission(
+        request=stale,
+        manifest=manifest,
+        collision=collision,
+        current_version=current,
+        governing_state=_current_state(manifest),
+    )
+    assert stale_decision.outcome is CandidateAdmissionOutcome.STALE
+    with pytest.raises(CandidateContractError):
+        evaluate_candidate_admission(
+            request=replace(_request(manifest, current), collision_request_digest=D),
+            manifest=manifest,
+            collision=collision,
+            current_version=current,
+            governing_state=_current_state(manifest),
+        )
+    with pytest.raises(CandidateContractError, match="incompleteness differs"):
+        replace(manifest, incomplete=False)
+
+
+def test_missing_expected_current_is_typed_stale_and_scope_retarget_is_distinct(
+    tmp_path,
+) -> None:
+    candidate = StoryCandidate(
+        "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        "66666666-6666-4666-8666-666666666666",
+        "77777777-7777-4777-8777-777777777777",
+        D,
+    )
+    collision = _eligible_current(tmp_path, candidate.candidate_id)
+    proposed = _manifest(collision)
+    expected = CandidateAdmissionRequest(
+        "55555555-5555-4555-8555-555555555555",
+        D,
+        "candidate-request:missing",
+        "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+        D,
+        1,
+        proposed.semantic_scope_digest,
+        proposed.collision_request_digest,
+        proposed.governing_state_binding.canonical_digest,
+        None,
+    )
+    stale = evaluate_candidate_admission(
+        request=expected,
+        manifest=proposed,
+        collision=collision,
+        current_version=None,
+        governing_state=_current_state(proposed),
+    )
+    assert stale.outcome is CandidateAdmissionOutcome.STALE
+    assert stale.current_candidate_id is None
+
+    other_scope = digest_bytes(
+        canonical_json_bytes(
+            {
+                "collision_namespace": proposed.collision_namespace,
+                "collision_key_digest": proposed.collision_key_digest,
+                "hypothesis_id": "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+            }
+        )
+    )
+    current_manifest = replace(
+        proposed,
+        hypothesis_id="eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+        semantic_scope_digest=other_scope,
+    )
+    current = StoryCandidateVersion(
+        "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+        candidate.candidate_id,
+        1,
+        None,
+        None,
+        candidate.committed_admission_decision_id,
+        current_manifest,
+    )
+    distinct = evaluate_candidate_admission(
+        request=_request(proposed, current),
+        manifest=proposed,
+        collision=collision,
+        current_version=current,
+        governing_state=_current_state(proposed),
+    )
+    assert distinct.outcome is CandidateAdmissionOutcome.BLOCKED
+
+
+def test_distinct_and_blocked_collision_results_remain_typed(tmp_path) -> None:
+    candidate = StoryCandidate(
+        "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        "66666666-6666-4666-8666-666666666666",
+        "77777777-7777-4777-8777-777777777777",
+        D,
+    )
+    eligible = _eligible_current(tmp_path, candidate.candidate_id)
+    distinct_collision = replace(
+        eligible,
+        outcome=CollisionEligibilityOutcome.COLLISION_CONFLICT,
+        reason=CollisionEligibilityReason.CURRENT_CANDIDATE_DIFFERS,
+    )
+    distinct_manifest = _manifest(distinct_collision)
+    distinct = evaluate_candidate_admission(
+        request=_request(distinct_manifest, None),
+        manifest=distinct_manifest,
+        collision=distinct_collision,
+        current_version=None,
+        governing_state=_current_state(distinct_manifest),
+    )
+    assert distinct.outcome is CandidateAdmissionOutcome.BLOCKED
+    related_manifest = replace(
+        distinct_manifest,
+        relationship_outcome=CanonicalOutcome.REL_RELATED_DISTINCT,
+    )
+    related_binding = replace(
+        distinct_collision.request.binding,
+        operation=CandidateUseOperation.ADMIT_NEW_CANDIDATE,
+        expected_candidate_id=None,
+    )
+    related_collision = replace(
+        distinct_collision,
+        request=CurrentCollisionEligibilityRequest(
+            related_binding, distinct_collision.request.named_request_digest
+        ),
+        outcome=CollisionEligibilityOutcome.ELIGIBLE,
+        reason=CollisionEligibilityReason.CURRENT_SLOT_UNOCCUPIED,
+        collision_state=CollisionState.UNOCCUPIED,
+        observed_candidate_id=None,
+    )
+    related_manifest = replace(
+        related_manifest,
+        collision_request_digest=related_collision.request.request_digest,
+        collision_decision_digest=digest_bytes(related_collision.canonical_bytes),
+    )
+    related = evaluate_candidate_admission(
+        request=replace(
+            _request(related_manifest, None),
+            collision_request_digest=related_manifest.collision_request_digest,
+        ),
+        manifest=related_manifest,
+        collision=related_collision,
+        current_version=None,
+        governing_state=_current_state(related_manifest),
+    )
+    assert related.outcome is CandidateAdmissionOutcome.BLOCKED
+    with pytest.raises(CandidateContractError, match="distinct"):
+        CandidateAdmission(
+            _request(related_manifest, None),
+            related_manifest,
+            CandidateAdmissionOutcome.DISTINCT,
+            CandidateAdmissionReason.RELATED_DISTINCT_PRE_EFFECT,
+            candidate.candidate_id,
+            "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+            D,
+        )
+
+    blocked_collision = replace(
+        eligible,
+        outcome=CollisionEligibilityOutcome.POLICY_BLOCKED,
+        reason=CollisionEligibilityReason.AUTHORITY_POLICY_BLOCKED,
+    )
+    blocked_manifest = _manifest(blocked_collision)
+    blocked = evaluate_candidate_admission(
+        request=_request(blocked_manifest, None),
+        manifest=blocked_manifest,
+        collision=blocked_collision,
+        current_version=None,
+        governing_state=_current_state(blocked_manifest),
+    )
+    assert blocked.outcome is CandidateAdmissionOutcome.BLOCKED
+
+
+@pytest.mark.parametrize(
+    (
+        "collision_outcome",
+        "collision_reason",
+        "expected_outcome",
+        "expected_admission_reason",
+    ),
+    [
+        (
+            CollisionEligibilityOutcome.UNAVAILABLE,
+            CollisionEligibilityReason.AUTHORITY_UNAVAILABLE,
+            CandidateAdmissionOutcome.INCOMPLETE,
+            CandidateAdmissionReason.COLLISION_AUTHORITY_UNAVAILABLE,
+        ),
+        (
+            CollisionEligibilityOutcome.BINDING_MISMATCH,
+            CollisionEligibilityReason.NAMED_REQUEST_BINDING_DIFFERS,
+            CandidateAdmissionOutcome.BLOCKED,
+            CandidateAdmissionReason.COLLISION_AUTHORITY_BLOCKED,
+        ),
+    ],
+)
+def test_unavailable_and_binding_mismatch_keep_typed_fail_closed_meaning(
+    tmp_path,
+    collision_outcome,
+    collision_reason,
+    expected_outcome,
+    expected_admission_reason,
+) -> None:
+    collision = replace(
+        _eligible_current(tmp_path, "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"),
+        outcome=collision_outcome,
+        reason=collision_reason,
+    )
+    manifest = _manifest(collision)
+    decision = evaluate_candidate_admission(
+        request=_request(manifest, None),
+        manifest=manifest,
+        collision=collision,
+        current_version=None,
+        governing_state=_current_state(manifest),
+    )
+    assert decision.outcome is expected_outcome
+    assert decision.reason is expected_admission_reason
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    [CanonicalOutcome.REL_SAME_STATE, CanonicalOutcome.REL_UNCERTAIN],
+)
+def test_same_state_and_uncertain_are_typed_blocked(tmp_path, outcome) -> None:
+    collision = _eligible_current(tmp_path, "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")
+    manifest = replace(_manifest(collision), relationship_outcome=outcome)
+    decision = evaluate_candidate_admission(
+        request=_request(manifest, None),
+        manifest=manifest,
+        collision=collision,
+        current_version=None,
+        governing_state=_current_state(manifest),
+    )
+    assert decision.outcome is CandidateAdmissionOutcome.BLOCKED
+
+
+def test_lineage_history_order_is_preserved_not_sorted(tmp_path) -> None:
+    manifest = _manifest(
+        _eligible_current(tmp_path, "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")
+    )
+    ordered = replace(
+        manifest,
+        lineage_history_digests=("sha256:" + "2" * 64, "sha256:" + "1" * 64),
+    )
+    assert (
+        CandidateGoverningManifest.from_value(
+            ordered.canonical_value()
+        ).lineage_history_digests
+        == ordered.lineage_history_digests
+    )
+
+
+def test_semantic_scope_separates_split_subjects_and_preserves_restored_subject(
+    tmp_path,
+) -> None:
+    collision = _eligible_current(tmp_path, "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")
+    original = _manifest(collision)
+    split_hypothesis = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee"
+    split_scope = digest_bytes(
+        canonical_json_bytes(
+            {
+                "collision_namespace": original.collision_namespace,
+                "collision_key_digest": original.collision_key_digest,
+                "hypothesis_id": split_hypothesis,
+            }
+        )
+    )
+    split = replace(
+        original, hypothesis_id=split_hypothesis, semantic_scope_digest=split_scope
+    )
+    assert split.semantic_scope_digest != original.semantic_scope_digest
+    restored = replace(original, lineage_generation=original.lineage_generation + 2)
+    assert restored.semantic_scope_digest == original.semantic_scope_digest
+
+
+def test_real_producers_build_exact_governing_manifest(tmp_path) -> None:
+    _, _, _, _, _, _, disposition = _persisted_disposition_store(
+        tmp_path, name="candidate-producer-integration"
+    )
+    base = exact_admission_request()
+    lead_request = replace(
+        base.lead,
+        lead_id=type(base.lead.lead_id).parse(disposition.lead_head.decision_lead_id),
+        promoting_gate_decision_id=type(base.lead.promoting_gate_decision_id).parse(
+            _id(101)
+        ),
+        definition_id=type(base.lead.definition_id).parse(_id(201)),
+        definition_version_id=type(base.lead.definition_version_id).parse(_id(301)),
+    )
+    assert lead_request.digest == disposition.lead_head.decision_lead_digest
+    signal_request = replace(
+        base.signal,
+        signal_id=lead_request.signal_id,
+        definition_id=lead_request.definition_id,
+        definition_version_id=lead_request.definition_version_id,
+        item_id=lead_request.item_id,
+        revision_id=lead_request.revision_id,
+        representation_id=lead_request.representation_id,
+        occurrence_id=lead_request.occurrence_id,
+        transition_id=lead_request.transition_id,
+    )
+    lead = NewsLead(
+        lead_request, EventId.new(), 1, lead_request.created_at, lead_request.digest
+    )
+    signal = DiscoverySignal(
+        signal_request,
+        EventId.new(),
+        1,
+        signal_request.admitted_at,
+        signal_request.digest,
+    )
+    gate_request = replace(
+        base.gate,
+        decision_id=lead_request.promoting_gate_decision_id,
+        signal_id=lead_request.signal_id,
+        evaluated_definition_version_id=lead_request.definition_version_id,
+        coverage=lead_request.coverage,
+    )
+    gate = GateDecision(
+        gate_request, EventId.new(), 1, gate_request.decided_at, gate_request.digest
+    )
+    proposed = disposition.route_binding.hypothesis
+    assert proposed is not None
+    hypothesis = EventHypothesis.allocate(
+        disposition.proposal_id, proposed.proposal_local_id
+    )
+    source = HypothesisSourceBinding(
+        disposition.disposition_id,
+        digest_bytes(disposition.canonical_bytes),
+        disposition.finding_set_digest,
+        disposition.route_binding_digest,
+        disposition.lead_head.decision_lead_id,
+        disposition.lead_head.decision_lead_digest,
+        disposition.lead_head.current_disposition_head_id,
+        disposition.lead_head.current_disposition_head_digest,
+    )
+    version = EventHypothesisVersion(
+        str(uuid.uuid5(uuid.UUID(hypothesis.hypothesis_id), "version:1")),
+        hypothesis.hypothesis_id,
+        1,
+        None,
+        None,
+        proposed.summary,
+        proposed.relationship_kind,
+        proposed.target_hypothesis_id,
+        None,
+        None,
+        disposition.proposal_id,
+        disposition.proposal_content_identity,
+        disposition.proposal_canonical_digest,
+        proposed.proposal_local_id,
+        disposition.work_item_id,
+        disposition.work_item_version_id,
+        disposition.work_item_version_digest,
+        disposition.retrieval_context_id,
+        disposition.retrieval_context_digest,
+        (source,),
+        disposition.validator_input.authenticated_context_identity,
+        str(EventId.new()),
+        "2042-01-01T00:00:00.000000Z",
+    )
+    collision_path = tmp_path / "collision"
+    collision_path.mkdir()
+    occupied = _eligible_current(collision_path, "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")
+    binding = replace(
+        occupied.request.binding,
+        subject_id=version.hypothesis_id,
+        subject_version_id=version.version_id,
+        subject_version_digest=version.canonical_digest,
+        operation=CandidateUseOperation.ADMIT_NEW_CANDIDATE,
+        expected_candidate_id=None,
+    )
+    collision = replace(
+        occupied,
+        request=CurrentCollisionEligibilityRequest(
+            binding, occupied.request.named_request_digest
+        ),
+        reason=CollisionEligibilityReason.CURRENT_SLOT_UNOCCUPIED,
+        collision_state=CollisionState.UNOCCUPIED,
+        observed_candidate_id=None,
+    )
+    assessment, evidence = _relationship_decision(
+        version, (), CanonicalOutcome.REL_NO_ADEQUATE_PRIOR_MATCH
+    )
+    relationship = RetainedRelationshipDecisionReceipt(assessment, evidence)
+    manifest = build_candidate_governing_manifest(
+        hypothesis_version=version,
+        **_lineage_args(version),
+        dispositions=(disposition,),
+        leads=(lead,),
+        signals=(signal,),
+        gates=(gate,),
+        relationship=relationship,
+        collision=collision,
+    )
+    assert manifest.candidate_kind is CandidateManifestKind.NEW_EVENT
+    assert manifest.lead_signal_bindings[0].coverage_basis
+    assert manifest.lineage_history_digests == ()
+    assert manifest.missing_context == disposition.route_binding.missing_context
+    assert (
+        manifest.retrieval_incompleteness
+        == disposition.route_binding.retrieval_incompleteness
+    )
+    assert manifest.lead_incompleteness_warnings == lead.request.incompleteness_warnings
+    assert manifest.signal_operational_finding_ids == tuple(
+        str(value) for value in signal.request.operational_finding_ids
+    )
+    comparator_hypothesis = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee"
+    comparator_hypothesis_version = "ffffffff-ffff-4fff-8fff-ffffffffffff"
+    comparator_key = "sha256:" + "2" * 64
+    comparator_scope = digest_bytes(
+        canonical_json_bytes(
+            {
+                "collision_namespace": binding.collision_namespace,
+                "collision_key_digest": comparator_key,
+                "hypothesis_id": comparator_hypothesis,
+            }
+        )
+    )
+    comparator_candidate_id = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+    comparator_binding = replace(
+        binding,
+        subject_id=comparator_hypothesis,
+        subject_version_id=comparator_hypothesis_version,
+        subject_version_digest=D,
+        operation=CandidateUseOperation.USE_CURRENT_CANDIDATE,
+        expected_candidate_id=comparator_candidate_id,
+        collision_key_digest=comparator_key,
+    )
+    comparator_collision = replace(
+        collision,
+        request=CurrentCollisionEligibilityRequest(
+            comparator_binding, collision.request.named_request_digest
+        ),
+        reason=CollisionEligibilityReason.CURRENT_CANDIDATE_MATCH,
+        collision_state=CollisionState.OCCUPIED,
+        observed_candidate_id=comparator_candidate_id,
+    )
+    comparator_manifest = replace(
+        manifest,
+        hypothesis_id=comparator_hypothesis,
+        hypothesis_version_id=comparator_hypothesis_version,
+        hypothesis_version_digest=D,
+        collision_request_digest=comparator_collision.request.request_digest,
+        collision_decision_digest=digest_bytes(comparator_collision.canonical_bytes),
+        collision_key_digest=comparator_key,
+        semantic_scope_digest=comparator_scope,
+    )
+    comparator_version = StoryCandidateVersion(
+        "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+        comparator_candidate_id,
+        1,
+        None,
+        None,
+        "66666666-6666-4666-8666-666666666666",
+        comparator_manifest,
+    )
+    proof = build_candidate_distinct_scope_proof(
+        proposed_manifest=manifest,
+        proposed_collision=collision,
+        comparator_collision=comparator_collision,
+        comparator_version=comparator_version,
+    )
+    with pytest.raises(CandidateContractError):
+        build_candidate_distinct_scope_proof(
+            proposed_manifest=manifest,
+            proposed_collision=collision,
+            comparator_collision=replace(
+                comparator_collision,
+                request=replace(
+                    comparator_collision.request,
+                    binding=replace(comparator_binding, collision_key_digest=D),
+                ),
+            ),
+            comparator_version=comparator_version,
+        )
+    distinct_request = replace(
+        _request(manifest, None), distinct_scope_proof_digest=proof.canonical_digest
+    )
+    distinct = evaluate_candidate_admission(
+        request=distinct_request,
+        manifest=manifest,
+        collision=collision,
+        current_version=None,
+        governing_state=_current_state(manifest),
+        comparator_collision=comparator_collision,
+        comparator_version=comparator_version,
+    )
+    assert distinct.outcome is CandidateAdmissionOutcome.DISTINCT
+    assert distinct.distinct_scope_proof == proof
+    lineage_args = _lineage_args(version)
+    lineage = candidates_module.replay_hypothesis_lineage(
+        lineage_args["lineage_receipts"],
+        initial_heads=lineage_args["lineage_initial_heads"],
+        versions=lineage_args["lineage_versions"],
+        relationship_proofs=lineage_args["lineage_relationship_proofs"],
+    )
+    assert (
+        candidates_module._derive_governing_state(
+            (gate,),
+            (lead,),
+            (signal,),
+            (disposition,),
+            version,
+            assessment,
+            lineage,
+        )
+        == manifest.governing_state_binding
+    )
+    second_gate_request = replace(
+        gate.request,
+        decision_id=type(gate.request.decision_id).parse(_id(102)),
+        idempotency_key="candidate-gate:permutation",
+    )
+    second_gate = GateDecision(
+        second_gate_request,
+        EventId.new(),
+        1,
+        second_gate_request.decided_at,
+        second_gate_request.digest,
+    )
+    derive = candidates_module._derive_governing_state
+    args = ((lead,), (signal,), (disposition,), version, assessment, lineage)
+    assert derive((gate, second_gate), *args) == derive((second_gate, gate), *args)
+    with pytest.raises(CandidateContractError):
+        build_candidate_governing_manifest(
+            hypothesis_version=version,
+            **_lineage_args(version),
+            dispositions=(disposition,),
+            leads=(lead,),
+            signals=(signal,),
+            gates=(gate, gate),
+            relationship=relationship,
+            collision=collision,
+        )
+    candidate_manifest = disposition.route_binding.candidate_manifest
+    assert candidate_manifest is not None
+    assert (
+        len(
+            {
+                digest_bytes(canonical_json_bytes(candidate_manifest.canonical_value()))
+                for _ in range(2)
+            }
+        )
+        == 1
+    )
+    with pytest.raises(CandidateContractError, match="one exact disposition"):
+        candidates_module._validate_contributing_dispositions(
+            {
+                disposition.lead_head.decision_lead_id,
+                "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+            },
+            (disposition,),
+        )
+
+    tampered_lead_request = replace(
+        lead.request, incompleteness_warnings=("Missing corroboration",)
+    )
+    tampered_lead = NewsLead(
+        tampered_lead_request,
+        EventId.new(),
+        1,
+        tampered_lead_request.created_at,
+        tampered_lead_request.digest,
+    )
+    with pytest.raises(CandidateContractError, match="supplied News Lead"):
+        build_candidate_governing_manifest(
+            hypothesis_version=version,
+            **_lineage_args(version),
+            dispositions=(disposition,),
+            leads=(tampered_lead,),
+            signals=(signal,),
+            gates=(gate,),
+            relationship=relationship,
+            collision=collision,
+        )
+
+    for field in (
+        "finding_set_digest",
+        "route_binding_digest",
+        "decision_lead_digest",
+        "decision_lead_head_digest",
+    ):
+        tampered_source = replace(source, **{field: "sha256:" + "9" * 64})
+        with pytest.raises(CandidateContractError):
+            tampered_version = replace(version, source_bindings=(tampered_source,))
+            build_candidate_governing_manifest(
+                hypothesis_version=tampered_version,
+                **_lineage_args(tampered_version),
+                dispositions=(disposition,),
+                leads=(lead,),
+                signals=(signal,),
+                gates=(gate,),
+                relationship=relationship,
+                collision=collision,
+            )
+
+    extra_request = replace(
+        signal.request, signal_id=type(signal.request.signal_id).new()
+    )
+    extra_signal = DiscoverySignal(
+        extra_request, EventId.new(), 1, extra_request.admitted_at, extra_request.digest
+    )
+    with pytest.raises(CandidateContractError, match="Signals differ"):
+        build_candidate_governing_manifest(
+            hypothesis_version=version,
+            **_lineage_args(version),
+            dispositions=(disposition,),
+            leads=(lead,),
+            signals=(signal, extra_signal),
+            gates=(gate,),
+            relationship=relationship,
+            collision=collision,
+        )
+    with pytest.raises(CandidateContractError):
+        build_candidate_governing_manifest(
+            hypothesis_version=version,
+            lineage_receipts=(),
+            lineage_initial_heads=(),
+            lineage_versions=(version,),
+            lineage_relationship_proofs=(),
+            dispositions=(disposition,),
+            leads=(lead,),
+            signals=(signal,),
+            gates=(gate,),
+            relationship=relationship,
+            collision=collision,
+        )
+    split_source, split_left, split_right = _version(950), _version(951), _version(952)
+    split_proofs = tuple(
+        _proof(
+            output,
+            (
+                split_source,
+                *(item for item in (split_left, split_right) if item != output),
+            ),
+            CanonicalOutcome.REL_RELATED_DISTINCT,
+        )
+        for output in (split_left, split_right)
+    )
+    split_receipt = HypothesisLineageReceipt.split(
+        expected_generation=0,
+        source=split_source,
+        outputs=(split_left, split_right),
+        relationship_proofs=split_proofs,
+    )
+    split_assessment, split_evidence = _relationship_decision(
+        split_source, (), CanonicalOutcome.REL_NO_ADEQUATE_PRIOR_MATCH
+    )
+    with pytest.raises(CandidateContractError, match="current lineage head"):
+        build_candidate_governing_manifest(
+            hypothesis_version=split_source,
+            lineage_receipts=(split_receipt,),
+            lineage_initial_heads=(HypothesisLineageHead.from_version(split_source),),
+            lineage_versions=(split_source, split_left, split_right),
+            lineage_relationship_proofs=split_proofs,
+            dispositions=(disposition,),
+            leads=(lead,),
+            signals=(signal,),
+            gates=(gate,),
+            relationship=RetainedRelationshipDecisionReceipt(
+                split_assessment, split_evidence
+            ),
+            collision=collision,
+        )
+    with pytest.raises(CandidateContractError):
+        build_candidate_governing_manifest(
+            hypothesis_version=version,
+            lineage_receipts=(),
+            lineage_initial_heads=(HypothesisLineageHead.from_version(version, 1),),
+            lineage_versions=(version,),
+            lineage_relationship_proofs=(),
+            dispositions=(disposition,),
+            leads=(lead,),
+            signals=(signal,),
+            gates=(gate,),
+            relationship=relationship,
+            collision=collision,
+        )
+
+
+def test_incomplete_d2_is_retained_and_blocks_admission(tmp_path) -> None:
+    collision = _eligible_current(tmp_path, "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")
+    manifest = _manifest(collision)
+    incomplete = replace(
+        manifest,
+        relationship_status=AssessmentStatus.INCOMPLETE,
+        relationship_outcome=None,
+        incomplete=True,
+    )
+    decision = evaluate_candidate_admission(
+        request=_request(incomplete, None),
+        manifest=incomplete,
+        collision=collision,
+        current_version=None,
+        governing_state=_current_state(incomplete),
+    )
+    assert decision.outcome is CandidateAdmissionOutcome.INCOMPLETE
+
+
+def test_candidate_kind_is_version_state_not_candidate_identity(tmp_path) -> None:
+    original = _manifest(
+        _eligible_current(tmp_path, "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")
+    )
+    correction_scope = digest_bytes(
+        canonical_json_bytes(
+            {
+                "collision_namespace": original.collision_namespace,
+                "collision_key_digest": original.collision_key_digest,
+                "hypothesis_id": original.hypothesis_id,
+            }
+        )
+    )
+    correction = replace(
+        original,
+        candidate_kind=CandidateManifestKind.CORRECTION,
+        semantic_scope_digest=correction_scope,
+        relationship_outcome=CanonicalOutcome.REL_CORRECTION_REVERSAL_OF,
+    )
+    assert correction.semantic_scope_digest == original.semantic_scope_digest
+
+
+def test_actual_d3_split_consolidation_and_reversal_preserve_scope_rules() -> None:
+    def scope(hypothesis_id: str, kind: CandidateManifestKind) -> str:
+        return digest_bytes(
+            canonical_json_bytes(
+                {
+                    "collision_namespace": "candidate-development",
+                    "collision_key_digest": D,
+                    "hypothesis_id": hypothesis_id,
+                }
+            )
+        )
+
+    source, left, right = _version(900), _version(901), _version(902)
+    split = _split(source, (left, right))
+    split_replay = _replay((split,), _heads(source))
+    split_ids = [head.node.hypothesis_id for head in split_replay.active_heads]
+    assert (
+        len({scope(item, CandidateManifestKind.NEW_EVENT) for item in split_ids}) == 2
+    )
+
+    merged = _version(903)
+    consolidation = _consolidation((left, right), merged)
+    consolidated = _replay((consolidation,), _heads(left, right))
+    assert len(consolidated.active_heads) == 1
+    merged_scope = scope(merged.hypothesis_id, CandidateManifestKind.NEW_EVENT)
+    assert merged_scope not in {
+        scope(left.hypothesis_id, CandidateManifestKind.NEW_EVENT),
+        scope(right.hypothesis_id, CandidateManifestKind.NEW_EVENT),
+    }
+
+    restored = (_successor(left, 904), _successor(right, 905))
+    reversal = HypothesisLineageReceipt.reversal(
+        expected_generation=1,
+        target=consolidation,
+        outputs=restored,
+        relationship_proofs=tuple(
+            _proof(output, (merged,), CanonicalOutcome.REL_CORRECTION_REVERSAL_OF)
+            for output in restored
+        ),
+    )
+    reversed_replay = _replay((consolidation, reversal), _heads(left, right))
+    assert {
+        scope(head.node.hypothesis_id, CandidateManifestKind.NEW_EVENT)
+        for head in reversed_replay.active_heads
+    } == {
+        scope(left.hypothesis_id, CandidateManifestKind.NEW_EVENT),
+        scope(right.hypothesis_id, CandidateManifestKind.NEW_EVENT),
+    }
+    assert scope(left.hypothesis_id, CandidateManifestKind.CORRECTION) == scope(
+        left.hypothesis_id, CandidateManifestKind.NEW_EVENT
+    )
+
+
+def test_first_version_and_admission_reason_invariants_fail_closed(tmp_path) -> None:
+    collision = _eligible_current(tmp_path, "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")
+    manifest = _manifest(collision)
+    candidate = StoryCandidate(
+        "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        "66666666-6666-4666-8666-666666666666",
+        "77777777-7777-4777-8777-777777777777",
+        manifest.semantic_scope_digest,
+    )
+    version = StoryCandidateVersion(
+        "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+        candidate.candidate_id,
+        1,
+        None,
+        None,
+        candidate.committed_admission_decision_id,
+        manifest,
+    )
+    with pytest.raises(CandidateContractError, match="committed Candidate"):
+        validate_candidate_first_version(
+            replace(
+                candidate,
+                committed_admission_decision_id="88888888-8888-4888-8888-888888888888",
+            ),
+            version,
+        )
+    request = _request(manifest, version)
+    with pytest.raises(CandidateContractError, match="outcome and reason"):
+        CandidateAdmission(
+            request,
+            manifest,
+            CandidateAdmissionOutcome.DUPLICATE_EQUIVALENT,
+            CandidateAdmissionReason.COLLISION_AUTHORITY_BLOCKED,
+            version.candidate_id,
+            version.version_id,
+            version.canonical_digest,
+        )
+    with pytest.raises(CandidateContractError, match="requires an exact current"):
+        CandidateAdmission(
+            replace(
+                request,
+                expected_current_version_id=None,
+                expected_current_version_digest=None,
+                expected_current_ordinal=0,
+            ),
+            manifest,
+            CandidateAdmissionOutcome.DUPLICATE_EQUIVALENT,
+            CandidateAdmissionReason.EXACT_MANIFEST_REPLAY,
+            None,
+            None,
+            None,
+        )
+    assert request.canonical_digest == digest_bytes(request.canonical_bytes)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        b"[]",
+        b"true",
+        b"1.0",
+        b'{"schema_version":"x","schema_version":"x"}',
+        b'{ "schema_version":"newsroom.increment6.story-candidate.v1"}',
+    ],
+)
+def test_canonical_parsers_reject_malformed_duplicate_and_noncanonical_json(
+    raw: bytes,
+) -> None:
+    with pytest.raises(CandidateContractError):
+        StoryCandidate.from_canonical_bytes(raw)
+
+
+def test_parser_rejects_unknown_deep_large_bool_int_and_builtin_subclasses() -> None:
+    deep = b'{"a":' * 25 + b"null" + b"}" * 25
+    large = b"{" + b'"x":"' + b"x" * 1_048_576 + b'"}'
+    over_envelope = b"{" + b'"x":"' + b"x" * 16_777_216 + b'"}'
+    for raw in (deep, large, over_envelope):
+        with pytest.raises(CandidateContractError):
+            StoryCandidate.from_canonical_bytes(raw)
+    with pytest.raises(CandidateContractError):
+        CandidateAdmissionRequest(
+            "55555555-5555-4555-8555-555555555555",
+            D,
+            "request:1",
+            None,
+            None,
+            True,
+            D,
+            D,
+            D,
+            None,
+        )
+
+    class Raw(bytes):
+        pass
+
+    with pytest.raises(CandidateContractError):
+        StoryCandidate.from_canonical_bytes(Raw(b"{}"))
+    with pytest.raises(CandidateContractError):
+        _ = object.__new__(StoryCandidate).canonical_bytes
+
+    binding = CandidateLeadSignalBinding(
+        "33333333-3333-4333-8333-333333333333",
+        D,
+        "44444444-4444-4444-8444-444444444444",
+        D,
+        "99999999-9999-4999-8999-999999999999",
+        1,
+        "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        1,
+        '{"obligation_id":"news"}',
+        False,
+    )
+    with pytest.raises(CandidateContractError):
+        replace(binding, coverage_basis='{"value":"\ud800"}')
+
+
+def test_constructed_values_cannot_exceed_the_parser_structural_envelope(
+    tmp_path,
+) -> None:
+    manifest = _manifest(
+        _eligible_current(tmp_path, "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")
+    )
+    with pytest.raises(CandidateContractError, match="structural bounds"):
+        replace(
+            manifest,
+            uncertainties=tuple(f"uncertainty-{index:05d}" for index in range(40_000)),
+        )
+    with pytest.raises(CandidateContractError, match="canonical UUID"):
+        replace(manifest, signal_operational_finding_ids=("not-a-finding-id",))
+    with pytest.raises(CandidateContractError):
+        replace(
+            manifest,
+            lead_signal_bindings=(object.__new__(CandidateLeadSignalBinding),),
+        )
+
+    class Status(str):
+        pass
+
+    with pytest.raises(CandidateContractError):
+        replace(manifest, hypothesis_status=Status(manifest.hypothesis_status))
+    with pytest.raises(CandidateContractError):
+        CandidateAdmission(
+            object.__new__(CandidateAdmissionRequest),
+            manifest,
+            CandidateAdmissionOutcome.BLOCKED,
+            CandidateAdmissionReason.COLLISION_AUTHORITY_BLOCKED,
+            None,
+            None,
+            None,
+        )
+
+
+def test_governing_currentness_statuses_and_exact_binding(tmp_path) -> None:
+    collision = _eligible_current(tmp_path, "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")
+    manifest = _manifest(collision)
+    request = _request(manifest, None)
+    for status, outcome in (
+        (
+            CandidateGoverningStateStatus.UNAVAILABLE,
+            CandidateAdmissionOutcome.INCOMPLETE,
+        ),
+        (
+            CandidateGoverningStateStatus.INCOMPLETE,
+            CandidateAdmissionOutcome.INCOMPLETE,
+        ),
+        (CandidateGoverningStateStatus.BLOCKED, CandidateAdmissionOutcome.BLOCKED),
+    ):
+        decision = evaluate_candidate_admission(
+            request=request,
+            manifest=manifest,
+            collision=collision,
+            current_version=None,
+            governing_state=CandidateGoverningState(status, None),
+        )
+        assert decision.outcome is outcome
+    changed = replace(manifest.governing_state_binding, coverage="sha256:" + "2" * 64)
+    stale = evaluate_candidate_admission(
+        request=request,
+        manifest=manifest,
+        collision=collision,
+        current_version=None,
+        governing_state=CandidateGoverningState(
+            CandidateGoverningStateStatus.COMPLETE, changed
+        ),
+    )
+    assert stale.outcome is CandidateAdmissionOutcome.STALE
+
+
+def test_partial_predecessor_and_request_cas_fail_closed(tmp_path) -> None:
+    manifest = _manifest(
+        _eligible_current(tmp_path, "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")
+    )
+    with pytest.raises(CandidateContractError, match="partial"):
+        replace(
+            _request(manifest, None),
+            expected_current_version_id="cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+        )
+    candidate = StoryCandidate(
+        "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        "66666666-6666-4666-8666-666666666666",
+        "77777777-7777-4777-8777-777777777777",
+        manifest.semantic_scope_digest,
+    )
+    with pytest.raises(CandidateContractError, match="partial"):
+        StoryCandidateVersion(
+            "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+            candidate.candidate_id,
+            2,
+            "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+            None,
+            "88888888-8888-4888-8888-888888888888",
+            manifest,
+        )
+
+
+def test_collision_receipt_refresh_is_material_duplicate(tmp_path) -> None:
+    candidate_id = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+    use_collision = _eligible_current(tmp_path, candidate_id)
+    use_binding = use_collision.request.binding
+    admit_binding = replace(
+        use_binding,
+        operation=CandidateUseOperation.ADMIT_NEW_CANDIDATE,
+        expected_candidate_id=None,
+    )
+    admit_collision = replace(
+        use_collision,
+        request=CurrentCollisionEligibilityRequest(
+            admit_binding, use_collision.request.named_request_digest
+        ),
+        reason=CollisionEligibilityReason.CURRENT_SLOT_UNOCCUPIED,
+        collision_state=CollisionState.UNOCCUPIED,
+        observed_candidate_id=None,
+    )
+    admitted_manifest, current_manifest = (
+        _manifest(admit_collision),
+        _manifest(use_collision),
+    )
+    current = StoryCandidateVersion(
+        "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+        candidate_id,
+        1,
+        None,
+        None,
+        "66666666-6666-4666-8666-666666666666",
+        admitted_manifest,
+    )
+    assert admitted_manifest.canonical_digest != current_manifest.canonical_digest
+    assert (
+        admitted_manifest.version_material_digest
+        == current_manifest.version_material_digest
+    )
+    assert admitted_manifest.version_material_digest != digest_bytes(
+        canonical_json_bytes(admitted_manifest.version_material_value())
+    )
+    duplicate = evaluate_candidate_admission(
+        request=_request(current_manifest, current),
+        manifest=current_manifest,
+        collision=use_collision,
+        current_version=current,
+        governing_state=_current_state(current_manifest),
+    )
+    assert duplicate.outcome is CandidateAdmissionOutcome.DUPLICATE_EQUIVALENT
+    changed = replace(current_manifest, uncertainties=("Materially changed",))
+    successor = evaluate_candidate_admission(
+        request=_request(changed, current),
+        manifest=changed,
+        collision=use_collision,
+        current_version=current,
+        governing_state=_current_state(changed),
+    )
+    assert successor.reason is CandidateAdmissionReason.SUCCESSOR_VERSION_PRE_EFFECT
+
+
+def test_d2_comparator_must_match_exact_d1_target_version() -> None:
+    base = _version(980)
+    successor = _successor(base, 981)
+    assessment, _ = _relationship_decision(
+        successor, (base,), CanonicalOutcome.REL_CORRECTION_REVERSAL_OF
+    )
+    candidates_module._validate_relationship_route(successor, assessment)
+    wrong = replace(
+        assessment.comparator,
+        version_id="eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+    )
+    tampered = replace(
+        assessment,
+        comparator=wrong,
+        comparator_manifest=replace(
+            assessment.comparator_manifest, comparators=(wrong,)
+        ),
+    )
+    with pytest.raises(CandidateContractError):
+        candidates_module._validate_relationship_route(successor, tampered)

--- a/newsroom/tests/test_increment6e2_candidates.py
+++ b/newsroom/tests/test_increment6e2_candidates.py
@@ -9,6 +9,13 @@ import pytest
 from newsroom.authority.canonical import canonical_json_bytes, digest_bytes
 from newsroom.authority.types import EventId
 from newsroom.discovery.record_models import DiscoverySignal, GateDecision, NewsLead
+from newsroom.discovery.types import (
+    DecisionTerminality,
+    GateOutcome,
+    NextAction,
+    NextActionKind,
+    TimeValidity,
+)
 from newsroom.increment6 import candidates as candidates_module
 from newsroom.increment6.candidates import (
     CANDIDATE_ADMISSION,
@@ -57,6 +64,7 @@ from newsroom.increment6.relationships import (
     RetainedRelationshipDecisionReceipt,
 )
 from newsroom.tests.discovery_3d_authority_helpers import exact_admission_request
+from newsroom.tests.discovery_3d_helpers import reason
 from newsroom.tests.test_increment6a2_work_items import _id
 from newsroom.tests.test_increment6c2_dispositions import _persisted_disposition_store
 from newsroom.tests.test_increment6d3_lineage import (
@@ -139,6 +147,16 @@ def _manifest(collision, *, incomplete: bool = False) -> CandidateGoverningManif
         collision_key_digest=binding.collision_key_digest,
         governing_state_binding=CandidateGoverningStateBinding(*((D,) * 9)),
         incomplete=incomplete,
+    )
+
+
+def _with_relationship(manifest, outcome):
+    return replace(
+        manifest,
+        relationship_outcome=outcome,
+        relationship_comparator_hypothesis_id="33333333-3333-4333-8333-333333333333",
+        relationship_comparator_version_id="44444444-4444-4444-8444-444444444444",
+        relationship_comparator_version_digest=D,
     )
 
 
@@ -541,9 +559,8 @@ def test_distinct_and_blocked_collision_results_remain_typed(tmp_path) -> None:
         governing_state=_current_state(distinct_manifest),
     )
     assert distinct.outcome is CandidateAdmissionOutcome.BLOCKED
-    related_manifest = replace(
-        distinct_manifest,
-        relationship_outcome=CanonicalOutcome.REL_RELATED_DISTINCT,
+    related_manifest = _with_relationship(
+        distinct_manifest, CanonicalOutcome.REL_RELATED_DISTINCT
     )
     related_binding = replace(
         distinct_collision.request.binding,
@@ -655,7 +672,7 @@ def test_unavailable_and_binding_mismatch_keep_typed_fail_closed_meaning(
 )
 def test_same_state_and_uncertain_are_typed_blocked(tmp_path, outcome) -> None:
     collision = _eligible_current(tmp_path, "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")
-    manifest = replace(_manifest(collision), relationship_outcome=outcome)
+    manifest = _with_relationship(_manifest(collision), outcome)
     decision = evaluate_candidate_admission(
         request=_request(manifest, None),
         manifest=manifest,
@@ -868,13 +885,24 @@ def test_real_producers_build_exact_governing_manifest(tmp_path) -> None:
         collision_state=CollisionState.OCCUPIED,
         observed_candidate_id=comparator_candidate_id,
     )
+    comparator_admit_binding = replace(
+        comparator_binding,
+        operation=CandidateUseOperation.ADMIT_NEW_CANDIDATE,
+        expected_candidate_id=None,
+    )
+    comparator_admission = replace(
+        collision,
+        request=CurrentCollisionEligibilityRequest(
+            comparator_admit_binding, collision.request.named_request_digest
+        ),
+    )
     comparator_manifest = replace(
         manifest,
         hypothesis_id=comparator_hypothesis,
         hypothesis_version_id=comparator_hypothesis_version,
         hypothesis_version_digest=D,
-        collision_request_digest=comparator_collision.request.request_digest,
-        collision_decision_digest=digest_bytes(comparator_collision.canonical_bytes),
+        collision_request_digest=comparator_admission.request.request_digest,
+        collision_decision_digest=digest_bytes(comparator_admission.canonical_bytes),
         collision_key_digest=comparator_key,
         semantic_scope_digest=comparator_scope,
     )
@@ -893,6 +921,24 @@ def test_real_producers_build_exact_governing_manifest(tmp_path) -> None:
         comparator_collision=comparator_collision,
         comparator_version=comparator_version,
     )
+    assert (
+        comparator_version.governing_manifest.collision_request_digest
+        == comparator_admission.request.request_digest
+        != comparator_collision.request.request_digest
+    )
+    with pytest.raises(CandidateContractError):
+        build_candidate_distinct_scope_proof(
+            proposed_manifest=manifest,
+            proposed_collision=collision,
+            comparator_collision=replace(
+                comparator_collision,
+                trusted_context=replace(
+                    comparator_collision.trusted_context,
+                    authority_scope_id="different-trusted-scope",
+                ),
+            ),
+            comparator_version=comparator_version,
+        )
     with pytest.raises(CandidateContractError):
         build_candidate_distinct_scope_proof(
             proposed_manifest=manifest,
@@ -965,6 +1011,53 @@ def test_real_producers_build_exact_governing_manifest(tmp_path) -> None:
             relationship=relationship,
             collision=collision,
         )
+    hold_basis = replace(
+        gate.request.basis,
+        operationally_executable=False,
+        policy_current=False,
+        time_validity=TimeValidity.CURRENT,
+    )
+    wrong_outcome = replace(
+        gate.request,
+        basis=hold_basis,
+        outcome=GateOutcome.OPERATIONAL_HOLD,
+        terminality=DecisionTerminality.PENDING_CONDITION,
+        primary_reason=reason("OPS.REQUIRED_CONTEXT_UNAVAILABLE"),
+        next_action=NextAction(
+            NextActionKind.WAIT_DEPENDENCY,
+            "WAIT_FOR_REQUIRED_CONTEXT",
+            dependency="fixture-context-authority",
+            instructions="Retain the Signal without creating a Lead.",
+        ),
+        idempotency_key="candidate-gate:wrong-outcome",
+    )
+    for wrong_gate_request in (
+        wrong_outcome,
+        replace(
+            gate.request,
+            evaluated_definition_version_id=type(
+                gate.request.evaluated_definition_version_id
+            ).parse(_id(302)),
+        ),
+    ):
+        wrong_gate = GateDecision(
+            wrong_gate_request,
+            EventId.new(),
+            1,
+            wrong_gate_request.decided_at,
+            wrong_gate_request.digest,
+        )
+        with pytest.raises(CandidateContractError):
+            build_candidate_governing_manifest(
+                hypothesis_version=version,
+                **_lineage_args(version),
+                dispositions=(disposition,),
+                leads=(lead,),
+                signals=(signal,),
+                gates=(wrong_gate,),
+                relationship=relationship,
+                collision=collision,
+            )
     candidate_manifest = disposition.route_binding.candidate_manifest
     assert candidate_manifest is not None
     assert (
@@ -1143,11 +1236,13 @@ def test_candidate_kind_is_version_state_not_candidate_identity(tmp_path) -> Non
             }
         )
     )
-    correction = replace(
-        original,
-        candidate_kind=CandidateManifestKind.CORRECTION,
-        semantic_scope_digest=correction_scope,
-        relationship_outcome=CanonicalOutcome.REL_CORRECTION_REVERSAL_OF,
+    correction = _with_relationship(
+        replace(
+            original,
+            candidate_kind=CandidateManifestKind.CORRECTION,
+            semantic_scope_digest=correction_scope,
+        ),
+        CanonicalOutcome.REL_CORRECTION_REVERSAL_OF,
     )
     assert correction.semantic_scope_digest == original.semantic_scope_digest
 
@@ -1499,3 +1594,105 @@ def test_d2_comparator_must_match_exact_d1_target_version() -> None:
     )
     with pytest.raises(CandidateContractError):
         candidates_module._validate_relationship_route(successor, tampered)
+
+
+def test_evaluator_rejects_collision_namespace_and_key_mismatch(tmp_path) -> None:
+    collision = _eligible_current(tmp_path, "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")
+    manifest = _manifest(collision)
+    for field, value in (
+        ("collision_namespace", "different-candidate-namespace"),
+        ("collision_key_digest", "sha256:" + "9" * 64),
+    ):
+        changed_binding = replace(collision.request.binding, **{field: value})
+        changed = replace(
+            collision,
+            request=CurrentCollisionEligibilityRequest(
+                changed_binding, collision.request.named_request_digest
+            ),
+        )
+        receipt_bound = replace(
+            manifest,
+            collision_request_digest=changed.request.request_digest,
+            collision_decision_digest=digest_bytes(changed.canonical_bytes),
+        )
+        with pytest.raises(CandidateContractError):
+            evaluate_candidate_admission(
+                request=_request(receipt_bound, None),
+                manifest=receipt_bound,
+                collision=changed,
+                current_version=None,
+                governing_state=_current_state(receipt_bound),
+            )
+
+
+def test_relationship_comparator_presence_matrix_and_nested_totality(tmp_path) -> None:
+    manifest = _manifest(
+        _eligible_current(tmp_path, "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")
+    )
+    comparator = (
+        "33333333-3333-4333-8333-333333333333",
+        "44444444-4444-4444-8444-444444444444",
+        D,
+    )
+    invalid = (
+        (AssessmentStatus.INCOMPLETE, None, comparator),
+        (
+            AssessmentStatus.COMPLETE,
+            CanonicalOutcome.REL_NO_ADEQUATE_PRIOR_MATCH,
+            comparator,
+        ),
+        (
+            AssessmentStatus.COMPLETE,
+            CanonicalOutcome.REL_DEVELOPMENT_OF,
+            (None, None, None),
+        ),
+    )
+    for status, outcome, values in invalid:
+        with pytest.raises(CandidateContractError):
+            replace(
+                manifest,
+                relationship_status=status,
+                relationship_outcome=outcome,
+                incomplete=status is AssessmentStatus.INCOMPLETE,
+                relationship_comparator_hypothesis_id=values[0],
+                relationship_comparator_version_id=values[1],
+                relationship_comparator_version_digest=values[2],
+            )
+    assert (
+        replace(
+            manifest,
+            relationship_status=AssessmentStatus.INCOMPLETE,
+            relationship_outcome=None,
+            incomplete=True,
+        ).relationship_comparator_hypothesis_id
+        is None
+    )
+    assert (
+        _with_relationship(
+            manifest, CanonicalOutcome.REL_DEVELOPMENT_OF
+        ).relationship_comparator_version_digest
+        == D
+    )
+    value = manifest.canonical_value()
+    for malformed in ({"bad": "element"}, ["bad"]):
+        changed = dict(value)
+        changed["uncertainties"] = [malformed]
+        with pytest.raises(CandidateContractError):
+            CandidateGoverningManifest.from_value(changed)
+        changed["uncertainties"] = value["uncertainties"]
+        changed["lead_signal_bindings"] = [malformed]
+        with pytest.raises(CandidateContractError):
+            CandidateGoverningManifest.from_value(changed)
+
+
+def test_story_candidate_digest_includes_schema_envelope() -> None:
+    candidate = StoryCandidate(
+        "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        "66666666-6666-4666-8666-666666666666",
+        "77777777-7777-4777-8777-777777777777",
+        D,
+    )
+    assert candidate.canonical_digest == digest_bytes(candidate.canonical_bytes)
+    replayed = StoryCandidate.from_canonical_bytes(candidate.canonical_bytes)
+    assert replayed.canonical_bytes == candidate.canonical_bytes
+    assert replayed.canonical_digest == candidate.canonical_digest


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-6e2a-candidate-contract
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

Closes #400
Refs #366
Refs #401
Refs #360
Refs #383

## Scope

Implements the contract-only Candidate phase from the accepted D-wave closeout without persistence, migration, authority mutation or external effect.

- base: `667e72c42a3ec09594169ad40969ddf067d0e873`
- exact head: `d3e66353d7fc523cbe54aaeb4379a6ea1bef4ed2`
- exact tree: `f98657d229082cea0e315fc4b63b212c6e6e8324`
- delta: 2 files, 3,242 insertions
- production allocation: one public module, 1,544 physical lines (below the final 1,700-line correction cap)
- commits: 2 total, including one coherent final correction commit

## Contract

- exact schema identities for Story Candidate, Candidate Version and Candidate Admission;
- opaque Candidate and Version identities allocated only by later committed authority, never by URL, Hypothesis or digest derivation;
- immutable contiguous Candidate Versions, exact predecessor validation and collision-independent, domain-separated version-material identity;
- exact D1 Hypothesis, D2 retained relationship/comparator, D3 lineage replay, Proposal disposition, News Lead, Discovery Signal, promoting Gate and E1 collision bindings;
- exact nine-category governing-state binding and typed complete/incomplete/unavailable/blocked currentness input for later same-transaction revalidation;
- typed producer-valid distinct-scope proof binding the proposed and comparator collision receipts, Candidate Version and full trusted-current authority context;
- typed `ADMISSIBLE`, `DUPLICATE_EQUIVALENT`, `DISTINCT`, `INCOMPLETE`, `STALE` and `BLOCKED` outcomes;
- exact actor/request/idempotency/CAS fields prepared for #401;
- strict canonical JSON, structural and byte bounds, exact replay, malformed input normalisation and public-constructor totality;
- explicit no-authority/no-persistence/no-Candidate-effect semantics.

The pure admission decision never allocates a Candidate, Version or committed decision identity and cannot perform an effect. #401 remains responsible for v24 persistence, atomic currentness revalidation and committed allocation.

## Final bounded correction cycle

The owner-authorised second and final correction cycle closes all six recorded material invariant families:

1. admission consumes the exact manifest collision namespace and key; distinct proof binds the full trusted authority context digest;
2. comparator first-Version historical admission remains immutable while later `USE_CURRENT_CANDIDATE` binds the exact Candidate/Version, current occupied result, manifest scope/key and trusted context;
3. every contributing Gate is exactly `PROMOTED_TO_LEAD` and evaluated the exact Signal/Lead Definition Version;
4. D2 comparator presence is closed: non-COMPLETE and COMPLETE no-match have none, every other COMPLETE pairwise relationship has one exact comparator triple;
5. tuple/list children are exact-typed before dedupe/sort and ordinary public construction/replay failures normalise to `CandidateContractError`;
6. Story Candidate identity is the SHA-256 digest of the schema-enveloped canonical bytes.

Targeted regressions cover namespace/key/context mismatch, historical-admit plus later-current comparator use, wrong Gate outcome/Definition Version, the complete D2 comparator matrix, malformed nested dict/list values and schema-envelope digest/replay identity.

## TDD and exact-head local evidence

- initial atom RED: Candidate module missing at collection (`ModuleNotFoundError`)
- final correction RED: **4 failed / 29 passed** (three contract gaps plus one initially invalid negative Gate fixture, replaced by a producer-valid operational-hold fixture)
- focused Candidate contract: **33 passed**
- exact Python 3.12.13 isolated focused gate: **33 passed**
- D1/D2/D3/E1/6R dependency closure: **123 passed**
- bounded Fast CI compatibility smoke selection: **115 passed**
- exact base-to-head source-integrity lane: PASS
- `uv lock --check`: PASS
- changed-file Ruff format/check: PASS
- changed-file `py_compile`: PASS
- `git diff --check`: PASS
- full repository suite: not run manually by design for this Tier-L atom

## Source integrity

- `newsroom/increment6/candidates.py`: `sha256:16a18e647f69abc610b0e2d398d15f1baec226252731f67a7ad3ec84d06e36da`
- `newsroom/tests/test_increment6e2_candidates.py`: `sha256:0efeb291e9727e82919774fb75bcf915121fb50c4fe34c727765867705fc6c4e`

## Non-effects

No migration, database table, authority store/write, current-head mutation, Candidate admission effect, feedback, Evidence Intake, publication, provider/model, live source, credential, egress, shadow, canary or production activation.

## Admission

This PR remains DRAFT. Merge is blocked until the exact corrected head has:

- all permanent checks green;
- one fresh independent substantive review with **0 P1 / 0 material P2**;
- zero unresolved review threads;
- final live-state verification.

No third correction cycle is authorised for these invariant families. If the final review finds a material defect, work stops for owner adjudication. After guarded merge, #400 closes and #401 may be activated from the new exact `main` head; no #401 implementation is included here.
