### PR TITLE
Add v24 Story Candidate admission authority

### DIFF
--- a/newsroom/authority/_event_hypothesis_lineage_system.py
+++ b/newsroom/authority/_event_hypothesis_lineage_system.py
@@ -1,4 +1,5 @@
 """Private checked v23 Event Hypothesis lineage authority."""
+# ruff: noqa: E701,E702 - keep the bounded D3 read-port seam within #401's line cap
 
 from __future__ import annotations
 
@@ -20,11 +21,14 @@ from newsroom.increment6.lineage import (
     LINEAGE_COMMAND_TYPE,
     LINEAGE_EVENT_TYPE,
     EventHypothesisLineageAuthority,
+    EventHypothesisLineageReadPort,
     HypothesisLineageContractError,
     HypothesisLineageHead,
+    HypothesisLineageProducerSnapshot,
     HypothesisLineageReceipt,
     HypothesisLineageRelationshipProof,
     _compose_event_hypothesis_lineage_authority,
+    _compose_event_hypothesis_lineage_read_port,
     lineage_command_definition,
     merge_lineage_authority_registries,
     replay_hypothesis_lineage,
@@ -299,7 +303,7 @@ class _LineageStore(_EventAuthorityStore):
         UtcTimestamp.parse(str(row["recorded_at"]))
         return receipt
 
-    def _full_replay(self, receipts: tuple[HypothesisLineageReceipt, ...]):
+    def _replay_inputs(self, receipts: tuple[HypothesisLineageReceipt, ...]):
         nodes = {
             node.version_id: node
             for receipt in receipts
@@ -334,11 +338,12 @@ class _LineageStore(_EventAuthorityStore):
                 - output_ids
             )
         )
+        return roots, tuple(versions), tuple(proofs)
+
+    def _full_replay(self, receipts: tuple[HypothesisLineageReceipt, ...]):
+        roots, versions, proofs = self._replay_inputs(receipts)
         return replay_hypothesis_lineage(
-            receipts,
-            initial_heads=roots,
-            versions=tuple(versions),
-            relationship_proofs=tuple(proofs),
+            receipts, initial_heads=roots, versions=versions, relationship_proofs=proofs
         )
 
     def _history_rows(self) -> tuple[HypothesisLineageReceipt, ...]:
@@ -349,7 +354,7 @@ class _LineageStore(_EventAuthorityStore):
             )
         )
 
-    def _verify(self) -> None:
+    def _verify(self):
         _VERIFY_RETAINED_RELATIONSHIP_INTEGRITY(self._port)
         self._validate_relational_invariants(self._connection)
         self._validate_immutable_records(self._connection)
@@ -361,7 +366,13 @@ class _LineageStore(_EventAuthorityStore):
         if orphan is not None:
             raise AuthoritySchemaError("lineage event coverage differs")
         history = self._history_rows()
-        replay = self._full_replay(history)
+        roots, versions, proofs = self._replay_inputs(history)
+        replay = replay_hypothesis_lineage(
+            history,
+            initial_heads=roots,
+            versions=versions,
+            relationship_proofs=proofs,
+        )
         verified = replay.history
         actual = tuple(
             (
@@ -399,6 +410,7 @@ class _LineageStore(_EventAuthorityStore):
         )
         if actual != expected:
             raise AuthoritySchemaError("lineage materialised heads differ")
+        return history, roots, versions, proofs, replay
 
     def _rebuild_heads(self, replay: object) -> None:
         from newsroom.increment6.lineage import HypothesisLineageReplay
@@ -671,6 +683,52 @@ def _open_unlocked_lineage_authority_for_test(
         busy_timeout_ms=busy_timeout_ms,
         unlocked=True,
     )
+
+
+# fmt: off
+def _create_event_hypothesis_lineage_read_port(connection: sqlite3.Connection, *,
+    retrieval_authority: RetrievalContextAuthority, authenticator: object, command_registry: CommandRegistry,
+    payload_schemas: PayloadSchemaRegistry, clock: Callable[[], UtcTimestamp] = UtcTimestamp.now):
+    """Compose exact D1/D2/D3 producer reads on the caller's transaction."""
+    if connection.in_transaction: raise HypothesisLineageContractError("Candidate lineage port requires idle open")
+    port = _create_event_hypothesis_relationship_read_port(connection, retrieval_authority=retrieval_authority,
+        authenticator=authenticator, command_registry=command_registry, payload_schemas=payload_schemas, clock=clock)
+    verifier = object.__new__(_LineageStore); verifier._conn = connection; verifier._closed = False; verifier._port = port
+    relationship_commands, relationship_schemas = merge_relationship_authority_registries(command_registry, payload_schemas)
+    verifier._command_registry, verifier._payload_schemas = merge_lineage_authority_registries(relationship_commands, relationship_schemas)
+
+    def verified():
+        if not connection.in_transaction: raise HypothesisLineageContractError("lineage producer transaction is absent")
+        return verifier._verify()
+
+    class _ReadAuthority:
+        def verify_retained_integrity_in_transaction(self) -> None: verified()
+
+        def require_retained_relationship_in_transaction(self, digest: str):
+            verified(); return port.require_retained_receipt_in_transaction(digest)
+
+        def require_producers_in_transaction(self, version_id: str, *, proof: object):
+            receipts, roots, versions, proofs, replay = verified()
+            current = port.require_current_version_in_transaction(version_id, proof=proof)
+            if current.version_id not in {item.version_id for item in versions}:
+                versions += (current,); roots += (HypothesisLineageHead.from_version(current),)
+                replay = replay_hypothesis_lineage(receipts, initial_heads=roots, versions=versions, relationship_proofs=proofs)
+            heads = {head.node.version_id: head for head in replay.active_heads}
+            for head in replay.active_heads:
+                retained = port.require_current_version_in_transaction(head.node.version_id, proof=proof)
+                if retained.canonical_digest != head.node.version_digest: raise HypothesisLineageContractError("Candidate D3 head is stale")
+            subject_head = heads.get(current.version_id)
+            if subject_head is None or subject_head.node.version_digest != current.canonical_digest:
+                raise HypothesisLineageContractError("Candidate D3 head is stale")
+            return HypothesisLineageProducerSnapshot(current, receipts, roots, versions, proofs, replay, subject_head)
+
+    try:
+        result = _compose_event_hypothesis_lineage_read_port(_ReadAuthority())
+        if type(result) is not EventHypothesisLineageReadPort: raise HypothesisLineageContractError("lineage read-port factory is forged")
+        return result
+    except HypothesisLineageContractError: raise
+    except Exception as exc: raise HypothesisLineageContractError("lineage read-port factory failed closed") from exc
+# fmt: on
 
 
 __all__: list[str] = []

--- a/newsroom/authority/migrations.py
+++ b/newsroom/authority/migrations.py
@@ -154,6 +154,17 @@ from .source_registry_migrations import (
     SOURCE_REGISTRY_MIGRATION_STATEMENTS,
     SOURCE_REGISTRY_SCHEMA_VERSION,
 )
+from .story_candidate_migrations import (
+    STORY_CANDIDATE_MIGRATION,
+    STORY_CANDIDATE_MIGRATION_CHECKSUM,
+    STORY_CANDIDATE_MIGRATION_NAME,
+    STORY_CANDIDATE_MIGRATION_STATEMENTS,
+    STORY_CANDIDATE_SCHEMA_VERSION,
+    StoryCandidateBackupReceipt,
+    prepare_story_candidate_backup,
+    require_story_candidate_backup,
+    story_candidate_backup_paths,
+)
 from .triage_disposition_migrations import (
     TRIAGE_DISPOSITION_MIGRATION,
     TRIAGE_DISPOSITION_MIGRATION_CHECKSUM,
@@ -189,7 +200,7 @@ from .triage_work_item_migrations import (
 )
 
 BASE_SCHEMA_VERSION = 1
-SCHEMA_VERSION = EVENT_HYPOTHESIS_LINEAGE_SCHEMA_VERSION
+SCHEMA_VERSION = STORY_CANDIDATE_SCHEMA_VERSION
 MIGRATION_NAME = "authority_event_foundation_v1"
 
 
@@ -636,11 +647,12 @@ def prepare_pending_migration_backup(
     | EventHypothesisBackupReceipt
     | EventHypothesisRelationshipBackupReceipt
     | EventHypothesisLineageBackupReceipt
+    | StoryCandidateBackupReceipt
     | None
 ):
     """Prepare the exact retained backup required by a checked predecessor."""
     version = int(conn.execute("PRAGMA user_version").fetchone()[0])
-    if version not in {16, 17, 18, 19, 20, 21, 22}:
+    if version not in {16, 17, 18, 19, 20, 21, 22, 23}:
         return None
     database_path = next(
         str(row[2])
@@ -669,8 +681,11 @@ def prepare_pending_migration_backup(
     if version == 21:
         backup_path, _ = event_hypothesis_relationship_backup_paths(database_path)
         return prepare_event_hypothesis_relationship_backup(conn, backup_path)
-    backup_path, _ = event_hypothesis_lineage_backup_paths(database_path)
-    return prepare_event_hypothesis_lineage_backup(conn, backup_path)
+    if version == 22:
+        backup_path, _ = event_hypothesis_lineage_backup_paths(database_path)
+        return prepare_event_hypothesis_lineage_backup(conn, backup_path)
+    backup_path, _ = story_candidate_backup_paths(database_path)
+    return prepare_story_candidate_backup(conn, backup_path)
 
 
 def apply_migration(
@@ -966,7 +981,7 @@ def apply_pending_migrations(conn: sqlite3.Connection, *, applied_at: str) -> No
             if starting_version != 0:
                 require_evaluation_handoff_backup(
                     conn,
-                    expected_history=EXPECTED_MIGRATION_HISTORY[:-7],
+                    expected_history=EXPECTED_MIGRATION_HISTORY[:-8],
                 )
             for statement in EVALUATION_HANDOFF_MIGRATION_STATEMENTS:
                 conn.execute(statement)
@@ -1001,7 +1016,7 @@ def apply_pending_migrations(conn: sqlite3.Connection, *, applied_at: str) -> No
             if starting_version != 0:
                 require_triage_work_item_backup(
                     conn,
-                    expected_history=EXPECTED_MIGRATION_HISTORY[:-6],
+                    expected_history=EXPECTED_MIGRATION_HISTORY[:-7],
                 )
             for statement in TRIAGE_WORK_ITEM_MIGRATION_STATEMENTS:
                 conn.execute(statement)
@@ -1035,7 +1050,7 @@ def apply_pending_migrations(conn: sqlite3.Connection, *, applied_at: str) -> No
             if starting_version != 0:
                 require_triage_disposition_backup(
                     conn,
-                    expected_history=EXPECTED_MIGRATION_HISTORY[:-5],
+                    expected_history=EXPECTED_MIGRATION_HISTORY[:-6],
                 )
             for statement in TRIAGE_DISPOSITION_MIGRATION_STATEMENTS:
                 conn.execute(statement)
@@ -1069,7 +1084,7 @@ def apply_pending_migrations(conn: sqlite3.Connection, *, applied_at: str) -> No
             if starting_version != 0:
                 require_triage_execution_backup(
                     conn,
-                    expected_history=EXPECTED_MIGRATION_HISTORY[:-4],
+                    expected_history=EXPECTED_MIGRATION_HISTORY[:-5],
                 )
             for statement in TRIAGE_EXECUTION_MIGRATION_STATEMENTS:
                 conn.execute(statement)
@@ -1102,7 +1117,7 @@ def apply_pending_migrations(conn: sqlite3.Connection, *, applied_at: str) -> No
                 conn.execute("BEGIN EXCLUSIVE")
             if starting_version != 0:
                 require_event_hypothesis_backup(
-                    conn, expected_history=EXPECTED_MIGRATION_HISTORY[:-3]
+                    conn, expected_history=EXPECTED_MIGRATION_HISTORY[:-4]
                 )
             for statement in EVENT_HYPOTHESIS_MIGRATION_STATEMENTS:
                 conn.execute(statement)
@@ -1137,7 +1152,7 @@ def apply_pending_migrations(conn: sqlite3.Connection, *, applied_at: str) -> No
                 conn.execute("BEGIN EXCLUSIVE")
             if starting_version != 0:
                 require_event_hypothesis_relationship_backup(
-                    conn, expected_history=EXPECTED_MIGRATION_HISTORY[:-2]
+                    conn, expected_history=EXPECTED_MIGRATION_HISTORY[:-3]
                 )
             for statement in EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION_STATEMENTS:
                 conn.execute(statement)
@@ -1191,6 +1206,31 @@ def apply_pending_migrations(conn: sqlite3.Connection, *, applied_at: str) -> No
                 ),
             )
             current = EVENT_HYPOTHESIS_LINEAGE_SCHEMA_VERSION
+        # fmt: off
+        if current == EVENT_HYPOTHESIS_LINEAGE_SCHEMA_VERSION:
+            if 0 < starting_version < EVENT_HYPOTHESIS_LINEAGE_SCHEMA_VERSION:
+                conn.execute(f"PRAGMA user_version={EVENT_HYPOTHESIS_LINEAGE_SCHEMA_VERSION}")
+                conn.execute("COMMIT")
+                database_path = next(str(row[2]) for row in conn.execute("PRAGMA database_list") if row[1] == "main")
+                if not database_path:
+                    raise sqlite3.DatabaseError("existing multihop upgrade requires a file-backed database")
+                backup_path, _ = story_candidate_backup_paths(database_path)
+                prepare_story_candidate_backup(conn, backup_path)
+                conn.execute("BEGIN EXCLUSIVE")
+            if starting_version != 0:
+                require_story_candidate_backup(
+                    conn, expected_history=tuple((r.version, r.name, r.checksum) for r in MIGRATIONS
+                                                 if r.version <= EVENT_HYPOTHESIS_LINEAGE_SCHEMA_VERSION),
+                )
+            for statement in STORY_CANDIDATE_MIGRATION_STATEMENTS:
+                conn.execute(statement)
+            conn.execute(
+                "INSERT INTO authority_migrations(version,name,checksum,applied_at) VALUES(?,?,?,?)",
+                (STORY_CANDIDATE_SCHEMA_VERSION, STORY_CANDIDATE_MIGRATION_NAME,
+                 STORY_CANDIDATE_MIGRATION_CHECKSUM, applied_at),
+            )
+            current = STORY_CANDIDATE_SCHEMA_VERSION
+        # fmt: on
         conn.execute(f"PRAGMA user_version={current}")
         conn.execute("COMMIT")
     except Exception:
@@ -1223,6 +1263,7 @@ MIGRATIONS: tuple[MigrationRecord | object, ...] = (
     EVENT_HYPOTHESIS_MIGRATION,
     EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION,
     EVENT_HYPOTHESIS_LINEAGE_MIGRATION,
+    STORY_CANDIDATE_MIGRATION,
 )
 
 
@@ -1344,5 +1385,10 @@ EXPECTED_MIGRATION_HISTORY: tuple[tuple[int, str, str], ...] = (
         EVENT_HYPOTHESIS_LINEAGE_SCHEMA_VERSION,
         EVENT_HYPOTHESIS_LINEAGE_MIGRATION_NAME,
         EVENT_HYPOTHESIS_LINEAGE_MIGRATION_CHECKSUM,
+    ),
+    (
+        STORY_CANDIDATE_SCHEMA_VERSION,
+        STORY_CANDIDATE_MIGRATION_NAME,
+        STORY_CANDIDATE_MIGRATION_CHECKSUM,
     ),
 )

--- a/newsroom/authority/story_candidate_migrations.py
+++ b/newsroom/authority/story_candidate_migrations.py
@@ -1,0 +1,113 @@
+"""Checked v24 Story Candidate authority migration and exact-v23 backup gate."""
+# ruff: noqa: E701,E702 - keep the immutable migration within #401's line cap
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from . import event_hypothesis_lineage_migrations as predecessor
+from .canonical import digest_canonical
+
+STORY_CANDIDATE_SCHEMA_VERSION = 24
+STORY_CANDIDATE_MIGRATION_NAME = "story_candidate_authority_v24"
+STORY_CANDIDATE_PREDECESSOR_MIGRATION_CHECKSUM = (
+    "sha256:6c24d402f246f4e82a49a9772d70677d922282aae3b6dde93c62c0ef9b1b7a72"
+)
+STORY_CANDIDATE_PREDECESSOR_FINGERPRINT = (
+    "sha256:c341333cf54d724bb4d2092bb9da81e9f3a434ddb03e6ddc14a51fdf2c6c1b52"
+)
+
+
+StoryCandidateBackupError = predecessor.EventHypothesisLineageBackupError
+StoryCandidateBackupReceipt = predecessor.EventHypothesisLineageBackupReceipt
+StoryCandidateMigrationRecord = predecessor.EventHypothesisLineageMigrationRecord
+
+
+# fmt: off
+def story_candidate_backup_paths(database: str | Path) -> tuple[Path, Path]:
+    source = Path(database); backup = source.with_name(source.name + ".pre-v24.sqlite3")
+    return backup, backup.with_name(backup.name + ".sha256")
+
+
+def _checked_backup(path: Path, logical: str) -> StoryCandidateBackupReceipt:
+    digest_path = path.with_name(path.name + ".sha256"); digest = predecessor._file_digest(path)
+    if digest_path.read_text(encoding="ascii") != digest + "\n":
+        raise StoryCandidateBackupError("backup digest differs")
+    target = sqlite3.connect(f"file:{path}?mode=ro", uri=True, isolation_level=None)
+    try:
+        if (target.execute("PRAGMA user_version").fetchone()[0] != 23
+            or predecessor._schema_fingerprint(target) != STORY_CANDIDATE_PREDECESSOR_FINGERPRINT
+            or predecessor._logical_database_digest(target) != logical):
+            raise StoryCandidateBackupError("backup differs from source")
+    finally: target.close()
+    return StoryCandidateBackupReceipt(path, digest_path, digest, logical)
+
+
+def prepare_story_candidate_backup(connection: sqlite3.Connection, backup_path: Path) -> StoryCandidateBackupReceipt:
+    if (connection.in_transaction or connection.execute("PRAGMA user_version").fetchone()[0] != 23
+        or predecessor._schema_fingerprint(connection) != STORY_CANDIDATE_PREDECESSOR_FINGERPRINT
+        or not isinstance(backup_path, Path) or not backup_path.is_absolute()):
+        raise StoryCandidateBackupError("backup requires checked schema v23")
+    source = Path(next(row[2] for row in connection.execute("PRAGMA database_list") if row[1] == "main"))
+    digest_path = backup_path.with_name(backup_path.name + ".sha256"); logical = predecessor._logical_database_digest(connection)
+    if not source or source.resolve() == backup_path.resolve() or backup_path.exists() != digest_path.exists():
+        raise StoryCandidateBackupError("backup boundary differs")
+    if not backup_path.exists():
+        backup_path.open("xb").close(); target = sqlite3.connect(backup_path, isolation_level=None)
+        try: connection.backup(target)
+        finally: target.close()
+        digest_path.write_text(predecessor._file_digest(backup_path) + "\n", encoding="ascii")
+    receipt = _checked_backup(backup_path, logical)
+    connection.execute("CREATE TEMP TABLE IF NOT EXISTS story_candidate_backup_gate(backup_path TEXT PRIMARY KEY,backup_digest TEXT NOT NULL,logical_digest TEXT NOT NULL) STRICT")
+    connection.execute("DELETE FROM story_candidate_backup_gate")
+    connection.execute("INSERT INTO story_candidate_backup_gate VALUES(?,?,?)", (str(backup_path), receipt.backup_digest, logical))
+    if connection.in_transaction: connection.commit()
+    return receipt
+
+
+def require_story_candidate_backup(connection: sqlite3.Connection, *, expected_history: tuple[tuple[int, str, str], ...]) -> StoryCandidateBackupReceipt:
+    try: row = connection.execute("SELECT backup_path,backup_digest,logical_digest FROM temp.story_candidate_backup_gate").fetchone()
+    except sqlite3.OperationalError as exc: raise StoryCandidateBackupError("v23 to v24 requires prepared backup") from exc
+    if row is None or predecessor._logical_database_digest(connection) != row[2]:
+        raise StoryCandidateBackupError("v23 to v24 requires prepared backup")
+    receipt = _checked_backup(Path(row[0]), str(row[2])); target = sqlite3.connect(f"file:{receipt.backup_path}?mode=ro", uri=True, isolation_level=None)
+    try: history = target.execute("SELECT version,name,checksum FROM authority_migrations ORDER BY version").fetchall()
+    finally: target.close()
+    if receipt.backup_digest != row[1] or history != list(expected_history):
+        raise StoryCandidateBackupError("prepared backup is not exact v23")
+    return receipt
+# fmt: on
+
+
+D = "substr({0},1,7)='sha256:' AND length({0})=71 AND substr({0},8) NOT GLOB '*[^0-9a-f]*'"
+U = "length({0})=36 AND substr({0},15,1)='4' AND lower(substr({0},20,1)) IN ('8','9','a','b')"
+G = "length({0})=36 AND substr({0},15,1) IN ('1','2','3','4','5') AND lower(substr({0},20,1)) IN ('8','9','a','b')"
+STORY_CANDIDATE_MIGRATION_STATEMENTS = (
+    f"""CREATE TABLE story_candidate_admission_receipts_v2(
+admission_digest TEXT PRIMARY KEY CHECK({D.format("admission_digest")}),request_id TEXT NOT NULL UNIQUE CHECK({U.format("request_id")}),request_digest TEXT NOT NULL UNIQUE CHECK({D.format("request_digest")}),actor_identity_digest TEXT NOT NULL CHECK({D.format("actor_identity_digest")}),idempotency_key TEXT NOT NULL,authority_aggregate_id TEXT NOT NULL CHECK({U.format("authority_aggregate_id")}),authority_event_id TEXT NOT NULL UNIQUE REFERENCES ledger_events(event_id),committed_admission_decision_id TEXT NOT NULL UNIQUE CHECK({U.format("committed_admission_decision_id")}),admission_bytes BLOB NOT NULL,candidate_id TEXT NOT NULL CHECK({U.format("candidate_id")}),candidate_bytes BLOB,version_id TEXT NOT NULL UNIQUE CHECK({U.format("version_id")}),version_ordinal INTEGER NOT NULL CHECK(version_ordinal BETWEEN 1 AND 9007199254740991),version_bytes BLOB NOT NULL,version_digest TEXT NOT NULL UNIQUE CHECK({D.format("version_digest")}),previous_version_id TEXT,previous_version_digest TEXT CHECK(previous_version_digest IS NULL OR {D.format("previous_version_digest")}),manifest_material_digest TEXT NOT NULL CHECK({D.format("manifest_material_digest")}),semantic_scope_digest TEXT NOT NULL CHECK({D.format("semantic_scope_digest")}),hypothesis_version_id TEXT NOT NULL CHECK({G.format("hypothesis_version_id")}),relationship_assessment_digest TEXT NOT NULL CHECK({D.format("relationship_assessment_digest")}),disposition_ids_bytes BLOB NOT NULL,collision_request_bytes BLOB NOT NULL,collision_request_digest TEXT NOT NULL CHECK({D.format("collision_request_digest")}),collision_decision_bytes BLOB NOT NULL,collision_decision_digest TEXT NOT NULL CHECK({D.format("collision_decision_digest")}),comparator_collision_request_bytes BLOB,comparator_collision_request_digest TEXT CHECK(comparator_collision_request_digest IS NULL OR {D.format("comparator_collision_request_digest")}),comparator_collision_decision_bytes BLOB,comparator_collision_decision_digest TEXT CHECK(comparator_collision_decision_digest IS NULL OR {D.format("comparator_collision_decision_digest")}),recorded_at TEXT NOT NULL,UNIQUE(actor_identity_digest,idempotency_key),UNIQUE(candidate_id,version_ordinal),UNIQUE(candidate_id,version_id),FOREIGN KEY(candidate_id,previous_version_id) REFERENCES story_candidate_admission_receipts_v2(candidate_id,version_id),CHECK(authority_aggregate_id=candidate_id),CHECK(committed_admission_decision_id NOT IN(authority_event_id,candidate_id,version_id)),CHECK(version_id!=candidate_id),CHECK((version_ordinal=1 AND candidate_bytes IS NOT NULL) OR (version_ordinal>1 AND candidate_bytes IS NULL)),CHECK((version_ordinal=1 AND previous_version_id IS NULL AND previous_version_digest IS NULL) OR (version_ordinal>1 AND previous_version_id IS NOT NULL AND previous_version_digest IS NOT NULL)),CHECK((comparator_collision_request_bytes IS NULL AND comparator_collision_request_digest IS NULL AND comparator_collision_decision_bytes IS NULL AND comparator_collision_decision_digest IS NULL) OR (comparator_collision_request_bytes IS NOT NULL AND comparator_collision_request_digest IS NOT NULL AND comparator_collision_decision_bytes IS NOT NULL AND comparator_collision_decision_digest IS NOT NULL))) STRICT""",
+    f"""CREATE TABLE story_candidate_collision_bindings(collision_namespace TEXT NOT NULL,collision_key_digest TEXT NOT NULL CHECK({D.format("collision_key_digest")}),candidate_id TEXT NOT NULL CHECK({U.format("candidate_id")}),semantic_scope_digest TEXT NOT NULL CHECK({D.format("semantic_scope_digest")}),admission_digest TEXT NOT NULL UNIQUE REFERENCES story_candidate_admission_receipts_v2(admission_digest),initial_request_digest TEXT NOT NULL CHECK({D.format("initial_request_digest")}),initial_decision_digest TEXT NOT NULL CHECK({D.format("initial_decision_digest")}),initial_decision_bytes BLOB NOT NULL,PRIMARY KEY(collision_namespace,collision_key_digest),UNIQUE(candidate_id),UNIQUE(semantic_scope_digest)) STRICT""",
+    f"""CREATE TABLE story_candidate_heads(candidate_id TEXT PRIMARY KEY CHECK({U.format("candidate_id")}),candidate_bytes BLOB NOT NULL,semantic_scope_digest TEXT NOT NULL UNIQUE CHECK({D.format("semantic_scope_digest")}),current_version_id TEXT NOT NULL UNIQUE CHECK({U.format("current_version_id")}),current_version_ordinal INTEGER NOT NULL CHECK(current_version_ordinal BETWEEN 1 AND 9007199254740991),current_version_digest TEXT NOT NULL UNIQUE CHECK({D.format("current_version_digest")}),current_admission_digest TEXT NOT NULL UNIQUE REFERENCES story_candidate_admission_receipts_v2(admission_digest),collision_namespace TEXT NOT NULL,collision_key_digest TEXT NOT NULL CHECK({D.format("collision_key_digest")}),updated_at TEXT NOT NULL,FOREIGN KEY(collision_namespace,collision_key_digest) REFERENCES story_candidate_collision_bindings(collision_namespace,collision_key_digest)) STRICT""",
+    "CREATE TRIGGER immutable_candidate_receipt BEFORE UPDATE ON story_candidate_admission_receipts_v2 BEGIN SELECT RAISE(ABORT,'immutable Candidate receipt'); END",
+    "CREATE TRIGGER retained_candidate_receipt BEFORE DELETE ON story_candidate_admission_receipts_v2 BEGIN SELECT RAISE(ABORT,'retained Candidate receipt'); END",
+    "CREATE TRIGGER immutable_candidate_collision BEFORE UPDATE ON story_candidate_collision_bindings BEGIN SELECT RAISE(ABORT,'immutable Candidate collision'); END",
+    "CREATE TRIGGER retained_candidate_collision BEFORE DELETE ON story_candidate_collision_bindings BEGIN SELECT RAISE(ABORT,'retained Candidate collision'); END",
+    "CREATE TRIGGER retained_candidate_head BEFORE DELETE ON story_candidate_heads BEGIN SELECT RAISE(ABORT,'retained Candidate head'); END",
+    "CREATE TRIGGER candidate_head_insert_guard BEFORE INSERT ON story_candidate_heads WHEN NOT EXISTS(SELECT 1 FROM story_candidate_admission_receipts_v2 r JOIN story_candidate_collision_bindings b ON b.admission_digest=r.admission_digest WHERE r.admission_digest=NEW.current_admission_digest AND r.candidate_id=NEW.candidate_id AND r.candidate_bytes=NEW.candidate_bytes AND r.version_id=NEW.current_version_id AND r.version_ordinal=1 AND r.version_digest=NEW.current_version_digest AND r.semantic_scope_digest=NEW.semantic_scope_digest AND r.recorded_at=NEW.updated_at AND b.candidate_id=NEW.candidate_id AND b.collision_namespace=NEW.collision_namespace AND b.collision_key_digest=NEW.collision_key_digest) BEGIN SELECT RAISE(ABORT,'Candidate head admission differs'); END",
+    "CREATE TRIGGER candidate_head_update_guard BEFORE UPDATE ON story_candidate_heads WHEN NEW.candidate_id!=OLD.candidate_id OR NEW.candidate_bytes!=OLD.candidate_bytes OR NEW.semantic_scope_digest!=OLD.semantic_scope_digest OR NEW.collision_namespace!=OLD.collision_namespace OR NEW.collision_key_digest!=OLD.collision_key_digest OR NEW.current_version_ordinal!=OLD.current_version_ordinal+1 OR NOT EXISTS(SELECT 1 FROM story_candidate_admission_receipts_v2 r WHERE r.admission_digest=NEW.current_admission_digest AND r.candidate_id=NEW.candidate_id AND r.version_id=NEW.current_version_id AND r.version_ordinal=NEW.current_version_ordinal AND r.version_digest=NEW.current_version_digest AND r.semantic_scope_digest=NEW.semantic_scope_digest AND r.previous_version_id=OLD.current_version_id AND r.previous_version_digest=OLD.current_version_digest AND r.recorded_at=NEW.updated_at) BEGIN SELECT RAISE(ABORT,'Candidate head transition differs'); END",
+)
+STORY_CANDIDATE_MIGRATION_CHECKSUM = digest_canonical(
+    {
+        "version": 24,
+        "name": STORY_CANDIDATE_MIGRATION_NAME,
+        "statements": list(STORY_CANDIDATE_MIGRATION_STATEMENTS),
+    }
+)
+STORY_CANDIDATE_MIGRATION = StoryCandidateMigrationRecord(
+    24, STORY_CANDIDATE_MIGRATION_NAME, STORY_CANDIDATE_MIGRATION_CHECKSUM
+)
+__all__ = [
+    n
+    for n in globals()
+    if n.startswith(("STORY_", "Story", "story_", "prepare_", "require_"))
+]

--- a/newsroom/authority/story_candidate_system.py
+++ b/newsroom/authority/story_candidate_system.py
@@ -1,0 +1,980 @@
+"""Server-owned checked v24 Story Candidate authority composition root."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Callable
+from pathlib import Path
+
+from newsroom.authority._capability import _CapabilityIssuer
+from newsroom.authority._discovery_store import (
+    _create_discovery_governing_producer_read_port,
+)
+from newsroom.authority._event_hypothesis_lineage_system import (
+    _create_event_hypothesis_lineage_read_port,
+)
+from newsroom.authority._event_store import _EventAuthorityStore
+from newsroom.authority.auth import AuthenticationProof, StaticAuthenticator
+from newsroom.authority.canonical import (
+    canonical_json_bytes,
+    digest_bytes,
+    digest_canonical,
+)
+from newsroom.authority.models import InlinePayload, SemanticCommand
+from newsroom.authority.persistence import EventReadPolicy, MetadataClass
+from newsroom.authority.policy import CommandRegistry, PayloadSchemaRegistry
+from newsroom.authority.service import CommandService
+from newsroom.authority.types import AggregateId, UtcTimestamp
+from newsroom.discovery import NewsLeadId
+from newsroom.increment6.candidates import (
+    CANDIDATE_COMMAND_SCHEMA,
+    CANDIDATE_COMMAND_TYPE,
+    CandidateAdmission,
+    CandidateAdmissionReason,
+    CandidateAdmissionRequest,
+    CandidateContractError,
+    CandidateGoverningState,
+    CandidateGoverningStateStatus,
+    StoryCandidate,
+    StoryCandidateAuthority,
+    StoryCandidateVersion,
+    _compose_story_candidate_authority,
+    build_candidate_distinct_scope_proof,
+    build_candidate_governing_manifest,
+    candidate_command_definition,
+    evaluate_candidate_admission,
+    merge_candidate_authority_registries,
+    validate_candidate_first_version,
+    validate_candidate_version_successor,
+)
+from newsroom.increment6.collision import (
+    CandidateUseOperation,
+    CurrentCollisionEffectEnforcer,
+    CurrentCollisionEligibilityDecision,
+    CurrentCollisionEligibilityRequest,
+)
+from newsroom.increment6.dispositions import ProposalDispositionStore
+from newsroom.increment6.lineage import merge_lineage_authority_registries
+from newsroom.increment6.relationships import merge_relationship_authority_registries
+from newsroom.increment6.work_items import RetrievalContextAuthority
+
+_TOKEN = object()
+
+
+def _uuid() -> str:
+    return str(uuid.uuid4())
+
+
+def _actor(authentication: object) -> str:
+    return digest_bytes(
+        canonical_json_bytes(
+            {
+                "principal_id": authentication.principal_id,
+                "credential_binding_digest": authentication.credential_binding_digest,
+            }
+        )
+    )  # type: ignore[attr-defined]
+
+
+# fmt: off
+def _collision_position(value):
+    return value.subject_id, value.subject_version_id, value.subject_version_digest, value.collision_namespace, value.collision_key_digest
+
+
+def _manifest_position(value):
+    return value.hypothesis_id, value.hypothesis_version_id, value.hypothesis_version_digest, value.collision_namespace, value.collision_key_digest
+
+
+def _collision_context(value):
+    return value.generation_id, value.query_valid_time, value.serving_time, value.authority_watermark
+# fmt: on
+
+
+def _payload(
+    request,
+    hypothesis_version_id,
+    relationship_digest,
+    disposition_ids,
+    collision_request,
+    comparator_collision_request=None,
+    admission=None,
+    collision_decision=None,
+    comparator_collision_decision=None,
+    effect_identity=None,
+):
+    return {
+        "schema_version": CANDIDATE_COMMAND_SCHEMA,
+        "request": request.canonical_value(),
+        "hypothesis_version_id": hypothesis_version_id,
+        "relationship_assessment_digest": relationship_digest,
+        "disposition_ids": list(disposition_ids),
+        "collision_request": collision_request.canonical_value(),
+        "comparator_collision_request": None
+        if comparator_collision_request is None
+        else comparator_collision_request.canonical_value(),
+        "admission": None
+        if admission is None
+        else json.loads(admission.canonical_bytes),
+        "collision_decision": None
+        if collision_decision is None
+        else json.loads(collision_decision.canonical_bytes),
+        "comparator_collision_decision": None
+        if comparator_collision_decision is None
+        else json.loads(comparator_collision_decision.canonical_bytes),
+        "effect_identity": effect_identity,
+    }
+
+
+# fmt: off
+class _CandidateStore(_EventAuthorityStore):
+    def __init__(
+        self,
+        token: object,
+        path: Path,
+        *,
+        retrieval_authority: RetrievalContextAuthority,
+        authenticator: StaticAuthenticator,
+        authorizer: object,
+        command_registry: CommandRegistry,
+        payload_schemas: PayloadSchemaRegistry,
+        collision_enforcer: CurrentCollisionEffectEnforcer,
+        clock: Callable[[], UtcTimestamp],
+        busy_timeout_ms: int,
+    ):
+        if (
+            token is not _TOKEN
+            or type(retrieval_authority) is not RetrievalContextAuthority
+            or type(authenticator) is not StaticAuthenticator
+            or type(collision_enforcer) is not CurrentCollisionEffectEnforcer
+        ):
+            raise CandidateContractError("Candidate composition collaborators differ")
+        relationship_commands, relationship_schemas = (
+            merge_relationship_authority_registries(command_registry, payload_schemas)
+        )
+        lineage_commands, lineage_schemas = merge_lineage_authority_registries(
+            relationship_commands, relationship_schemas
+        )
+        commands, schemas = merge_candidate_authority_registries(
+            lineage_commands, lineage_schemas
+        )
+        issuer = _CapabilityIssuer(command_registry=commands, payload_schemas=schemas)
+        super().__init__(
+            path,
+            issuer=issuer,
+            command_registry=commands,
+            payload_schemas=schemas,
+            command_service_version="increment6-candidate-v1",
+            busy_timeout_ms=busy_timeout_ms,
+            clock=clock,
+        )
+        try:
+            self._retrieval = retrieval_authority
+            self._authenticator = authenticator
+            self._collision = collision_enforcer
+            self._lineage = _create_event_hypothesis_lineage_read_port(
+                self._connection,
+                retrieval_authority=retrieval_authority,
+                authenticator=authenticator,
+                command_registry=commands,
+                payload_schemas=schemas,
+                clock=clock,
+            )
+            self._dispositions = ProposalDispositionStore(
+                self._connection, retrieval_authority, authenticator
+            )
+            self._service = CommandService(
+                registry=commands,
+                payload_schemas=schemas,
+                authenticator=authenticator,
+                authorizer=authorizer,
+                committed_lookup=self,
+                clock=clock,
+                _issuer=issuer,
+            )
+            with self._lock, self._transaction():
+                self._verify()
+        except BaseException:
+            try:
+                self.close()
+            except BaseException:  # noqa: BLE001, S110 - preserve opening failure
+                pass
+            raise
+
+    def _command(
+        self, payload: dict, request: CandidateAdmissionRequest, aggregate_id: str
+    ):
+        return SemanticCommand(
+            command_type=CANDIDATE_COMMAND_TYPE,
+            aggregate_id=AggregateId.parse(aggregate_id),
+            expected_aggregate_version=request.expected_current_ordinal,
+            payload=InlinePayload(payload),
+            idempotency_key=request.idempotency_key,
+        )
+
+    def _receipt(self, row):
+        candidate_bytes = row["candidate_bytes"]
+        if candidate_bytes is None:
+            candidate_bytes = self._connection.execute(
+                "SELECT candidate_bytes FROM story_candidate_heads WHERE candidate_id=?",
+                (row["candidate_id"],),
+            ).fetchone()
+            if candidate_bytes is None:
+                raise CandidateContractError("Candidate identity is absent")
+            candidate_bytes = candidate_bytes[0]
+        comparator = row["comparator_collision_decision_bytes"]
+        return (
+            CandidateAdmission.from_canonical_bytes(bytes(row["admission_bytes"])),
+            StoryCandidate.from_canonical_bytes(bytes(candidate_bytes)),
+            StoryCandidateVersion.from_canonical_bytes(bytes(row["version_bytes"])),
+            CurrentCollisionEligibilityDecision.from_canonical_bytes(
+                bytes(row["collision_decision_bytes"])
+            ),
+            None
+            if comparator is None
+            else CurrentCollisionEligibilityDecision.from_canonical_bytes(
+                bytes(comparator)
+            ),
+            tuple(json.loads(bytes(row["disposition_ids_bytes"]))),
+        )
+
+    def _row(self, digest: str):
+        return self._connection.execute(
+            "SELECT r.*,c.command_type,c.aggregate_type command_aggregate_type,"
+            "c.aggregate_id command_aggregate_id,c.expected_aggregate_version,"
+            "c.idempotency_namespace,c.idempotency_key command_idempotency_key,"
+            "c.stable_semantic_request_digest,c.authentication_context_id command_auth,"
+            "c.authorization_request_digest command_request,c.authorization_decision_id command_decision,"
+            "c.result_bytes,c.result_digest,c.committed_at,v.aggregate_version retained_aggregate_version,"
+            "v.trust_scope version_trust_scope,v.recorded_at version_recorded_at,"
+            "g.current_version,p.payload_bytes,au.event_type audit_event_type,"
+            "au.detail_digest,au.recorded_at audit_recorded_at,"
+            "au.authentication_context_id audit_auth,au.authorization_request_digest audit_request,"
+            "au.authorization_decision_id audit_decision FROM story_candidate_admission_receipts_v2 r "
+            "JOIN ledger_events e ON e.event_id=r.authority_event_id "
+            "JOIN authority_commands c ON c.command_id=e.command_id "
+            "JOIN authority_aggregate_versions v ON v.command_id=c.command_id "
+            "JOIN authority_aggregates g ON g.aggregate_type=v.aggregate_type AND g.aggregate_id=v.aggregate_id "
+            "JOIN authority_payloads p ON p.payload_id=e.payload_id "
+            "JOIN authority_audit_events au ON au.command_id=c.command_id "
+            "WHERE r.admission_digest=?",
+            (digest,),
+        ).fetchone()
+
+    @staticmethod
+    def _columns(row, names):
+        return tuple(row[name] for name in names.split())
+
+    def _verify_row(self, digest: str):
+        row = self._row(digest)
+        if row is None:
+            raise CandidateContractError("Candidate receipt coverage differs")
+        admission, candidate, version, collision, comparator, disposition_ids = (
+            self._receipt(row)
+        )
+        request, manifest = admission.request, admission.governing_manifest
+        definition = candidate_command_definition()
+        policy = EventReadPolicy("candidate-retained-v1", "candidate.retained", definition.required_scope,
+                                 frozenset({str(row["actor_identity_digest"])}), frozenset({definition.security_scope}),
+                                 frozenset({definition.trust_scope}), frozenset({MetadataClass.PROVENANCE}), max_results=1)
+        provenance = self.event_provenance(event_id=str(row["authority_event_id"]), policy=policy)
+        event, authentication = provenance.event, provenance.authentication
+        authorisation, decision = provenance.authorization_request, provenance.authorization_decision
+        contract = provenance.payload_schema_contract
+        payload_meta = {
+            "kind": event.payload_mode, "schema_version": contract.schema_version,
+            "schema_contract_version": contract.contract_version, "schema_contract_digest": contract.contract_digest,
+            "canonicalizer_version": contract.canonicalizer_implementation_version,
+            "digest": event.payload_digest, "inline_digest": event.payload_digest,
+            "object_admission_id": None, "blob_digest": None, "object_class": None, "allowed_use": None,
+        }
+        aggregate_version = request.expected_current_ordinal + 1
+        stable = digest_canonical({"command_type": definition.command_type, "command_definition_version": definition.definition_version,
+            "command_definition_digest": definition.digest, "aggregate_type": definition.aggregate_type,
+            "aggregate_id": row["authority_aggregate_id"], "expected_aggregate_version": request.expected_current_ordinal,
+            "payload": payload_meta})
+        result = self._decode_result(bytes(row["result_bytes"]), str(row["result_digest"]), replayed=False)
+        detail = {
+            "operation": "COMMAND_COMMIT", "command_type": definition.command_type, "aggregate_id": row["authority_aggregate_id"],
+            "expected_aggregate_version": request.expected_current_ordinal, "definition_digest": definition.digest,
+            "definition_version": definition.definition_version, "payload": payload_meta,
+            "authentication_context_digest": authentication.canonical_digest,
+            "authorization_request_record_digest": authorisation.canonical_record_digest,
+            "authorization_request_digest": authorisation.request_digest, "authorization_decision_digest": decision.canonical_digest,
+            "idempotency_namespace": row["idempotency_namespace"], "idempotency_key": row["command_idempotency_key"],
+            "stable_semantic_request_digest": stable, "correlation_id": event.correlation_id,
+            "causation_kind": event.causation_kind, "causation_identifier": event.causation_identifier,
+            "causation_external_system": event.causation_external_system, "replay_of_command_id": None,
+        }
+        effect = {"candidate_id": row["candidate_id"], "committed_admission_decision_id": row["committed_admission_decision_id"],
+                  "version_id": row["version_id"], "version_ordinal": row["version_ordinal"]}
+        expected_payload = _payload(
+            request, row["hypothesis_version_id"], row["relationship_assessment_digest"], disposition_ids,
+            collision.request, None if comparator is None else comparator.request,
+            admission, collision, comparator, effect,
+        )
+        expected_reason = (CandidateAdmissionReason.RELATED_DISTINCT_PRE_EFFECT if admission.distinct_scope_proof is not None
+                           else CandidateAdmissionReason.NEW_CANDIDATE_PRE_EFFECT if version.ordinal == 1
+                           else CandidateAdmissionReason.SUCCESSOR_VERSION_PRE_EFFECT)
+        optional = self._columns(
+            row,
+            "comparator_collision_request_bytes comparator_collision_request_digest "
+            "comparator_collision_decision_bytes comparator_collision_decision_digest",
+        )
+        route = (definition.command_type, definition.definition_version, definition.digest, definition.aggregate_type,
+                 definition.event_type, definition.event_schema_version, definition.payload_schema_version,
+                 definition.payload_schema_contract_version, definition.payload_schema_contract_digest,
+                 definition.payload_canonicalizer_version)
+        actual_route = (provenance.command_definition.command_type, provenance.command_definition.definition_version,
+                        provenance.command_definition.definition_digest, event.aggregate_type, event.event_type,
+                        event.event_schema_version, event.payload_schema_version, event.payload_schema_contract_version,
+                        event.payload_schema_contract_digest, event.payload_canonicalizer_version)
+        actor = digest_bytes(canonical_json_bytes({"principal_id": authentication.principal_id,
+                                                   "credential_binding_digest": authentication.credential_binding_digest}))
+        failures = (
+            digest_bytes(admission.canonical_bytes) != row["admission_digest"],
+            self._columns(row, "request_id request_digest actor_identity_digest idempotency_key")
+            != (request.request_id, request.canonical_digest, request.actor_identity_digest, request.idempotency_key),
+            request.collision_request_digest != row["collision_request_digest"],
+            route != actual_route,
+            event.producer_version != self._command_service_version,
+            (event.retention_scope, event.trust_scope, row["version_trust_scope"])
+            != (definition.retention_scope, definition.trust_scope.value, definition.trust_scope.value),
+            (event.aggregate_id, event.aggregate_version)
+            != (row["authority_aggregate_id"], aggregate_version),
+            self._columns(row, "command_type command_aggregate_type command_aggregate_id expected_aggregate_version")
+            != (definition.command_type, definition.aggregate_type, row["authority_aggregate_id"], request.expected_current_ordinal),
+            row["retained_aggregate_version"] != aggregate_version,
+            self._columns(row, "command_idempotency_key idempotency_key stable_semantic_request_digest")
+            != (request.idempotency_key, request.idempotency_key, stable),
+            row["idempotency_namespace"]
+            != digest_canonical({"authority_domain": authentication.authority_domain, "principal_id": authentication.principal_id, "command_type": definition.command_type}),
+            (result.command_id, result.aggregate_type, result.aggregate_id, result.aggregate_version, result.ledger_seq, result.event_id)
+            != (event.command_id, definition.aggregate_type, row["authority_aggregate_id"], aggregate_version, event.ledger_seq, event.event_id),
+            len({event.recorded_at, row["committed_at"], row["version_recorded_at"], row["audit_recorded_at"], row["recorded_at"]}) != 1,
+            bytes(row["payload_bytes"]) != canonical_json_bytes(expected_payload),
+            actor != row["actor_identity_digest"],
+            len({self._columns(row, "command_auth command_request command_decision"), (event.authentication_context_id, event.authorization_request_digest, event.authorization_decision_id), self._columns(row, "audit_auth audit_request audit_decision")}) != 1,
+            row["audit_event_type"] != definition.event_type,
+            row["detail_digest"] != digest_canonical(detail),
+            not decision.allowed or definition.required_scope not in decision.effective_scopes,
+            (authorisation.operation_type, authorisation.required_scope)
+            != (f"command:{definition.command_type}", definition.required_scope),
+            collision.request.request_digest != row["collision_request_digest"],
+            collision.request.canonical_value() != json.loads(bytes(row["collision_request_bytes"])),
+            collision.canonical_bytes != bytes(row["collision_decision_bytes"]),
+            collision.decision_digest != row["collision_decision_digest"],
+            manifest.collision_decision_digest != collision.decision_digest,
+            _collision_position(collision.request.binding) != _manifest_position(manifest),
+            manifest.version_material_digest != row["manifest_material_digest"],
+            version.committed_admission_decision_id != row["committed_admission_decision_id"],
+            version.ordinal != aggregate_version,
+            (comparator is None) != (admission.distinct_scope_proof is None),
+            not (all(item is None for item in optional) or all(item is not None for item in optional)),
+            admission.reason is not expected_reason,
+            (version.candidate_id, version.version_id, version.ordinal, version.canonical_digest)
+            != self._columns(row, "candidate_id version_id version_ordinal version_digest"),
+            version.canonical_digest != digest_bytes(bytes(row["version_bytes"])),
+            (version.previous_version_id, version.previous_version_digest)
+            != self._columns(row, "previous_version_id previous_version_digest"),
+            (admission.current_candidate_id, admission.current_candidate_version_id, admission.current_candidate_version_digest)
+            != ((None, None, None) if version.ordinal == 1 else (version.candidate_id, version.previous_version_id, version.previous_version_digest)),
+            row["authority_aggregate_id"] != row["candidate_id"],
+            (candidate.candidate_id, candidate.semantic_scope_digest)
+            != self._columns(row, "candidate_id semantic_scope_digest"),
+            (version.ordinal == 1) != (row["candidate_bytes"] is not None),
+            version.ordinal == 1 and candidate.canonical_bytes != bytes(row["candidate_bytes"]),
+            version.governing_manifest != manifest,
+            (manifest.semantic_scope_digest, manifest.hypothesis_version_id, manifest.relationship_assessment_digest)
+            != self._columns(row, "semantic_scope_digest hypothesis_version_id relationship_assessment_digest"),
+            version.ordinal == 1 and (candidate.committed_admission_decision_id, candidate.authority_event_id)
+            != (row["committed_admission_decision_id"], row["authority_event_id"]),
+        )
+        if any(failures):
+            raise CandidateContractError("Candidate retained authority graph differs")
+        if comparator is not None and (
+            comparator.request.request_digest != optional[1]
+            or canonical_json_bytes(comparator.request.canonical_value()) != bytes(optional[0])
+            or comparator.canonical_bytes != bytes(optional[2])
+            or comparator.decision_digest != optional[3]
+        ):
+            raise CandidateContractError("Candidate comparator collision differs")
+        UtcTimestamp.parse(str(row["recorded_at"]))
+        return admission, candidate, version, collision, comparator, disposition_ids, row
+
+    def _all_receipts(self):
+        return {
+            str(row["admission_digest"]): self._verify_row(str(row["admission_digest"]))
+            for row in self._connection.execute(
+                "SELECT admission_digest FROM story_candidate_admission_receipts_v2 "
+                "ORDER BY recorded_at,admission_digest"
+            )
+        }
+
+    def _verify_local(self):
+        self._validate_relational_invariants(self._connection)
+        self._validate_immutable_records(self._connection)
+        self._validate_registry_coverage(self._connection)
+        verified = self._all_receipts()
+        event_count = self._connection.execute(
+            "SELECT COUNT(*) FROM ledger_events WHERE event_type=?",
+            (candidate_command_definition().event_type,),
+        ).fetchone()[0]
+        if event_count != len(verified):
+            raise CandidateContractError("Candidate event coverage differs")
+        by_version = {item[2].version_id: item for item in verified.values()}
+        for admission, _, _, collision, comparator, _, _ in verified.values():
+            proof = admission.distinct_scope_proof
+            if proof is not None:
+                retained = by_version.get(proof.comparator_version_id)
+                if retained is None or comparator is None or build_candidate_distinct_scope_proof(
+                    proposed_manifest=admission.governing_manifest,
+                    proposed_collision=collision,
+                    comparator_collision=comparator,
+                    comparator_version=retained[2],
+                ) != proof:
+                    raise CandidateContractError("Candidate distinct proof differs")
+        heads = {row["candidate_id"]: row for row in self._connection.execute(
+            "SELECT h.*,g.current_version generic_current FROM story_candidate_heads h "
+            "LEFT JOIN authority_aggregates g ON g.aggregate_type='story_candidate_admission' AND g.aggregate_id=h.candidate_id"
+        )}
+        bindings = {row["candidate_id"]: row for row in self._connection.execute(
+            "SELECT * FROM story_candidate_collision_bindings"
+        )}
+        groups = {}
+        for item in verified.values():
+            groups.setdefault(item[2].candidate_id, []).append(item)
+        if set(groups) != set(heads) or set(groups) != set(bindings):
+            raise CandidateContractError("Candidate coverage differs")
+        for candidate_id, values in groups.items():
+            values.sort(key=lambda item: item[2].ordinal)
+            head, binding = heads[candidate_id], bindings[candidate_id]
+            first, last = values[0], values[-1]
+            if [item[2].ordinal for item in values] != list(range(1, len(values) + 1)):
+                raise CandidateContractError("Candidate Version chain differs")
+            decision = CurrentCollisionEligibilityDecision.from_canonical_bytes(
+                bytes(binding["initial_decision_bytes"])
+            )
+            if (
+                (binding["collision_namespace"], binding["collision_key_digest"], binding["semantic_scope_digest"], binding["admission_digest"], binding["initial_request_digest"], binding["initial_decision_digest"], binding["initial_decision_bytes"])
+                != (first[3].request.binding.collision_namespace, first[3].request.binding.collision_key_digest, first[1].semantic_scope_digest, first[0].canonical_digest, first[3].request.request_digest, first[3].decision_digest, first[3].canonical_bytes)
+                or decision != first[3]
+                or (head["candidate_bytes"], head["semantic_scope_digest"], head["current_version_id"], head["current_version_ordinal"], head["current_version_digest"], head["current_admission_digest"], head["collision_namespace"], head["collision_key_digest"], head["updated_at"], head["generic_current"])
+                != (first[1].canonical_bytes, first[1].semantic_scope_digest, last[2].version_id, last[2].ordinal, last[2].canonical_digest, last[0].canonical_digest, binding["collision_namespace"], binding["collision_key_digest"], last[6]["recorded_at"], last[2].ordinal)
+            ):
+                raise CandidateContractError("Candidate head or collision binding differs")
+            validate_candidate_first_version(first[1], first[2])
+            for previous, successor in zip(values, values[1:], strict=False):  # noqa: RUF007
+                validate_candidate_version_successor(previous[2], successor[2])
+        if self._connection.execute("PRAGMA foreign_key_check").fetchone() is not None:
+            raise CandidateContractError("Candidate foreign keys differ")
+        return verified
+
+    def _verify(self):
+        verified = self._verify_local()
+        self._verify_upstream(verified)
+        return verified
+
+    def _verify_upstream(self, verified):
+        digests = {
+            admission.governing_manifest.relationship_assessment_digest
+            for admission, *_ in verified.values()
+        }
+        relationships = {
+            digest: self._lineage.require_retained_relationship_in_transaction(
+                digest
+            ).assessment
+            for digest in digests
+        }
+        if not relationships:
+            self._lineage.verify_retained_integrity_in_transaction()
+        self._dispositions.verify_retained_integrity_in_transaction()
+        for admission, *_ in verified.values():
+            manifest = admission.governing_manifest
+            assessment = relationships[manifest.relationship_assessment_digest]
+            comparator = assessment.comparator
+            if (
+                (assessment.subject.hypothesis_id, assessment.subject.version_id,
+                    assessment.subject.version_digest, assessment.status, assessment.decision,
+                    None if comparator is None else comparator.hypothesis_id,
+                    None if comparator is None else comparator.version_id,
+                    None if comparator is None else comparator.version_digest)
+                != (manifest.hypothesis_id, manifest.hypothesis_version_id,
+                    manifest.hypothesis_version_digest, manifest.relationship_status,
+                    manifest.relationship_outcome, manifest.relationship_comparator_hypothesis_id,
+                    manifest.relationship_comparator_version_id,
+                    manifest.relationship_comparator_version_digest)):
+                raise CandidateContractError("Candidate relationship differs")
+
+    def _existing(self, request, actor):
+        rows = self._connection.execute(
+            "SELECT * FROM story_candidate_admission_receipts_v2 WHERE "
+            "request_id=? OR request_digest=? OR "
+            "(actor_identity_digest=? AND idempotency_key=?)",
+            (
+                request.request_id,
+                request.canonical_digest,
+                actor,
+                request.idempotency_key,
+            ),
+        ).fetchall()
+        if not rows:
+            return None
+        row = rows[0]
+        if (
+            len(rows) != 1
+            or
+            row["request_digest"] != request.canonical_digest
+            or row["request_id"] != request.request_id
+        ):
+            raise CandidateContractError("Candidate replay diverges")
+        return self._verify_local()[str(row["admission_digest"])]
+
+    def _current_scope(self, scope):
+        row = self._connection.execute(
+            "SELECT r.version_bytes FROM story_candidate_heads h JOIN story_candidate_admission_receipts_v2 r ON r.admission_digest=h.current_admission_digest WHERE h.semantic_scope_digest=?",
+            (scope,),
+        ).fetchone()
+        return (
+            None
+            if row is None
+            else StoryCandidateVersion.from_canonical_bytes(bytes(row[0]))
+        )
+
+    def _producers(self, manifest, proof):
+        snapshot = self._lineage.require_current_producers_in_transaction(
+            manifest.hypothesis_version_id, proof=proof
+        )
+        relationship = self._lineage.require_retained_relationship_in_transaction(
+            manifest.relationship_assessment_digest
+        )
+        disposition_ids = tuple(
+            sorted(
+                item.disposition_id
+                for item in snapshot.subject.source_bindings
+            )
+        )
+        dispositions = tuple(
+            self._dispositions.require_current_in_transaction(item, proof=proof)
+            for item in disposition_ids
+        )
+        lead_ids = tuple(
+            sorted(
+                {NewsLeadId.parse(item.decision_lead_id) for item in dispositions},
+                key=str,
+            )
+        )
+        discovery = _create_discovery_governing_producer_read_port(
+            self._connection
+        ).require_current_governing_producers(lead_ids)
+        return (
+            snapshot,
+            relationship,
+            disposition_ids,
+            dispositions,
+            tuple(zip(*discovery, strict=True)),
+        )
+
+    @staticmethod
+    def _manifest(producers, collision):
+        snapshot, relationship, _, dispositions, discovery = producers
+        return build_candidate_governing_manifest(
+            hypothesis_version=snapshot.subject,
+            lineage_receipts=snapshot.receipts,
+            lineage_initial_heads=snapshot.initial_heads,
+            lineage_versions=snapshot.versions,
+            lineage_relationship_proofs=snapshot.relationship_proofs,
+            dispositions=dispositions,
+            leads=discovery[0],
+            signals=discovery[1],
+            gates=discovery[2],
+            relationship=relationship,
+            collision=collision,
+        )
+
+    def admit(
+        self,
+        admission_bytes: bytes,
+        *,
+        collision_request: CurrentCollisionEligibilityRequest,
+        proof: AuthenticationProof,
+        comparator_collision_request: CurrentCollisionEligibilityRequest | None = None,
+    ):
+        supplied = CandidateAdmission.from_canonical_bytes(admission_bytes)
+        request = supplied.request
+        if type(collision_request) is not CurrentCollisionEligibilityRequest:
+            raise CandidateContractError("Candidate collision request differs")
+        authentication = self._authenticator.authenticate(proof, now=self._clock())
+        actor = _actor(authentication)
+        if actor != request.actor_identity_digest:
+            raise CandidateContractError("Candidate actor binding differs")
+        if not self._connection.in_transaction:
+            with self._lock, self._transaction():
+                return self.admit(
+                    admission_bytes,
+                    collision_request=collision_request,
+                    proof=proof,
+                    comparator_collision_request=comparator_collision_request,
+                )
+        if type(comparator_collision_request) not in (
+            type(None),
+            CurrentCollisionEligibilityRequest,
+        ):
+            raise CandidateContractError("Candidate comparator request differs")
+        if (comparator_collision_request is None) != (
+            supplied.distinct_scope_proof is None
+        ):
+            raise CandidateContractError("Candidate distinct comparator differs")
+        replay = self._existing(request, actor)
+        if replay is not None:
+            historical_admission, _, historical_version, *_, row = replay
+            historical_comparator_digest = row[
+                "comparator_collision_request_digest"
+            ]
+            if (
+                historical_admission.canonical_bytes != admission_bytes
+                or collision_request.request_digest != row["collision_request_digest"]
+                or (comparator_collision_request is None)
+                != (historical_comparator_digest is None)
+                or (
+                    comparator_collision_request is not None
+                    and comparator_collision_request.request_digest
+                    != historical_comparator_digest
+                )
+            ):
+                raise CandidateContractError("Candidate exact replay differs")
+            payload = json.loads(bytes(row["payload_bytes"]))
+            grant = self._service._authorize_for_commit(
+                self._command(payload, request, str(row["authority_aggregate_id"])),
+                proof=proof,
+            )
+            committed = self._commit_grant_in_transaction(
+                self._connection, grant, recorded_at=str(row["recorded_at"])
+            )
+            if (
+                not committed.replayed
+                or committed.event_id != row["authority_event_id"]
+            ):
+                raise CandidateContractError("Candidate generic command replay differs")
+            return historical_version
+        self._verify_local()
+        manifest = supplied.governing_manifest
+        binding = collision_request.binding
+        if (
+            collision_request.request_digest != request.collision_request_digest
+            or _collision_position(binding) != _manifest_position(manifest)
+        ):
+            raise CandidateContractError("Candidate collision input differs")
+        slot = self._connection.execute(
+            "SELECT candidate_id,semantic_scope_digest FROM story_candidate_collision_bindings "
+            "WHERE collision_namespace=? AND collision_key_digest=?",
+            (binding.collision_namespace, binding.collision_key_digest),
+        ).fetchone()
+        current = self._current_scope(request.semantic_scope_digest)
+        if (slot is None) != (current is None) or (
+            slot is not None
+            and tuple(slot) != (current.candidate_id, request.semantic_scope_digest)
+        ):
+            raise CandidateContractError("Candidate local collision binding differs")
+        expected = (request.expected_current_version_id, request.expected_current_version_digest, request.expected_current_ordinal)
+        actual = (None, None, 0) if current is None else (current.version_id, current.canonical_digest, current.ordinal)
+        expected_operation = CandidateUseOperation.ADMIT_NEW_CANDIDATE if current is None else CandidateUseOperation.USE_CURRENT_CANDIDATE
+        if (expected != actual or binding.operation is not expected_operation
+            or binding.expected_candidate_id != (None if current is None else current.candidate_id)):
+            raise CandidateContractError("Candidate local CAS differs")
+        comparator_version = None
+        if comparator_collision_request is not None:
+            comparator_binding = comparator_collision_request.binding
+            comparator_id = comparator_binding.expected_candidate_id
+            comparator_version = None if comparator_id is None else self._current_candidate(comparator_id)
+            proof_value = supplied.distinct_scope_proof
+            comparator_manifest = None if comparator_version is None else comparator_version.governing_manifest
+            if (
+                comparator_version is None
+                or proof_value is None
+                or binding.operation is not CandidateUseOperation.ADMIT_NEW_CANDIDATE
+                or comparator_binding.operation is not CandidateUseOperation.USE_CURRENT_CANDIDATE
+                or comparator_id != proof_value.comparator_candidate_id
+                or comparator_version.version_id != proof_value.comparator_version_id
+                or comparator_version.canonical_digest != proof_value.comparator_version_digest
+                or comparator_manifest.semantic_scope_digest != proof_value.comparator_semantic_scope_digest
+                or _collision_position(comparator_binding) != _manifest_position(comparator_manifest)
+                or _collision_context(binding) != _collision_context(comparator_binding)
+                or binding.subject_id == comparator_binding.subject_id
+                or (
+                    binding.collision_namespace,
+                    binding.collision_key_digest,
+                )
+                == (
+                    comparator_binding.collision_namespace,
+                    comparator_binding.collision_key_digest,
+                )
+            ):
+                raise CandidateContractError("Candidate distinct comparator is stale")
+        producers = self._producers(manifest, proof)
+        disposition_ids = producers[2]
+
+        def effect(collision: CurrentCollisionEligibilityDecision, comparator_collision=None):
+            rebuilt = self._manifest(producers, collision)
+            state = CandidateGoverningState(CandidateGoverningStateStatus.COMPLETE, rebuilt.governing_state_binding)
+            admission = evaluate_candidate_admission(
+                request=request, manifest=rebuilt, collision=collision,
+                current_version=current, governing_state=state,
+                comparator_collision=comparator_collision,
+                comparator_version=comparator_version,
+            )
+            if admission.canonical_bytes != admission_bytes:
+                raise CandidateContractError("Candidate Admission differs from current producer replay")
+            if admission.reason is CandidateAdmissionReason.EXACT_MANIFEST_REPLAY:
+                if current is None:
+                    raise CandidateContractError("Candidate equivalent head is absent")
+                return current
+            if admission.reason not in {
+                CandidateAdmissionReason.NEW_CANDIDATE_PRE_EFFECT,
+                CandidateAdmissionReason.RELATED_DISTINCT_PRE_EFFECT,
+                CandidateAdmissionReason.SUCCESSOR_VERSION_PRE_EFFECT,
+            }:
+                raise CandidateContractError("Candidate admission is not effect eligible")
+            candidate_id = _uuid() if current is None else current.candidate_id
+            ordinal = 1 if current is None else current.ordinal + 1
+            decision_id, version_id = _uuid(), _uuid()
+            effect_identity = {"candidate_id": candidate_id, "committed_admission_decision_id": decision_id,
+                               "version_id": version_id, "version_ordinal": ordinal}
+            payload = _payload(
+                request, manifest.hypothesis_version_id, manifest.relationship_assessment_digest,
+                disposition_ids, collision_request, comparator_collision_request,
+                admission, collision, comparator_collision, effect_identity,
+            )
+            grant = self._service._authorize_for_commit(self._command(payload, request, candidate_id), proof=proof)
+            recorded = self._clock().to_text()
+            committed = self._commit_grant_in_transaction(self._connection, grant, recorded_at=recorded)
+            if committed.replayed:
+                raise CandidateContractError("fresh Candidate command replayed")
+            candidate = (StoryCandidate(candidate_id, decision_id, committed.event_id, rebuilt.semantic_scope_digest)
+                         if current is None else self.load_candidate_in_transaction(current.candidate_id))
+            version = StoryCandidateVersion(
+                version_id, candidate_id, ordinal, None if current is None else current.version_id,
+                None if current is None else current.canonical_digest, decision_id, rebuilt,
+            )
+            (validate_candidate_first_version(candidate, version) if current is None
+             else validate_candidate_version_successor(current, version))
+            self._persist(
+                admission, candidate, version, committed, actor, recorded,
+                disposition_ids, collision, payload, comparator_collision,
+            )
+            self._verify_local()
+            return version
+
+        if comparator_collision_request is None:
+            return self._collision.enforce(request=collision_request, effect=effect)
+        return self._collision.enforce(request=collision_request, effect=lambda collision:
+            self._collision.enforce(request=comparator_collision_request,
+                                    effect=lambda comparator: effect(collision, comparator)))
+
+    def _persist(self, a, c, v, committed, actor, recorded, disposition_ids, collision, payload, comparator):
+        b, ad = collision.request.binding, a.canonical_digest
+        optional = (None, None, None, None) if comparator is None else (
+            canonical_json_bytes(comparator.request.canonical_value()),
+            comparator.request.request_digest,
+            comparator.canonical_bytes,
+            comparator.decision_digest,
+        )
+        values = (
+            ad, a.request.request_id, a.request.canonical_digest, actor,
+            a.request.idempotency_key, str(committed.aggregate_id), committed.event_id,
+            v.committed_admission_decision_id, a.canonical_bytes, c.candidate_id,
+            c.canonical_bytes if v.ordinal == 1 else None, v.version_id, v.ordinal,
+            v.canonical_bytes, v.canonical_digest, v.previous_version_id,
+            v.previous_version_digest, a.governing_manifest.version_material_digest,
+            a.governing_manifest.semantic_scope_digest,
+            a.governing_manifest.hypothesis_version_id,
+            a.governing_manifest.relationship_assessment_digest,
+            canonical_json_bytes(list(disposition_ids)),
+            canonical_json_bytes(payload["collision_request"]),
+            collision.request.request_digest, collision.canonical_bytes,
+            collision.decision_digest, *optional, recorded,
+        )
+        self._connection.execute(
+            "INSERT INTO story_candidate_admission_receipts_v2 VALUES("
+            + ",".join("?" for _ in values) + ")", values
+        )
+        if v.ordinal == 1:
+            self._connection.execute(
+                "INSERT INTO story_candidate_collision_bindings VALUES(?,?,?,?,?,?,?,?)",
+                (b.collision_namespace, b.collision_key_digest, c.candidate_id,
+                 c.semantic_scope_digest, ad, collision.request.request_digest,
+                 collision.decision_digest, collision.canonical_bytes),
+            )
+            self._connection.execute(
+                "INSERT INTO story_candidate_heads VALUES(?,?,?,?,?,?,?,?,?,?)",
+                (c.candidate_id, c.canonical_bytes, c.semantic_scope_digest,
+                 v.version_id, v.ordinal, v.canonical_digest, ad,
+                 b.collision_namespace, b.collision_key_digest, recorded),
+            )
+            return
+        binding = self._connection.execute(
+            "SELECT candidate_id,semantic_scope_digest FROM story_candidate_collision_bindings "
+            "WHERE collision_namespace=? AND collision_key_digest=?",
+            (b.collision_namespace, b.collision_key_digest),
+        ).fetchone()
+        if binding is None or tuple(binding) != (c.candidate_id, c.semantic_scope_digest):
+            raise CandidateContractError("Candidate collision binding differs")
+        changed = self._connection.execute(
+            "UPDATE story_candidate_heads SET current_version_id=?,current_version_ordinal=?,"
+            "current_version_digest=?,current_admission_digest=?,updated_at=? WHERE candidate_id=? "
+            "AND current_version_id=? AND current_version_digest=?",
+            (v.version_id, v.ordinal, v.canonical_digest, ad, recorded, c.candidate_id,
+             v.previous_version_id, v.previous_version_digest),
+        ).rowcount
+        if changed != 1:
+            raise CandidateContractError("Candidate head CAS differs")
+
+    def load_candidate_in_transaction(self, candidate_id: str):
+        row = self._connection.execute(
+            "SELECT candidate_bytes FROM story_candidate_heads WHERE candidate_id=?",
+            (candidate_id,),
+        ).fetchone()
+        if row is None:
+            raise CandidateContractError("unknown Candidate")
+        return StoryCandidate.from_canonical_bytes(bytes(row[0]))
+
+    def _current_candidate(self, candidate_id: str):
+        row = self._connection.execute(
+            "SELECT r.version_bytes FROM story_candidate_heads h JOIN story_candidate_admission_receipts_v2 r ON r.admission_digest=h.current_admission_digest WHERE h.candidate_id=?",
+            (candidate_id,),
+        ).fetchone()
+        if row is None:
+            raise CandidateContractError("unknown Candidate")
+        return StoryCandidateVersion.from_canonical_bytes(bytes(row[0]))
+
+    def load_candidate(self, candidate_id: str):
+        with self._lock, self._transaction():
+            self._verify()
+            return self.load_candidate_in_transaction(candidate_id)
+
+    def versions(self, candidate_id: str):
+        with self._lock, self._transaction():
+            self._verify()
+            rows = self._connection.execute(
+                "SELECT version_bytes FROM story_candidate_admission_receipts_v2 WHERE candidate_id=? ORDER BY version_ordinal",
+                (candidate_id,),
+            ).fetchall()
+            return tuple(
+                StoryCandidateVersion.from_canonical_bytes(bytes(row[0]))
+                for row in rows
+            )
+
+    def load_version(self, version_id: str):
+        with self._lock, self._transaction():
+            verified = self._verify()
+            row = self._connection.execute(
+                "SELECT admission_digest FROM story_candidate_admission_receipts_v2 "
+                "WHERE version_id=?",
+                (version_id,),
+            ).fetchone()
+            if row is None:
+                raise CandidateContractError("unknown Candidate Version")
+            return verified[str(row[0])][2]
+
+    def current(
+        self,
+        candidate_id: str,
+        *,
+        collision_request: CurrentCollisionEligibilityRequest,
+        proof: AuthenticationProof,
+    ):
+        if type(collision_request) is not CurrentCollisionEligibilityRequest:
+            raise CandidateContractError("Candidate current collision request differs")
+        self._authenticator.authenticate(proof, now=self._clock())
+        with self._lock, self._transaction():
+            verified = self._verify_local()
+            row = self._connection.execute(
+                "SELECT r.admission_digest,r.disposition_ids_bytes "
+                "FROM story_candidate_heads h JOIN "
+                "story_candidate_admission_receipts_v2 r "
+                "ON r.admission_digest=h.current_admission_digest "
+                "WHERE h.candidate_id=?",
+                (candidate_id,),
+            ).fetchone()
+            if row is None:
+                raise CandidateContractError("unknown Candidate")
+            _, _, v, *_ = verified[str(row["admission_digest"])]
+            binding = collision_request.binding
+            if (binding.operation is not CandidateUseOperation.USE_CURRENT_CANDIDATE
+                or binding.expected_candidate_id != candidate_id
+                or _collision_position(binding) != _manifest_position(v.governing_manifest)):
+                raise CandidateContractError(
+                    "Candidate current collision binding differs"
+                )
+            manifest = v.governing_manifest
+            disposition_ids = tuple(json.loads(bytes(row["disposition_ids_bytes"])))
+            producers = self._producers(manifest, proof)
+            if producers[2] != disposition_ids:
+                raise CandidateContractError("Candidate dispositions differ")
+
+            def use(collision):
+                rebuilt = self._manifest(producers, collision)
+                if (
+                    rebuilt.version_material_digest != manifest.version_material_digest
+                    or rebuilt.semantic_scope_digest != manifest.semantic_scope_digest
+                ):
+                    raise CandidateContractError(
+                        "Candidate current governing material differs"
+                    )
+                return v
+
+            return self._collision.enforce(request=collision_request, effect=use)
+
+    def rollback_scope(self, operation: Callable[[object], None]) -> None:
+        """Test-only inspection of real uncommitted Candidate authority rows."""
+        if not callable(operation):
+            raise CandidateContractError("Candidate rollback operation differs")
+        with self._lock:
+            self._connection.execute("BEGIN IMMEDIATE")
+            try:
+                operation(self)
+                self._verify()
+            finally:
+                if self._connection.in_transaction:
+                    self._connection.execute("ROLLBACK")
+
+
+# fmt: on
+
+
+class _Authority:
+    def __init__(self, store):
+        self._store = store
+
+    def __getattr__(self, name):
+        return getattr(self._store, name)
+
+    def close(self):
+        self._store.close()
+
+
+def open_story_candidate_authority_system(database: str | Path, **kwargs):
+    raw = _Authority(_CandidateStore(_TOKEN, Path(database), **kwargs))
+    try:
+        facade = _compose_story_candidate_authority(raw)
+        if type(facade) is not StoryCandidateAuthority:
+            raise CandidateContractError("Candidate facade differs")
+        return facade
+    except BaseException:
+        try:
+            raw.close()
+        except BaseException:  # noqa: BLE001, S110 - preserve facade failure
+            pass
+        raise
+
+
+class _UnlockedCandidateStore(_CandidateStore):
+    def _acquire_writer_lock(self) -> None:
+        self._lock_fd = None
+
+
+def _open_unlocked_story_candidate_authority_for_test(database: str | Path, **kwargs):
+    return _Authority(_UnlockedCandidateStore(_TOKEN, Path(database), **kwargs))
+
+
+__all__ = ["open_story_candidate_authority_system"]

--- a/newsroom/increment6/candidates.py
+++ b/newsroom/increment6/candidates.py
@@ -1,9 +1,12 @@
+# ruff: noqa: E701,E702,E731,E741 - keep the bounded #401 authority seam compact
 from __future__ import annotations
 
 import json
 import re
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
+from pathlib import Path
 from typing import Self
 
 from newsroom.authority.canonical import (
@@ -11,6 +14,14 @@ from newsroom.authority.canonical import (
     canonical_json_bytes,
     digest_bytes,
 )
+from newsroom.authority.models import CommandDefinition
+from newsroom.authority.policy import (
+    CommandRegistry,
+    PayloadGoldenVector,
+    PayloadSchemaContract,
+    PayloadSchemaRegistry,
+)
+from newsroom.authority.types import PayloadMode, TrustScope, UtcTimestamp
 from newsroom.discovery.record_models import DiscoverySignal, GateDecision, NewsLead
 from newsroom.discovery.types import GateOutcome
 from newsroom.increment6.collision import (
@@ -18,6 +29,7 @@ from newsroom.increment6.collision import (
     CollisionEligibilityOutcome,
     CollisionState,
     CurrentCollisionEligibilityDecision,
+    CurrentCollisionEligibilityRequest,
 )
 from newsroom.increment6.dispositions import ProposalDisposition
 from newsroom.increment6.hypotheses import EventHypothesisVersion
@@ -42,7 +54,10 @@ STORY_CANDIDATE = "newsroom.increment6.story-candidate.v1"
 STORY_CANDIDATE_VERSION = "newsroom.increment6.story-candidate-version.v1"
 CANDIDATE_ADMISSION = "newsroom.increment6.candidate-admission.v1"
 CANDIDATE_CURRENT_VERSION = "EXACT_RETAINED_MAX_ORDINAL_HEAD"
+CANDIDATE_COMMAND_TYPE = "increment6.story-candidate.admit"
+CANDIDATE_COMMAND_SCHEMA = "newsroom.increment6.candidate-admission-command.v1"
 MAX_CANDIDATE_CANONICAL_BYTES = 16_777_216
+MAX_CANDIDATE_COMMAND_BYTES = MAX_CANDIDATE_CANONICAL_BYTES
 _UUID = re.compile(
     r"[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z"
 )
@@ -56,7 +71,11 @@ _SOURCE_FIELDS = "definition_id definition_version_id item_id revision_id repres
 _POLICIES = "signal_admission_policy gate_policy duplicate_policy newness_policy time_validity_policy exclusion_policy"
 _CONTEXT = "collision_namespace generation_id query_valid_time serving_time authority_watermark"
 _NO_EFFECTS = "authorises_authority authorises_persistence authorises_external_effect authorises_publication authorises_evidence authorises_egress production_activation_authorised candidate_effect_performed creates_candidate creates_version mutates_current_version"
-_PUBLIC = "STORY_CANDIDATE,STORY_CANDIDATE_VERSION,CANDIDATE_ADMISSION,CANDIDATE_CURRENT_VERSION,CandidateContractError,CandidateAdmissionOutcome,CandidateAdmissionReason,CandidateLeadSignalBinding,CandidateGoverningStateStatus,CandidateGoverningStateBinding,CandidateGoverningState,CandidateGoverningManifest,StoryCandidate,StoryCandidateVersion,CandidateDistinctScopeProof,CandidateAdmissionRequest,CandidateAdmission,build_candidate_governing_manifest,build_candidate_distinct_scope_proof,evaluate_candidate_admission,validate_candidate_first_version,validate_candidate_version_successor"
+_COMMAND_FIELDS = "schema_version request hypothesis_version_id relationship_assessment_digest disposition_ids collision_request comparator_collision_request admission collision_decision comparator_collision_decision effect_identity"
+_EFFECT_FIELDS = (
+    "candidate_id committed_admission_decision_id version_id version_ordinal"
+)
+_PUBLIC = "STORY_CANDIDATE,STORY_CANDIDATE_VERSION,CANDIDATE_ADMISSION,CANDIDATE_CURRENT_VERSION,CANDIDATE_COMMAND_TYPE,CandidateContractError,CandidateAdmissionOutcome,CandidateAdmissionReason,CandidateLeadSignalBinding,CandidateGoverningStateStatus,CandidateGoverningStateBinding,CandidateGoverningState,CandidateGoverningManifest,StoryCandidate,StoryCandidateVersion,CandidateDistinctScopeProof,CandidateAdmissionRequest,CandidateAdmission,StoryCandidateAuthority,build_candidate_governing_manifest,build_candidate_distinct_scope_proof,evaluate_candidate_admission,validate_candidate_first_version,validate_candidate_version_successor,candidate_command_definition,merge_candidate_authority_registries,open_story_candidate_authority"
 _CANDIDATE_ROUTES = {
     "NEW_EVENT_CANDIDATE": CandidateManifestKind.NEW_EVENT,
     "DEVELOPMENT_CANDIDATE": CandidateManifestKind.DEVELOPMENT,
@@ -629,6 +648,16 @@ class StoryCandidate(_NoEffect, _CanonicalFields):
             "authority_event_id",
         ):
             _uuid(getattr(self, name), name)
+        _valid(
+            len(
+                {
+                    self.candidate_id,
+                    self.committed_admission_decision_id,
+                    self.authority_event_id,
+                }
+            )
+            == 3
+        )
         _digest(self.semantic_scope_digest, "semantic_scope_digest")
 
     @property
@@ -664,6 +693,16 @@ class StoryCandidateVersion(_NoEffect, _CanonicalFields):
         _valid(type(self) is StoryCandidateVersion)
         for name in ("candidate_id", "version_id", "committed_admission_decision_id"):
             _uuid(getattr(self, name), name)
+        _valid(
+            len(
+                {
+                    self.candidate_id,
+                    self.version_id,
+                    self.committed_admission_decision_id,
+                }
+            )
+            == 3
+        )
         ordinal = _ordinal(self.ordinal)
         predecessor = _all_or_none(
             (self.previous_version_id, self.previous_version_digest),
@@ -1539,6 +1578,139 @@ def evaluate_candidate_admission(
     if v.governing_manifest.version_material_digest == m.version_material_digest:
         return result(O.DUPLICATE_EQUIVALENT, R.EXACT_MANIFEST_REPLAY)
     return result(O.ADMISSIBLE, R.SUCCESSOR_VERSION_PRE_EFFECT)
+
+
+# fmt: off
+def _candidate_command_canonicalizer(value: object) -> bytes:
+    raw = _normalise(lambda: _json(value), "Candidate command cannot be canonicalised")
+    document = _exact(_decode(raw), set(_COMMAND_FIELDS.split()), "Candidate command")
+    _require(document["schema_version"] == CANDIDATE_COMMAND_SCHEMA, "Candidate command schema differs")
+    request = CandidateAdmissionRequest.from_value(document["request"])
+    collision = CurrentCollisionEligibilityRequest.from_mapping(document["collision_request"])
+    comparator_request = (None if document["comparator_collision_request"] is None
+        else CurrentCollisionEligibilityRequest.from_mapping(document["comparator_collision_request"]))
+    nested = document["admission"], document["collision_decision"], document["effect_identity"]
+    if all(item is None for item in nested):
+        _require(comparator_request is None and document["comparator_collision_decision"] is None
+            and request.collision_request_digest == collision.request_digest, "Candidate pre-effect payload differs")
+        return raw
+    _require(all(item is not None for item in nested), "Candidate effect payload is partial")
+    admission = CandidateAdmission.from_canonical_bytes(_json(document["admission"]))
+    decision = CurrentCollisionEligibilityDecision.from_canonical_bytes(_json(document["collision_decision"]))
+    comparator = (None if document["comparator_collision_decision"] is None
+        else CurrentCollisionEligibilityDecision.from_canonical_bytes(_json(document["comparator_collision_decision"])))
+    effect = _exact(document["effect_identity"], set(_EFFECT_FIELDS.split()), "Candidate effect identity")
+    for name in ("candidate_id", "committed_admission_decision_id", "version_id"): _uuid(effect[name], name)
+    _ordinal(effect["version_ordinal"], "version_ordinal"); dispositions = document["disposition_ids"]
+    _valid(type(dispositions) is list and all(type(item) is str for item in dispositions)
+        and dispositions == sorted(set(dispositions)))
+    manifest = admission.governing_manifest
+    _valid(admission.request == request and decision.request == collision
+        and (comparator is None) == (comparator_request is None)
+        and (comparator is None or comparator.request == comparator_request)
+        and request.collision_request_digest == collision.request_digest
+        and document["hypothesis_version_id"] == manifest.hypothesis_version_id
+        and document["relationship_assessment_digest"] == manifest.relationship_assessment_digest)
+    return raw
+
+
+_CANDIDATE_COMMAND_VECTOR = b'{"admission":null,"collision_decision":null,"collision_request":{"binding":{"authority_watermark":0,"collision_key_digest":"sha256:0000000000000000000000000000000000000000000000000000000000000000","collision_namespace":"candidate-vector","expected_candidate_id":null,"generation_id":"generation-vector","operation":"ADMIT_NEW_CANDIDATE","query_valid_time":"2042-01-01T00:00:00Z","serving_time":"2042-01-01T00:00:00Z","subject_id":"00000000-0000-4000-8000-000000000001","subject_version_digest":"sha256:0000000000000000000000000000000000000000000000000000000000000000","subject_version_id":"00000000-0000-4000-8000-000000000001"},"named_request_digest":"sha256:0000000000000000000000000000000000000000000000000000000000000000"},"comparator_collision_decision":null,"comparator_collision_request":null,"disposition_ids":[],"effect_identity":null,"hypothesis_version_id":"00000000-0000-4000-8000-000000000001","relationship_assessment_digest":"sha256:0000000000000000000000000000000000000000000000000000000000000000","request":{"actor_identity_digest":"sha256:0000000000000000000000000000000000000000000000000000000000000000","collision_request_digest":"sha256:a9617eb9457d3d5f75ce67227dce71b530831bad1adf1325791bee22ccc7e053","distinct_scope_proof_digest":null,"expected_current_ordinal":0,"expected_current_version_digest":null,"expected_current_version_id":null,"expected_governing_state_digest":"sha256:0000000000000000000000000000000000000000000000000000000000000000","idempotency_key":"candidate:vector","request_id":"00000000-0000-4000-8000-000000000001","semantic_scope_digest":"sha256:0000000000000000000000000000000000000000000000000000000000000000"},"schema_version":"newsroom.increment6.candidate-admission-command.v1"}'
+
+
+def _candidate_payload_contract() -> PayloadSchemaContract:
+    value = json.loads(_CANDIDATE_COMMAND_VECTOR)
+    vector = PayloadGoldenVector("candidate-command", "candidate:command", value, _CANDIDATE_COMMAND_VECTOR)
+    return PayloadSchemaContract(CANDIDATE_COMMAND_SCHEMA, PayloadMode.INLINE, "candidate-command-schema-v1",
+        "candidate-command-json-v1", _candidate_command_canonicalizer, (vector,))
+
+
+def candidate_command_definition() -> CommandDefinition:
+    contract = _candidate_payload_contract()
+    return CommandDefinition(command_type=CANDIDATE_COMMAND_TYPE, definition_version="candidate-command-v1",
+        aggregate_type="story_candidate_admission", event_type="story_candidate_admitted", event_schema_version=1,
+        payload_mode=PayloadMode.INLINE, payload_schema_version=contract.schema_version,
+        payload_schema_contract_version=contract.contract_version, payload_schema_contract_digest=contract.contract_digest,
+        payload_canonicalizer_version=contract.canonicalizer_implementation_version, trust_scope=TrustScope.ADMITTED,
+        security_scope="authority.story-candidate", retention_scope="authority.audit",
+        required_scope="authority.story-candidate.admit", max_inline_bytes=MAX_CANDIDATE_COMMAND_BYTES)
+
+
+def merge_candidate_authority_registries(commands: CommandRegistry, schemas: PayloadSchemaRegistry) -> tuple[CommandRegistry, PayloadSchemaRegistry]:
+    definition, contract = candidate_command_definition(), _candidate_payload_contract()
+    definitions, contracts = tuple(commands.definitions()), tuple(schemas.contracts())
+    command_matches = tuple(item for item in definitions if item.command_type == CANDIDATE_COMMAND_TYPE)
+    schema_matches = tuple(item for item in contracts if (item.schema_version, item.payload_mode) == (CANDIDATE_COMMAND_SCHEMA, PayloadMode.INLINE))
+    if command_matches not in ((), (definition,)) or schema_matches not in ((), (contract,)):
+        raise CandidateContractError("Candidate authority registry conflicts")
+    definitions += () if command_matches else (definition,); contracts += () if schema_matches else (contract,)
+    return (CommandRegistry(definitions, current_versions={item.command_type: (definition.definition_version if item.command_type == CANDIDATE_COMMAND_TYPE else commands.resolve(item.command_type).definition_version) for item in definitions}),
+        PayloadSchemaRegistry(contracts, current_versions={(item.schema_version, item.payload_mode): (contract.contract_version if (item.schema_version, item.payload_mode) == (CANDIDATE_COMMAND_SCHEMA, PayloadMode.INLINE) else schemas.resolve(item.schema_version, item.payload_mode).contract_version) for item in contracts}))
+
+
+_FACADE_TOKEN = object()
+
+
+class StoryCandidateAuthority:
+    __slots__ = ("__authority",)
+
+    def __init__(self, token: object, authority: object) -> None:
+        if token is not _FACADE_TOKEN: raise CandidateContractError("Candidate authority construction is private")
+        self.__authority = authority
+
+    def _call(self, name: str, *args: object, expected: type, **kwargs: object):
+        message = f"Candidate {name} returned a forged result"
+        value = _normalise(lambda: getattr(self.__authority, name)(*args, **kwargs), message)
+        _require(type(value) is expected, message); return value
+
+    def admit(self, admission_bytes: bytes, *, collision_request: CurrentCollisionEligibilityRequest,
+        proof: object, comparator_collision_request: CurrentCollisionEligibilityRequest | None = None) -> StoryCandidateVersion:
+        return self._call("admit", admission_bytes, collision_request=collision_request, proof=proof,
+            comparator_collision_request=comparator_collision_request, expected=StoryCandidateVersion)
+
+    def load_version(self, version_id: str) -> StoryCandidateVersion:
+        return self._call("load_version", version_id, expected=StoryCandidateVersion)
+
+    def load_candidate(self, candidate_id: str) -> StoryCandidate:
+        return self._call("load_candidate", candidate_id, expected=StoryCandidate)
+
+    def versions(self, candidate_id: str) -> tuple[StoryCandidateVersion, ...]:
+        value = _normalise(lambda: self.__authority.versions(candidate_id), "Candidate history failed")
+        _require(type(value) is tuple and all(type(item) is StoryCandidateVersion for item in value), "Candidate history is forged")
+        return value
+
+    def current(self, candidate_id: str, *, collision_request: CurrentCollisionEligibilityRequest, proof: object) -> StoryCandidateVersion:
+        return self._call("current", candidate_id, collision_request=collision_request, proof=proof, expected=StoryCandidateVersion)
+
+    require_current = current
+
+    def close(self) -> None: _normalise(self.__authority.close, "Candidate authority close failed")
+    def __enter__(self) -> Self: return self
+    def __exit__(self, *_: object) -> None: self.close()
+
+
+def _compose_story_candidate_authority(authority: object) -> StoryCandidateAuthority:
+    return StoryCandidateAuthority(_FACADE_TOKEN, authority)
+
+
+def open_story_candidate_authority(database: str | Path, *, retrieval_authority: object, authenticator: object,
+    authorizer: object, command_registry: CommandRegistry, payload_schemas: PayloadSchemaRegistry,
+    collision_enforcer: object, clock: Callable[[], UtcTimestamp] = UtcTimestamp.now,
+    busy_timeout_ms: int = 5000) -> StoryCandidateAuthority:
+    from newsroom.authority.story_candidate_system import (
+        open_story_candidate_authority_system,
+    )
+    try: result = open_story_candidate_authority_system(database, retrieval_authority=retrieval_authority,
+        authenticator=authenticator, authorizer=authorizer, command_registry=command_registry,
+        payload_schemas=payload_schemas, collision_enforcer=collision_enforcer, clock=clock, busy_timeout_ms=busy_timeout_ms)
+    except CandidateContractError: raise
+    except Exception as exc: raise CandidateContractError("Candidate authority open failed") from exc
+    if type(result) is StoryCandidateAuthority: return result
+    close = getattr(result, "close", None)
+    if callable(close):
+        try: close()
+        except BaseException: pass  # noqa: BLE001, S110 - preserve forged result failure
+    raise CandidateContractError("Candidate authority opener returned forged facade")
+# fmt: on
 
 
 __all__ = tuple(_PUBLIC.split(","))

--- a/newsroom/increment6/lineage.py
+++ b/newsroom/increment6/lineage.py
@@ -5,6 +5,7 @@ already-decided 6D2 relationship assessments.  They allocate no Version,
 write no authority state, and grant no Candidate, evidence, publication,
 model, provider, egress, or external-effect capability.
 """
+# ruff: noqa: E701 - keep the bounded D3 read-port contract within #401's line cap
 
 from __future__ import annotations
 
@@ -38,6 +39,7 @@ from newsroom.increment6.relationships import (
     ComparatorSetManifest,
     HypothesisVersionBinding,
     RelationshipAssessment,
+    RetainedRelationshipDecisionReceipt,
     assess_relationships,
 )
 
@@ -1660,6 +1662,65 @@ class EventHypothesisLineageAuthority:
         self.close()
 
 
+# fmt: off
+@dataclass(frozen=True, slots=True)
+class HypothesisLineageProducerSnapshot:
+    subject: EventHypothesisVersion
+    receipts: tuple[HypothesisLineageReceipt, ...]
+    initial_heads: tuple[HypothesisLineageHead, ...]
+    versions: tuple[EventHypothesisVersion, ...]
+    relationship_proofs: tuple[HypothesisLineageRelationshipProof, ...]
+    replay: HypothesisLineageReplay
+    subject_active_head: HypothesisLineageHead
+
+    def __post_init__(self) -> None:
+        try:
+            replay = replay_hypothesis_lineage(self.receipts, initial_heads=self.initial_heads,
+                versions=self.versions, relationship_proofs=self.relationship_proofs)
+        except HypothesisLineageContractError: raise
+        except Exception as exc: raise HypothesisLineageContractError("invalid lineage producer snapshot") from exc
+        if (type(self) is not HypothesisLineageProducerSnapshot or type(self.subject) is not EventHypothesisVersion
+            or type(self.replay) is not HypothesisLineageReplay or type(self.subject_active_head) is not HypothesisLineageHead
+            or replay != self.replay or self.subject not in self.versions or self.subject_active_head not in replay.active_heads
+            or self.subject_active_head.node.version_id != self.subject.version_id
+            or self.subject_active_head.node.version_digest != self.subject.canonical_digest):
+            raise HypothesisLineageContractError("lineage producer snapshot differs from its exact subject head")
+
+
+_PRODUCER_PORT_TOKEN = object()
+
+
+class EventHypothesisLineageReadPort:
+    """Token-gated D1/D2/D3 view bound to an active authority transaction."""
+    __slots__ = ("__authority",)
+
+    def __init__(self, token: object, authority: object) -> None:
+        if token is not _PRODUCER_PORT_TOKEN: raise HypothesisLineageContractError("lineage read port is private")
+        self.__authority = authority
+
+    def _call(self, name, *args, expected, **kwargs):
+        message = f"lineage {name} transaction read failed"
+        value = _normalise_exact(lambda: getattr(self.__authority, name)(*args, **kwargs), message, expected)
+        if expected is HypothesisLineageProducerSnapshot:
+            return _normalise(lambda: HypothesisLineageProducerSnapshot(value.subject, value.receipts, value.initial_heads,
+                value.versions, value.relationship_proofs, value.replay, value.subject_active_head), message)
+        return value
+
+    def verify_retained_integrity_in_transaction(self) -> None:
+        return self._call("verify_retained_integrity_in_transaction", expected=type(None))
+
+    def require_current_producers_in_transaction(self, version_id: str, *, proof: object) -> HypothesisLineageProducerSnapshot:
+        return self._call("require_producers_in_transaction", version_id, proof=proof, expected=HypothesisLineageProducerSnapshot)
+
+    def require_retained_relationship_in_transaction(self, assessment_digest: str) -> RetainedRelationshipDecisionReceipt:
+        return self._call("require_retained_relationship_in_transaction", assessment_digest, expected=RetainedRelationshipDecisionReceipt)
+
+
+def _compose_event_hypothesis_lineage_read_port(authority: object) -> EventHypothesisLineageReadPort:
+    return EventHypothesisLineageReadPort(_PRODUCER_PORT_TOKEN, authority)
+# fmt: on
+
+
 def _compose_event_hypothesis_lineage_authority(
     authority: object,
 ) -> EventHypothesisLineageAuthority:
@@ -1718,12 +1779,14 @@ __all__ = [
     "MAX_LINEAGE_REPLAY_NODES",
     "MAX_LINEAGE_REPLAY_RECEIPTS",
     "EventHypothesisLineageAuthority",
+    "EventHypothesisLineageReadPort",
     "HypothesisLineageContractError",
     "HypothesisLineageEdge",
     "HypothesisLineageEvidenceBinding",
     "HypothesisLineageHead",
     "HypothesisLineageKind",
     "HypothesisLineageNodeBinding",
+    "HypothesisLineageProducerSnapshot",
     "HypothesisLineageReceipt",
     "HypothesisLineageRelationshipBinding",
     "HypothesisLineageRelationshipProof",

--- a/newsroom/tests/authority_migration_compatibility.py
+++ b/newsroom/tests/authority_migration_compatibility.py
@@ -163,6 +163,11 @@ PINNED_MIGRATION_HISTORY: tuple[HistoryRow, ...] = (
         "event_hypothesis_lineage_authority_v23",
         "sha256:6c24d402f246f4e82a49a9772d70677d922282aae3b6dde93c62c0ef9b1b7a72",
     ),
+    (
+        24,
+        "story_candidate_authority_v24",
+        "sha256:1eea25005483de124e0add0100f4805ed5a537852fc70916f17a209c633e0ca0",
+    ),
 )
 
 

--- a/newsroom/tests/graphiti_adapter_4d_migration_helpers.py
+++ b/newsroom/tests/graphiti_adapter_4d_migration_helpers.py
@@ -35,7 +35,100 @@ from newsroom.authority.triage_work_item_migrations import (
 
 
 def drop_empty_v23_lineage_schema(connection: sqlite3.Connection) -> None:
+    """Remove exact empty v24/v23 schemas as one rollback-safe operation."""
+    savepoint = "checked_candidate_lineage_downgrade"
+    connection.execute(f"SAVEPOINT {savepoint}")
+    try:
+        _drop_empty_v23_lineage_schema(connection)
+    except Exception:
+        connection.execute(f"ROLLBACK TO SAVEPOINT {savepoint}")
+        connection.execute(f"RELEASE SAVEPOINT {savepoint}")
+        raise
+    connection.execute(f"RELEASE SAVEPOINT {savepoint}")
+
+
+def _drop_empty_v23_lineage_schema(connection: sqlite3.Connection) -> None:
     """Remove an exact, empty v23 lineage schema atomically."""
+    if int(connection.execute("PRAGMA user_version").fetchone()[0]) == 24:
+        candidate_tables = (
+            "story_candidate_heads",
+            "story_candidate_collision_bindings",
+            "story_candidate_admission_receipts_v2",
+        )
+        candidate_triggers = (
+            "candidate_head_update_guard",
+            "candidate_head_insert_guard",
+            "retained_candidate_head",
+            "retained_candidate_collision",
+            "immutable_candidate_collision",
+            "retained_candidate_receipt",
+            "immutable_candidate_receipt",
+        )
+        history = connection.execute(
+            "SELECT name,checksum FROM authority_migrations WHERE version=24"
+        ).fetchone()
+        from newsroom.authority.story_candidate_migrations import (
+            STORY_CANDIDATE_MIGRATION_CHECKSUM,
+            STORY_CANDIDATE_MIGRATION_NAME,
+            STORY_CANDIDATE_MIGRATION_STATEMENTS,
+        )
+
+        required = {("table", name) for name in candidate_tables} | {
+            ("trigger", name) for name in candidate_triggers
+        }
+        present = set(
+            connection.execute(
+                "SELECT type,name FROM sqlite_master WHERE name IN ("
+                + ",".join("?" for _ in required)
+                + ")",
+                tuple(name for _, name in required),
+            ).fetchall()
+        )
+        actual_sql = {
+            " ".join(str(row[0]).split())
+            for row in connection.execute(
+                "SELECT sql FROM sqlite_master WHERE name IN ("
+                + ",".join("?" for _ in required)
+                + ")",
+                tuple(name for _, name in required),
+            )
+        }
+        expected_sql = {
+            " ".join(statement.split())
+            for statement in STORY_CANDIDATE_MIGRATION_STATEMENTS
+        }
+        if (
+            history
+            != (STORY_CANDIDATE_MIGRATION_NAME, STORY_CANDIDATE_MIGRATION_CHECKSUM)
+            or present != required
+            or actual_sql != expected_sql
+        ):
+            raise sqlite3.DatabaseError(
+                "downgrade requires exact empty v24 Candidate schema"
+            )
+        for table in candidate_tables:
+            if connection.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone() != (0,):
+                raise sqlite3.DatabaseError("v24 Candidate tables must be empty")
+        savepoint_v24 = "checked_empty_v24_candidate_downgrade"
+        connection.execute(f"SAVEPOINT {savepoint_v24}")
+        try:
+            guard = connection.execute(
+                "SELECT sql FROM sqlite_master WHERE type='trigger' "
+                "AND name='immutable_authority_migrations_delete'"
+            ).fetchone()[0]
+            connection.execute("DROP TRIGGER immutable_authority_migrations_delete")
+            for trigger in candidate_triggers:
+                connection.execute(f'DROP TRIGGER "{trigger}"')
+            for table in candidate_tables:
+                connection.execute(f'DROP TABLE "{table}"')
+            connection.execute("DELETE FROM authority_migrations WHERE version=24")
+            connection.execute(guard)
+            connection.execute("PRAGMA user_version=23")
+            connection.execute(f"RELEASE SAVEPOINT {savepoint_v24}")
+        except Exception:
+            connection.execute(f"ROLLBACK TO SAVEPOINT {savepoint_v24}")
+            connection.execute(f"RELEASE SAVEPOINT {savepoint_v24}")
+            raise
     savepoint = "checked_empty_v23_lineage_downgrade"
     lineage_tables = (
         "event_hypothesis_lineage",

--- a/newsroom/tests/test_authority_migration_compatibility.py
+++ b/newsroom/tests/test_authority_migration_compatibility.py
@@ -43,6 +43,7 @@ _EXPECTED_NAMES = {
     21: "event_hypothesis_authority_v21",
     22: "event_hypothesis_relationship_authority_v22",
     23: "event_hypothesis_lineage_authority_v23",
+    24: "story_candidate_authority_v24",
 }
 _EXPECTED_CHECKSUMS = {
     13: "sha256:c3e5ae627dda1c04bebc50952786413d977bd399e67b7f5b87452794f08f49ab",
@@ -56,6 +57,7 @@ _EXPECTED_CHECKSUMS = {
     21: "sha256:42009475669a475af8e3e24bbcd02e6fcd9fbb71a800e18d83624e34e79e5e21",
     22: "sha256:e59eb222a95e2901ccaae29ce1b9e8eded797306e9796718a6d2c4fa505a6636",
     23: "sha256:6c24d402f246f4e82a49a9772d70677d922282aae3b6dde93c62c0ef9b1b7a72",
+    24: "sha256:1eea25005483de124e0add0100f4805ed5a537852fc70916f17a209c633e0ca0",
 }
 
 _EXPECTED_MATRIX = """version | migration | objects | history fingerprint | schema fingerprint | object fingerprint
@@ -71,6 +73,7 @@ v20 | triage_execution_authority_v20 | 1147 | sha256:01aaf90aef4a4e7e5d7946ab944
 v21 | event_hypothesis_authority_v21 | 1170 | sha256:7404a1b6ffb14aacff8d3e9bb1ddff7f751287100003bfa268d55722c4e34ab0 | sha256:d314d06118a25f8a32a0f9d8acb1af5383abd6b30be682cb5f65943ae15c213f | sha256:d5c9fe7ac19900901f4ccb64545bf9defca4db9e6d82de7e71bb66f9c8d9aaff
 v22 | event_hypothesis_relationship_authority_v22 | 1179 | sha256:69acb590abbd8cbb3e6acdad8e6a0c0f31e13e1ed0a718098b64d545c343c1ed | sha256:2118fa893fb7fd2911bbde3056b79b1d0e26ccd6903e1c4228616f342898eaad | sha256:117392ff7fd1160034ec0792ab9f0d94e3a4643dc6fc280b44855ac67efff77a
 v23 | event_hypothesis_lineage_authority_v23 | 1192 | sha256:cd4750c9e0c44e3a91b6e6ecbb45ba382dc96fa77fbf2d87d3670801fb6bc9bc | sha256:c341333cf54d724bb4d2092bb9da81e9f3a434ddb03e6ddc14a51fdf2c6c1b52 | sha256:a23a710567b0cdf97f753e4412f1ca0a16b2d85c939a82f32a181f8efa583cce
+v24 | story_candidate_authority_v24 | 1221 | sha256:87fbc9d10bfea4239e9105cf851827404afb12012cc91ccf358ae9def233f6ff | sha256:abf8430bfd676a9b0e574847cde9375d90aa1e32680725a08b30c0657d567a7c | sha256:42452161bfddc32e5553bb0aab38c325dda223ec811f47cfae195d642fe06926
 """
 
 

--- a/newsroom/tests/test_increment6d1_hypothesis_migrations.py
+++ b/newsroom/tests/test_increment6d1_hypothesis_migrations.py
@@ -91,13 +91,15 @@ def _history(connection: sqlite3.Connection) -> list[tuple[int, str, str]]:
 
 def test_fresh_v21_has_exact_allocation_history_and_integrity() -> None:
     connection = _fresh()
-    assert SCHEMA_VERSION == 23
-    assert EXPECTED_MIGRATION_HISTORY[-3] == (
+    assert SCHEMA_VERSION == 24
+    assert next(item for item in EXPECTED_MIGRATION_HISTORY if item[0] == 21) == (
         21,
         EVENT_HYPOTHESIS_MIGRATION_NAME,
         EVENT_HYPOTHESIS_MIGRATION_CHECKSUM,
     )
-    assert _history(connection) == list(EXPECTED_MIGRATION_HISTORY[:-2])
+    assert _history(connection) == [
+        item for item in EXPECTED_MIGRATION_HISTORY if item[0] <= 21
+    ]
     assert {
         r[0]
         for r in connection.execute(
@@ -139,14 +141,16 @@ def test_exact_v20_predecessor_backup_receipt_reuse_and_upgrade(tmp_path: Path) 
     database = tmp_path / "authority.sqlite3"
     connection = _fresh(database)
     _downgrade_to_v20(connection)
-    assert _history(connection) == list(EXPECTED_MIGRATION_HISTORY[:-3])
+    assert _history(connection) == [
+        item for item in EXPECTED_MIGRATION_HISTORY if item[0] <= 20
+    ]
     assert schema_fingerprint(connection) == EVENT_HYPOTHESIS_PREDECESSOR_FINGERPRINT
     backup, digest = event_hypothesis_backup_paths(database)
     receipt = prepare_event_hypothesis_backup(connection, backup)
     assert prepare_event_hypothesis_backup(connection, backup) == receipt
     assert receipt.backup_path == backup and receipt.digest_path == digest
     apply_pending_migrations(connection, applied_at="2042-01-01T00:00:01.000000Z")
-    assert connection.execute("PRAGMA user_version").fetchone() == (23,)
+    assert connection.execute("PRAGMA user_version").fetchone() == (SCHEMA_VERSION,)
     assert _history(connection) == list(EXPECTED_MIGRATION_HISTORY)
     assert schema_fingerprint(connection) == EXPECTED_SCHEMA_FINGERPRINT
 
@@ -175,7 +179,9 @@ def test_incomplete_or_tampered_v20_backup_is_rejected(
     with pytest.raises(EventHypothesisBackupError):
         apply_pending_migrations(connection, applied_at="2042-01-01T00:00:01.000000Z")
     assert connection.execute("PRAGMA user_version").fetchone() == (20,)
-    assert _history(connection) == list(EXPECTED_MIGRATION_HISTORY[:-3])
+    assert _history(connection) == [
+        item for item in EXPECTED_MIGRATION_HISTORY if item[0] <= 20
+    ]
     assert schema_fingerprint(connection) == EVENT_HYPOTHESIS_PREDECESSOR_FINGERPRINT
 
 
@@ -189,7 +195,7 @@ def test_direct_v20_apply_requires_prepared_backup_and_v24_rejects(
     assert connection.execute("PRAGMA user_version").fetchone() == (20,)
     assert schema_fingerprint(connection) == EVENT_HYPOTHESIS_PREDECESSOR_FINGERPRINT
     newer = _open()
-    newer.execute("PRAGMA user_version=24")
+    newer.execute(f"PRAGMA user_version={SCHEMA_VERSION + 1}")
     with pytest.raises(sqlite3.DatabaseError, match="newer"):
         apply_pending_migrations(newer, applied_at="2042-01-01T00:00:00.000000Z")
 
@@ -213,7 +219,9 @@ def test_injected_v21_failure_rolls_back_exact_v20(
     with pytest.raises(sqlite3.OperationalError):
         apply_pending_migrations(connection, applied_at="2042-01-01T00:00:01.000000Z")
     assert connection.execute("PRAGMA user_version").fetchone() == (20,)
-    assert _history(connection) == list(EXPECTED_MIGRATION_HISTORY[:-3])
+    assert _history(connection) == [
+        item for item in EXPECTED_MIGRATION_HISTORY if item[0] <= 20
+    ]
     assert schema_fingerprint(connection) == before
     assert (
         connection.execute(
@@ -232,13 +240,17 @@ def test_older_file_backed_multihop_retains_each_stage_backup(tmp_path: Path) ->
     _downgrade_to_v19(connection)
     migrations.prepare_pending_migration_backup(connection)
     apply_pending_migrations(connection, applied_at="2042-01-01T00:00:01.000000Z")
-    assert connection.execute("PRAGMA user_version").fetchone() == (23,)
+    assert connection.execute("PRAGMA user_version").fetchone() == (SCHEMA_VERSION,)
     assert (tmp_path / "multihop.sqlite3.pre-v20.sqlite3").is_file()
     assert (tmp_path / "multihop.sqlite3.pre-v20.sqlite3.sha256").is_file()
     assert (tmp_path / "multihop.sqlite3.pre-v21.sqlite3").is_file()
     assert (tmp_path / "multihop.sqlite3.pre-v21.sqlite3.sha256").is_file()
     assert (tmp_path / "multihop.sqlite3.pre-v22.sqlite3").is_file()
     assert (tmp_path / "multihop.sqlite3.pre-v22.sqlite3.sha256").is_file()
+    assert (tmp_path / "multihop.sqlite3.pre-v23.sqlite3").is_file()
+    assert (tmp_path / "multihop.sqlite3.pre-v23.sqlite3.sha256").is_file()
+    assert (tmp_path / "multihop.sqlite3.pre-v24.sqlite3").is_file()
+    assert (tmp_path / "multihop.sqlite3.pre-v24.sqlite3.sha256").is_file()
 
 
 def test_v21_sql_guards_are_sensitive() -> None:

--- a/newsroom/tests/test_increment6d2_relationship_migrations.py
+++ b/newsroom/tests/test_increment6d2_relationship_migrations.py
@@ -24,6 +24,7 @@ from newsroom.authority.event_hypothesis_relationship_migrations import (
 from newsroom.authority.migrations import (
     EXPECTED_MIGRATION_HISTORY,
     EXPECTED_SCHEMA_FINGERPRINT,
+    SCHEMA_VERSION,
     apply_pending_migrations,
     schema_fingerprint,
 )
@@ -69,9 +70,9 @@ def test_fresh_v22_has_exact_single_table_history_and_pins() -> None:
     )
     assert (
         EXPECTED_SCHEMA_FINGERPRINT
-        == "sha256:c341333cf54d724bb4d2092bb9da81e9f3a434ddb03e6ddc14a51fdf2c6c1b52"
+        == "sha256:abf8430bfd676a9b0e574847cde9375d90aa1e32680725a08b30c0657d567a7c"
     )
-    assert EXPECTED_MIGRATION_HISTORY[-2] == (
+    assert next(item for item in EXPECTED_MIGRATION_HISTORY if item[0] == 22) == (
         22,
         EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION_NAME,
         EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION_CHECKSUM,
@@ -137,7 +138,7 @@ def test_exact_v21_backup_upgrade_and_injected_rollback(
     )
     monkeypatch.undo()
     apply_pending_migrations(connection, applied_at="2042-01-01T00:00:01.000000Z")
-    assert connection.execute("PRAGMA user_version").fetchone() == (23,)
+    assert connection.execute("PRAGMA user_version").fetchone() == (SCHEMA_VERSION,)
 
 
 def test_standard_sqlite_connection_v22_backup_gate_closes_implicit_transaction(
@@ -156,7 +157,7 @@ def test_standard_sqlite_connection_v22_backup_gate_closes_implicit_transaction(
 
         apply_pending_migrations(connection, applied_at="2042-01-01T00:00:01.000000Z")
 
-        assert connection.execute("PRAGMA user_version").fetchone() == (23,)
+        assert connection.execute("PRAGMA user_version").fetchone() == (SCHEMA_VERSION,)
     finally:
         connection.close()
 
@@ -167,6 +168,6 @@ def test_v21_backup_required_and_v24_fails_closed(tmp_path: Path) -> None:
     with pytest.raises(EventHypothesisRelationshipBackupError, match="prepared backup"):
         apply_pending_migrations(connection, applied_at="2042-01-01T00:00:01.000000Z")
     newer = _open()
-    newer.execute("PRAGMA user_version=24")
+    newer.execute(f"PRAGMA user_version={SCHEMA_VERSION + 1}")
     with pytest.raises(sqlite3.DatabaseError, match="newer"):
         apply_pending_migrations(newer, applied_at="2042-01-01T00:00:00.000000Z")

--- a/newsroom/tests/test_increment6d3_lineage_migrations.py
+++ b/newsroom/tests/test_increment6d3_lineage_migrations.py
@@ -15,7 +15,11 @@ from newsroom.authority.event_hypothesis_lineage_migrations import (
     event_hypothesis_lineage_backup_paths,
     prepare_event_hypothesis_lineage_backup,
 )
-from newsroom.authority.migrations import apply_pending_migrations, schema_fingerprint
+from newsroom.authority.migrations import (
+    SCHEMA_VERSION,
+    apply_pending_migrations,
+    schema_fingerprint,
+)
 from newsroom.tests.graphiti_adapter_4d_migration_helpers import (
     drop_empty_v23_lineage_schema,
 )
@@ -78,7 +82,7 @@ def test_exact_v22_default_connection_backup_upgrade_and_rollback(
     assert connection.execute("PRAGMA user_version").fetchone() == (22,)
     monkeypatch.undo()
     apply_pending_migrations(connection, applied_at="2042-01-02T00:00:00.000000Z")
-    assert connection.execute("PRAGMA user_version").fetchone() == (23,)
+    assert connection.execute("PRAGMA user_version").fetchone() == (SCHEMA_VERSION,)
 
 
 def test_v22_requires_backup_and_v24_fails_closed(tmp_path: Path) -> None:
@@ -87,7 +91,7 @@ def test_v22_requires_backup_and_v24_fails_closed(tmp_path: Path) -> None:
     with pytest.raises(EventHypothesisLineageBackupError, match="prepared backup"):
         apply_pending_migrations(connection, applied_at="2042-01-02T00:00:00.000000Z")
     newer = sqlite3.connect(":memory:", isolation_level=None)
-    newer.execute("PRAGMA user_version=24")
+    newer.execute(f"PRAGMA user_version={SCHEMA_VERSION + 1}")
     with pytest.raises(sqlite3.DatabaseError, match="newer"):
         apply_pending_migrations(newer, applied_at="2042-01-02T00:00:00.000000Z")
 

--- a/newsroom/tests/test_increment6d3_lineage_store.py
+++ b/newsroom/tests/test_increment6d3_lineage_store.py
@@ -372,6 +372,9 @@ def test_v22_to_v23_preserves_retained_relationship_before_lineage_use(
         apply_pending_migrations,
         prepare_pending_migration_backup,
     )
+    from newsroom.authority.story_candidate_migrations import (
+        story_candidate_backup_paths,
+    )
     from newsroom.tests.graphiti_adapter_4d_migration_helpers import (
         drop_empty_v23_lineage_schema,
     )
@@ -388,9 +391,11 @@ def test_v22_to_v23_preserves_retained_relationship_before_lineage_use(
     assert connection.execute("PRAGMA user_version").fetchone() == (22,)
     for path in event_hypothesis_lineage_backup_paths(seed[1]):
         path.unlink(missing_ok=True)
+    for path in story_candidate_backup_paths(seed[1]):
+        path.unlink(missing_ok=True)
     assert prepare_pending_migration_backup(connection) is not None
     apply_pending_migrations(connection, applied_at="2042-01-03T00:00:00.000000Z")
-    assert connection.execute("PRAGMA user_version").fetchone() == (23,)
+    assert connection.execute("PRAGMA user_version").fetchone() == (24,)
     assert (
         connection.execute(
             "SELECT * FROM event_hypothesis_relationship_decisions ORDER BY decision_id"
@@ -696,6 +701,21 @@ def test_public_facade_normalises_forged_results_and_ordinary_exceptions(
             command_registry=object(),  # type: ignore[arg-type]
             payload_schemas=object(),  # type: ignore[arg-type]
         )
+
+
+def test_candidate_read_port_reconstructs_exact_producer_snapshot() -> None:
+    from newsroom.increment6 import lineage
+
+    class Raw:
+        def require_producers_in_transaction(self, *_: object, **__: object):
+            return object.__new__(lineage.HypothesisLineageProducerSnapshot)
+
+    port = lineage._compose_event_hypothesis_lineage_read_port(Raw())
+    with pytest.raises(
+        lineage.HypothesisLineageContractError,
+        match="lineage require_producers_in_transaction transaction read failed",
+    ):
+        port.require_current_producers_in_transaction("version", proof=object())
 
 
 def test_second_public_writer_fails_closed_until_first_closes(tmp_path) -> None:
@@ -1401,10 +1421,10 @@ class _LineageAdapter:
                 apply_pending_migrations(
                     connection, applied_at="2042-01-03T00:00:00.000000Z"
                 )
-                assert connection.execute("PRAGMA user_version").fetchone() == (23,)
+                assert connection.execute("PRAGMA user_version").fetchone() == (24,)
                 assert connection.execute(
                     "SELECT MAX(version) FROM authority_migrations"
-                ).fetchone() == (23,)
+                ).fetchone() == (24,)
             finally:
                 connection.close()
         return _ConformanceHandle(location)

--- a/newsroom/tests/test_increment6e2_candidate_authority.py
+++ b/newsroom/tests/test_increment6e2_candidate_authority.py
@@ -1,0 +1,503 @@
+from __future__ import annotations
+
+import inspect
+import sqlite3
+import uuid
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from newsroom.authority import migrations
+from newsroom.authority._discovery_store import (
+    _create_discovery_governing_producer_read_port,
+)
+from newsroom.authority._event_hypothesis_lineage_system import (
+    _create_event_hypothesis_lineage_read_port,
+)
+from newsroom.authority.auth import StaticAuthorizer
+from newsroom.authority.canonical import canonical_json_bytes, digest_bytes
+from newsroom.authority.story_candidate_migrations import STORY_CANDIDATE_MIGRATION_NAME
+from newsroom.discovery import NewsLeadId
+from newsroom.increment6.candidates import (
+    CandidateAdmissionRequest,
+    CandidateContractError,
+    CandidateGoverningState,
+    CandidateGoverningStateStatus,
+    StoryCandidateAuthority,
+    build_candidate_governing_manifest,
+    candidate_command_definition,
+    evaluate_candidate_admission,
+    open_story_candidate_authority,
+)
+from newsroom.increment6.collision import (
+    CandidateUseCollisionBinding,
+    CandidateUseOperation,
+    CurrentCollisionAuthoritySnapshot,
+    CurrentCollisionEffectEnforcer,
+    CurrentCollisionEligibilityRequest,
+    CurrentCollisionReceiptEvidence,
+    TrustedCurrentCollisionAuthorityBoundary,
+)
+from newsroom.increment6.dispositions import ProposalDispositionStore
+from newsroom.increment6.lineage import lineage_command_definition
+from newsroom.increment6.outcomes import CanonicalOutcome
+from newsroom.increment6.relationships import (
+    open_event_hypothesis_relationship_authority,
+    relationship_command_definition,
+)
+from newsroom.tests import test_increment6d3_lineage as d3
+from newsroom.tests import test_increment6d3_lineage_store as d3store
+from newsroom.tests.graphiti_adapter_4d_migration_helpers import (
+    drop_empty_v23_lineage_schema,
+)
+from newsroom.tests.test_increment5c2_named_tool_authority_execution import (
+    COLLISION_DIGEST,
+    QUERY_VALID,
+    SERVING,
+    authority_database,
+    authorize,
+    collision_request,
+    executor,
+)
+from newsroom.tests.test_increment6e1_collision import (
+    _enforcer,
+    _occupied_evidence,
+    _trusted_context,
+)
+
+
+def test_authority_api_consumes_the_exact_candidate_admission_contract() -> None:
+    signature = inspect.signature(StoryCandidateAuthority.admit)
+    assert "admission_bytes" in signature.parameters
+    assert "request" not in signature.parameters
+    assert "hypothesis_version_id" not in signature.parameters
+    assert "relationship_assessment_digest" not in signature.parameters
+    assert "disposition_ids" not in signature.parameters
+    assert "collision_request" in signature.parameters
+    assert "comparator_collision_request" in signature.parameters
+
+
+def test_v24_allocates_only_exact_candidate_tables(tmp_path: Path) -> None:
+    connection = sqlite3.connect(tmp_path / "authority.sqlite3", isolation_level=None)
+    migrations.apply_pending_migrations(
+        connection, applied_at="2042-01-01T00:00:00.000000Z"
+    )
+    assert connection.execute("PRAGMA user_version").fetchone() == (24,)
+    assert connection.execute(
+        "SELECT name FROM authority_migrations WHERE version=24"
+    ).fetchone() == (STORY_CANDIDATE_MIGRATION_NAME,)
+    retained_v5 = {"story_candidates", "story_candidate_versions"}
+    assert {
+        row[0]
+        for row in connection.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'story_candidate_%'"
+        )
+    } - retained_v5 == {
+        "story_candidate_heads",
+        "story_candidate_admission_receipts_v2",
+        "story_candidate_collision_bindings",
+    }
+
+
+@pytest.mark.parametrize(
+    "failure", ("missing_trigger", "predecessor", "nonempty", "history", "version")
+)
+def test_v24_downgrade_preflight_is_non_mutating(tmp_path: Path, failure: str) -> None:
+    database = tmp_path / "authority.sqlite3"
+    connection = sqlite3.connect(database, isolation_level=None)
+    migrations.apply_pending_migrations(
+        connection, applied_at="2042-01-01T00:00:00.000000Z"
+    )
+    before = (
+        connection.execute("PRAGMA user_version").fetchone(),
+        tuple(connection.iterdump()),
+    )
+    if failure == "missing_trigger":
+        connection.execute("DROP TRIGGER candidate_head_insert_guard")
+    elif failure == "predecessor":
+        connection.execute("DROP TRIGGER event_hypothesis_lineage_head_insert_guard")
+    elif failure == "nonempty":
+        connection.execute("PRAGMA foreign_keys=OFF")
+        connection.execute(
+            "INSERT INTO story_candidate_admission_receipts_v2(admission_digest,request_id,request_digest,actor_identity_digest,idempotency_key,authority_aggregate_id,authority_event_id,committed_admission_decision_id,admission_bytes,candidate_id,candidate_bytes,version_id,version_ordinal,version_bytes,version_digest,manifest_material_digest,semantic_scope_digest,hypothesis_version_id,relationship_assessment_digest,disposition_ids_bytes,collision_request_bytes,collision_request_digest,collision_decision_bytes,collision_decision_digest,recorded_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+            (
+                "sha256:" + "1" * 64,
+                "11111111-1111-4111-8111-111111111111",
+                "sha256:" + "2" * 64,
+                "sha256:" + "3" * 64,
+                "x",
+                "22222222-2222-4222-8222-222222222222",
+                "33333333-3333-4333-8333-333333333333",
+                "66666666-6666-4666-8666-666666666666",
+                b"x",
+                "22222222-2222-4222-8222-222222222222",
+                b"x",
+                "55555555-5555-4555-8555-555555555555",
+                1,
+                b"x",
+                "sha256:" + "9" * 64,
+                "sha256:" + "4" * 64,
+                "sha256:" + "5" * 64,
+                "44444444-4444-4444-8444-444444444444",
+                "sha256:" + "6" * 64,
+                b"[]",
+                b"{}",
+                "sha256:" + "7" * 64,
+                b"{}",
+                "sha256:" + "8" * 64,
+                "x",
+            ),
+        )
+    elif failure == "history":
+        connection.execute("DROP TRIGGER immutable_authority_migrations_update")
+        connection.execute(
+            "UPDATE authority_migrations SET checksum=? WHERE version=24",
+            ("sha256:" + "f" * 64,),
+        )
+    else:
+        connection.execute("PRAGMA user_version=25")
+    damaged = (
+        connection.execute("PRAGMA user_version").fetchone(),
+        tuple(connection.iterdump()),
+    )
+    with pytest.raises(sqlite3.DatabaseError):
+        drop_empty_v23_lineage_schema(connection)
+    assert (
+        connection.execute("PRAGMA user_version").fetchone(),
+        tuple(connection.iterdump()),
+    ) == damaged
+    assert damaged != before
+
+
+def test_real_new_candidate_admission_commits_and_exact_replay_skips_providers(
+    tmp_path: Path,
+) -> None:
+    seed, args, _ = d3store._seed(tmp_path)
+    version = seed[2]
+    assessment, evidence = d3._decision(
+        version, (), CanonicalOutcome.REL_NO_ADEQUATE_PRIOR_MATCH
+    )
+    scopes = {
+        relationship_command_definition().required_scope,
+        lineage_command_definition().required_scope,
+        candidate_command_definition().required_scope,
+    }
+    args["authorizer"] = StaticAuthorizer(
+        policy_version="candidate-test-v1",
+        grants_by_principal={"editor": frozenset(scopes), "other": frozenset(scopes)},
+    )
+    relationship = open_event_hypothesis_relationship_authority(**args)
+    try:
+        relationship.retain(
+            assessment.canonical_bytes,
+            tuple(item.canonical_bytes for item in evidence),
+            proof=seed[0][3],
+        )
+    finally:
+        relationship.close()
+
+    binding = CandidateUseCollisionBinding(
+        version.hypothesis_id,
+        version.version_id,
+        version.canonical_digest,
+        CandidateUseOperation.ADMIT_NEW_CANDIDATE,
+        None,
+        "candidate-development",
+        COLLISION_DIGEST,
+        "retrieval-generation-v2",
+        QUERY_VALID,
+        SERVING,
+        42,
+    )
+    named = collision_request(
+        idempotency_key=binding.idempotency_key, generation_id=binding.generation_id
+    )
+    collision_root = tmp_path / "collision"
+    collision_root.mkdir()
+    collision_db = authority_database(collision_root)
+    with sqlite3.connect(collision_db) as connection:
+        connection.execute("DELETE FROM development_candidates_v2")
+    result = executor(collision_root, collision_db).execute(
+        named, authorize(collision_root, named)
+    )
+    collision_request_value = CurrentCollisionEligibilityRequest(
+        binding, named.request_digest
+    )
+    collision_evidence = CurrentCollisionReceiptEvidence(
+        named, result.receipt.canonical_bytes, result.authority_receipt_bytes
+    )
+    context = _trusted_context(collision_evidence)
+    snapshot = CurrentCollisionAuthoritySnapshot(collision_evidence, context)
+    calls = []
+    enforcer = CurrentCollisionEffectEnforcer(
+        current_authority_provider=lambda request: calls.append(request) or snapshot,
+        trusted_boundary=TrustedCurrentCollisionAuthorityBoundary(
+            context.authority_scope_id,
+            context.authority_profile_id,
+            context.adapter_config_digest,
+            context.port_registry_digest,
+            context.port_id,
+        ),
+    )
+
+    connection = sqlite3.connect(args["database"], isolation_level=None)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA foreign_keys=ON")
+    connection.execute("PRAGMA journal_mode=WAL")
+    connection.execute("PRAGMA synchronous=FULL")
+    lineage = _create_event_hypothesis_lineage_read_port(
+        connection,
+        retrieval_authority=args["retrieval_authority"],
+        authenticator=args["authenticator"],
+        command_registry=args["command_registry"],
+        payload_schemas=args["payload_schemas"],
+        clock=args["clock"],
+    )
+    store = ProposalDispositionStore(
+        connection, args["retrieval_authority"], args["authenticator"]
+    )
+    connection.execute("BEGIN IMMEDIATE")
+    try:
+        discovery_port = _create_discovery_governing_producer_read_port(connection)
+        lineage_snapshot = lineage.require_current_producers_in_transaction(
+            version.version_id, proof=seed[0][3]
+        )
+        retained_relationship = lineage.require_retained_relationship_in_transaction(
+            assessment.canonical_digest
+        )
+        disposition_ids = tuple(
+            sorted(item.disposition_id for item in version.source_bindings)
+        )
+        dispositions = tuple(
+            store.require_current_in_transaction(item, proof=seed[0][3])
+            for item in disposition_ids
+        )
+        lead_ids = tuple(
+            sorted(
+                {NewsLeadId.parse(item.decision_lead_id) for item in dispositions},
+                key=str,
+            )
+        )
+        discovery = discovery_port.require_current_governing_producers(lead_ids)
+        from newsroom.increment6.collision import decide_current_collision_eligibility
+
+        decision = decide_current_collision_eligibility(
+            request=collision_request_value,
+            evidence=collision_evidence,
+            trusted_context=context,
+        )
+        manifest = build_candidate_governing_manifest(
+            hypothesis_version=version,
+            lineage_receipts=lineage_snapshot.receipts,
+            lineage_initial_heads=lineage_snapshot.initial_heads,
+            lineage_versions=lineage_snapshot.versions,
+            lineage_relationship_proofs=lineage_snapshot.relationship_proofs,
+            dispositions=dispositions,
+            leads=tuple(x[0] for x in discovery),
+            signals=tuple(x[1] for x in discovery),
+            gates=tuple(x[2] for x in discovery),
+            relationship=retained_relationship,
+            collision=decision,
+        )
+    finally:
+        connection.rollback()
+        connection.close()
+    authentication = args["authenticator"].authenticate(seed[0][3], now=args["clock"]())
+    actor = digest_bytes(
+        canonical_json_bytes(
+            {
+                "principal_id": authentication.principal_id,
+                "credential_binding_digest": authentication.credential_binding_digest,
+            }
+        )
+    )
+    request = CandidateAdmissionRequest(
+        str(uuid.uuid4()),
+        actor,
+        "candidate:e2e",
+        None,
+        None,
+        0,
+        manifest.semantic_scope_digest,
+        collision_request_value.request_digest,
+        manifest.governing_state_binding.canonical_digest,
+        None,
+    )
+    admission = evaluate_candidate_admission(
+        request=request,
+        manifest=manifest,
+        collision=decision,
+        current_version=None,
+        governing_state=CandidateGoverningState(
+            CandidateGoverningStateStatus.COMPLETE, manifest.governing_state_binding
+        ),
+    )
+    authority = open_story_candidate_authority(**args, collision_enforcer=enforcer)
+    try:
+        committed = authority.admit(
+            admission.canonical_bytes,
+            collision_request=collision_request_value,
+            proof=seed[0][3],
+        )
+        assert committed.ordinal == 1
+        assert len(calls) == 2
+        calls.clear()
+        replay = authority.admit(
+            admission.canonical_bytes,
+            collision_request=collision_request_value,
+            proof=seed[0][3],
+        )
+        assert replay == committed and calls == []
+        divergent = replace(
+            admission,
+            request=replace(
+                admission.request, idempotency_key="candidate:e2e:divergent"
+            ),
+        )
+        with pytest.raises(CandidateContractError, match="replay diverges"):
+            authority.admit(
+                divergent.canonical_bytes,
+                collision_request=collision_request_value,
+                proof=seed[0][3],
+            )
+        assert calls == []
+    finally:
+        authority.close()
+    reopened = open_story_candidate_authority(**args, collision_enforcer=enforcer)
+    try:
+        assert reopened.load_version(committed.version_id) == committed
+    finally:
+        reopened.close()
+    with sqlite3.connect(args["database"]) as connection:
+        trigger = connection.execute(
+            "SELECT sql FROM sqlite_master WHERE name='candidate_head_update_guard'"
+        ).fetchone()[0]
+        original = connection.execute(
+            "SELECT updated_at FROM story_candidate_heads"
+        ).fetchone()[0]
+        connection.execute("DROP TRIGGER candidate_head_update_guard")
+        connection.execute(
+            "UPDATE story_candidate_heads SET updated_at='2044-01-01T00:00:00Z'"
+        )
+        connection.execute(trigger)
+    with pytest.raises(CandidateContractError):
+        open_story_candidate_authority(**args, collision_enforcer=enforcer)
+    with sqlite3.connect(args["database"]) as connection:
+        connection.execute("DROP TRIGGER candidate_head_update_guard")
+        connection.execute("UPDATE story_candidate_heads SET updated_at=?", (original,))
+        connection.execute(trigger)
+    with sqlite3.connect(args["database"]) as connection:
+        connection.execute("DROP TRIGGER immutable_candidate_receipt")
+        connection.execute(
+            "UPDATE story_candidate_admission_receipts_v2 SET admission_bytes=?",
+            (b"{}",),
+        )
+    with pytest.raises(CandidateContractError):
+        open_story_candidate_authority(**args, collision_enforcer=enforcer)
+
+
+class _CandidateOpeningSignal(BaseException):
+    pass
+
+
+class _CandidateClosingSignal(BaseException):
+    pass
+
+
+def _candidate_open_arguments(tmp_path: Path) -> dict[str, object]:
+    root = tmp_path / "candidate-open"
+    root.mkdir()
+    _, args, _ = d3store._seed(root)
+    scopes = {
+        relationship_command_definition().required_scope,
+        lineage_command_definition().required_scope,
+        candidate_command_definition().required_scope,
+    }
+    args["authorizer"] = StaticAuthorizer(
+        policy_version="candidate-open-v1",
+        grants_by_principal={
+            "editor": frozenset(scopes),
+            "other": frozenset(scopes),
+        },
+    )
+    collision_root = tmp_path / "candidate-collision"
+    collision_root.mkdir()
+    _, evidence = _occupied_evidence(collision_root)
+    return {
+        **args,
+        "collision_enforcer": _enforcer(evidence),
+        "busy_timeout_ms": 5_000,
+    }
+
+
+def test_second_public_candidate_writer_fails_until_first_closes(
+    tmp_path: Path,
+) -> None:
+    arguments = _candidate_open_arguments(tmp_path)
+    first = open_story_candidate_authority(**arguments)
+    try:
+        with pytest.raises(CandidateContractError, match="open failed"):
+            open_story_candidate_authority(**arguments)
+    finally:
+        first.close()
+    reopened = open_story_candidate_authority(**arguments)
+    reopened.close()
+
+
+@pytest.mark.parametrize("failure", ("lineage-port", "command-service"))
+@pytest.mark.parametrize("error_type", (RuntimeError, _CandidateOpeningSignal))
+def test_candidate_open_failure_preserves_signal_releases_lock_and_allows_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure: str,
+    error_type: type[BaseException],
+) -> None:
+    from newsroom.authority import story_candidate_system as private
+
+    arguments = _candidate_open_arguments(tmp_path)
+    error = error_type("candidate opening failed")
+    closed: list[object] = []
+    original_close = private._CandidateStore.close
+
+    def close_then_fail(store) -> None:
+        closed.append(store)
+        original_close(store)
+        raise _CandidateClosingSignal("candidate closing failed")
+
+    with monkeypatch.context() as scoped:
+        scoped.setattr(private._CandidateStore, "close", close_then_fail)
+        target = (
+            "_create_event_hypothesis_lineage_read_port"
+            if failure == "lineage-port"
+            else "CommandService"
+        )
+        scoped.setattr(
+            private,
+            target,
+            lambda *args, **kwargs: (_ for _ in ()).throw(error),
+        )
+        with pytest.raises(error_type) as caught:
+            private.open_story_candidate_authority_system(**arguments)
+        assert caught.value is error
+        assert len(closed) == 1
+
+    corrected = private.open_story_candidate_authority_system(**arguments)
+    corrected.close()
+
+
+def test_candidate_system_rejects_forged_facade_and_releases_writer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from newsroom.authority import story_candidate_system as private
+
+    arguments = _candidate_open_arguments(tmp_path)
+    with monkeypatch.context() as scoped:
+        scoped.setattr(
+            private, "_compose_story_candidate_authority", lambda _: object()
+        )
+        with pytest.raises(CandidateContractError, match="facade differs"):
+            private.open_story_candidate_authority_system(**arguments)
+
+    corrected = private.open_story_candidate_authority_system(**arguments)
+    corrected.close()

--- a/newsroom/tests/test_increment6e2_candidate_store.py
+++ b/newsroom/tests/test_increment6e2_candidate_store.py
@@ -1,0 +1,1299 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, replace
+from pathlib import Path
+from threading import Lock
+from typing import ClassVar
+
+import pytest
+
+from newsroom.authority._discovery_store import (
+    _create_discovery_governing_producer_read_port,
+)
+from newsroom.authority._event_hypothesis_lineage_system import (
+    _create_event_hypothesis_lineage_read_port,
+)
+from newsroom.authority.auth import AuthenticationProof, StaticAuthorizer
+from newsroom.authority.canonical import canonical_json_bytes, digest_bytes
+from newsroom.authority.migrations import (
+    SCHEMA_VERSION,
+    apply_pending_migrations,
+    prepare_pending_migration_backup,
+)
+from newsroom.authority.persistence import AuthoritySchemaError
+from newsroom.authority.story_candidate_system import (
+    _open_unlocked_story_candidate_authority_for_test,
+)
+from newsroom.authority.types import UtcTimestamp
+from newsroom.discovery import NewsLeadId
+from newsroom.increment6.candidates import (
+    CandidateAdmission,
+    CandidateAdmissionReason,
+    CandidateAdmissionRequest,
+    CandidateContractError,
+    CandidateGoverningState,
+    CandidateGoverningStateStatus,
+    build_candidate_governing_manifest,
+    candidate_command_definition,
+    evaluate_candidate_admission,
+    merge_candidate_authority_registries,
+)
+from newsroom.increment6.collision import (
+    CandidateUseCollisionBinding,
+    CandidateUseOperation,
+    CurrentCollisionAuthoritySnapshot,
+    CurrentCollisionEffectEnforcer,
+    CurrentCollisionEligibilityRequest,
+    CurrentCollisionReceiptEvidence,
+    TrustedCurrentCollisionAuthorityBoundary,
+    decide_current_collision_eligibility,
+)
+from newsroom.increment6.dispositions import ProposalDispositionStore
+from newsroom.increment6.lineage import (
+    lineage_command_definition,
+    merge_lineage_authority_registries,
+)
+from newsroom.increment6.outcomes import CanonicalOutcome
+from newsroom.increment6.relationships import (
+    ComparatorEvidence,
+    ComparatorSetManifest,
+    HypothesisVersionBinding,
+    assess_relationships,
+    open_event_hypothesis_relationship_authority,
+    relationship_command_definition,
+    merge_relationship_authority_registries,
+)
+from newsroom.tests import test_increment6d1_hypothesis_store as d1
+from newsroom.tests import test_increment6d2_relationship_store as d2
+from newsroom.tests import test_increment6d3_lineage as d3
+from newsroom.tests.authority_store_conformance import (
+    CASE_INVENTORY,
+    Applicability,
+    AuthorityValue,
+    BindingConflict,
+    CaseId,
+    IntegrityViolation,
+    LostResponse,
+    RollbackScope,
+    StoredAuthorityState,
+    TamperKind,
+    WriteCommand,
+    _SCENARIOS,
+    run_conformance,
+)
+from newsroom.tests.test_increment5c2_named_tool_authority_execution import (
+    QUERY_VALID,
+    SERVING,
+    authority_database,
+    authorize,
+    collision_request,
+    digest,
+    executor,
+)
+from newsroom.tests.test_increment6e1_collision import _trusted_context
+
+
+_RECORDS = (
+    ("record-1", "alpha"),
+    ("record-2", "beta"),
+    ("record-a", "alpha"),
+    ("record-b", "beta"),
+    ("record-rollback-normal", "alpha"),
+    ("record-rollback-abort", "alpha"),
+)
+_REQUESTS = ("different-request",) + tuple(f"request-{name}" for name, _ in _RECORDS)
+_IDEMPOTENCIES = ("different-idempotency",) + tuple(
+    f"idempotency-{name}" for name, _ in _RECORDS
+)
+_PREDECESSORS = ("different-cas_predecessor", "record-0", "record-1")
+_UPSTREAMS = (
+    (
+        ("authority", "authority-head-1"),
+        ("policy", "policy-head-1"),
+    ),
+)
+_ACTOR_PROOFS = {
+    "actor-1": AuthenticationProof(method="STATIC_TOKEN", credential="credential"),
+    "different-actor": AuthenticationProof(method="STATIC_TOKEN", credential="other"),
+}
+_PRINCIPAL_ACTORS = {"editor": "actor-1", "other": "different-actor"}
+
+
+def _generic(
+    record_id: str, predecessor: str | None = None, value: str | None = None
+) -> WriteCommand:
+    predecessor = predecessor or ("record-1" if record_id == "record-2" else "record-0")
+    value = value or ("beta" if record_id in {"record-2", "record-b"} else "alpha")
+    return WriteCommand(
+        record_id=record_id,
+        canonical_bytes=f'{{"value":"{value}"}}'.encode(),
+        scalar_columns={"value": value, "version": 1},
+        identity_columns={"record_id": record_id, "authority": "fixture"},
+        linked_rows=(
+            {"child_id": f"child-{record_id}", "record_id": record_id, "ordinal": 0},
+        ),
+        actor="actor-1",
+        request=f"request-{record_id}",
+        idempotency=f"idempotency-{record_id}",
+        cas_predecessor=predecessor,
+        required_upstream_heads=_UPSTREAMS[0],
+    )
+
+
+def _code(values: tuple, value: object, field: str) -> int:
+    try:
+        return values.index(value)
+    except ValueError as exc:
+        raise CandidateContractError(
+            f"unsupported conformance {field} binding"
+        ) from exc
+
+
+def _request_uuid(codes: tuple[int, ...]) -> str:
+    raw = bytearray(hashlib.sha256(bytes(codes)).digest()[:16])
+    raw[: len(codes)] = bytes(codes)
+    raw[6] = (raw[6] & 0x0F) | 0x40
+    raw[8] = (raw[8] & 0x3F) | 0x80
+    return str(uuid.UUID(bytes=bytes(raw)))
+
+
+def _request_codes(value: str) -> tuple[int, ...]:
+    raw = uuid.UUID(value).bytes
+    return tuple(raw[:6])
+
+
+def _collision_digest(subject_version_id: str) -> str:
+    return digest(f"candidate-conformance:{subject_version_id}")
+
+
+def _database_was_locked(error: BaseException) -> bool:
+    current: BaseException | None = error
+    while current is not None:
+        if isinstance(current, sqlite3.OperationalError) and "locked" in str(current):
+            return True
+        current = current.__cause__
+    return False
+
+
+@dataclass
+class _Location:
+    seed: tuple
+    collision_root: Path
+
+    def __post_init__(self) -> None:
+        ids = tuple(item[0] for item in _RECORDS)
+        versions = self.seed[3]
+        mapped = (
+            versions[0],
+            versions[1],
+            versions[0],
+            versions[0],
+            versions[0],
+            versions[1],
+        )
+        self.subjects = dict(zip(ids, mapped, strict=True))
+        self.relationships = {
+            item.version_id: self.seed[8][item.version_id] for item in mapped
+        }
+        self.snapshots: dict[str, CurrentCollisionAuthoritySnapshot] = {}
+        self.collision_results: dict[
+            tuple[str, CandidateUseOperation, str | None], tuple[object, object]
+        ] = {}
+        self.collision_lock = Lock()
+
+
+def _collaborators(seed) -> dict[str, object]:
+    scopes = {
+        relationship_command_definition().required_scope,
+        lineage_command_definition().required_scope,
+        candidate_command_definition().required_scope,
+    }
+    return {
+        "database": seed[1],
+        "retrieval_authority": seed[0][1],
+        "authenticator": seed[0][2],
+        "authorizer": StaticAuthorizer(
+            policy_version="candidate-conformance-v1",
+            grants_by_principal={
+                "editor": frozenset(scopes),
+                "other": frozenset(scopes),
+            },
+        ),
+        "command_registry": seed[4],
+        "payload_schemas": seed[5],
+        "clock": lambda: UtcTimestamp.parse("2042-01-02T00:00:00.000000Z"),
+        "busy_timeout_ms": 5_000,
+    }
+
+
+def _migrate_to_current(database: Path) -> None:
+    connection = sqlite3.connect(database, isolation_level=None)
+    try:
+        prepare_pending_migration_backup(connection)
+        apply_pending_migrations(connection, applied_at="2042-01-02T00:00:00.000000Z")
+        if connection.execute("PRAGMA user_version").fetchone() != (SCHEMA_VERSION,):
+            raise AssertionError(
+                "Candidate adapter migration did not reach current schema"
+            )
+    finally:
+        connection.close()
+
+
+def _build_seed(root: Path) -> tuple:
+    seed = d2._seed_location(root, subjects=2)
+    _migrate_to_current(seed[1])
+    args = _collaborators(seed)
+    retained = {}
+    authority = open_event_hypothesis_relationship_authority(**args)
+    try:
+        for version in {item.version_id: item for item in seed[3]}.values():
+            assessment, evidence = d3._decision(
+                version, (), CanonicalOutcome.REL_NO_ADEQUATE_PRIOR_MATCH
+            )
+            authority.retain(
+                assessment.canonical_bytes,
+                tuple(item.canonical_bytes for item in evidence),
+                proof=seed[0][3],
+            )
+            retained[version.version_id] = assessment.canonical_digest
+    finally:
+        authority.close()
+    connection = sqlite3.connect(seed[1], isolation_level=None)
+    try:
+        connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    finally:
+        connection.close()
+    return (*seed, retained)
+
+
+@dataclass(frozen=True)
+class _SeedSnapshot:
+    database_bytes: bytes
+    tail: tuple
+
+    def clone(self, root: Path) -> tuple:
+        root.mkdir(mode=0o700)
+        database = root / "candidate-authority.sqlite3"
+        database.write_bytes(self.database_bytes)
+        os.chmod(database, 0o600)
+        return (self.tail[0], database, *self.tail[1:])
+
+
+def _seed_snapshot(root: Path) -> _SeedSnapshot:
+    global_cache = d2._SEED_CACHE
+    global_state = d2._seed_cache_state(global_cache)
+    d2._SEED_CACHE = None
+    try:
+        seed = _build_seed(root)
+        if len(seed[3]) != 2 or len(seed[8]) != 2:
+            raise AssertionError("Candidate adapter seed snapshot shape")
+        return _SeedSnapshot(seed[1].read_bytes(), (seed[0], *seed[2:]))
+    finally:
+        d2._SEED_CACHE = global_cache
+        if d2._seed_cache_state(d2._SEED_CACHE) != global_state:
+            raise AssertionError("global relationship seed cache changed")
+
+
+def _named_snapshot(
+    location: _Location,
+    binding: CandidateUseCollisionBinding,
+    *,
+    occupied_candidate_id: str | None = None,
+) -> tuple[CurrentCollisionEligibilityRequest, object]:
+    cache_key = (
+        binding.subject_version_id,
+        binding.operation,
+        occupied_candidate_id,
+    )
+    with location.collision_lock:
+        cached = location.collision_results.get(cache_key)
+        if cached is not None:
+            return cached  # type: ignore[return-value]
+        result = _create_named_snapshot(
+            location, binding, occupied_candidate_id=occupied_candidate_id
+        )
+        location.collision_results[cache_key] = result
+        return result  # type: ignore[return-value]
+
+
+def _create_named_snapshot(
+    location: _Location,
+    binding: CandidateUseCollisionBinding,
+    *,
+    occupied_candidate_id: str | None,
+) -> tuple[CurrentCollisionEligibilityRequest, object]:
+    key = binding.collision_key_digest
+    root = location.collision_root / str(uuid.uuid4())
+    root.mkdir(parents=True)
+    database = authority_database(root)
+    with sqlite3.connect(database) as connection:
+        connection.execute("DELETE FROM development_candidates_v2")
+        if occupied_candidate_id is not None:
+            connection.execute(
+                "INSERT INTO development_candidates_v2 VALUES(?,?)",
+                (occupied_candidate_id, key),
+            )
+    base = collision_request(
+        idempotency_key=binding.idempotency_key,
+        generation_id=binding.generation_id,
+    )
+    named = replace(base, collision_key_digest=key)
+    result = executor(root, database).execute(named, authorize(root, named))
+    evidence = CurrentCollisionReceiptEvidence(
+        named,
+        result.receipt.canonical_bytes,
+        result.authority_receipt_bytes,
+    )
+    request = CurrentCollisionEligibilityRequest(binding, named.request_digest)
+    context = _trusted_context(evidence)
+    snapshot = CurrentCollisionAuthoritySnapshot(evidence, context)
+    location.snapshots[request.request_digest] = snapshot
+    return request, decide_current_collision_eligibility(
+        request=request, evidence=evidence, trusted_context=context
+    )
+
+
+def _enforcer(location: _Location) -> CurrentCollisionEffectEnforcer:
+    if not location.snapshots:
+        # Establish the exact trusted boundary once; providers remain request keyed.
+        version = next(iter(location.subjects.values()))
+        binding = CandidateUseCollisionBinding(
+            version.hypothesis_id,
+            version.version_id,
+            version.canonical_digest,
+            CandidateUseOperation.ADMIT_NEW_CANDIDATE,
+            None,
+            "candidate-development",
+            _collision_digest(version.version_id),
+            "retrieval-generation-v2",
+            QUERY_VALID,
+            SERVING,
+            42,
+        )
+        _named_snapshot(location, binding)
+    context = next(iter(location.snapshots.values())).trusted_context
+    return CurrentCollisionEffectEnforcer(
+        current_authority_provider=lambda request: location.snapshots[
+            request.request_digest
+        ],
+        trusted_boundary=TrustedCurrentCollisionAuthorityBoundary(
+            context.authority_scope_id,
+            context.authority_profile_id,
+            context.adapter_config_digest,
+            context.port_registry_digest,
+            context.port_id,
+        ),
+    )
+
+
+def _actor_digest(seed: tuple, actor: str) -> str:
+    proof = _ACTOR_PROOFS[actor]
+    authentication = seed[0][2].authenticate(
+        proof, now=UtcTimestamp.parse("2042-01-02T00:00:00.000000Z")
+    )
+    return digest_bytes(
+        canonical_json_bytes(
+            {
+                "principal_id": authentication.principal_id,
+                "credential_binding_digest": authentication.credential_binding_digest,
+            }
+        )
+    )
+
+
+def _manifest(location: _Location, version, collision):
+    connection = sqlite3.connect(location.seed[1], isolation_level=None)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA foreign_keys=ON")
+    connection.execute("PRAGMA journal_mode=WAL")
+    commands, schemas = merge_relationship_authority_registries(
+        location.seed[4], location.seed[5]
+    )
+    commands, schemas = merge_lineage_authority_registries(commands, schemas)
+    commands, schemas = merge_candidate_authority_registries(commands, schemas)
+    lineage = _create_event_hypothesis_lineage_read_port(
+        connection,
+        retrieval_authority=location.seed[0][1],
+        authenticator=location.seed[0][2],
+        command_registry=commands,
+        payload_schemas=schemas,
+        clock=lambda: UtcTimestamp.parse("2042-01-02T00:00:00.000000Z"),
+    )
+    store = ProposalDispositionStore(
+        connection, location.seed[0][1], location.seed[0][2]
+    )
+    connection.execute("BEGIN IMMEDIATE")
+    try:
+        snapshot = lineage.require_current_producers_in_transaction(
+            version.version_id, proof=location.seed[0][3]
+        )
+        relationship = lineage.require_retained_relationship_in_transaction(
+            location.relationships[version.version_id]
+        )
+        disposition_ids = tuple(
+            sorted(item.disposition_id for item in version.source_bindings)
+        )
+        dispositions = tuple(
+            store.require_current_in_transaction(item, proof=location.seed[0][3])
+            for item in disposition_ids
+        )
+        lead_ids = tuple(
+            sorted(
+                {NewsLeadId.parse(item.decision_lead_id) for item in dispositions},
+                key=str,
+            )
+        )
+        discovery = _create_discovery_governing_producer_read_port(
+            connection
+        ).require_current_governing_producers(lead_ids)
+        return build_candidate_governing_manifest(
+            hypothesis_version=version,
+            lineage_receipts=snapshot.receipts,
+            lineage_initial_heads=snapshot.initial_heads,
+            lineage_versions=snapshot.versions,
+            lineage_relationship_proofs=snapshot.relationship_proofs,
+            dispositions=dispositions,
+            leads=tuple(item[0] for item in discovery),
+            signals=tuple(item[1] for item in discovery),
+            gates=tuple(item[2] for item in discovery),
+            relationship=relationship,
+            collision=collision,
+        )
+    finally:
+        connection.rollback()
+        connection.close()
+
+
+def _admission(location: _Location, command: WriteCommand):
+    record_code = _code(
+        _RECORDS, (command.record_id, command.scalar_columns.get("value")), "record"
+    )
+    base = _generic(
+        command.record_id, command.cas_predecessor, command.scalar_columns.get("value")
+    )
+    if (
+        command.canonical_bytes != base.canonical_bytes
+        or command.scalar_columns != base.scalar_columns
+        or command.identity_columns != base.identity_columns
+        or command.linked_rows != base.linked_rows
+    ):
+        raise CandidateContractError("unsupported conformance representation")
+    request_code = _code(_REQUESTS, command.request, "request")
+    idempotency_code = _code(_IDEMPOTENCIES, command.idempotency, "idempotency")
+    predecessor_code = _code(_PREDECESSORS, command.cas_predecessor, "CAS predecessor")
+    upstream_code = _code(_UPSTREAMS, command.required_upstream_heads, "upstream")
+    actor_code = _code(tuple(_ACTOR_PROOFS), command.actor, "actor")
+    version = location.subjects[command.record_id]
+    binding = CandidateUseCollisionBinding(
+        version.hypothesis_id,
+        version.version_id,
+        version.canonical_digest,
+        CandidateUseOperation.ADMIT_NEW_CANDIDATE,
+        None,
+        "candidate-development",
+        _collision_digest(version.version_id),
+        "retrieval-generation-v2",
+        QUERY_VALID,
+        SERVING,
+        42,
+    )
+    collision_request_value, collision = _named_snapshot(location, binding)
+    manifest = _manifest(location, version, collision)
+    codes = (
+        record_code,
+        request_code,
+        idempotency_code,
+        predecessor_code,
+        upstream_code,
+        actor_code,
+    )
+    request = CandidateAdmissionRequest(
+        _request_uuid(codes),
+        _actor_digest(location.seed, command.actor),
+        "candidate:" + ":".join(str(item) for item in codes),
+        None,
+        None,
+        0,
+        manifest.semantic_scope_digest,
+        collision_request_value.request_digest,
+        manifest.governing_state_binding.canonical_digest,
+        None,
+    )
+    admission = evaluate_candidate_admission(
+        request=request,
+        manifest=manifest,
+        collision=collision,
+        current_version=None,
+        governing_state=CandidateGoverningState(
+            CandidateGoverningStateStatus.COMPLETE,
+            manifest.governing_state_binding,
+        ),
+    )
+    return admission, collision_request_value
+
+
+def _advance_record_one(location: _Location):
+    previous = location.subjects["record-1"]
+    connection = sqlite3.connect(location.seed[1], isolation_level=None)
+    try:
+        fixture = (connection, *location.seed[0][1:])
+        proposal, dispositions = location.seed[7]["authority"]
+        upstream = d1._open(fixture)
+        try:
+            advanced = upstream.retain(
+                proposal,
+                dispositions,
+                proof=location.seed[0][3],
+                expected_target_version=previous,
+            )
+        finally:
+            upstream.close()
+    finally:
+        connection.close()
+    subject = HypothesisVersionBinding.from_version(advanced)
+    comparator = HypothesisVersionBinding.from_version(previous)
+    evidence = ComparatorEvidence(subject, comparator, 59, 0, 80, 0, 0)
+    assessment = assess_relationships(
+        subject, ComparatorSetManifest.complete((comparator,)), (evidence,)
+    )
+    assert assessment.decision is CanonicalOutcome.REL_DEVELOPMENT_OF
+    args = _collaborators(location.seed)
+    commands, schemas = merge_relationship_authority_registries(
+        args["command_registry"], args["payload_schemas"]
+    )
+    commands, schemas = merge_lineage_authority_registries(commands, schemas)
+    args["command_registry"], args["payload_schemas"] = (
+        merge_candidate_authority_registries(commands, schemas)
+    )
+    relationship = open_event_hypothesis_relationship_authority(**args)
+    try:
+        relationship.retain(
+            assessment.canonical_bytes,
+            (evidence.canonical_bytes,),
+            proof=location.seed[0][3],
+        )
+    finally:
+        relationship.close()
+    location.subjects["record-1"] = advanced
+    location.relationships[advanced.version_id] = assessment.canonical_digest
+    return previous, advanced
+
+
+class _Handle:
+    def __init__(self, location: _Location) -> None:
+        self.location = location
+        self.authority = None
+        self.open_error: Exception | None = None
+        try:
+            self.authority = _open_unlocked_story_candidate_authority_for_test(
+                **_collaborators(location.seed), collision_enforcer=_enforcer(location)
+            )
+        except Exception as exc:
+            if not isinstance(exc, (AuthoritySchemaError, CandidateContractError)):
+                raise
+            self.open_error = exc
+
+    def _opened(self):
+        if self.open_error is not None:
+            raise IntegrityViolation(
+                "Candidate authority open failed"
+            ) from self.open_error
+        assert self.authority is not None
+        return self.authority
+
+    def _row(self, record_id: str, connection=None):
+        owned = connection is None
+        connection = connection or sqlite3.connect(self.location.seed[1])
+        try:
+            version = self.location.subjects[record_id]
+            return connection.execute(
+                "SELECT admission_digest,version_id FROM story_candidate_admission_receipts_v2 "
+                "WHERE hypothesis_version_id=?",
+                (version.version_id,),
+            ).fetchone()
+        finally:
+            if owned:
+                connection.close()
+
+    def _decode(self, version_id: str, connection=None) -> WriteCommand:
+        owned = connection is None
+        connection = connection or sqlite3.connect(self.location.seed[1])
+        try:
+            row = connection.execute(
+                "SELECT r.request_id,r.idempotency_key,a.principal_id "
+                "FROM story_candidate_admission_receipts_v2 r "
+                "JOIN ledger_events e ON e.event_id=r.authority_event_id "
+                "JOIN authority_commands c ON c.command_id=e.command_id "
+                "JOIN authentication_contexts a ON a.authentication_context_id="
+                "c.authentication_context_id WHERE r.version_id=?",
+                (version_id,),
+            ).fetchone()
+            if row is None:
+                raise CandidateContractError("unknown conformance Candidate")
+            codes = _request_codes(str(row[0]))
+            encoded = tuple(int(item) for item in str(row[1]).split(":")[1:])
+            if codes != encoded or len(codes) != 6:
+                raise CandidateContractError(
+                    "Candidate conformance request binding differs"
+                )
+            record_id, value = _RECORDS[codes[0]]
+            actor = _PRINCIPAL_ACTORS[str(row[2])]
+            return replace(
+                _generic(record_id, _PREDECESSORS[codes[3]], value),
+                request=_REQUESTS[codes[1]],
+                idempotency=_IDEMPOTENCIES[codes[2]],
+                actor=actor,
+                required_upstream_heads=_UPSTREAMS[codes[4]],
+            )
+        except (IndexError, KeyError, ValueError) as exc:
+            raise CandidateContractError(
+                "Candidate conformance binding differs"
+            ) from exc
+        finally:
+            if owned:
+                connection.close()
+
+    def submit(self, command: WriteCommand, *, lose_response: bool = False):
+        existing = self._row(command.record_id)
+        if existing is not None:
+            try:
+                retained_command = self._decode(str(existing[1]))
+                if retained_command != command:
+                    raise BindingConflict(command.record_id)
+                connection = sqlite3.connect(self.location.seed[1])
+                try:
+                    row = connection.execute(
+                        "SELECT admission_bytes,collision_request_bytes FROM "
+                        "story_candidate_admission_receipts_v2 WHERE version_id=?",
+                        (existing[1],),
+                    ).fetchone()
+                finally:
+                    connection.close()
+                admission = CandidateAdmission.from_canonical_bytes(bytes(row[0]))
+                collision = CurrentCollisionEligibilityRequest.from_mapping(
+                    json.loads(bytes(row[1]))
+                )
+                retained = self._opened().admit(
+                    admission.canonical_bytes,
+                    collision_request=collision,
+                    proof=_ACTOR_PROOFS[command.actor],
+                )
+            except BindingConflict:
+                raise
+            except Exception as exc:
+                raise IntegrityViolation(command.record_id) from exc
+            if lose_response:
+                raise LostResponse(command.record_id)
+            return AuthorityValue.from_command(self._decode(retained.version_id))
+        try:
+            admission, collision = _admission(self.location, command)
+            retained = self._opened().admit(
+                admission.canonical_bytes,
+                collision_request=collision,
+                proof=_ACTOR_PROOFS[command.actor],
+            )
+        except Exception as exc:
+            row = self._row(command.record_id)
+            if row is not None:
+                try:
+                    self._opened().load_version(str(row[1]))
+                except Exception as integrity_exc:
+                    raise IntegrityViolation(command.record_id) from integrity_exc
+                raise BindingConflict(command.record_id) from exc
+            if _database_was_locked(exc):
+                raise BindingConflict(command.record_id) from exc
+            if isinstance(exc, (sqlite3.OperationalError, CandidateContractError)):
+                raise BindingConflict(command.record_id) from exc
+            raise IntegrityViolation(command.record_id) from exc
+        if lose_response:
+            raise LostResponse(command.record_id)
+        return AuthorityValue.from_command(self._decode(retained.version_id))
+
+    def observe(self, record_id: str):
+        row = self._row(record_id)
+        if row is None:
+            return None
+        try:
+            self._opened().load_version(str(row[1]))
+            command = self._decode(str(row[1]))
+        except Exception as exc:
+            raise IntegrityViolation(record_id) from exc
+        return (
+            StoredAuthorityState.from_command(command)
+            if command.record_id == record_id
+            else None
+        )
+
+    def history(self):
+        connection = sqlite3.connect(self.location.seed[1])
+        try:
+            rows = connection.execute(
+                "SELECT version_id FROM story_candidate_admission_receipts_v2 "
+                "ORDER BY recorded_at,admission_digest"
+            ).fetchall()
+        finally:
+            connection.close()
+        try:
+            values = []
+            for row in rows:
+                self._opened().load_version(str(row[0]))
+                values.append(AuthorityValue.from_command(self._decode(str(row[0]))))
+            return tuple(values)
+        except Exception as exc:
+            raise IntegrityViolation("history") from exc
+
+    list_history = history
+
+    def read(self, record_id: str):
+        row = self._row(record_id)
+        if row is None:
+            raise KeyError(record_id)
+        state = self.observe(record_id)
+        if state is None:
+            raise KeyError(record_id)
+        return AuthorityValue.from_command(self._decode(str(row[1])))
+
+    def set_upstream_head(self, authority: str, value: str) -> None:
+        if value.endswith("head-1") or self._row("record-1") is None:
+            return
+        subject = self.location.subjects["record-1"]
+        connection = sqlite3.connect(self.location.seed[1], isolation_level=None)
+        try:
+            if authority == "authority":
+                fixture = (connection, *self.location.seed[0][1:])
+                proposal, dispositions = self.location.seed[7]["authority"]
+                upstream = d1._open(fixture)
+                try:
+                    upstream.retain(
+                        proposal,
+                        dispositions,
+                        proof=self.location.seed[0][3],
+                        expected_target_version=subject,
+                    )
+                finally:
+                    upstream.close()
+            elif authority == "policy":
+                item, current = self.location.seed[7]["policy"]
+                successor = replace(
+                    d1.work_item_helpers._version(item, 2), retrieval=current.retrieval
+                )
+                from newsroom.increment6.work_items import TriageWorkItemStore
+
+                TriageWorkItemStore(
+                    connection, self.location.seed[0][1]
+                ).append_version(
+                    current.version_id, current.canonical_digest, successor
+                )
+            else:
+                raise IntegrityViolation("unsupported upstream authority")
+        finally:
+            connection.close()
+
+    def current_use(self, record_id: str):
+        row = self._row(record_id)
+        if row is None:
+            raise KeyError(record_id)
+        connection = sqlite3.connect(self.location.seed[1])
+        try:
+            candidate_id = str(
+                connection.execute(
+                    "SELECT candidate_id FROM story_candidate_admission_receipts_v2 "
+                    "WHERE version_id=?",
+                    (row[1],),
+                ).fetchone()[0]
+            )
+        finally:
+            connection.close()
+        version = self.location.subjects[record_id]
+        binding = CandidateUseCollisionBinding(
+            version.hypothesis_id,
+            version.version_id,
+            version.canonical_digest,
+            CandidateUseOperation.USE_CURRENT_CANDIDATE,
+            candidate_id,
+            "candidate-development",
+            _collision_digest(version.version_id),
+            "retrieval-generation-v2",
+            QUERY_VALID,
+            SERVING,
+            42,
+        )
+        request, _ = _named_snapshot(
+            self.location, binding, occupied_candidate_id=candidate_id
+        )
+        try:
+            self._opened().current(
+                candidate_id, collision_request=request, proof=self.location.seed[0][3]
+            )
+        except Exception as exc:
+            raise IntegrityViolation(record_id) from exc
+        return AuthorityValue.from_command(self._decode(str(row[1])))
+
+    def tamper(self, record_id: str, kind: TamperKind) -> None:
+        row = self._row(record_id)
+        assert row is not None
+        connection = sqlite3.connect(self.location.seed[1], isolation_level=None)
+        connection.execute("PRAGMA foreign_keys=OFF")
+        connection.execute("PRAGMA ignore_check_constraints=ON")
+        connection.execute("DROP TRIGGER IF EXISTS immutable_candidate_receipt")
+        column, value = {
+            TamperKind.CANONICAL: ("admission_bytes", b"{}"),
+            TamperKind.SCALAR: ("version_ordinal", 7),
+            TamperKind.IDENTITY: ("semantic_scope_digest", "sha256:" + "0" * 64),
+            TamperKind.LINKED_ROW: ("disposition_ids_bytes", b"[]"),
+            TamperKind.DIGEST: ("version_digest", "sha256:" + "0" * 64),
+            TamperKind.PROVENANCE: ("actor_identity_digest", "sha256:" + "0" * 64),
+            TamperKind.OFFLINE_REWRITE: (
+                "authority_aggregate_id",
+                str(uuid.uuid4()),
+            ),
+        }[kind]
+        connection.execute(
+            f"UPDATE story_candidate_admission_receipts_v2 SET {column}=? "
+            "WHERE admission_digest=?",
+            (value, row[0]),
+        )
+        connection.close()
+
+    def rollback_scope(self, operation: Callable[[RollbackScope], None]) -> None:
+        store = self._opened()._store
+        prepared = {
+            record_id: _admission(self.location, _generic(record_id))
+            for record_id in ("record-rollback-normal", "record-rollback-abort")
+        }
+
+        class Scope:
+            def submit(_, command):
+                try:
+                    admission, collision = prepared[command.record_id]
+                except KeyError as exc:
+                    raise CandidateContractError(
+                        "unsupported rollback conformance record"
+                    ) from exc
+                if admission.request.request_id != _request_uuid(
+                    (
+                        _code(
+                            _RECORDS,
+                            (command.record_id, command.scalar_columns.get("value")),
+                            "record",
+                        ),
+                        _code(_REQUESTS, command.request, "request"),
+                        _code(_IDEMPOTENCIES, command.idempotency, "idempotency"),
+                        _code(
+                            _PREDECESSORS, command.cas_predecessor, "CAS predecessor"
+                        ),
+                        _code(_UPSTREAMS, command.required_upstream_heads, "upstream"),
+                        _code(tuple(_ACTOR_PROOFS), command.actor, "actor"),
+                    )
+                ):
+                    raise CandidateContractError("rollback command binding differs")
+                retained = transaction.admit(
+                    admission.canonical_bytes,
+                    collision_request=collision,
+                    proof=_ACTOR_PROOFS[command.actor],
+                )
+                return AuthorityValue.from_command(
+                    self._decode(retained.version_id, transaction._connection)
+                )
+
+            def observe(_, record_id):
+                row = self._row(record_id, transaction._connection)
+                if row is None:
+                    return None
+                command = self._decode(str(row[1]), transaction._connection)
+                return StoredAuthorityState.from_command(command)
+
+            def history(_):
+                rows = transaction._connection.execute(
+                    "SELECT version_id FROM story_candidate_admission_receipts_v2 "
+                    "ORDER BY recorded_at,admission_digest"
+                ).fetchall()
+                return tuple(
+                    AuthorityValue.from_command(
+                        self._decode(str(row[0]), transaction._connection)
+                    )
+                    for row in rows
+                )
+
+        def inspect(scope):
+            nonlocal transaction
+            transaction = scope
+            operation(Scope())
+
+        transaction = None
+        store.rollback_scope(inspect)
+
+    def close(self) -> None:
+        if self.authority is not None:
+            self.authority.close()
+
+
+class _Adapter:
+    name = "story-candidate-v24-real"
+    applicability: ClassVar = {
+        case: Applicability.required() for case in CASE_INVENTORY
+    }
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.snapshot = _seed_snapshot(root / "capacity-2-seed")
+
+    def create_location(self) -> _Location:
+        root = self.root / str(uuid.uuid4())
+        return _Location(self.snapshot.clone(root), root / "collision")
+
+    def open_handle(self, location: _Location, *, migrate: bool = False) -> _Handle:
+        if migrate:
+            _migrate_to_current(location.seed[1])
+        return _Handle(location)
+
+
+@pytest.mark.parametrize("case", CASE_INVENTORY, ids=lambda case: case.value)
+def test_real_candidate_store_passes_required_conformance_case(
+    tmp_path: Path, case: CaseId
+) -> None:
+    adapter = _Adapter(tmp_path)
+    assert adapter.applicability[case] == Applicability.required()
+    _SCENARIOS[case](adapter)
+
+
+@pytest.mark.parametrize("mismatch", ("operation", "current-subject-key"))
+def test_wrong_primary_collision_binding_rejects_before_candidate_producers(
+    tmp_path: Path, mismatch: str
+) -> None:
+    adapter = _Adapter(tmp_path)
+    location = adapter.create_location()
+    handle = adapter.open_handle(location)
+    command = _generic("record-1")
+    admission, collision = _admission(location, command)
+    binding = collision.binding
+    if mismatch == "operation":
+        binding = replace(
+            binding,
+            operation=CandidateUseOperation.USE_CURRENT_CANDIDATE,
+            expected_candidate_id=str(uuid.uuid4()),
+        )
+    else:
+        binding = replace(
+            binding,
+            collision_key_digest=digest("wrong-current-subject-key"),
+        )
+    divergent = replace(collision, binding=binding)
+    store = handle._opened()._store
+    producer_calls: list[object] = []
+    original = store._producers
+    store._producers = lambda *args, **kwargs: producer_calls.append((args, kwargs))
+    connection = sqlite3.connect(location.seed[1])
+    try:
+        before = connection.execute(
+            "SELECT count(*) FROM story_candidate_admission_receipts_v2"
+        ).fetchone()
+        with pytest.raises(CandidateContractError):
+            handle._opened().admit(
+                admission.canonical_bytes,
+                collision_request=divergent,
+                proof=location.seed[0][3],
+            )
+        after = connection.execute(
+            "SELECT count(*) FROM story_candidate_admission_receipts_v2"
+        ).fetchone()
+    finally:
+        store._producers = original
+        connection.close()
+        handle.close()
+    assert producer_calls == []
+    assert before == after == (0,)
+
+
+def test_retained_collision_key_rejects_different_scope_before_producers_or_effect(
+    tmp_path: Path,
+) -> None:
+    adapter = _Adapter(tmp_path)
+    location = adapter.create_location()
+    handle = adapter.open_handle(location)
+    handle.submit(_generic("record-1"))
+    row = handle._row("record-1")
+    assert row is not None
+    retained = handle._opened().load_version(str(row[1]))
+    version = location.subjects["record-2"]
+    binding = CandidateUseCollisionBinding(
+        version.hypothesis_id,
+        version.version_id,
+        version.canonical_digest,
+        CandidateUseOperation.ADMIT_NEW_CANDIDATE,
+        None,
+        retained.governing_manifest.collision_namespace,
+        retained.governing_manifest.collision_key_digest,
+        "retrieval-generation-v2",
+        QUERY_VALID,
+        SERVING,
+        42,
+    )
+    collision_request_value, collision = _named_snapshot(location, binding)
+    manifest = _manifest(location, version, collision)
+    request = CandidateAdmissionRequest(
+        str(uuid.uuid4()),
+        _actor_digest(location.seed, "actor-1"),
+        "candidate:retained-collision-key",
+        None,
+        None,
+        0,
+        manifest.semantic_scope_digest,
+        collision_request_value.request_digest,
+        manifest.governing_state_binding.canonical_digest,
+        None,
+    )
+    admission = evaluate_candidate_admission(
+        request=request,
+        manifest=manifest,
+        collision=collision,
+        current_version=None,
+        governing_state=CandidateGoverningState(
+            CandidateGoverningStateStatus.COMPLETE,
+            manifest.governing_state_binding,
+        ),
+    )
+    assert admission.reason is CandidateAdmissionReason.NEW_CANDIDATE_PRE_EFFECT
+    store = handle._opened()._store
+    producer_calls: list[object] = []
+    effect_calls: list[object] = []
+    original_producers = store._producers
+    original_provider = store._collision._current_authority_provider
+
+    def observed_producers(*args, **kwargs):
+        producer_calls.append((args, kwargs))
+        return original_producers(*args, **kwargs)
+
+    store._producers = observed_producers
+    store._collision._current_authority_provider = lambda request: (
+        effect_calls.append(request) or original_provider(request)
+    )
+    try:
+        with pytest.raises(CandidateContractError):
+            handle._opened().admit(
+                admission.canonical_bytes,
+                collision_request=collision_request_value,
+                proof=location.seed[0][3],
+            )
+    finally:
+        store._producers = original_producers
+        store._collision._current_authority_provider = original_provider
+        handle.close()
+    assert producer_calls == effect_calls == []
+    with sqlite3.connect(location.seed[1]) as connection:
+        assert connection.execute(
+            "SELECT count(*) FROM story_candidate_admission_receipts_v2"
+        ).fetchone() == (1,)
+
+
+@pytest.mark.parametrize("mismatch", ("operation", "subject", "key"))
+def test_current_rejects_wrong_collision_binding_before_producers_or_effect(
+    tmp_path: Path, mismatch: str
+) -> None:
+    adapter = _Adapter(tmp_path)
+    location = adapter.create_location()
+    handle = adapter.open_handle(location)
+    command = _generic("record-1")
+    handle.submit(command)
+    row = handle._row(command.record_id)
+    assert row is not None
+    retained = handle._opened().load_version(str(row[1]))
+    manifest = retained.governing_manifest
+    binding = CandidateUseCollisionBinding(
+        manifest.hypothesis_id,
+        manifest.hypothesis_version_id,
+        manifest.hypothesis_version_digest,
+        CandidateUseOperation.USE_CURRENT_CANDIDATE,
+        retained.candidate_id,
+        manifest.collision_namespace,
+        manifest.collision_key_digest,
+        "retrieval-generation-v2",
+        QUERY_VALID,
+        SERVING,
+        42,
+    )
+    if mismatch == "operation":
+        binding = replace(
+            binding,
+            operation=CandidateUseOperation.ADMIT_NEW_CANDIDATE,
+            expected_candidate_id=None,
+        )
+    elif mismatch == "subject":
+        other = location.subjects["record-2"]
+        binding = replace(
+            binding,
+            subject_id=other.hypothesis_id,
+            subject_version_id=other.version_id,
+            subject_version_digest=other.canonical_digest,
+        )
+    else:
+        binding = replace(binding, collision_key_digest=digest("wrong-current-key"))
+    collision_request_value, _ = _named_snapshot(
+        location, binding, occupied_candidate_id=retained.candidate_id
+    )
+    store = handle._opened()._store
+    producer_calls: list[object] = []
+    effect_calls: list[object] = []
+    original_producers = store._producers
+    original_provider = store._collision._current_authority_provider
+    store._producers = lambda *args, **kwargs: producer_calls.append((args, kwargs))
+    store._collision._current_authority_provider = lambda request: (
+        effect_calls.append(request) or original_provider(request)
+    )
+    try:
+        with pytest.raises(CandidateContractError):
+            handle._opened().current(
+                retained.candidate_id,
+                collision_request=collision_request_value,
+                proof=location.seed[0][3],
+            )
+    finally:
+        store._producers = original_producers
+        store._collision._current_authority_provider = original_provider
+        handle.close()
+    assert producer_calls == effect_calls == []
+    with sqlite3.connect(location.seed[1]) as connection:
+        assert connection.execute(
+            "SELECT count(*) FROM story_candidate_admission_receipts_v2"
+        ).fetchone() == (1,)
+
+
+def test_real_successor_commits_then_history_current_and_reopen_retain_both_versions(
+    tmp_path: Path,
+) -> None:
+    adapter = _Adapter(tmp_path)
+    location = adapter.create_location()
+    first_handle = adapter.open_handle(location)
+    first_admission, first_collision = _admission(location, _generic("record-1"))
+    first = first_handle._opened().admit(
+        first_admission.canonical_bytes,
+        collision_request=first_collision,
+        proof=location.seed[0][3],
+    )
+    first_handle.close()
+
+    previous, advanced = _advance_record_one(location)
+    assert advanced.previous_version_id == previous.version_id
+    first_manifest = first.governing_manifest
+    binding = CandidateUseCollisionBinding(
+        advanced.hypothesis_id,
+        advanced.version_id,
+        advanced.canonical_digest,
+        CandidateUseOperation.USE_CURRENT_CANDIDATE,
+        first.candidate_id,
+        first_manifest.collision_namespace,
+        first_manifest.collision_key_digest,
+        "retrieval-generation-v2",
+        QUERY_VALID,
+        SERVING,
+        42,
+    )
+    collision_request_value, collision = _named_snapshot(
+        location, binding, occupied_candidate_id=first.candidate_id
+    )
+    manifest = _manifest(location, advanced, collision)
+    request = CandidateAdmissionRequest(
+        str(uuid.uuid4()),
+        _actor_digest(location.seed, "actor-1"),
+        "candidate:successor-record-1",
+        first.version_id,
+        first.canonical_digest,
+        first.ordinal,
+        manifest.semantic_scope_digest,
+        collision_request_value.request_digest,
+        manifest.governing_state_binding.canonical_digest,
+        None,
+    )
+    admission = evaluate_candidate_admission(
+        request=request,
+        manifest=manifest,
+        collision=collision,
+        current_version=first,
+        governing_state=CandidateGoverningState(
+            CandidateGoverningStateStatus.COMPLETE,
+            manifest.governing_state_binding,
+        ),
+    )
+    assert admission.reason is CandidateAdmissionReason.SUCCESSOR_VERSION_PRE_EFFECT
+
+    second_handle = adapter.open_handle(location)
+    second = second_handle._opened().admit(
+        admission.canonical_bytes,
+        collision_request=collision_request_value,
+        proof=location.seed[0][3],
+    )
+    try:
+        assert second.ordinal == 2
+        assert second.previous_version_id == first.version_id
+        assert second_handle._opened().load_version(first.version_id) == first
+        assert second_handle._opened().versions(first.candidate_id) == (first, second)
+        assert (
+            second_handle._opened().current(
+                first.candidate_id,
+                collision_request=collision_request_value,
+                proof=location.seed[0][3],
+            )
+            == second
+        )
+    finally:
+        second_handle.close()
+
+    reopened = adapter.open_handle(location)
+    try:
+        assert reopened._opened().load_version(first.version_id) == first
+        assert reopened._opened().versions(first.candidate_id) == (first, second)
+        assert (
+            reopened._opened().current(
+                first.candidate_id,
+                collision_request=collision_request_value,
+                proof=location.seed[0][3],
+            )
+            == second
+        )
+    finally:
+        reopened.close()
+
+
+class _DefectiveAdapter(_Adapter):
+    def __init__(self, root: Path, defect: str, case: CaseId) -> None:
+        super().__init__(root)
+        self.defect = defect
+        self.applicability = {
+            item: (
+                Applicability.required()
+                if item is case
+                else Applicability.waived(
+                    reason="focused mutation sensitivity",
+                    waiver_reference="issue:401#adapter-sensitivity",
+                )
+            )
+            for item in CASE_INVENTORY
+        }
+
+    def open_handle(self, location: _Location, *, migrate: bool = False) -> _Handle:
+        handle = super().open_handle(location, migrate=migrate)
+        if self.defect == "no-store":
+            handle.submit = lambda command, **_: AuthorityValue.from_command(command)
+        elif self.defect == "bypass":
+            handle.read = lambda record_id: AuthorityValue.from_command(
+                _generic(record_id)
+            )
+        return handle
+
+
+@pytest.mark.parametrize(
+    ("defect", "case"),
+    (("no-store", CaseId.FRESH_REPLAY), ("bypass", CaseId.TAMPER_REJECTION)),
+)
+def test_conformance_sensitivity_rejects_candidate_adapter_defects(
+    tmp_path: Path, defect: str, case: CaseId
+) -> None:
+    report = run_conformance(_DefectiveAdapter(tmp_path, defect, case))
+    assert not report.passed
+    assert any(failure.case is case for failure in report.failures)

--- a/newsroom/tests/test_increment6e2_candidates.py
+++ b/newsroom/tests/test_increment6e2_candidates.py
@@ -7,7 +7,12 @@ from dataclasses import replace
 import pytest
 
 from newsroom.authority.canonical import canonical_json_bytes, digest_bytes
-from newsroom.authority.types import EventId
+from newsroom.authority.policy import (
+    CommandRegistry,
+    PayloadSchemaContract,
+    PayloadSchemaRegistry,
+)
+from newsroom.authority.types import EventId, PayloadMode
 from newsroom.discovery.record_models import DiscoverySignal, GateDecision, NewsLead
 from newsroom.discovery.types import (
     DecisionTerminality,
@@ -37,6 +42,7 @@ from newsroom.increment6.candidates import (
     build_candidate_distinct_scope_proof,
     build_candidate_governing_manifest,
     evaluate_candidate_admission,
+    merge_candidate_authority_registries,
     validate_candidate_first_version,
     validate_candidate_version_successor,
 )
@@ -62,6 +68,8 @@ from newsroom.increment6.proposals import CandidateManifestKind
 from newsroom.increment6.relationships import (
     AssessmentStatus,
     RetainedRelationshipDecisionReceipt,
+    relationship_command_definition,
+    relationship_payload_contract,
 )
 from newsroom.tests.discovery_3d_authority_helpers import exact_admission_request
 from newsroom.tests.discovery_3d_helpers import reason
@@ -84,6 +92,49 @@ from newsroom.tests.test_increment6e1_collision import _decide, _occupied_eviden
 D = "sha256:" + "1" * 64
 HYPOTHESIS_ID = "11111111-1111-4111-8111-111111111111"
 VERSION_ID = "22222222-2222-4222-8222-222222222222"
+
+
+def test_candidate_registry_merge_preserves_upstream_current_versions() -> None:
+    definition = relationship_command_definition()
+    contract = relationship_payload_contract()
+    newer_definition = replace(definition, definition_version="relationship-command-v9")
+    newer_contract = replace(contract, contract_version="relationship-contract-v9")
+    other_mode = PayloadSchemaContract(
+        contract.schema_version,
+        PayloadMode.NO_PAYLOAD,
+        "other-mode-v1",
+        "other-mode-canonicalizer-v1",
+        lambda _: b"",
+        (replace(contract.golden_vectors[0], name="other-mode", expected_bytes=b""),),
+    )
+    commands = CommandRegistry(
+        (definition, newer_definition),
+        current_versions={definition.command_type: definition.definition_version},
+    )
+    schemas = PayloadSchemaRegistry(
+        (contract, newer_contract, other_mode),
+        current_versions={
+            (contract.schema_version, contract.payload_mode): contract.contract_version,
+            (
+                other_mode.schema_version,
+                other_mode.payload_mode,
+            ): other_mode.contract_version,
+        },
+    )
+
+    merged_commands, merged_schemas = merge_candidate_authority_registries(
+        commands, schemas
+    )
+
+    assert merged_commands.resolve(definition.command_type) == definition
+    assert (
+        merged_schemas.resolve(contract.schema_version, contract.payload_mode)
+        == contract
+    )
+    assert (
+        merged_schemas.resolve(other_mode.schema_version, other_mode.payload_mode)
+        == other_mode
+    )
 
 
 def _manifest(collision, *, incomplete: bool = False) -> CandidateGoverningManifest:


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-6e2b-story-candidate-authority
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

Closes #401
Refs #366
Refs #146

## Scope

Adds the checked v24 Story Candidate admission authority: exact immutable Candidate identities and contiguous Versions, collision bindings, guarded current heads, transactional admission effects, exact replay/lost-response behaviour, and retained/current D-wave producer revalidation.

The authority uses exactly three v24 Candidate tables and one Candidate admission effect. It consumes Discovery and D1/D2/D3 authority only through reviewed transaction-aware ports, keeps historical replay before currentness, and performs fresh local CAS and retained collision-slot checks before D-wave, Disposition, Discovery and E1 reads.

## Exact revision

- Base: `b44f07628fb64de56bedc930140f4afaf12a48a5`
- Head: `08dfb60ac5fcee81e542c061c2d558149cac3946`
- Tree: `922ca28195b2a40f67cec1f2848b2e2394ca1b47`
- Product commit: `08dfb60ac5fcee81e542c061c2d558149cac3946`
- Production scope: exactly 6 files
- Production churn: 1,468 changed lines (`1,450` additions, `18` deletions)
- Migration checksum: `sha256:1eea25005483de124e0add0100f4805ed5a537852fc70916f17a209c633e0ca0`
- Schema fingerprint: `sha256:abf8430bfd676a9b0e574847cde9375d90aa1e32680725a08b30c0657d567a7c`

## Evidence

- TDD RED: a self-consistent ADMIT_NEW request for a different semantic scope reused an already-retained collision namespace/key, reached producer and E1 work, and failed only at the SQL UNIQUE constraint. The corrected local slot gate rejects before either provider and preserves the sole retained receipt.
- Candidate contract + authority: **48 passed in 36.56s**.
- Real Candidate #384 matrix, direct local-gate sensitivities and real successor: **20 passed in 176.39s**; all 11 `CASE_INVENTORY` cases required, 0 failures/errors/skips, slowest testcase **20.652s** (<75s warning and <90s hard cap).
- #395 exact migration compatibility: **49 passed in 15.10s**.
- D1/D2/D3/E1/6R dependency closure: **123 passed in 13.89s**.
- Fast CI compatibility smoke: **115 passed in 2.33s**.
- Exact committed-head source integrity, `uv lock --check`, compileall, bounded Ruff/format and `git diff --check`: passed.
- The prior `bb8adaa1` automatic SDLC attempt is superseded: its shard failures were duration hard-cap evidence, not pytest assertion failures. The capacity-2 adapter-local snapshot retains all 11 real cases while leaving the shared D3/D2 seed cache unchanged.
- Exact corrected-head [SDLC run 31632059645](https://github.com/fol2/newsroom/actions/runs/31632059645): route, source, authenticated service, all ten core shards, reducer and decision **PASS**; exact JUnit union **3,457 unique tests**, 0 failures/errors, 41 optional skips, 0 required skips; critical path **268,780ms**; every shard <300s; max testcase **82.670s** (<90s hard cap), recorded as one inherited D2 warning.
- [Independent exact-head substantive review](https://github.com/fol2/newsroom/pull/424#pullrequestreview-4920385580): **P1 0 / material P2 0**; only non-material compact-style/test-cache notes.

## Non-effects

No Feedback/Reconciliation (#402/#403), Evidence Intake, evaluation handoff, publication, provider/model, live source, credential, external request, egress, shadow, canary, service or production activation. No complete manual SDLC admission run was triggered.
