### PR TITLE
Add transaction-aware Discovery governing-producer read port

### DIFF
--- a/newsroom/authority/_discovery_store.py
+++ b/newsroom/authority/_discovery_store.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
+# ruff: noqa: I001 - preserve legacy import layout within bounded change
+# fmt: off - preserve legacy layout and bounded addition within the line cap
 
 import sqlite3
 from collections.abc import Mapping
-from typing import Any, Callable, TypeVar
+from threading import get_ident
+from typing import Any
 
 from newsroom.authority._capability import _AuthorizedCommandGrant
 from newsroom.authority._check_store import _CheckAuthorityStore
-from newsroom.authority.canonical import canonical_json_bytes, digest_bytes
+from newsroom.authority.canonical import canonical_json_bytes, digest_bytes, digest_canonical
 from newsroom.authority.persistence import AuthorityPersistenceError, AuthoritySchemaError
 from newsroom.authority.types import EventId, PayloadMode, TrustScope, UtcTimestamp
+from newsroom.discovery import _compose_discovery_governing_producer_read_port
 from newsroom.discovery.models import (
     DiscoverySignalRequest,
     GateDecisionRequest,
@@ -36,6 +40,7 @@ from newsroom.discovery.record_models import (
     WatchCondition,
 )
 from newsroom.discovery.types import (
+    DiscoveryContractError,
     DiscoveryIdentifierReuse,
     DiscoverySemanticCollision,
     DiscoverySignalId,
@@ -59,8 +64,6 @@ from ._discovery_decoding import (
     signal_request_from_bytes,
     watch_request_from_bytes,
 )
-
-_Record = TypeVar("_Record")
 
 _SOURCE_OBSERVATION_COMPATIBILITY_COLUMNS = (
     "adapter_policy_id",
@@ -109,6 +112,208 @@ _DISCOVERY_RECORD_SPECS: dict[str, tuple[str, str, TrustScope]] = {
     ),
 }
 
+class _DiscoveryGoverningProducerReader:
+    __slots__ = ("_connection", "_owner")
+
+    def __init__(self, connection: sqlite3.Connection) -> None:
+        self._connection = connection
+        self._owner = get_ident()
+
+    def _require_transaction(self) -> None:
+        if (
+            get_ident() != self._owner
+            or self._connection.isolation_level is not None
+            or self._connection.row_factory is not sqlite3.Row
+            or not self._connection.in_transaction
+        ):
+            raise DiscoveryContractError("Discovery transaction ownership differs")
+
+    def require_current_governing_producers(
+        self, lead_ids: tuple[NewsLeadId, ...]
+    ) -> tuple[tuple[NewsLead, DiscoverySignal, GateDecision], ...]:
+        self._require_transaction()
+        if (
+            type(lead_ids) is not tuple
+            or not lead_ids
+            or any(type(value) is not NewsLeadId for value in lead_ids)
+            or tuple(str(value) for value in lead_ids)
+            != tuple(sorted({str(value) for value in lead_ids}))
+        ):
+            raise DiscoveryContractError("Lead IDs must be exact ordered unique values")
+        connection = self._connection
+        _validate_discovery_reads_in_transaction(connection)
+        result: list[tuple[NewsLead, DiscoverySignal, GateDecision]] = []
+        for lead_id in lead_ids:
+            lead_row = _DiscoveryAuthorityStore._row(
+                connection, "news_leads", "lead_id", str(lead_id)
+            )
+            lead = _DiscoveryAuthorityStore._lead_from_row(
+                connection, lead_row, replayed=False
+            )
+            signal_row = _DiscoveryAuthorityStore._row(connection, "discovery_signals", "signal_id", str(lead.request.signal_id))
+            signal = _DiscoveryAuthorityStore._signal_from_row(
+                connection, signal_row, replayed=False
+            )
+            gate_row = connection.execute(
+                "SELECT d.* FROM discovery_gate_decision_heads h "
+                "JOIN discovery_gate_decisions d "
+                "ON d.decision_id=h.current_decision_id "
+                "WHERE h.signal_id=?",
+                (str(signal.request.signal_id),),
+            ).fetchone()
+            if gate_row is None:
+                raise DiscoveryStateError("current Gate Decision is not retained")
+            gate = _DiscoveryAuthorityStore._gate_from_row(connection, gate_row, replayed=False)
+            if (
+                lead.request.signal_id != signal.request.signal_id
+                or lead.request.promoting_gate_decision_id != gate.request.decision_id
+                or gate.request.signal_id != signal.request.signal_id
+                or gate.request.outcome is not GateOutcome.PROMOTED_TO_LEAD
+                or lead.request.definition_id != signal.request.definition_id
+                or lead.request.item_id != signal.request.item_id
+                or lead.request.revision_id != signal.request.revision_id
+                or lead.request.representation_id != signal.request.representation_id
+                or lead.request.occurrence_id != signal.request.occurrence_id
+                or lead.request.transition_id != signal.request.transition_id
+                or lead.request.coverage != gate.request.coverage
+                or gate.request.evaluated_definition_version_id
+                != signal.request.definition_version_id
+                or gate.request.evaluated_definition_version_id
+                != lead.request.definition_version_id
+            ):
+                raise DiscoveryVersionConflict("Discovery closure differs from authority")
+            result.append((lead, signal, gate))
+        return tuple(result)
+
+
+def _validate_discovery_reads_in_transaction(connection: sqlite3.Connection) -> None:
+    _DiscoveryAuthorityStore._validate_relational_invariants(connection)
+    _DiscoveryAuthorityStore._validate_immutable_records(object.__new__(_DiscoveryAuthorityStore), connection)
+    for row in connection.execute(
+        "SELECT c.*,p.mode,p.schema_version,p.schema_contract_version,p.schema_contract_digest,"
+        "p.canonicalizer_implementation_version,p.payload_digest,p.payload_bytes,p.object_admission_id,"
+        "e.ledger_seq,e.event_id,e.event_type,e.aggregate_version,e.recorded_at,e.trust_scope,e.correlation_id,"
+        "e.causation_kind,e.causation_identifier,e.causation_external_system,e.authentication_context_id event_auth,e.authorization_request_digest event_request,e.authorization_decision_id event_decision,a.event_type audit_event_type,"
+        "a.detail_digest,a.recorded_at audit_recorded_at,a.authentication_context_id audit_auth,a.authorization_request_digest audit_request,a.authorization_decision_id audit_decision,x.authority_domain,x.principal_id,"
+        "x.canonical_digest auth_digest,r.canonical_record_digest request_record_digest,d.canonical_digest decision_digest "
+        "FROM authority_commands c JOIN authority_payloads p ON p.payload_id=c.payload_id "
+        "JOIN ledger_events e ON e.command_id=c.command_id JOIN authority_audit_events a ON a.command_id=c.command_id "
+        "JOIN authentication_contexts x ON x.authentication_context_id=c.authentication_context_id "
+        "JOIN authorization_requests r ON r.request_digest=c.authorization_request_digest "
+        "JOIN authorization_decisions d ON d.authorization_decision_id=c.authorization_decision_id "
+        "WHERE e.event_type IN (?,?,?,?,?)",
+        tuple(spec[1] for spec in _DISCOVERY_RECORD_SPECS.values()),
+    ):
+        def fields(output: str, source: str, captured: sqlite3.Row = row) -> dict[str, Any]:
+            return dict(zip(output.split(), (captured[key] for key in source.split())))
+
+        payload = fields(
+            "kind schema_version schema_contract_version schema_contract_digest canonicalizer_version digest object_admission_id",
+            "mode schema_version schema_contract_version schema_contract_digest canonicalizer_implementation_version payload_digest object_admission_id",
+        )
+        payload.update(
+            inline_digest=digest_bytes(bytes(row["payload_bytes"])),
+            blob_digest=None,
+            object_class=None,
+            allowed_use=None,
+        )
+        command = fields(
+            "command_type command_definition_version command_definition_digest aggregate_type aggregate_id expected_aggregate_version",
+            "command_type command_definition_version command_definition_digest aggregate_type aggregate_id expected_aggregate_version",
+        )
+        command["payload"] = payload
+        expected_result = {
+            "command_id": str(row["command_id"]),
+            "aggregate_type": str(row["aggregate_type"]),
+            "aggregate_id": str(row["aggregate_id"]),
+            "aggregate_version": int(row["aggregate_version"]),
+            "ledger_seq": int(row["ledger_seq"]),
+            "event_id": str(row["event_id"]),
+        }
+        detail = {key: row[key] for key in "command_type aggregate_id expected_aggregate_version authorization_request_digest idempotency_namespace idempotency_key stable_semantic_request_digest correlation_id causation_kind causation_identifier causation_external_system".split()}  # noqa: SIM905
+        detail.update(
+            operation="COMMAND_COMMIT",
+            definition_digest=row["command_definition_digest"],
+            definition_version=row["command_definition_version"],
+            payload=payload,
+            authentication_context_digest=row["auth_digest"],
+            authorization_request_record_digest=row["request_record_digest"],
+            authorization_decision_digest=row["decision_digest"],
+            replay_of_command_id=None,
+        )
+        if (
+            (spec := _DISCOVERY_RECORD_SPECS.get(row["command_type"])) is None
+            or (row["aggregate_type"], row["event_type"], row["trust_scope"]) != (spec[0], spec[1], spec[2].value)
+            or digest_canonical(command) != row["stable_semantic_request_digest"]
+            or _DiscoveryAuthorityStore._decode_canonical(bytes(row["result_bytes"])) != expected_result
+            or digest_bytes(bytes(row["result_bytes"])) != row["result_digest"]
+            or len({(row["authentication_context_id"], row["authorization_request_digest"], row["authorization_decision_id"]), (row["event_auth"], row["event_request"], row["event_decision"]), (row["audit_auth"], row["audit_request"], row["audit_decision"])}) != 1 or row["committed_at"] != row["recorded_at"]
+            or row["audit_recorded_at"] != row["recorded_at"]
+            or row["audit_event_type"] != row["event_type"]
+            or row["idempotency_namespace"]
+            != digest_canonical(
+                {
+                    "authority_domain": row["authority_domain"],
+                    "principal_id": row["principal_id"],
+                    "command_type": row["command_type"],
+                }
+            )
+            or row["detail_digest"] != digest_canonical(detail)
+        ):
+            raise AuthorityPersistenceError(
+                "Discovery command or audit authority differs"
+            )
+    for row in connection.execute("SELECT * FROM discovery_signals"):
+        record = _DiscoveryAuthorityStore._signal_from_row(
+            connection, row, replayed=False
+        )
+        _DiscoveryAuthorityStore._require_exact_signal_lineage(
+            connection, record.request
+        )
+    for row in connection.execute("SELECT * FROM discovery_gate_decisions"):
+        _DiscoveryAuthorityStore._gate_from_row(connection, row, replayed=False)
+    for row in connection.execute("SELECT * FROM news_leads"):
+        record = _DiscoveryAuthorityStore._lead_from_row(
+            connection, row, replayed=False
+        )
+        _DiscoveryAuthorityStore._require_source_contract_matches_lead(
+            connection, record.request
+        )
+    _DiscoveryAuthorityStore._validate_discovery_heads(connection)
+    _DiscoveryAuthorityStore._validate_discovery_event_coverage(connection)
+    if connection.execute("PRAGMA foreign_key_check").fetchone() is not None:
+        raise AuthoritySchemaError("Discovery foreign-key integrity differs")
+
+
+def _create_discovery_governing_producer_read_port(
+    connection: sqlite3.Connection,
+):
+    try:
+        if (
+            type(connection) is not sqlite3.Connection
+            or connection.isolation_level is not None
+            or connection.row_factory is not sqlite3.Row
+            or not connection.in_transaction
+            or connection.execute("PRAGMA foreign_keys").fetchone()[0] != 1
+            or str(connection.execute("PRAGMA journal_mode").fetchone()[0]).lower()
+            != "wal"
+            or connection.execute("PRAGMA synchronous").fetchone()[0] != 2
+        ):
+            raise DiscoveryContractError(
+                "Discovery read-port factory requires an exact active checked connection"
+            )
+        reader = _DiscoveryGoverningProducerReader(connection)
+        return _compose_discovery_governing_producer_read_port(
+            reader.require_current_governing_producers
+        )
+    except DiscoveryContractError:
+        raise
+    except Exception as exc:
+        raise DiscoveryContractError(
+            "Discovery read-port factory failed closed"
+        ) from exc
+
+# fmt: on
 
 class _DiscoveryAuthorityStore(_CheckAuthorityStore):
     """Private single-writer Signal, Gate and Lead authority store."""

--- a/newsroom/discovery/__init__.py
+++ b/newsroom/discovery/__init__.py
@@ -62,7 +62,41 @@ from .types import (
     permitted_newness_for_transition,
 )
 
-__all__ = [
+_GOVERNING_PRODUCER_PORT_TOKEN = object()
+
+
+class DiscoveryGoverningProducerReadPort:
+    __slots__ = ("__read",)
+
+    def __init__(self, token: object, read: object) -> None:
+        if token is not _GOVERNING_PRODUCER_PORT_TOKEN or not callable(read):
+            raise DiscoveryContractError("Discovery port is authority-private")
+        self.__read = read
+
+    def require_current_governing_producers(
+        self, lead_ids: tuple[NewsLeadId, ...]
+    ) -> tuple[tuple[NewsLead, DiscoverySignal, GateDecision], ...]:
+        try:
+            result = self.__read(lead_ids)
+            if type(result) is not tuple or any(
+                type(item) is not tuple
+                or len(item) != 3
+                or tuple(map(type, item)) != (NewsLead, DiscoverySignal, GateDecision)
+                for item in result
+            ):
+                raise DiscoveryContractError("Discovery read returned forged records")
+            return result
+        except DiscoveryContractError:
+            raise
+        except Exception as exc:
+            raise DiscoveryContractError("Discovery transaction read failed") from exc
+
+
+def _compose_discovery_governing_producer_read_port(read: object):
+    return DiscoveryGoverningProducerReadPort(_GOVERNING_PRODUCER_PORT_TOKEN, read)
+
+
+__all__ = [  # noqa: RUF022 - preserve established public grouping
     "ACTIVE_INCREMENT_3D_DISPOSITIONS",
     "DecisionTerminality",
     "DiscoveryAuthorityError",
@@ -70,6 +104,7 @@ __all__ = [
     "DiscoveryCurrentActionSource",
     "DiscoveryCurrentPhase",
     "DiscoveryCurrentStatus",
+    "DiscoveryGoverningProducerReadPort",
     "DiscoveryIdentifierReuse",
     "DiscoveryReadPolicy",
     "DiscoverySemanticCollision",

--- a/newsroom/tests/test_authority_import_boundary.py
+++ b/newsroom/tests/test_authority_import_boundary.py
@@ -74,3 +74,16 @@ def test_increment6_authority_systems_are_cold_import_order_independent() -> Non
             capture_output=True,
             text=True,
         )
+
+
+def test_discovery_read_port_is_cold_import_order_independent() -> None:
+    for first, second in (
+        ("newsroom.discovery", "newsroom.authority._discovery_store"),
+        ("newsroom.authority._discovery_store", "newsroom.discovery"),
+    ):
+        subprocess.run(
+            [sys.executable, "-c", f"import {first}; import {second}"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )

--- a/newsroom/tests/test_discovery_3d_authority_store.py
+++ b/newsroom/tests/test_discovery_3d_authority_store.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
+import sqlite3
 from dataclasses import replace
 from pathlib import Path
-import sqlite3
 
 import pytest
 
 from newsroom.authority import AuthorityPersistenceError, AuthoritySchemaError
+from newsroom.authority._discovery_store import (
+    _create_discovery_governing_producer_read_port,
+)
 from newsroom.discovery import (
     DecisionTerminality,
+    DiscoveryContractError,
+    DiscoveryGoverningProducerReadPort,
     DiscoverySemanticCollision,
     DiscoverySignalId,
     DiscoveryVersionConflict,
@@ -58,6 +63,268 @@ def _trigger_sql(conn: sqlite3.Connection, name: str) -> str:
     ).fetchone()
     assert row is not None and isinstance(row[0], str)
     return str(row[0])
+
+
+def _transaction_connection(database: Path) -> sqlite3.Connection:
+    connection = sqlite3.connect(database, isolation_level=None)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA foreign_keys=ON")
+    connection.execute("PRAGMA journal_mode=WAL")
+    connection.execute("PRAGMA synchronous=FULL")
+    connection.execute("BEGIN IMMEDIATE")
+    return connection
+
+
+def test_governing_producer_read_port_is_private_and_transaction_bound(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "authority.sqlite3"
+    _seed_and_admit(database)
+    with pytest.raises(DiscoveryContractError, match="authority-private"):
+        DiscoveryGoverningProducerReadPort(object(), object())
+
+    connection = _transaction_connection(database)
+    try:
+        port = _create_discovery_governing_producer_read_port(connection)
+        connection.execute("COMMIT")
+        with pytest.raises(DiscoveryContractError, match="transaction"):
+            port.require_current_governing_producers((LEAD_ID,))
+    finally:
+        if connection.in_transaction:
+            connection.execute("ROLLBACK")
+        connection.close()
+
+
+def test_governing_producer_read_port_returns_exact_ordered_closure(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "authority.sqlite3"
+    admitted = _seed_and_admit(database)
+    connection = _transaction_connection(database)
+    try:
+        port = _create_discovery_governing_producer_read_port(connection)
+        changes = connection.total_changes
+        assert port.require_current_governing_producers((LEAD_ID,)) == (
+            (admitted.lead, admitted.signal, admitted.gate),
+        )
+        assert connection.in_transaction and connection.total_changes == changes
+        with pytest.raises(DiscoveryContractError):
+            port.require_current_governing_producers((LEAD_ID, LEAD_ID))
+    finally:
+        connection.execute("ROLLBACK")
+        connection.close()
+
+
+def test_governing_producer_read_port_rejects_currentness_and_offline_rewrite(
+    tmp_path: Path,
+) -> None:
+    from newsroom.discovery import TimeValidity
+
+    from .discovery_3d_helpers import reason
+
+    current_db = tmp_path / "current.sqlite3"
+    _seed_and_admit(current_db)
+    hold = replace(
+        exact_gate_request(),
+        decision_id=GateDecisionId.parse(
+            "00000000-0000-4000-8000-000000007096"
+        ),
+        decision_ordinal=2,
+        previous_decision_id=GATE_ID,
+        basis=replace(
+            exact_gate_request().basis,
+            policy_current=False,
+            operationally_executable=False,
+            time_validity=TimeValidity.CURRENT,
+        ),
+        outcome=GateOutcome.OPERATIONAL_HOLD,
+        terminality=DecisionTerminality.PENDING_CONDITION,
+        primary_reason=reason("OPS.POLICY_STALE"),
+        next_action=NextAction(
+            NextActionKind.REVIEW,
+            "REVIEW_STALE_POLICY",
+            owner="discovery-operator",
+            instructions="Revalidate the current deterministic Gate policy.",
+        ),
+        idempotency_key="governing-port-current-gate",
+    )
+    with open_discovery_system(current_db) as system:
+        system.discovery.decide_gate(hold, proof=proof())
+    connection = _transaction_connection(current_db)
+    try:
+        port = _create_discovery_governing_producer_read_port(connection)
+        with pytest.raises(DiscoveryContractError):
+            port.require_current_governing_producers((LEAD_ID,))
+    finally:
+        connection.execute("ROLLBACK")
+        connection.close()
+
+
+    definition_db = tmp_path / "definition.sqlite3"
+    _seed_and_admit(definition_db)
+    with open_discovery_system(definition_db) as system:
+        system.sources.record_definition_version(
+            replace(
+                version_request(),
+                version_id=SourceDefinitionVersionId.parse(
+                    "00000000-0000-4000-8000-000000006205"
+                ),
+                version_number=2,
+                expected_previous_version_id=version_request().version_id,
+                locator="fixture://increment-3d/governing-port-v2",
+                change_reason="Exercise governing-producer currentness.",
+                idempotency_key="governing-port-definition-v2",
+            ),
+            proof=proof(),
+        )
+    connection = _transaction_connection(definition_db)
+    try:
+        port = _create_discovery_governing_producer_read_port(connection)
+        with pytest.raises(DiscoveryContractError):
+            port.require_current_governing_producers((LEAD_ID,))
+    finally:
+        connection.execute("ROLLBACK")
+        connection.close()
+
+    tampered_db = tmp_path / "offline.sqlite3"
+    _seed_and_admit(tampered_db)
+    rewritten = replace(
+        exact_signal_request(), purpose="SELF_CONSISTENT_OFFLINE_REWRITE"
+    )
+    with sqlite3.connect(tampered_db) as connection:
+        triggers = {
+            name: _trigger_sql(connection, name)
+            for name in (
+                "immutable_discovery_signals_update",
+                "immutable_authority_payloads_update",
+                "immutable_ledger_events_update",
+            )
+        }
+        for name in triggers:
+            connection.execute(f"DROP TRIGGER {name}")
+        event = connection.execute(
+            "SELECT authority_event_id FROM discovery_signals WHERE signal_id=?",
+            (str(SIGNAL_ID),),
+        ).fetchone()[0]
+        payload_id = connection.execute(
+            "SELECT payload_id FROM ledger_events WHERE event_id=?", (event,)
+        ).fetchone()[0]
+        connection.execute(
+            "UPDATE discovery_signals SET purpose=?,semantic_digest=?,"
+            "canonical_bytes=?,canonical_digest=? WHERE signal_id=?",
+            (
+                rewritten.purpose,
+                rewritten.semantic_digest,
+                rewritten.canonical_bytes,
+                rewritten.digest,
+                str(SIGNAL_ID),
+            ),
+        )
+        connection.execute(
+            "UPDATE authority_payloads SET payload_bytes=?,payload_digest=? "
+            "WHERE payload_id=?",
+            (rewritten.canonical_bytes, rewritten.digest, payload_id),
+        )
+        connection.execute(
+            "UPDATE ledger_events SET payload_digest=? WHERE event_id=?",
+            (rewritten.digest, event),
+        )
+        for sql in triggers.values():
+            connection.execute(sql)
+        connection.commit()
+    connection = _transaction_connection(tampered_db)
+    try:
+        port = _create_discovery_governing_producer_read_port(connection)
+        with pytest.raises(DiscoveryContractError):
+            port.require_current_governing_producers((LEAD_ID,))
+    finally:
+        connection.execute("ROLLBACK")
+        connection.close()
+
+@pytest.mark.parametrize(
+    ("trigger_name", "table", "column", "value"),
+    (
+        (
+            "immutable_authority_commands_update",
+            "authority_commands",
+            "idempotency_key",
+            "offline-command-rewrite",
+        ),
+        (
+            "immutable_authority_commands_update",
+            "authority_commands",
+            "command_type",
+            "offline.bypass",
+        ),
+        (
+            "immutable_authority_audit_events_update",
+            "authority_audit_events",
+            "detail_digest",
+            "sha256:" + "0" * 64,
+        ),
+    ),
+)
+def test_governing_producer_read_port_rejects_command_and_audit_tamper(
+    tmp_path: Path,
+    trigger_name: str,
+    table: str,
+    column: str,
+    value: str,
+) -> None:
+    database = tmp_path / f"{table}.sqlite3"
+    _seed_and_admit(database)
+    with sqlite3.connect(database) as connection:
+        trigger = _trigger_sql(connection, trigger_name)
+        connection.execute(f"DROP TRIGGER {trigger_name}")
+        connection.execute(
+            f"UPDATE {table} SET {column}=? WHERE command_id=("
+            "SELECT command_id FROM ledger_events WHERE event_id=("
+            "SELECT authority_event_id FROM discovery_signals WHERE signal_id=?))",
+            (value, str(SIGNAL_ID)),
+        )
+        connection.execute(trigger)
+        connection.commit()
+    connection = _transaction_connection(database)
+    try:
+        port = _create_discovery_governing_producer_read_port(connection)
+        with pytest.raises(DiscoveryContractError):
+            port.require_current_governing_producers((LEAD_ID,))
+    finally:
+        connection.execute("ROLLBACK")
+        connection.close()
+
+
+def test_governing_producer_read_port_rejects_split_security_binding(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "security-split.sqlite3"
+    _seed_and_admit(database)
+    with sqlite3.connect(database) as connection:
+        trigger = _trigger_sql(connection, "immutable_authority_audit_events_update")
+        connection.execute("DROP TRIGGER immutable_authority_audit_events_update")
+        connection.execute(
+            "UPDATE authority_audit_events SET "
+            "authentication_context_id=(SELECT authentication_context_id FROM "
+            "authority_audit_events WHERE event_type!='discovery.signal.admitted' LIMIT 1),"
+            "authorization_request_digest=(SELECT authorization_request_digest FROM "
+            "authority_audit_events WHERE event_type!='discovery.signal.admitted' LIMIT 1),"
+            "authorization_decision_id=(SELECT authorization_decision_id FROM "
+            "authority_audit_events WHERE event_type!='discovery.signal.admitted' LIMIT 1) "
+            "WHERE command_id=(SELECT command_id FROM ledger_events WHERE event_id=("
+            "SELECT authority_event_id FROM discovery_signals WHERE signal_id=?))",
+            (str(SIGNAL_ID),),
+        )
+        connection.execute(trigger)
+        connection.commit()
+    connection = _transaction_connection(database)
+    try:
+        port = _create_discovery_governing_producer_read_port(connection)
+        with pytest.raises(DiscoveryContractError):
+            port.require_current_governing_producers((LEAD_ID,))
+    finally:
+        connection.execute("ROLLBACK")
+        connection.close()
+
 
 
 def test_signal_gate_lead_authority_replays_and_reopens(tmp_path: Path) -> None:


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-6e2b-discovery-governing-producer-read-port
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

Closes #422
Refs #401
Refs #146

## Scope

Adds the narrow immutable, authority-private, token-gated and transaction-aware Discovery governing-producer read port required by the Candidate authority writer.

The port consumes exact ordered unique Lead identities inside a caller-owned active transaction, revalidates retained Discovery and central authority integrity, and returns exact typed `(NewsLead, DiscoverySignal, GateDecision)` closures in Lead order. It neither exposes SQLite nor starts, commits, rolls back or mutates the transaction.

## Exact revision

- Base: `fb5b91cbf308d610763d5d21126bcfaf0b1f166b`
- Head: `61e06d161ccdac5cafc6cfce270fd9c666679b41`
- Tree: `2b9212491d5fb7a287588cfd2efd5dbbe76ca2d3`
- Production scope: 2 files
- Production churn: 250 changed lines (`245` additions, `5` deletions)

## Evidence

- TDD RED: missing private factory initially failed collection; command/audit scalar tamper and `command_type` selection-bypass regressions initially returned closures instead of failing closed.
- TDD GREEN: exact closure, construction forgery, active transaction ownership, current Gate and Definition Version, canonical/digest/ledger integrity, command/audit scalars, security-triple binding, self-consistent offline rewrite and selection-bypass cases pass.
- Focused Discovery and authority-boundary suite: `112 passed`.
- Affected Source, Check and central-authority integrity suite: `24 passed`.
- Staged focused publication gate: `47 passed`.
- Production Ruff: passed.
- Public Discovery Ruff format: passed.
- `git diff --check`: passed.
- Independent final review: `0 P1 / 0 material P2`.

## Non-effects

No migration, table, trigger, command, write policy, raw connection/store/capability API, Candidate persistence, collision effect, D-wave write, Handoff, feedback, publication, provider/model/network request, egress or production activation.


