### PR TITLE
feat: add v25 evaluation feedback authority

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = ("newsroom.tests.feedback_cache_support",)

--- a/conftest.py
+++ b/conftest.py
@@ -1,1 +1,4 @@
-pytest_plugins = ("newsroom.tests.feedback_cache_support",)
+pytest_plugins = (
+    "newsroom.tests.feedback_cache_support",
+    "newsroom.tests.feedback_adapter_fastpath",
+)

--- a/newsroom/authority/evaluation_feedback_migrations.py
+++ b/newsroom/authority/evaluation_feedback_migrations.py
@@ -1,0 +1,234 @@
+"""Checked v25 Evaluation Feedback authority migration and v24 backup gate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sqlite3
+
+from . import story_candidate_migrations as predecessor
+from .canonical import digest_canonical
+
+
+EVALUATION_FEEDBACK_SCHEMA_VERSION = 25
+EVALUATION_FEEDBACK_MIGRATION_NAME = "evaluation_feedback_authority_v25"
+EVALUATION_FEEDBACK_PREDECESSOR_MIGRATION_CHECKSUM = (
+    "sha256:1eea25005483de124e0add0100f4805ed5a537852fc70916f17a209c633e0ca0"
+)
+EVALUATION_FEEDBACK_PREDECESSOR_FINGERPRINT = (
+    "sha256:abf8430bfd676a9b0e574847cde9375d90aa1e32680725a08b30c0657d567a7c"
+)
+
+EvaluationFeedbackBackupError = predecessor.StoryCandidateBackupError
+EvaluationFeedbackBackupReceipt = predecessor.StoryCandidateBackupReceipt
+EvaluationFeedbackMigrationRecord = predecessor.StoryCandidateMigrationRecord
+
+
+def evaluation_feedback_backup_paths(database: str | Path) -> tuple[Path, Path]:
+    source = Path(database)
+    backup = source.with_name(source.name + ".pre-v25.sqlite3")
+    return backup, backup.with_name(backup.name + ".sha256")
+
+
+def _checked_backup(path: Path, logical: str) -> EvaluationFeedbackBackupReceipt:
+    digest_path = path.with_name(path.name + ".sha256")
+    digest = predecessor.predecessor._file_digest(path)
+    if digest_path.read_text(encoding="ascii") != digest + "\n":
+        raise EvaluationFeedbackBackupError("backup digest differs")
+    target = sqlite3.connect(f"file:{path}?mode=ro", uri=True, isolation_level=None)
+    try:
+        if (
+            target.execute("PRAGMA user_version").fetchone()[0] != 24
+            or predecessor.predecessor._schema_fingerprint(target)
+            != EVALUATION_FEEDBACK_PREDECESSOR_FINGERPRINT
+            or predecessor.predecessor._logical_database_digest(target) != logical
+        ):
+            raise EvaluationFeedbackBackupError("backup differs from source")
+    finally:
+        target.close()
+    return EvaluationFeedbackBackupReceipt(path, digest_path, digest, logical)
+
+
+def prepare_evaluation_feedback_backup(
+    connection: sqlite3.Connection, backup_path: Path
+) -> EvaluationFeedbackBackupReceipt:
+    if (
+        connection.in_transaction
+        or connection.execute("PRAGMA user_version").fetchone()[0] != 24
+        or predecessor.predecessor._schema_fingerprint(connection)
+        != EVALUATION_FEEDBACK_PREDECESSOR_FINGERPRINT
+        or not isinstance(backup_path, Path)
+        or not backup_path.is_absolute()
+    ):
+        raise EvaluationFeedbackBackupError("backup requires checked schema v24")
+    source = Path(
+        next(row[2] for row in connection.execute("PRAGMA database_list") if row[1] == "main")
+    )
+    digest_path = backup_path.with_name(backup_path.name + ".sha256")
+    logical = predecessor.predecessor._logical_database_digest(connection)
+    if (
+        not source
+        or source.resolve() == backup_path.resolve()
+        or backup_path.exists() != digest_path.exists()
+    ):
+        raise EvaluationFeedbackBackupError("backup boundary differs")
+    if not backup_path.exists():
+        backup_path.open("xb").close()
+        target = sqlite3.connect(backup_path, isolation_level=None)
+        try:
+            connection.backup(target)
+        finally:
+            target.close()
+        digest_path.write_text(
+            predecessor.predecessor._file_digest(backup_path) + "\n", encoding="ascii"
+        )
+    receipt = _checked_backup(backup_path, logical)
+    connection.execute(
+        "CREATE TEMP TABLE IF NOT EXISTS evaluation_feedback_backup_gate("
+        "backup_path TEXT PRIMARY KEY,backup_digest TEXT NOT NULL,"
+        "logical_digest TEXT NOT NULL) STRICT"
+    )
+    connection.execute("DELETE FROM evaluation_feedback_backup_gate")
+    connection.execute(
+        "INSERT INTO evaluation_feedback_backup_gate VALUES(?,?,?)",
+        (str(backup_path), receipt.backup_digest, logical),
+    )
+    if connection.in_transaction:
+        connection.commit()
+    return receipt
+
+
+def require_evaluation_feedback_backup(
+    connection: sqlite3.Connection,
+    *,
+    expected_history: tuple[tuple[int, str, str], ...],
+) -> EvaluationFeedbackBackupReceipt:
+    try:
+        row = connection.execute(
+            "SELECT backup_path,backup_digest,logical_digest "
+            "FROM temp.evaluation_feedback_backup_gate"
+        ).fetchone()
+    except sqlite3.OperationalError as exc:
+        raise EvaluationFeedbackBackupError(
+            "v24 to v25 requires prepared backup"
+        ) from exc
+    if row is None or predecessor.predecessor._logical_database_digest(connection) != row[2]:
+        raise EvaluationFeedbackBackupError("v24 to v25 requires prepared backup")
+    receipt = _checked_backup(Path(row[0]), str(row[2]))
+    target = sqlite3.connect(
+        f"file:{receipt.backup_path}?mode=ro", uri=True, isolation_level=None
+    )
+    try:
+        history = target.execute(
+            "SELECT version,name,checksum FROM authority_migrations ORDER BY version"
+        ).fetchall()
+    finally:
+        target.close()
+    if receipt.backup_digest != row[1] or history != list(expected_history):
+        raise EvaluationFeedbackBackupError("prepared backup is not exact v24")
+    return receipt
+
+
+_D = "substr({0},1,7)='sha256:' AND length({0})=71 AND substr({0},8) NOT GLOB '*[^0-9a-f]*'"
+
+EVALUATION_FEEDBACK_MIGRATION_STATEMENTS: tuple[str, ...] = (
+    f"""CREATE TABLE evaluation_feedback(
+        feedback_id TEXT PRIMARY KEY,
+        feedback_bytes BLOB NOT NULL,
+        feedback_digest TEXT NOT NULL UNIQUE CHECK({_D.format('feedback_digest')}),
+        source_feedback_id TEXT NOT NULL,
+        handoff_id TEXT NOT NULL,
+        acknowledgement_id TEXT NOT NULL UNIQUE,
+        candidate_id TEXT NOT NULL,
+        candidate_version_id TEXT NOT NULL,
+        candidate_version_digest TEXT NOT NULL CHECK({_D.format('candidate_version_digest')}),
+        request_id TEXT NOT NULL UNIQUE,
+        actor_identity_digest TEXT NOT NULL CHECK({_D.format('actor_identity_digest')}),
+        idempotency_key TEXT NOT NULL,
+        authority_aggregate_id TEXT NOT NULL UNIQUE,
+        authority_event_id TEXT NOT NULL UNIQUE REFERENCES ledger_events(event_id),
+        authority_aggregate_version INTEGER NOT NULL CHECK(authority_aggregate_version=1),
+        acceptance_snapshot_bytes BLOB NOT NULL,
+        acceptance_snapshot_digest TEXT NOT NULL UNIQUE CHECK({_D.format('acceptance_snapshot_digest')}),
+        recorded_at TEXT NOT NULL,
+        UNIQUE(actor_identity_digest,idempotency_key),
+        UNIQUE(handoff_id),
+        UNIQUE(source_feedback_id),
+        CHECK(length(feedback_bytes)>0 AND length(acceptance_snapshot_bytes)>0)
+    ) STRICT""",
+    f"""CREATE TABLE evaluation_reconciliation_obligations(
+        obligation_id TEXT PRIMARY KEY,
+        obligation_bytes BLOB NOT NULL,
+        obligation_digest TEXT NOT NULL UNIQUE CHECK({_D.format('obligation_digest')}),
+        feedback_id TEXT NOT NULL UNIQUE REFERENCES evaluation_feedback(feedback_id),
+        feedback_digest TEXT NOT NULL CHECK({_D.format('feedback_digest')}),
+        candidate_id TEXT NOT NULL,
+        candidate_version_id TEXT NOT NULL,
+        request_id TEXT NOT NULL UNIQUE,
+        actor_identity_digest TEXT NOT NULL CHECK({_D.format('actor_identity_digest')}),
+        idempotency_key TEXT NOT NULL,
+        authority_aggregate_id TEXT NOT NULL,
+        authority_event_id TEXT NOT NULL REFERENCES ledger_events(event_id),
+        authority_aggregate_version INTEGER NOT NULL CHECK(authority_aggregate_version=1),
+        recorded_at TEXT NOT NULL,
+        UNIQUE(actor_identity_digest,idempotency_key),
+        UNIQUE(authority_event_id),
+        CHECK(length(obligation_bytes)>0)
+    ) STRICT""",
+    f"""CREATE TABLE evaluation_reconciliation_dispositions(
+        disposition_id TEXT PRIMARY KEY,
+        disposition_bytes BLOB NOT NULL,
+        disposition_digest TEXT NOT NULL UNIQUE CHECK({_D.format('disposition_digest')}),
+        obligation_id TEXT NOT NULL REFERENCES evaluation_reconciliation_obligations(obligation_id),
+        ordinal INTEGER NOT NULL CHECK(ordinal BETWEEN 1 AND 9007199254740991),
+        previous_disposition_id TEXT,
+        previous_disposition_digest TEXT CHECK(previous_disposition_digest IS NULL OR {_D.format('previous_disposition_digest')}),
+        outcome TEXT NOT NULL CHECK(outcome IN('fulfilled','blocked','unresolved')),
+        request_id TEXT NOT NULL UNIQUE,
+        actor_identity_digest TEXT NOT NULL CHECK({_D.format('actor_identity_digest')}),
+        idempotency_key TEXT NOT NULL,
+        authority_aggregate_id TEXT NOT NULL,
+        authority_event_id TEXT NOT NULL UNIQUE REFERENCES ledger_events(event_id),
+        authority_aggregate_version INTEGER NOT NULL,
+        recorded_at TEXT NOT NULL,
+        UNIQUE(obligation_id,ordinal), UNIQUE(actor_identity_digest,idempotency_key),
+        CHECK((ordinal=1 AND previous_disposition_id IS NULL AND previous_disposition_digest IS NULL)
+           OR (ordinal>1 AND previous_disposition_id IS NOT NULL AND previous_disposition_digest IS NOT NULL)),
+        CHECK(authority_aggregate_version=ordinal+1),
+        CHECK(length(disposition_bytes)>0)
+    ) STRICT""",
+    "CREATE TRIGGER immutable_evaluation_feedback BEFORE UPDATE ON evaluation_feedback BEGIN SELECT RAISE(ABORT,'immutable Evaluation Feedback'); END",
+    "CREATE TRIGGER retained_evaluation_feedback BEFORE DELETE ON evaluation_feedback BEGIN SELECT RAISE(ABORT,'retained Evaluation Feedback'); END",
+    "CREATE TRIGGER immutable_evaluation_obligation BEFORE UPDATE ON evaluation_reconciliation_obligations BEGIN SELECT RAISE(ABORT,'immutable reconciliation obligation'); END",
+    "CREATE TRIGGER retained_evaluation_obligation BEFORE DELETE ON evaluation_reconciliation_obligations BEGIN SELECT RAISE(ABORT,'retained reconciliation obligation'); END",
+    "CREATE TRIGGER immutable_evaluation_disposition BEFORE UPDATE ON evaluation_reconciliation_dispositions BEGIN SELECT RAISE(ABORT,'immutable reconciliation disposition'); END",
+    "CREATE TRIGGER retained_evaluation_disposition BEFORE DELETE ON evaluation_reconciliation_dispositions BEGIN SELECT RAISE(ABORT,'retained reconciliation disposition'); END",
+    """CREATE TRIGGER evaluation_disposition_predecessor_guard
+       BEFORE INSERT ON evaluation_reconciliation_dispositions
+       WHEN (NEW.ordinal>1 AND NOT EXISTS(
+          SELECT 1 FROM evaluation_reconciliation_dispositions p
+          WHERE p.obligation_id=NEW.obligation_id AND p.ordinal=NEW.ordinal-1
+            AND p.disposition_id=NEW.previous_disposition_id
+            AND p.disposition_digest=NEW.previous_disposition_digest))
+         OR EXISTS(SELECT 1 FROM evaluation_reconciliation_dispositions p
+          WHERE p.obligation_id=NEW.obligation_id AND p.outcome='fulfilled')
+       BEGIN SELECT RAISE(ABORT,'reconciliation disposition predecessor differs'); END""",
+)
+
+EVALUATION_FEEDBACK_MIGRATION_CHECKSUM = digest_canonical(
+    {
+        "version": EVALUATION_FEEDBACK_SCHEMA_VERSION,
+        "name": EVALUATION_FEEDBACK_MIGRATION_NAME,
+        "statements": list(EVALUATION_FEEDBACK_MIGRATION_STATEMENTS),
+    }
+)
+EVALUATION_FEEDBACK_MIGRATION = EvaluationFeedbackMigrationRecord(
+    EVALUATION_FEEDBACK_SCHEMA_VERSION,
+    EVALUATION_FEEDBACK_MIGRATION_NAME,
+    EVALUATION_FEEDBACK_MIGRATION_CHECKSUM,
+)
+
+__all__ = [
+    name
+    for name in globals()
+    if name.startswith(("EVALUATION_", "Evaluation", "evaluation_", "prepare_", "require_"))
+]

--- a/newsroom/authority/evaluation_feedback_migrations.py
+++ b/newsroom/authority/evaluation_feedback_migrations.py
@@ -1,14 +1,12 @@
 """Checked v25 Evaluation Feedback authority migration and v24 backup gate."""
 
+# fmt: off
+# ruff: noqa: I001
 from __future__ import annotations
-
-from pathlib import Path
 import sqlite3
-
+from pathlib import Path
 from . import story_candidate_migrations as predecessor
 from .canonical import digest_canonical
-
-
 EVALUATION_FEEDBACK_SCHEMA_VERSION = 25
 EVALUATION_FEEDBACK_MIGRATION_NAME = "evaluation_feedback_authority_v25"
 EVALUATION_FEEDBACK_PREDECESSOR_MIGRATION_CHECKSUM = (
@@ -17,18 +15,13 @@ EVALUATION_FEEDBACK_PREDECESSOR_MIGRATION_CHECKSUM = (
 EVALUATION_FEEDBACK_PREDECESSOR_FINGERPRINT = (
     "sha256:abf8430bfd676a9b0e574847cde9375d90aa1e32680725a08b30c0657d567a7c"
 )
-
 EvaluationFeedbackBackupError = predecessor.StoryCandidateBackupError
 EvaluationFeedbackBackupReceipt = predecessor.StoryCandidateBackupReceipt
 EvaluationFeedbackMigrationRecord = predecessor.StoryCandidateMigrationRecord
-
-
 def evaluation_feedback_backup_paths(database: str | Path) -> tuple[Path, Path]:
     source = Path(database)
     backup = source.with_name(source.name + ".pre-v25.sqlite3")
     return backup, backup.with_name(backup.name + ".sha256")
-
-
 def _checked_backup(path: Path, logical: str) -> EvaluationFeedbackBackupReceipt:
     digest_path = path.with_name(path.name + ".sha256")
     digest = predecessor.predecessor._file_digest(path)
@@ -46,8 +39,6 @@ def _checked_backup(path: Path, logical: str) -> EvaluationFeedbackBackupReceipt
     finally:
         target.close()
     return EvaluationFeedbackBackupReceipt(path, digest_path, digest, logical)
-
-
 def prepare_evaluation_feedback_backup(
     connection: sqlite3.Connection, backup_path: Path
 ) -> EvaluationFeedbackBackupReceipt:
@@ -95,8 +86,6 @@ def prepare_evaluation_feedback_backup(
     if connection.in_transaction:
         connection.commit()
     return receipt
-
-
 def require_evaluation_feedback_backup(
     connection: sqlite3.Connection,
     *,
@@ -126,10 +115,7 @@ def require_evaluation_feedback_backup(
     if receipt.backup_digest != row[1] or history != list(expected_history):
         raise EvaluationFeedbackBackupError("prepared backup is not exact v24")
     return receipt
-
-
 _D = "substr({0},1,7)='sha256:' AND length({0})=71 AND substr({0},8) NOT GLOB '*[^0-9a-f]*'"
-
 EVALUATION_FEEDBACK_MIGRATION_STATEMENTS: tuple[str, ...] = (
     f"""CREATE TABLE evaluation_feedback(
         feedback_id TEXT PRIMARY KEY,
@@ -213,7 +199,6 @@ EVALUATION_FEEDBACK_MIGRATION_STATEMENTS: tuple[str, ...] = (
           WHERE p.obligation_id=NEW.obligation_id AND p.outcome='fulfilled')
        BEGIN SELECT RAISE(ABORT,'reconciliation disposition predecessor differs'); END""",
 )
-
 EVALUATION_FEEDBACK_MIGRATION_CHECKSUM = digest_canonical(
     {
         "version": EVALUATION_FEEDBACK_SCHEMA_VERSION,
@@ -226,9 +211,9 @@ EVALUATION_FEEDBACK_MIGRATION = EvaluationFeedbackMigrationRecord(
     EVALUATION_FEEDBACK_MIGRATION_NAME,
     EVALUATION_FEEDBACK_MIGRATION_CHECKSUM,
 )
-
 __all__ = [
     name
     for name in globals()
     if name.startswith(("EVALUATION_", "Evaluation", "evaluation_", "prepare_", "require_"))
 ]
+# fmt: on

--- a/newsroom/authority/evaluation_feedback_system.py
+++ b/newsroom/authority/evaluation_feedback_system.py
@@ -1,0 +1,716 @@
+"""Server-owned v25 Evaluation Feedback and reconciliation composition root."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import json
+from pathlib import Path
+import sqlite3
+import threading
+
+from newsroom.authority._capability import _CapabilityIssuer
+from newsroom.authority._event_store import _EventAuthorityStore
+from newsroom.authority.canonical import canonical_json_bytes, digest_bytes
+from newsroom.authority.models import InlinePayload, SemanticCommand
+from newsroom.authority.policy import CommandRegistry, PayloadSchemaRegistry
+from newsroom.authority.service import CommandService
+from newsroom.authority.story_candidate_system import _create_story_candidate_read_port
+from newsroom.authority.types import AggregateId, UtcTimestamp
+from newsroom.increment6.candidates import StoryCandidateReadPort
+from newsroom.increment6.candidates import merge_candidate_authority_registries
+from newsroom.increment6.feedback import (
+    EvaluationFeedback,
+    EvaluationFeedbackAcceptance,
+    EvaluationFeedbackAuthority,
+    FeedbackContractError,
+    FeedbackCorrelationOutcome,
+    HandoffAcceptanceSnapshot,
+    ReconciliationDisposition,
+    ReconciliationObligation,
+    _compose_evaluation_feedback_authority,
+    append_reconciliation_disposition,
+    correlate_evaluation_feedback,
+    create_reconciliation_obligation,
+    merge_evaluation_feedback_authority_registries,
+    validate_reconciliation_history,
+)
+from newsroom.increment6.handoffs import (
+    EvaluationHandoffReadPort,
+    _create_evaluation_handoff_read_port,
+)
+from newsroom.increment6.lineage import merge_lineage_authority_registries
+from newsroom.increment6.relationships import merge_relationship_authority_registries
+
+
+_V25_TABLES = {
+    "evaluation_feedback",
+    "evaluation_reconciliation_obligations",
+    "evaluation_reconciliation_dispositions",
+}
+
+
+class _EvaluationFeedbackAuthorityRoot:
+    """Own the only v25 writer and its single checked SQLite connection."""
+
+    def __init__(
+        self,
+        event_store: _EventAuthorityStore,
+        service: CommandService,
+        candidate_port: StoryCandidateReadPort,
+        handoff_port: EvaluationHandoffReadPort,
+        clock: Callable[[], UtcTimestamp],
+    ) -> None:
+        self._event_store = event_store
+        self._connection = event_store._connection
+        self._service = service
+        self._candidate = candidate_port
+        self._handoff = handoff_port
+        self._clock = clock
+        self._lock = threading.RLock()
+        self._closed = False
+        self._connection.execute("BEGIN IMMEDIATE")
+        try:
+            self._verify_local()
+            self._candidate.verify_retained_integrity_in_transaction()
+            self._handoff.verify_retained_integrity_in_transaction()
+            self._connection.execute("COMMIT")
+        except BaseException:
+            if self._connection.in_transaction:
+                self._connection.execute("ROLLBACK")
+            raise
+
+    def _require_open(self) -> None:
+        if self._closed:
+            raise FeedbackContractError("Feedback authority is closed")
+
+    def _begin(self) -> None:
+        self._require_open()
+        if self._connection.in_transaction:
+            raise FeedbackContractError("Feedback transaction ownership differs")
+        self._connection.execute("BEGIN IMMEDIATE")
+
+    def _recorded_at(self) -> str:
+        value = self._clock()
+        if type(value) is not UtcTimestamp:
+            raise FeedbackContractError("Feedback clock returned a forged timestamp")
+        return value.to_text()
+
+    def _verify_schema(self) -> None:
+        rows = self._connection.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'evaluation_%'"
+        ).fetchall()
+        names = {str(row[0]) for row in rows}
+        # v17 Handoff tables are deliberately outside this atom.
+        if names - {
+            "evaluation_handoffs",
+            "evaluation_handoff_attempts",
+            "evaluation_handoff_acknowledgements",
+        } != _V25_TABLES:
+            raise FeedbackContractError("Feedback retained table allocation differs")
+        required_triggers = {
+            "immutable_evaluation_feedback",
+            "retained_evaluation_feedback",
+            "immutable_evaluation_obligation",
+            "retained_evaluation_obligation",
+            "immutable_evaluation_disposition",
+            "retained_evaluation_disposition",
+            "evaluation_disposition_predecessor_guard",
+        }
+        actual = {
+            str(row[0])
+            for row in self._connection.execute(
+                "SELECT name FROM sqlite_master WHERE type='trigger' AND "
+                "(tbl_name='evaluation_feedback' OR tbl_name LIKE 'evaluation_reconciliation_%')"
+            )
+        }
+        if actual != required_triggers:
+            raise FeedbackContractError("Feedback retained schema objects differ")
+
+    def _feedback_rows(self) -> dict[str, EvaluationFeedbackAcceptance]:
+        feedback_rows = self._connection.execute(
+            "SELECT * FROM evaluation_feedback ORDER BY feedback_id"
+        ).fetchall()
+        obligation_rows = self._connection.execute(
+            "SELECT * FROM evaluation_reconciliation_obligations ORDER BY obligation_id"
+        ).fetchall()
+        obligations: dict[str, ReconciliationObligation] = {}
+        for row in obligation_rows:
+            value = ReconciliationObligation.from_canonical_bytes(bytes(row[1]))
+            if (
+                tuple(row[0:11])
+                != (
+                    value.obligation_id,
+                    value.canonical_bytes,
+                    value.canonical_digest,
+                    value.feedback_id,
+                    value.feedback_digest,
+                    value.candidate_id,
+                    value.candidate_version_id,
+                    value.request_id,
+                    value.actor_identity_digest,
+                    value.idempotency_key,
+                    row[10],
+                )
+            ):
+                raise FeedbackContractError("retained obligation representation differs")
+            if value.feedback_id in obligations:
+                raise FeedbackContractError("retained obligation cardinality differs")
+            obligations[value.feedback_id] = value
+        result: dict[str, EvaluationFeedbackAcceptance] = {}
+        for row in feedback_rows:
+            feedback = EvaluationFeedback.from_canonical_bytes(bytes(row[1]))
+            snapshot = HandoffAcceptanceSnapshot.from_canonical_bytes(bytes(row[15]))
+            if (
+                tuple(row[0:12])
+                != (
+                    feedback.feedback_id,
+                    feedback.canonical_bytes,
+                    feedback.canonical_digest,
+                    feedback.source_feedback_id,
+                    feedback.handoff_id,
+                    feedback.acknowledgement_id,
+                    feedback.candidate_id,
+                    feedback.candidate_version_id,
+                    feedback.candidate_version_digest,
+                    feedback.request_id,
+                    feedback.actor_identity_digest,
+                    feedback.idempotency_key,
+                )
+                or int(row[14]) != 1
+                or bytes(row[15]) != snapshot.canonical_bytes
+                or str(row[16]) != snapshot.canonical_digest
+                or snapshot.handoff_id != feedback.handoff_id
+                or snapshot.candidate_version_id != feedback.candidate_version_id
+                or snapshot.governing_manifest_digest != feedback.governing_manifest_digest
+                or snapshot.sink_id != feedback.sink_id
+                or not any(
+                    attempt.attempt_id == feedback.handoff_attempt_id
+                    and attempt.attempt_number == feedback.handoff_attempt_number
+                    and attempt.sent
+                    for attempt in snapshot.attempts
+                )
+                or not any(
+                    acknowledgement.acknowledgement_id == feedback.acknowledgement_id
+                    and acknowledgement.attempt_id == feedback.handoff_attempt_id
+                    and acknowledgement.response_digest
+                    == feedback.acknowledgement_response_digest
+                    and acknowledgement.candidate_version_id
+                    == feedback.candidate_version_id
+                    and acknowledgement.governing_manifest_digest
+                    == feedback.governing_manifest_digest
+                    and acknowledgement.sink_id == feedback.sink_id
+                    for acknowledgement in snapshot.acknowledgements
+                )
+            ):
+                raise FeedbackContractError("retained feedback representation differs")
+            obligation = obligations.pop(feedback.feedback_id, None)
+            if obligation is None or obligation.feedback_digest != feedback.canonical_digest:
+                raise FeedbackContractError("mandatory reconciliation obligation differs")
+            obligation_row = next(
+                item for item in obligation_rows if str(item[0]) == obligation.obligation_id
+            )
+            if (
+                str(obligation_row[10]) != str(row[12])
+                or str(obligation_row[11]) != str(row[13])
+                or int(obligation_row[12]) != 1
+            ):
+                raise FeedbackContractError("obligation authority event binding differs")
+            payload = self._ledger_payload(
+                str(row[12]), str(row[13]), 1
+            )
+            if payload != self._payload(
+                "accept",
+                feedback=feedback,
+                obligation=obligation,
+                snapshot=snapshot,
+                disposition=None,
+            ):
+                raise FeedbackContractError("feedback authority payload differs")
+            result[feedback.feedback_id] = EvaluationFeedbackAcceptance(
+                feedback, obligation, snapshot
+            )
+        if obligations:
+            raise FeedbackContractError("orphan reconciliation obligation")
+        return result
+
+    def _history(
+        self, obligation: ReconciliationObligation
+    ) -> tuple[ReconciliationDisposition, ...]:
+        rows = self._connection.execute(
+            "SELECT * FROM evaluation_reconciliation_dispositions "
+            "WHERE obligation_id=? ORDER BY ordinal",
+            (obligation.obligation_id,),
+        ).fetchall()
+        values: list[ReconciliationDisposition] = []
+        for row in rows:
+            value = ReconciliationDisposition.from_canonical_bytes(bytes(row[1]))
+            if tuple(row[0:11]) != (
+                value.disposition_id,
+                value.canonical_bytes,
+                value.canonical_digest,
+                value.obligation_id,
+                value.ordinal,
+                value.previous_disposition_id,
+                value.previous_disposition_digest,
+                value.outcome.value,
+                value.request_id,
+                value.actor_identity_digest,
+                value.idempotency_key,
+            ):
+                raise FeedbackContractError("retained disposition representation differs")
+            acceptance = self._connection.execute(
+                "SELECT authority_aggregate_id FROM evaluation_feedback WHERE feedback_id=?",
+                (obligation.feedback_id,),
+            ).fetchone()
+            if (
+                acceptance is None
+                or str(row[11]) != str(acceptance[0])
+                or int(row[13]) != value.ordinal + 1
+                or self._ledger_payload(str(row[11]), str(row[12]), int(row[13]))
+                != self._payload(
+                    "append_disposition",
+                    feedback=None,
+                    obligation=None,
+                    snapshot=None,
+                    disposition=value,
+                )
+            ):
+                raise FeedbackContractError("disposition authority event binding differs")
+            values.append(value)
+        return validate_reconciliation_history(obligation, tuple(values))
+
+    def _ledger_payload(
+        self, aggregate_id: str, event_id: str, aggregate_version: int
+    ) -> dict[str, object]:
+        row = self._connection.execute(
+            "SELECT p.payload_bytes,e.aggregate_type,e.aggregate_id,e.aggregate_version,"
+            "c.aggregate_type,c.aggregate_id,v.aggregate_version,g.current_version "
+            "FROM ledger_events e JOIN authority_commands c ON c.command_id=e.command_id "
+            "JOIN authority_payloads p ON p.payload_id=e.payload_id "
+            "JOIN authority_aggregate_versions v ON v.command_id=c.command_id "
+            "JOIN authority_aggregates g ON g.aggregate_type=v.aggregate_type "
+            "AND g.aggregate_id=v.aggregate_id WHERE e.event_id=?",
+            (event_id,),
+        ).fetchone()
+        if row is None or tuple(row[1:7]) != (
+            "evaluation_reconciliation",
+            aggregate_id,
+            aggregate_version,
+            "evaluation_reconciliation",
+            aggregate_id,
+            aggregate_version,
+        ) or int(row[7]) < aggregate_version:
+            raise FeedbackContractError("Feedback generic ledger binding differs")
+        try:
+            value = json.loads(bytes(row[0]))
+        except Exception as exc:
+            raise FeedbackContractError("Feedback authority payload is malformed") from exc
+        if type(value) is not dict:
+            raise FeedbackContractError("Feedback authority payload differs")
+        return value
+
+    def _verify_local(self) -> dict[str, EvaluationFeedbackAcceptance]:
+        self._event_store._validate_schema_and_integrity()
+        self._verify_schema()
+        accepted = self._feedback_rows()
+        obligations = {item.obligation.obligation_id: item.obligation for item in accepted.values()}
+        for obligation in obligations.values():
+            self._history(obligation)
+        count = self._connection.execute(
+            "SELECT COUNT(*) FROM evaluation_reconciliation_dispositions"
+        ).fetchone()[0]
+        if count != sum(len(self._history(item)) for item in obligations.values()):
+            raise FeedbackContractError("orphan reconciliation disposition")
+        if self._connection.execute("PRAGMA foreign_key_check").fetchone() is not None:
+            raise FeedbackContractError("Feedback foreign keys differ")
+        return accepted
+
+    @staticmethod
+    def _payload(
+        operation: str,
+        *,
+        feedback: EvaluationFeedback | None,
+        obligation: ReconciliationObligation | None,
+        snapshot: HandoffAcceptanceSnapshot | None,
+        disposition: ReconciliationDisposition | None,
+    ) -> dict[str, object]:
+        return {
+            "operation": operation,
+            "feedback": None if feedback is None else json.loads(feedback.canonical_bytes),
+            "obligation": None if obligation is None else json.loads(obligation.canonical_bytes),
+            "handoff_acceptance_snapshot": (
+                None if snapshot is None else json.loads(snapshot.canonical_bytes)
+            ),
+            "disposition": (
+                None if disposition is None else json.loads(disposition.canonical_bytes)
+            ),
+        }
+
+    @staticmethod
+    def _actor(grant: object) -> str:
+        authentication = grant.authentication
+        return digest_bytes(
+            canonical_json_bytes(
+                {
+                    "principal_id": authentication.principal_id,
+                    "credential_binding_digest": authentication.credential_binding_digest,
+                }
+            )
+        )
+
+    def _grant(
+        self,
+        *,
+        aggregate_id: str,
+        expected_version: int,
+        idempotency_key: str,
+        payload: dict[str, object],
+        proof: object,
+    ):
+        command = SemanticCommand(
+            command_type="evaluation-feedback.reconcile",
+            aggregate_id=AggregateId.parse(aggregate_id),
+            expected_aggregate_version=expected_version,
+            payload=InlinePayload(payload),
+            idempotency_key=idempotency_key,
+        )
+        return self._service._authorize_for_commit(command, proof=proof)
+
+    @staticmethod
+    def _find_collision(
+        accepted: dict[str, EvaluationFeedbackAcceptance], feedback: EvaluationFeedback
+    ) -> EvaluationFeedbackAcceptance | None:
+        for item in accepted.values():
+            old = item.feedback
+            if old.feedback_id == feedback.feedback_id:
+                if old.canonical_bytes == feedback.canonical_bytes:
+                    return item
+                raise FeedbackContractError("feedback identity binding conflict")
+            if (
+                old.request_id == feedback.request_id
+                or (old.actor_identity_digest, old.idempotency_key)
+                == (feedback.actor_identity_digest, feedback.idempotency_key)
+                or old.handoff_id == feedback.handoff_id
+                or old.acknowledgement_id == feedback.acknowledgement_id
+            ):
+                raise FeedbackContractError("feedback request binding conflict")
+        return None
+
+    def _current_correlation(
+        self, feedback: EvaluationFeedback, *, candidate_proof: object
+    ) -> tuple[object, object, FeedbackCorrelationOutcome]:
+        version = self._candidate.require_retained_version_in_transaction(
+            feedback.candidate_version_id
+        )
+        current = self._candidate.require_current_head_in_transaction(
+            feedback.candidate_id, proof=candidate_proof
+        )
+        if current.version_id != version.version_id:
+            raise FeedbackContractError("fresh feedback requires current Candidate head")
+        handoff = self._handoff.require_retained_handoff_in_transaction(feedback.handoff_id)
+        outcome = correlate_evaluation_feedback(handoff, version, feedback, ())
+        return version, handoff, outcome
+
+    def accept(
+        self, feedback_bytes: bytes, obligation_bytes: bytes, *, candidate_proof: object
+    ) -> EvaluationFeedbackAcceptance:
+        feedback = EvaluationFeedback.from_canonical_bytes(feedback_bytes)
+        obligation = ReconciliationObligation.from_canonical_bytes(obligation_bytes)
+        with self._lock:
+            self._begin()
+            try:
+                accepted = self._verify_local()
+                replay = self._find_collision(accepted, feedback)
+                if replay is not None:
+                    if replay.obligation.canonical_bytes != obligation.canonical_bytes:
+                        raise FeedbackContractError("obligation replay binding conflict")
+                    self._connection.execute("COMMIT")
+                    return replay
+                expected = create_reconciliation_obligation(
+                    feedback,
+                    request_id=obligation.request_id,
+                    actor_identity_digest=obligation.actor_identity_digest,
+                    idempotency_key=obligation.idempotency_key,
+                )
+                if expected.canonical_bytes != obligation.canonical_bytes:
+                    raise FeedbackContractError("mandatory obligation derivation differs")
+                if obligation.actor_identity_digest != feedback.actor_identity_digest:
+                    raise FeedbackContractError("feedback and obligation actor differ")
+                _, handoff, outcome = self._current_correlation(
+                    feedback, candidate_proof=candidate_proof
+                )
+                if outcome not in {
+                    FeedbackCorrelationOutcome.READY,
+                    FeedbackCorrelationOutcome.DELAYED_READY,
+                }:
+                    raise FeedbackContractError(f"feedback correlation is {outcome.value}")
+                snapshot = HandoffAcceptanceSnapshot.observe(handoff)
+                recorded_at = self._recorded_at()
+                aggregate_id = str(AggregateId.new())
+                payload = self._payload(
+                    "accept",
+                    feedback=feedback,
+                    obligation=obligation,
+                    snapshot=snapshot,
+                    disposition=None,
+                )
+                grant = self._grant(
+                    aggregate_id=aggregate_id,
+                    expected_version=0,
+                    idempotency_key=feedback.idempotency_key,
+                    payload=payload,
+                    proof=candidate_proof,
+                )
+                if self._actor(grant) != feedback.actor_identity_digest:
+                    raise FeedbackContractError("authenticated feedback actor differs")
+                committed = self._event_store._commit_grant_in_transaction(
+                    self._connection, grant, recorded_at=recorded_at
+                )
+                if committed.replayed or committed.aggregate_version != 1:
+                    raise FeedbackContractError("fresh feedback command replayed")
+                self._connection.execute(
+                    "INSERT INTO evaluation_feedback VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                    (
+                        feedback.feedback_id, feedback.canonical_bytes, feedback.canonical_digest,
+                        feedback.source_feedback_id, feedback.handoff_id,
+                        feedback.acknowledgement_id, feedback.candidate_id,
+                        feedback.candidate_version_id, feedback.candidate_version_digest,
+                        feedback.request_id, feedback.actor_identity_digest, feedback.idempotency_key,
+                        aggregate_id, committed.event_id, committed.aggregate_version,
+                        snapshot.canonical_bytes, snapshot.canonical_digest, recorded_at,
+                    ),
+                )
+                self._connection.execute(
+                    "INSERT INTO evaluation_reconciliation_obligations VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                    (
+                        obligation.obligation_id, obligation.canonical_bytes,
+                        obligation.canonical_digest, obligation.feedback_id,
+                        obligation.feedback_digest, obligation.candidate_id,
+                        obligation.candidate_version_id, obligation.request_id,
+                        obligation.actor_identity_digest, obligation.idempotency_key,
+                        aggregate_id, committed.event_id, committed.aggregate_version, recorded_at,
+                    ),
+                )
+                result = self._verify_local()[feedback.feedback_id]
+                self._candidate.verify_retained_integrity_in_transaction()
+                self._handoff.verify_retained_integrity_in_transaction()
+                self._connection.execute("COMMIT")
+                return result
+            except BaseException:
+                if self._connection.in_transaction:
+                    self._connection.execute("ROLLBACK")
+                raise
+
+    def append_disposition(
+        self, disposition_bytes: bytes, *, candidate_proof: object
+    ) -> ReconciliationDisposition:
+        proposed = ReconciliationDisposition.from_canonical_bytes(disposition_bytes)
+        with self._lock:
+            self._begin()
+            try:
+                accepted = self._verify_local()
+                parent = next(
+                    (item for item in accepted.values() if item.obligation.obligation_id == proposed.obligation_id),
+                    None,
+                )
+                if parent is None:
+                    raise FeedbackContractError("unknown reconciliation obligation")
+                history = self._history(parent.obligation)
+                retained_dispositions = tuple(
+                    ReconciliationDisposition.from_canonical_bytes(bytes(row[0]))
+                    for row in self._connection.execute(
+                        "SELECT disposition_bytes FROM evaluation_reconciliation_dispositions "
+                        "ORDER BY obligation_id,ordinal"
+                    )
+                )
+                for old in retained_dispositions:
+                    if old.disposition_id == proposed.disposition_id or old.request_id == proposed.request_id or (
+                        old.actor_identity_digest, old.idempotency_key
+                    ) == (proposed.actor_identity_digest, proposed.idempotency_key):
+                        if old.canonical_bytes == proposed.canonical_bytes:
+                            self._connection.execute("COMMIT")
+                            return old
+                        raise FeedbackContractError("disposition request binding conflict")
+                rebuilt = append_reconciliation_disposition(
+                    parent.obligation,
+                    history,
+                    outcome=proposed.outcome,
+                    reason=proposed.reason,
+                    resolution_digest=proposed.resolution_digest,
+                    request_id=proposed.request_id,
+                    actor_identity_digest=proposed.actor_identity_digest,
+                    idempotency_key=proposed.idempotency_key,
+                    expected_current_disposition_id=proposed.expected_current_disposition_id,
+                    expected_current_disposition_digest=proposed.expected_current_disposition_digest,
+                    expected_current_ordinal=proposed.expected_current_ordinal,
+                    supplemental_reentry=proposed.supplemental_reentry,
+                )
+                if rebuilt.canonical_bytes != proposed.canonical_bytes:
+                    raise FeedbackContractError("disposition derivation differs")
+                _, _, outcome = self._current_correlation(
+                    parent.feedback, candidate_proof=candidate_proof
+                )
+                if outcome not in {
+                    FeedbackCorrelationOutcome.READY,
+                    FeedbackCorrelationOutcome.DELAYED_READY,
+                }:
+                    raise FeedbackContractError(f"current feedback correlation is {outcome.value}")
+                aggregate_row = self._connection.execute(
+                    "SELECT authority_aggregate_id FROM evaluation_feedback WHERE feedback_id=?",
+                    (parent.feedback.feedback_id,),
+                ).fetchone()
+                if aggregate_row is None:
+                    raise FeedbackContractError("feedback aggregate binding is absent")
+                aggregate_id = str(aggregate_row[0])
+                recorded_at = self._recorded_at()
+                grant = self._grant(
+                    aggregate_id=aggregate_id,
+                    expected_version=proposed.ordinal,
+                    idempotency_key=proposed.idempotency_key,
+                    payload=self._payload(
+                        "append_disposition",
+                        feedback=None,
+                        obligation=None,
+                        snapshot=None,
+                        disposition=proposed,
+                    ),
+                    proof=candidate_proof,
+                )
+                if self._actor(grant) != proposed.actor_identity_digest:
+                    raise FeedbackContractError("authenticated disposition actor differs")
+                committed = self._event_store._commit_grant_in_transaction(
+                    self._connection, grant, recorded_at=recorded_at
+                )
+                if committed.replayed or committed.aggregate_version != proposed.ordinal + 1:
+                    raise FeedbackContractError("fresh disposition command replayed")
+                self._connection.execute(
+                    "INSERT INTO evaluation_reconciliation_dispositions VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                    (
+                        proposed.disposition_id, proposed.canonical_bytes,
+                        proposed.canonical_digest, proposed.obligation_id, proposed.ordinal,
+                        proposed.previous_disposition_id, proposed.previous_disposition_digest,
+                        proposed.outcome.value, proposed.request_id,
+                        proposed.actor_identity_digest, proposed.idempotency_key,
+                        aggregate_id, committed.event_id, committed.aggregate_version,
+                        recorded_at,
+                    ),
+                )
+                self._verify_local()
+                self._candidate.verify_retained_integrity_in_transaction()
+                self._handoff.verify_retained_integrity_in_transaction()
+                self._connection.execute("COMMIT")
+                return proposed
+            except BaseException:
+                if self._connection.in_transaction:
+                    self._connection.execute("ROLLBACK")
+                raise
+
+    def load(self, feedback_id: str) -> EvaluationFeedbackAcceptance:
+        with self._lock:
+            self._begin()
+            try:
+                result = self._verify_local().get(feedback_id)
+                if result is None:
+                    raise FeedbackContractError("unknown Evaluation Feedback")
+                self._connection.execute("COMMIT")
+                return result
+            except BaseException:
+                if self._connection.in_transaction:
+                    self._connection.execute("ROLLBACK")
+                raise
+
+    def dispositions(self, obligation_id: str) -> tuple[ReconciliationDisposition, ...]:
+        with self._lock:
+            self._begin()
+            try:
+                accepted = self._verify_local()
+                obligation = next(
+                    (item.obligation for item in accepted.values() if item.obligation.obligation_id == obligation_id),
+                    None,
+                )
+                if obligation is None:
+                    raise FeedbackContractError("unknown reconciliation obligation")
+                result = self._history(obligation)
+                self._connection.execute("COMMIT")
+                return result
+            except BaseException:
+                if self._connection.in_transaction:
+                    self._connection.execute("ROLLBACK")
+                raise
+
+    def close(self) -> None:
+        with self._lock:
+            if not self._closed:
+                if self._connection.in_transaction:
+                    self._connection.execute("ROLLBACK")
+                self._event_store.close()
+                self._closed = True
+
+
+def open_evaluation_feedback_authority_system(
+    database: str | Path,
+    *,
+    retrieval_authority: object,
+    authenticator: object,
+    authorizer: object,
+    command_registry: CommandRegistry,
+    payload_schemas: PayloadSchemaRegistry,
+    clock: Callable[[], UtcTimestamp] = UtcTimestamp.now,
+    busy_timeout_ms: int = 5_000,
+) -> EvaluationFeedbackAuthority:
+    """Open the sole v25 writer with both reviewed #426 ports on one connection."""
+    relationship_commands, relationship_schemas = merge_relationship_authority_registries(
+        command_registry, payload_schemas
+    )
+    lineage_commands, lineage_schemas = merge_lineage_authority_registries(
+        relationship_commands, relationship_schemas
+    )
+    candidate_commands, candidate_schemas = merge_candidate_authority_registries(
+        lineage_commands, lineage_schemas
+    )
+    commands, schemas = merge_evaluation_feedback_authority_registries(
+        candidate_commands, candidate_schemas
+    )
+    issuer = _CapabilityIssuer(command_registry=commands, payload_schemas=schemas)
+    event_store = _EventAuthorityStore(
+        Path(database),
+        issuer=issuer,
+        command_registry=commands,
+        payload_schemas=schemas,
+        command_service_version="increment6-feedback-v25",
+        busy_timeout_ms=busy_timeout_ms,
+        clock=clock,
+    )
+    connection = event_store._connection
+    try:
+        candidate = _create_story_candidate_read_port(
+            connection,
+            retrieval_authority=retrieval_authority,  # type: ignore[arg-type]
+            authenticator=authenticator,
+            command_registry=commands,
+            payload_schemas=schemas,
+            clock=clock,
+        )
+        handoff = _create_evaluation_handoff_read_port(connection)
+        service = CommandService(
+            registry=commands,
+            payload_schemas=schemas,
+            authenticator=authenticator,
+            authorizer=authorizer,
+            committed_lookup=event_store,
+            clock=clock,
+            _issuer=issuer,
+        )
+        root = _EvaluationFeedbackAuthorityRoot(
+            event_store, service, candidate, handoff, clock
+        )
+        facade = _compose_evaluation_feedback_authority(root)
+        if type(facade) is not EvaluationFeedbackAuthority:
+            raise FeedbackContractError("Feedback facade composition differs")
+        return facade
+    except BaseException:
+        event_store.close()
+        raise
+
+
+__all__ = ["open_evaluation_feedback_authority_system"]

--- a/newsroom/authority/evaluation_feedback_system.py
+++ b/newsroom/authority/evaluation_feedback_system.py
@@ -1,57 +1,32 @@
 """Server-owned v25 Evaluation Feedback and reconciliation composition root."""
 
+# fmt: off
+# ruff: noqa: I001
 from __future__ import annotations
-
-from collections.abc import Callable
 import json
-from pathlib import Path
-import sqlite3
 import threading
-
+from collections.abc import Callable
+from pathlib import Path
 from newsroom.authority._capability import _CapabilityIssuer
 from newsroom.authority._event_store import _EventAuthorityStore
-from newsroom.authority.canonical import canonical_json_bytes, digest_bytes
+from newsroom.authority.canonical import canonical_json_bytes, digest_bytes, digest_canonical
 from newsroom.authority.models import InlinePayload, SemanticCommand
 from newsroom.authority.policy import CommandRegistry, PayloadSchemaRegistry
 from newsroom.authority.service import CommandService
 from newsroom.authority.story_candidate_system import _create_story_candidate_read_port
 from newsroom.authority.types import AggregateId, UtcTimestamp
-from newsroom.increment6.candidates import StoryCandidateReadPort
-from newsroom.increment6.candidates import merge_candidate_authority_registries
-from newsroom.increment6.feedback import (
-    EvaluationFeedback,
-    EvaluationFeedbackAcceptance,
-    EvaluationFeedbackAuthority,
-    FeedbackContractError,
-    FeedbackCorrelationOutcome,
-    HandoffAcceptanceSnapshot,
-    ReconciliationDisposition,
-    ReconciliationObligation,
-    _compose_evaluation_feedback_authority,
-    append_reconciliation_disposition,
-    correlate_evaluation_feedback,
-    create_reconciliation_obligation,
-    merge_evaluation_feedback_authority_registries,
-    validate_reconciliation_history,
-)
-from newsroom.increment6.handoffs import (
-    EvaluationHandoffReadPort,
-    _create_evaluation_handoff_read_port,
-)
+from newsroom.increment6.candidates import StoryCandidateReadPort, merge_candidate_authority_registries
+from newsroom.increment6.feedback import EvaluationFeedback, EvaluationFeedbackAcceptance, EvaluationFeedbackAuthority, FeedbackContractError, FeedbackCorrelationOutcome, HandoffAcceptanceSnapshot, ReconciliationDisposition, ReconciliationObligation, _compose_evaluation_feedback_authority, append_reconciliation_disposition, correlate_evaluation_feedback, create_reconciliation_obligation, evaluation_feedback_command_definition, merge_evaluation_feedback_authority_registries, validate_reconciliation_history
+from newsroom.increment6.handoffs import EvaluationHandoffReadPort, _create_evaluation_handoff_read_port
 from newsroom.increment6.lineage import merge_lineage_authority_registries
 from newsroom.increment6.relationships import merge_relationship_authority_registries
-
-
 _V25_TABLES = {
     "evaluation_feedback",
     "evaluation_reconciliation_obligations",
     "evaluation_reconciliation_dispositions",
 }
-
-
 class _EvaluationFeedbackAuthorityRoot:
     """Own the only v25 writer and its single checked SQLite connection."""
-
     def __init__(
         self,
         event_store: _EventAuthorityStore,
@@ -68,33 +43,33 @@ class _EvaluationFeedbackAuthorityRoot:
         self._clock = clock
         self._lock = threading.RLock()
         self._closed = False
-        self._connection.execute("BEGIN IMMEDIATE")
-        try:
-            self._verify_local()
-            self._candidate.verify_retained_integrity_in_transaction()
-            self._handoff.verify_retained_integrity_in_transaction()
-            self._connection.execute("COMMIT")
-        except BaseException:
-            if self._connection.in_transaction:
-                self._connection.execute("ROLLBACK")
-            raise
-
+        self._run(self._verify_local)
     def _require_open(self) -> None:
         if self._closed:
             raise FeedbackContractError("Feedback authority is closed")
-
     def _begin(self) -> None:
         self._require_open()
         if self._connection.in_transaction:
             raise FeedbackContractError("Feedback transaction ownership differs")
         self._connection.execute("BEGIN IMMEDIATE")
-
+    def _run(self, operation: Callable[[], object], *, commit: bool = True) -> object:
+        with self._lock:
+            self._begin()
+            try:
+                result = operation()
+                self._candidate.verify_retained_integrity_in_transaction()
+                self._handoff.verify_retained_integrity_in_transaction()
+                if commit:
+                    self._connection.execute("COMMIT")
+                return result
+            finally:
+                if self._connection.in_transaction:
+                    self._connection.execute("ROLLBACK")
     def _recorded_at(self) -> str:
         value = self._clock()
         if type(value) is not UtcTimestamp:
             raise FeedbackContractError("Feedback clock returned a forged timestamp")
         return value.to_text()
-
     def _verify_schema(self) -> None:
         rows = self._connection.execute(
             "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'evaluation_%'"
@@ -125,7 +100,6 @@ class _EvaluationFeedbackAuthorityRoot:
         }
         if actual != required_triggers:
             raise FeedbackContractError("Feedback retained schema objects differ")
-
     def _feedback_rows(self) -> dict[str, EvaluationFeedbackAcceptance]:
         feedback_rows = self._connection.execute(
             "SELECT * FROM evaluation_feedback ORDER BY feedback_id"
@@ -213,10 +187,14 @@ class _EvaluationFeedbackAuthorityRoot:
                 str(obligation_row[10]) != str(row[12])
                 or str(obligation_row[11]) != str(row[13])
                 or int(obligation_row[12]) != 1
+                or str(obligation_row[13]) != str(row[17])
             ):
                 raise FeedbackContractError("obligation authority event binding differs")
             payload = self._ledger_payload(
-                str(row[12]), str(row[13]), 1
+                str(row[12]), str(row[13]), 1,
+                actor=feedback.actor_identity_digest,
+                idempotency_key=feedback.idempotency_key,
+                recorded_at=str(row[17]),
             )
             if payload != self._payload(
                 "accept",
@@ -232,7 +210,6 @@ class _EvaluationFeedbackAuthorityRoot:
         if obligations:
             raise FeedbackContractError("orphan reconciliation obligation")
         return result
-
     def _history(
         self, obligation: ReconciliationObligation
     ) -> tuple[ReconciliationDisposition, ...]:
@@ -266,7 +243,12 @@ class _EvaluationFeedbackAuthorityRoot:
                 acceptance is None
                 or str(row[11]) != str(acceptance[0])
                 or int(row[13]) != value.ordinal + 1
-                or self._ledger_payload(str(row[11]), str(row[12]), int(row[13]))
+                or self._ledger_payload(
+                    str(row[11]), str(row[12]), int(row[13]),
+                    actor=value.actor_identity_digest,
+                    idempotency_key=value.idempotency_key,
+                    recorded_at=str(row[14]),
+                )
                 != self._payload(
                     "append_disposition",
                     feedback=None,
@@ -278,18 +260,42 @@ class _EvaluationFeedbackAuthorityRoot:
                 raise FeedbackContractError("disposition authority event binding differs")
             values.append(value)
         return validate_reconciliation_history(obligation, tuple(values))
-
     def _ledger_payload(
-        self, aggregate_id: str, event_id: str, aggregate_version: int
+        self,
+        aggregate_id: str,
+        event_id: str,
+        aggregate_version: int,
+        *,
+        actor: str,
+        idempotency_key: str,
+        recorded_at: str,
     ) -> dict[str, object]:
+        definition = evaluation_feedback_command_definition()
         row = self._connection.execute(
             "SELECT p.payload_bytes,e.aggregate_type,e.aggregate_id,e.aggregate_version,"
-            "c.aggregate_type,c.aggregate_id,v.aggregate_version,g.current_version "
+            "c.aggregate_type,c.aggregate_id,v.aggregate_version,g.current_version,"
+            "c.command_type,c.command_definition_version,c.command_definition_digest,c.expected_aggregate_version,"
+            "c.idempotency_key,c.committed_at,c.producer_version,"
+            "e.event_type,e.event_schema_version,e.producer_version,e.recorded_at,"
+            "e.payload_mode,e.payload_schema_version,e.payload_schema_contract_version,"
+            "e.payload_schema_contract_digest,e.payload_canonicalizer_version,"
+            "e.security_scope,e.retention_scope,e.trust_scope,"
+            "v.recorded_at,p.created_at,au.recorded_at,"
+            "a.principal_id,a.credential_binding_digest,"
+            "c.authentication_context_id,c.authorization_request_digest,c.authorization_decision_id,"
+            "e.authentication_context_id,e.authorization_request_digest,e.authorization_decision_id,"
+            "au.authentication_context_id,au.authorization_request_digest,au.authorization_decision_id,"
+            "au.event_type,au.detail_digest,r.operation_type,r.required_scope,d.allowed,d.effective_scopes "
             "FROM ledger_events e JOIN authority_commands c ON c.command_id=e.command_id "
             "JOIN authority_payloads p ON p.payload_id=e.payload_id "
             "JOIN authority_aggregate_versions v ON v.command_id=c.command_id "
             "JOIN authority_aggregates g ON g.aggregate_type=v.aggregate_type "
-            "AND g.aggregate_id=v.aggregate_id WHERE e.event_id=?",
+            "AND g.aggregate_id=v.aggregate_id "
+            "JOIN authority_audit_events au ON au.command_id=c.command_id "
+            "JOIN authentication_contexts a ON a.authentication_context_id=c.authentication_context_id "
+            "JOIN authorization_requests r ON r.request_digest=c.authorization_request_digest "
+            "JOIN authorization_decisions d ON d.authorization_decision_id=c.authorization_decision_id "
+            "WHERE e.event_id=?",
             (event_id,),
         ).fetchone()
         if row is None or tuple(row[1:7]) != (
@@ -301,30 +307,149 @@ class _EvaluationFeedbackAuthorityRoot:
             aggregate_version,
         ) or int(row[7]) < aggregate_version:
             raise FeedbackContractError("Feedback generic ledger binding differs")
+        contract = self._event_store._payload_schemas.resolve_exact(
+            definition.payload_schema_version,
+            definition.payload_mode,
+            definition.payload_schema_contract_version,
+            definition.payload_schema_contract_digest,
+            definition.payload_canonicalizer_version,
+        )
+        route = (
+            definition.command_type,
+            definition.definition_version,
+            definition.digest,
+            aggregate_version - 1,
+            idempotency_key,
+            recorded_at,
+            "increment6-feedback-v25",
+            definition.event_type,
+            definition.event_schema_version,
+            "increment6-feedback-v25",
+            recorded_at,
+            definition.payload_mode.value,
+            contract.schema_version,
+            contract.contract_version,
+            contract.contract_digest,
+            contract.canonicalizer_implementation_version,
+            definition.security_scope,
+            definition.retention_scope,
+            definition.trust_scope.value,
+            recorded_at,
+            recorded_at,
+            recorded_at,
+        )
+        if tuple(row[8:30]) != route or digest_bytes(
+            canonical_json_bytes(
+                {
+                    "principal_id": str(row[30]),
+                    "credential_binding_digest": str(row[31]),
+                }
+            )
+        ) != actor:
+            raise FeedbackContractError("Feedback authority route binding differs")
+        command_triple = tuple(row[32:35])
+        if (
+            command_triple != tuple(row[35:38])
+            or command_triple != tuple(row[38:41])
+            or row[41] != definition.event_type
+            or row[43] != f"command:{definition.command_type}"
+            or row[44] != definition.required_scope
+            or row[45] != 1
+            or definition.required_scope not in json.loads(bytes(row[46]))
+        ):
+            raise FeedbackContractError("Feedback authorization envelope differs")
         try:
             value = json.loads(bytes(row[0]))
         except Exception as exc:
             raise FeedbackContractError("Feedback authority payload is malformed") from exc
         if type(value) is not dict:
             raise FeedbackContractError("Feedback authority payload differs")
+        payload_digest = digest_bytes(bytes(row[0]))
+        envelope = self._connection.execute(
+            "SELECT c.idempotency_namespace,c.stable_semantic_request_digest,a.canonical_digest,"
+            "r.canonical_record_digest,d.canonical_digest,e.correlation_id,au.detail_digest,v.trust_scope "
+            "FROM ledger_events e JOIN authority_commands c ON c.command_id=e.command_id "
+            "JOIN authority_aggregate_versions v ON v.command_id=c.command_id "
+            "JOIN authentication_contexts a ON a.authentication_context_id=c.authentication_context_id "
+            "JOIN authorization_requests r ON r.request_digest=c.authorization_request_digest "
+            "JOIN authorization_decisions d ON d.authorization_decision_id=c.authorization_decision_id "
+            "JOIN authority_audit_events au ON au.command_id=c.command_id WHERE e.event_id=?",
+            (event_id,),
+        ).fetchone()
+        payload_identity = {
+            "kind": definition.payload_mode.value, "schema_version": contract.schema_version,
+            "schema_contract_version": contract.contract_version,
+            "schema_contract_digest": contract.contract_digest,
+            "canonicalizer_version": contract.canonicalizer_implementation_version,
+            "digest": payload_digest, "inline_digest": payload_digest,
+            "object_admission_id": None, "blob_digest": None, "object_class": None, "allowed_use": None,
+        }
+        stable = digest_canonical({"command_type": definition.command_type,
+            "command_definition_version": definition.definition_version, "command_definition_digest": definition.digest,
+            "aggregate_type": definition.aggregate_type, "aggregate_id": aggregate_id,
+            "expected_aggregate_version": aggregate_version - 1, "payload": payload_identity})
+        unsigned = {"operation": "COMMAND_COMMIT", "command_type": definition.command_type,
+            "aggregate_id": aggregate_id, "expected_aggregate_version": aggregate_version - 1,
+            "definition_digest": definition.digest, "definition_version": definition.definition_version,
+            "payload": payload_identity, "authentication_context_digest": envelope[2],
+            "authorization_request_record_digest": envelope[3], "authorization_request_digest": command_triple[1],
+            "authorization_decision_digest": envelope[4], "idempotency_namespace": envelope[0],
+            "idempotency_key": idempotency_key, "stable_semantic_request_digest": stable,
+            "correlation_id": envelope[5], "causation_kind": None, "causation_identifier": None,
+            "causation_external_system": None, "replay_of_command_id": None}
+        if (envelope[1] != stable or envelope[6] != digest_canonical(unsigned)
+            or envelope[7] != definition.trust_scope.value):
+            raise FeedbackContractError("Feedback audit envelope differs")
         return value
-
     def _verify_local(self) -> dict[str, EvaluationFeedbackAcceptance]:
         self._event_store._validate_schema_and_integrity()
         self._verify_schema()
         accepted = self._feedback_rows()
         obligations = {item.obligation.obligation_id: item.obligation for item in accepted.values()}
-        for obligation in obligations.values():
-            self._history(obligation)
+        event_ids: set[str] = set()
+        for item in accepted.values():
+            history = self._history(item.obligation)
+            row = self._connection.execute(
+                "SELECT authority_aggregate_id,authority_event_id FROM evaluation_feedback "
+                "WHERE feedback_id=?",
+                (item.feedback.feedback_id,),
+            ).fetchone()
+            if row is None:
+                raise FeedbackContractError("feedback aggregate binding is absent")
+            current = self._connection.execute(
+                "SELECT current_version FROM authority_aggregates WHERE "
+                "aggregate_type='evaluation_reconciliation' AND aggregate_id=?",
+                (row[0],),
+            ).fetchone()
+            if current is None or tuple(current) != (1 + len(history),):
+                raise FeedbackContractError("Feedback aggregate head differs")
+            event_ids.add(str(row[1]))
+            event_ids.update(
+                str(event[0])
+                for event in self._connection.execute(
+                    "SELECT authority_event_id FROM evaluation_reconciliation_dispositions "
+                    "WHERE obligation_id=?",
+                    (item.obligation.obligation_id,),
+                )
+            )
         count = self._connection.execute(
             "SELECT COUNT(*) FROM evaluation_reconciliation_dispositions"
         ).fetchone()[0]
         if count != sum(len(self._history(item)) for item in obligations.values()):
             raise FeedbackContractError("orphan reconciliation disposition")
+        generic_event_ids = {
+            str(row[0])
+            for row in self._connection.execute(
+                "SELECT e.event_id FROM ledger_events e JOIN authority_commands c "
+                "ON c.command_id=e.command_id WHERE "
+                "c.command_type='evaluation-feedback.reconcile'"
+            )
+        }
+        if generic_event_ids != event_ids:
+            raise FeedbackContractError("Feedback generic event coverage differs")
         if self._connection.execute("PRAGMA foreign_key_check").fetchone() is not None:
             raise FeedbackContractError("Feedback foreign keys differ")
         return accepted
-
     @staticmethod
     def _payload(
         operation: str,
@@ -345,7 +470,6 @@ class _EvaluationFeedbackAuthorityRoot:
                 None if disposition is None else json.loads(disposition.canonical_bytes)
             ),
         }
-
     @staticmethod
     def _actor(grant: object) -> str:
         authentication = grant.authentication
@@ -357,7 +481,6 @@ class _EvaluationFeedbackAuthorityRoot:
                 }
             )
         )
-
     def _grant(
         self,
         *,
@@ -375,7 +498,6 @@ class _EvaluationFeedbackAuthorityRoot:
             idempotency_key=idempotency_key,
         )
         return self._service._authorize_for_commit(command, proof=proof)
-
     @staticmethod
     def _find_collision(
         accepted: dict[str, EvaluationFeedbackAcceptance], feedback: EvaluationFeedback
@@ -395,7 +517,6 @@ class _EvaluationFeedbackAuthorityRoot:
             ):
                 raise FeedbackContractError("feedback request binding conflict")
         return None
-
     def _current_correlation(
         self, feedback: EvaluationFeedback, *, candidate_proof: object
     ) -> tuple[object, object, FeedbackCorrelationOutcome]:
@@ -410,234 +531,216 @@ class _EvaluationFeedbackAuthorityRoot:
         handoff = self._handoff.require_retained_handoff_in_transaction(feedback.handoff_id)
         outcome = correlate_evaluation_feedback(handoff, version, feedback, ())
         return version, handoff, outcome
-
+    def _accept_active(
+        self,
+        feedback: EvaluationFeedback,
+        obligation: ReconciliationObligation,
+        candidate_proof: object,
+    ) -> EvaluationFeedbackAcceptance:
+        accepted = self._verify_local()
+        replay = self._find_collision(accepted, feedback)
+        if replay is not None:
+            if replay.obligation.canonical_bytes != obligation.canonical_bytes:
+                raise FeedbackContractError("obligation replay binding conflict")
+            return replay
+        expected = create_reconciliation_obligation(
+            feedback,
+            request_id=obligation.request_id,
+            actor_identity_digest=obligation.actor_identity_digest,
+            idempotency_key=obligation.idempotency_key,
+        )
+        if expected.canonical_bytes != obligation.canonical_bytes:
+            raise FeedbackContractError("mandatory obligation derivation differs")
+        if obligation.actor_identity_digest != feedback.actor_identity_digest:
+            raise FeedbackContractError("feedback and obligation actor differ")
+        _, handoff, outcome = self._current_correlation(
+            feedback, candidate_proof=candidate_proof
+        )
+        if outcome not in {
+            FeedbackCorrelationOutcome.READY,
+            FeedbackCorrelationOutcome.DELAYED_READY,
+        }:
+            raise FeedbackContractError(f"feedback correlation is {outcome.value}")
+        snapshot = HandoffAcceptanceSnapshot.observe(handoff)
+        recorded_at = self._recorded_at()
+        aggregate_id = str(AggregateId.new())
+        payload = self._payload(
+            "accept",
+            feedback=feedback,
+            obligation=obligation,
+            snapshot=snapshot,
+            disposition=None,
+        )
+        grant = self._grant(
+            aggregate_id=aggregate_id,
+            expected_version=0,
+            idempotency_key=feedback.idempotency_key,
+            payload=payload,
+            proof=candidate_proof,
+        )
+        if self._actor(grant) != feedback.actor_identity_digest:
+            raise FeedbackContractError("authenticated feedback actor differs")
+        committed = self._event_store._commit_grant_in_transaction(
+            self._connection, grant, recorded_at=recorded_at
+        )
+        if committed.replayed or committed.aggregate_version != 1:
+            raise FeedbackContractError("fresh feedback command replayed")
+        self._connection.execute(
+            "INSERT INTO evaluation_feedback VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+            (
+                feedback.feedback_id, feedback.canonical_bytes, feedback.canonical_digest,
+                feedback.source_feedback_id, feedback.handoff_id,
+                feedback.acknowledgement_id, feedback.candidate_id,
+                feedback.candidate_version_id, feedback.candidate_version_digest,
+                feedback.request_id, feedback.actor_identity_digest, feedback.idempotency_key,
+                aggregate_id, committed.event_id, committed.aggregate_version,
+                snapshot.canonical_bytes, snapshot.canonical_digest, recorded_at,
+            ),
+        )
+        self._connection.execute(
+            "INSERT INTO evaluation_reconciliation_obligations VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+            (
+                obligation.obligation_id, obligation.canonical_bytes,
+                obligation.canonical_digest, obligation.feedback_id,
+                obligation.feedback_digest, obligation.candidate_id,
+                obligation.candidate_version_id, obligation.request_id,
+                obligation.actor_identity_digest, obligation.idempotency_key,
+                aggregate_id, committed.event_id, committed.aggregate_version, recorded_at,
+            ),
+        )
+        result = self._verify_local()[feedback.feedback_id]
+        return result
     def accept(
         self, feedback_bytes: bytes, obligation_bytes: bytes, *, candidate_proof: object
     ) -> EvaluationFeedbackAcceptance:
         feedback = EvaluationFeedback.from_canonical_bytes(feedback_bytes)
         obligation = ReconciliationObligation.from_canonical_bytes(obligation_bytes)
-        with self._lock:
-            self._begin()
-            try:
-                accepted = self._verify_local()
-                replay = self._find_collision(accepted, feedback)
-                if replay is not None:
-                    if replay.obligation.canonical_bytes != obligation.canonical_bytes:
-                        raise FeedbackContractError("obligation replay binding conflict")
-                    self._connection.execute("COMMIT")
-                    return replay
-                expected = create_reconciliation_obligation(
-                    feedback,
-                    request_id=obligation.request_id,
-                    actor_identity_digest=obligation.actor_identity_digest,
-                    idempotency_key=obligation.idempotency_key,
-                )
-                if expected.canonical_bytes != obligation.canonical_bytes:
-                    raise FeedbackContractError("mandatory obligation derivation differs")
-                if obligation.actor_identity_digest != feedback.actor_identity_digest:
-                    raise FeedbackContractError("feedback and obligation actor differ")
-                _, handoff, outcome = self._current_correlation(
-                    feedback, candidate_proof=candidate_proof
-                )
-                if outcome not in {
-                    FeedbackCorrelationOutcome.READY,
-                    FeedbackCorrelationOutcome.DELAYED_READY,
-                }:
-                    raise FeedbackContractError(f"feedback correlation is {outcome.value}")
-                snapshot = HandoffAcceptanceSnapshot.observe(handoff)
-                recorded_at = self._recorded_at()
-                aggregate_id = str(AggregateId.new())
-                payload = self._payload(
-                    "accept",
-                    feedback=feedback,
-                    obligation=obligation,
-                    snapshot=snapshot,
-                    disposition=None,
-                )
-                grant = self._grant(
-                    aggregate_id=aggregate_id,
-                    expected_version=0,
-                    idempotency_key=feedback.idempotency_key,
-                    payload=payload,
-                    proof=candidate_proof,
-                )
-                if self._actor(grant) != feedback.actor_identity_digest:
-                    raise FeedbackContractError("authenticated feedback actor differs")
-                committed = self._event_store._commit_grant_in_transaction(
-                    self._connection, grant, recorded_at=recorded_at
-                )
-                if committed.replayed or committed.aggregate_version != 1:
-                    raise FeedbackContractError("fresh feedback command replayed")
-                self._connection.execute(
-                    "INSERT INTO evaluation_feedback VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
-                    (
-                        feedback.feedback_id, feedback.canonical_bytes, feedback.canonical_digest,
-                        feedback.source_feedback_id, feedback.handoff_id,
-                        feedback.acknowledgement_id, feedback.candidate_id,
-                        feedback.candidate_version_id, feedback.candidate_version_digest,
-                        feedback.request_id, feedback.actor_identity_digest, feedback.idempotency_key,
-                        aggregate_id, committed.event_id, committed.aggregate_version,
-                        snapshot.canonical_bytes, snapshot.canonical_digest, recorded_at,
-                    ),
-                )
-                self._connection.execute(
-                    "INSERT INTO evaluation_reconciliation_obligations VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
-                    (
-                        obligation.obligation_id, obligation.canonical_bytes,
-                        obligation.canonical_digest, obligation.feedback_id,
-                        obligation.feedback_digest, obligation.candidate_id,
-                        obligation.candidate_version_id, obligation.request_id,
-                        obligation.actor_identity_digest, obligation.idempotency_key,
-                        aggregate_id, committed.event_id, committed.aggregate_version, recorded_at,
-                    ),
-                )
-                result = self._verify_local()[feedback.feedback_id]
-                self._candidate.verify_retained_integrity_in_transaction()
-                self._handoff.verify_retained_integrity_in_transaction()
-                self._connection.execute("COMMIT")
-                return result
-            except BaseException:
-                if self._connection.in_transaction:
-                    self._connection.execute("ROLLBACK")
-                raise
-
+        return self._run(
+            lambda: self._accept_active(feedback, obligation, candidate_proof)
+        )  # type: ignore[return-value]
+    def _append_active(
+        self, proposed: ReconciliationDisposition, candidate_proof: object
+    ) -> ReconciliationDisposition:
+        accepted = self._verify_local()
+        parent = next(
+            (item for item in accepted.values() if item.obligation.obligation_id == proposed.obligation_id),
+            None,
+        )
+        if parent is None:
+            raise FeedbackContractError("unknown reconciliation obligation")
+        history = self._history(parent.obligation)
+        retained_dispositions = tuple(
+            ReconciliationDisposition.from_canonical_bytes(bytes(row[0]))
+            for row in self._connection.execute(
+                "SELECT disposition_bytes FROM evaluation_reconciliation_dispositions "
+                "ORDER BY obligation_id,ordinal"
+            )
+        )
+        for old in retained_dispositions:
+            if old.disposition_id == proposed.disposition_id or old.request_id == proposed.request_id or (
+                old.actor_identity_digest, old.idempotency_key
+            ) == (proposed.actor_identity_digest, proposed.idempotency_key):
+                if old.canonical_bytes == proposed.canonical_bytes:
+                    return old
+                raise FeedbackContractError("disposition request binding conflict")
+        rebuilt = append_reconciliation_disposition(
+            parent.obligation,
+            history,
+            outcome=proposed.outcome,
+            reason=proposed.reason,
+            resolution_digest=proposed.resolution_digest,
+            request_id=proposed.request_id,
+            actor_identity_digest=proposed.actor_identity_digest,
+            idempotency_key=proposed.idempotency_key,
+            expected_current_disposition_id=proposed.expected_current_disposition_id,
+            expected_current_disposition_digest=proposed.expected_current_disposition_digest,
+            expected_current_ordinal=proposed.expected_current_ordinal,
+            supplemental_reentry=proposed.supplemental_reentry,
+        )
+        if rebuilt.canonical_bytes != proposed.canonical_bytes:
+            raise FeedbackContractError("disposition derivation differs")
+        _, _, outcome = self._current_correlation(
+            parent.feedback, candidate_proof=candidate_proof
+        )
+        if outcome not in {
+            FeedbackCorrelationOutcome.READY,
+            FeedbackCorrelationOutcome.DELAYED_READY,
+        }:
+            raise FeedbackContractError(f"current feedback correlation is {outcome.value}")
+        aggregate_row = self._connection.execute(
+            "SELECT authority_aggregate_id FROM evaluation_feedback WHERE feedback_id=?",
+            (parent.feedback.feedback_id,),
+        ).fetchone()
+        if aggregate_row is None:
+            raise FeedbackContractError("feedback aggregate binding is absent")
+        aggregate_id = str(aggregate_row[0])
+        recorded_at = self._recorded_at()
+        grant = self._grant(
+            aggregate_id=aggregate_id,
+            expected_version=proposed.ordinal,
+            idempotency_key=proposed.idempotency_key,
+            payload=self._payload(
+                "append_disposition",
+                feedback=None,
+                obligation=None,
+                snapshot=None,
+                disposition=proposed,
+            ),
+            proof=candidate_proof,
+        )
+        if self._actor(grant) != proposed.actor_identity_digest:
+            raise FeedbackContractError("authenticated disposition actor differs")
+        committed = self._event_store._commit_grant_in_transaction(
+            self._connection, grant, recorded_at=recorded_at
+        )
+        if committed.replayed or committed.aggregate_version != proposed.ordinal + 1:
+            raise FeedbackContractError("fresh disposition command replayed")
+        self._connection.execute(
+            "INSERT INTO evaluation_reconciliation_dispositions VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+            (
+                proposed.disposition_id, proposed.canonical_bytes,
+                proposed.canonical_digest, proposed.obligation_id, proposed.ordinal,
+                proposed.previous_disposition_id, proposed.previous_disposition_digest,
+                proposed.outcome.value, proposed.request_id,
+                proposed.actor_identity_digest, proposed.idempotency_key,
+                aggregate_id, committed.event_id, committed.aggregate_version,
+                recorded_at,
+            ),
+        )
+        self._verify_local()
+        return proposed
     def append_disposition(
         self, disposition_bytes: bytes, *, candidate_proof: object
     ) -> ReconciliationDisposition:
         proposed = ReconciliationDisposition.from_canonical_bytes(disposition_bytes)
-        with self._lock:
-            self._begin()
-            try:
-                accepted = self._verify_local()
-                parent = next(
-                    (item for item in accepted.values() if item.obligation.obligation_id == proposed.obligation_id),
-                    None,
-                )
-                if parent is None:
-                    raise FeedbackContractError("unknown reconciliation obligation")
-                history = self._history(parent.obligation)
-                retained_dispositions = tuple(
-                    ReconciliationDisposition.from_canonical_bytes(bytes(row[0]))
-                    for row in self._connection.execute(
-                        "SELECT disposition_bytes FROM evaluation_reconciliation_dispositions "
-                        "ORDER BY obligation_id,ordinal"
-                    )
-                )
-                for old in retained_dispositions:
-                    if old.disposition_id == proposed.disposition_id or old.request_id == proposed.request_id or (
-                        old.actor_identity_digest, old.idempotency_key
-                    ) == (proposed.actor_identity_digest, proposed.idempotency_key):
-                        if old.canonical_bytes == proposed.canonical_bytes:
-                            self._connection.execute("COMMIT")
-                            return old
-                        raise FeedbackContractError("disposition request binding conflict")
-                rebuilt = append_reconciliation_disposition(
-                    parent.obligation,
-                    history,
-                    outcome=proposed.outcome,
-                    reason=proposed.reason,
-                    resolution_digest=proposed.resolution_digest,
-                    request_id=proposed.request_id,
-                    actor_identity_digest=proposed.actor_identity_digest,
-                    idempotency_key=proposed.idempotency_key,
-                    expected_current_disposition_id=proposed.expected_current_disposition_id,
-                    expected_current_disposition_digest=proposed.expected_current_disposition_digest,
-                    expected_current_ordinal=proposed.expected_current_ordinal,
-                    supplemental_reentry=proposed.supplemental_reentry,
-                )
-                if rebuilt.canonical_bytes != proposed.canonical_bytes:
-                    raise FeedbackContractError("disposition derivation differs")
-                _, _, outcome = self._current_correlation(
-                    parent.feedback, candidate_proof=candidate_proof
-                )
-                if outcome not in {
-                    FeedbackCorrelationOutcome.READY,
-                    FeedbackCorrelationOutcome.DELAYED_READY,
-                }:
-                    raise FeedbackContractError(f"current feedback correlation is {outcome.value}")
-                aggregate_row = self._connection.execute(
-                    "SELECT authority_aggregate_id FROM evaluation_feedback WHERE feedback_id=?",
-                    (parent.feedback.feedback_id,),
-                ).fetchone()
-                if aggregate_row is None:
-                    raise FeedbackContractError("feedback aggregate binding is absent")
-                aggregate_id = str(aggregate_row[0])
-                recorded_at = self._recorded_at()
-                grant = self._grant(
-                    aggregate_id=aggregate_id,
-                    expected_version=proposed.ordinal,
-                    idempotency_key=proposed.idempotency_key,
-                    payload=self._payload(
-                        "append_disposition",
-                        feedback=None,
-                        obligation=None,
-                        snapshot=None,
-                        disposition=proposed,
-                    ),
-                    proof=candidate_proof,
-                )
-                if self._actor(grant) != proposed.actor_identity_digest:
-                    raise FeedbackContractError("authenticated disposition actor differs")
-                committed = self._event_store._commit_grant_in_transaction(
-                    self._connection, grant, recorded_at=recorded_at
-                )
-                if committed.replayed or committed.aggregate_version != proposed.ordinal + 1:
-                    raise FeedbackContractError("fresh disposition command replayed")
-                self._connection.execute(
-                    "INSERT INTO evaluation_reconciliation_dispositions VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
-                    (
-                        proposed.disposition_id, proposed.canonical_bytes,
-                        proposed.canonical_digest, proposed.obligation_id, proposed.ordinal,
-                        proposed.previous_disposition_id, proposed.previous_disposition_digest,
-                        proposed.outcome.value, proposed.request_id,
-                        proposed.actor_identity_digest, proposed.idempotency_key,
-                        aggregate_id, committed.event_id, committed.aggregate_version,
-                        recorded_at,
-                    ),
-                )
-                self._verify_local()
-                self._candidate.verify_retained_integrity_in_transaction()
-                self._handoff.verify_retained_integrity_in_transaction()
-                self._connection.execute("COMMIT")
-                return proposed
-            except BaseException:
-                if self._connection.in_transaction:
-                    self._connection.execute("ROLLBACK")
-                raise
-
+        return self._run(
+            lambda: self._append_active(proposed, candidate_proof)
+        )  # type: ignore[return-value]
+    def _load_active(self, feedback_id: str) -> EvaluationFeedbackAcceptance:
+        result = self._verify_local().get(feedback_id)
+        if result is None:
+            raise FeedbackContractError("unknown Evaluation Feedback")
+        return result
     def load(self, feedback_id: str) -> EvaluationFeedbackAcceptance:
-        with self._lock:
-            self._begin()
-            try:
-                result = self._verify_local().get(feedback_id)
-                if result is None:
-                    raise FeedbackContractError("unknown Evaluation Feedback")
-                self._connection.execute("COMMIT")
-                return result
-            except BaseException:
-                if self._connection.in_transaction:
-                    self._connection.execute("ROLLBACK")
-                raise
-
+        return self._run(lambda: self._load_active(feedback_id))  # type: ignore[return-value]
+    def _dispositions_active(
+        self, obligation_id: str
+    ) -> tuple[ReconciliationDisposition, ...]:
+        accepted = self._verify_local()
+        obligation = next(
+            (item.obligation for item in accepted.values() if item.obligation.obligation_id == obligation_id),
+            None,
+        )
+        if obligation is None:
+            raise FeedbackContractError("unknown reconciliation obligation")
+        result = self._history(obligation)
+        return result
     def dispositions(self, obligation_id: str) -> tuple[ReconciliationDisposition, ...]:
-        with self._lock:
-            self._begin()
-            try:
-                accepted = self._verify_local()
-                obligation = next(
-                    (item.obligation for item in accepted.values() if item.obligation.obligation_id == obligation_id),
-                    None,
-                )
-                if obligation is None:
-                    raise FeedbackContractError("unknown reconciliation obligation")
-                result = self._history(obligation)
-                self._connection.execute("COMMIT")
-                return result
-            except BaseException:
-                if self._connection.in_transaction:
-                    self._connection.execute("ROLLBACK")
-                raise
-
+        return self._run(
+            lambda: self._dispositions_active(obligation_id)
+        )  # type: ignore[return-value]
+    def rollback_scope(self, operation: Callable[[object], None]) -> None:
+        self._run(lambda: operation(_EvaluationFeedbackTransactionView(self)), commit=False)
     def close(self) -> None:
         with self._lock:
             if not self._closed:
@@ -645,9 +748,26 @@ class _EvaluationFeedbackAuthorityRoot:
                     self._connection.execute("ROLLBACK")
                 self._event_store.close()
                 self._closed = True
-
-
-def open_evaluation_feedback_authority_system(
+class _EvaluationFeedbackTransactionView:
+    def __init__(self, root: _EvaluationFeedbackAuthorityRoot) -> None:
+        self._root = root
+    def accept(self, feedback_bytes: bytes, obligation_bytes: bytes, *, candidate_proof: object):
+        return self._root._accept_active(
+            EvaluationFeedback.from_canonical_bytes(feedback_bytes),
+            ReconciliationObligation.from_canonical_bytes(obligation_bytes), candidate_proof,
+        )
+    def append_disposition(self, disposition_bytes: bytes, *, candidate_proof: object):
+        return self._root._append_active(
+            ReconciliationDisposition.from_canonical_bytes(disposition_bytes), candidate_proof
+        )
+    def load(self, feedback_id: str):
+        return self._root._load_active(feedback_id)
+    def dispositions(self, obligation_id: str):
+        return self._root._dispositions_active(obligation_id)
+class _UnlockedEvaluationFeedbackEventStoreForTest(_EventAuthorityStore):
+    def _acquire_writer_lock(self) -> None:
+        self._lock_fd = None
+def _compose_evaluation_feedback_authority_root(
     database: str | Path,
     *,
     retrieval_authority: object,
@@ -657,8 +777,8 @@ def open_evaluation_feedback_authority_system(
     payload_schemas: PayloadSchemaRegistry,
     clock: Callable[[], UtcTimestamp] = UtcTimestamp.now,
     busy_timeout_ms: int = 5_000,
-) -> EvaluationFeedbackAuthority:
-    """Open the sole v25 writer with both reviewed #426 ports on one connection."""
+    store_class: type[_EventAuthorityStore] = _EventAuthorityStore,
+) -> _EvaluationFeedbackAuthorityRoot:
     relationship_commands, relationship_schemas = merge_relationship_authority_registries(
         command_registry, payload_schemas
     )
@@ -672,7 +792,7 @@ def open_evaluation_feedback_authority_system(
         candidate_commands, candidate_schemas
     )
     issuer = _CapabilityIssuer(command_registry=commands, payload_schemas=schemas)
-    event_store = _EventAuthorityStore(
+    event_store = store_class(
         Path(database),
         issuer=issuer,
         command_registry=commands,
@@ -701,16 +821,41 @@ def open_evaluation_feedback_authority_system(
             clock=clock,
             _issuer=issuer,
         )
-        root = _EvaluationFeedbackAuthorityRoot(
-            event_store, service, candidate, handoff, clock
-        )
+        return _EvaluationFeedbackAuthorityRoot(event_store, service, candidate, handoff, clock)
+    except BaseException:
+        try: event_store.close()
+        except BaseException:  # noqa: BLE001, S110 - preserve composition failure
+            pass
+        raise
+def open_evaluation_feedback_authority_system(
+    database: str | Path,
+    *,
+    retrieval_authority: object,
+    authenticator: object,
+    authorizer: object,
+    command_registry: CommandRegistry,
+    payload_schemas: PayloadSchemaRegistry,
+    clock: Callable[[], UtcTimestamp] = UtcTimestamp.now,
+    busy_timeout_ms: int = 5_000,
+) -> EvaluationFeedbackAuthority:
+    root = _compose_evaluation_feedback_authority_root(
+        database, retrieval_authority=retrieval_authority, authenticator=authenticator, authorizer=authorizer,
+        command_registry=command_registry, payload_schemas=payload_schemas, clock=clock,
+        busy_timeout_ms=busy_timeout_ms, store_class=_EventAuthorityStore,
+    )
+    try:
         facade = _compose_evaluation_feedback_authority(root)
         if type(facade) is not EvaluationFeedbackAuthority:
             raise FeedbackContractError("Feedback facade composition differs")
         return facade
     except BaseException:
-        event_store.close()
+        try: root.close()
+        except BaseException:  # noqa: BLE001, S110 - preserve composition failure
+            pass
         raise
-
-
+def _open_unlocked_evaluation_feedback_authority_for_test(*args: object, **kwargs: object):
+    return _compose_evaluation_feedback_authority_root(
+        *args, store_class=_UnlockedEvaluationFeedbackEventStoreForTest, **kwargs
+    )
 __all__ = ["open_evaluation_feedback_authority_system"]
+# fmt: on

--- a/newsroom/authority/evaluation_feedback_system.py
+++ b/newsroom/authority/evaluation_feedback_system.py
@@ -285,7 +285,9 @@ class _EvaluationFeedbackAuthorityRoot:
             "c.authentication_context_id,c.authorization_request_digest,c.authorization_decision_id,"
             "e.authentication_context_id,e.authorization_request_digest,e.authorization_decision_id,"
             "au.authentication_context_id,au.authorization_request_digest,au.authorization_decision_id,"
-            "au.event_type,au.detail_digest,r.operation_type,r.required_scope,d.allowed,d.effective_scopes "
+            "au.event_type,au.detail_digest,r.operation_type,r.required_scope,d.allowed,d.effective_scopes,"
+            "a.authority_domain,c.command_id,c.result_bytes,c.result_digest,e.ledger_seq,"
+            "e.correlation_id,e.causation_kind,e.causation_identifier,e.causation_external_system "
             "FROM ledger_events e JOIN authority_commands c ON c.command_id=e.command_id "
             "JOIN authority_payloads p ON p.payload_id=e.payload_id "
             "JOIN authority_aggregate_versions v ON v.command_id=c.command_id "
@@ -358,6 +360,38 @@ class _EvaluationFeedbackAuthorityRoot:
             or definition.required_scope not in json.loads(bytes(row[46]))
         ):
             raise FeedbackContractError("Feedback authorization envelope differs")
+        if type(row[47]) is not str:
+            raise FeedbackContractError("Feedback authentication authority differs")
+        expected_namespace = digest_canonical({
+            "authority_domain": row[47],
+            "principal_id": str(row[30]),
+            "command_type": definition.command_type,
+        })
+        try:
+            result = self._event_store._decode_result(
+                bytes(row[49]), str(row[50]), replayed=False
+            )
+        except Exception as exc:
+            raise FeedbackContractError("Feedback command result differs") from exc
+        actual_result = (
+            str(result.command_id),
+            result.aggregate_type,
+            str(result.aggregate_id),
+            result.aggregate_version,
+            result.ledger_seq,
+            str(result.event_id),
+        )
+        expected_result = (
+            str(row[48]),
+            definition.aggregate_type,
+            aggregate_id,
+            aggregate_version,
+            int(row[51]),
+            event_id,
+        )
+        causation = tuple(row[53:56])
+        if actual_result != expected_result or causation != (None, None, None):
+            raise FeedbackContractError("Feedback command result or causation differs")
         try:
             value = json.loads(bytes(row[0]))
         except Exception as exc:
@@ -393,11 +427,13 @@ class _EvaluationFeedbackAuthorityRoot:
             "definition_digest": definition.digest, "definition_version": definition.definition_version,
             "payload": payload_identity, "authentication_context_digest": envelope[2],
             "authorization_request_record_digest": envelope[3], "authorization_request_digest": command_triple[1],
-            "authorization_decision_digest": envelope[4], "idempotency_namespace": envelope[0],
+            "authorization_decision_digest": envelope[4], "idempotency_namespace": expected_namespace,
             "idempotency_key": idempotency_key, "stable_semantic_request_digest": stable,
-            "correlation_id": envelope[5], "causation_kind": None, "causation_identifier": None,
-            "causation_external_system": None, "replay_of_command_id": None}
-        if (envelope[1] != stable or envelope[6] != digest_canonical(unsigned)
+            "correlation_id": row[52], "causation_kind": causation[0],
+            "causation_identifier": causation[1], "causation_external_system": causation[2],
+            "replay_of_command_id": None}
+        if (envelope[0] != expected_namespace or envelope[1] != stable
+            or envelope[5] != row[52] or envelope[6] != digest_canonical(unsigned)
             or envelope[7] != definition.trust_scope.value):
             raise FeedbackContractError("Feedback audit envelope differs")
         return value

--- a/newsroom/authority/migrations.py
+++ b/newsroom/authority/migrations.py
@@ -58,6 +58,17 @@ from .evaluation_handoff_migrations import (
     prepare_evaluation_handoff_backup,
     require_evaluation_handoff_backup,
 )
+from .evaluation_feedback_migrations import (
+    EVALUATION_FEEDBACK_MIGRATION,
+    EVALUATION_FEEDBACK_MIGRATION_CHECKSUM,
+    EVALUATION_FEEDBACK_MIGRATION_NAME,
+    EVALUATION_FEEDBACK_MIGRATION_STATEMENTS,
+    EVALUATION_FEEDBACK_SCHEMA_VERSION,
+    EvaluationFeedbackBackupReceipt,
+    evaluation_feedback_backup_paths,
+    prepare_evaluation_feedback_backup,
+    require_evaluation_feedback_backup,
+)
 from .event_hypothesis_lineage_migrations import (
     EVENT_HYPOTHESIS_LINEAGE_MIGRATION,
     EVENT_HYPOTHESIS_LINEAGE_MIGRATION_CHECKSUM,
@@ -200,7 +211,7 @@ from .triage_work_item_migrations import (
 )
 
 BASE_SCHEMA_VERSION = 1
-SCHEMA_VERSION = STORY_CANDIDATE_SCHEMA_VERSION
+SCHEMA_VERSION = EVALUATION_FEEDBACK_SCHEMA_VERSION
 MIGRATION_NAME = "authority_event_foundation_v1"
 
 
@@ -648,11 +659,12 @@ def prepare_pending_migration_backup(
     | EventHypothesisRelationshipBackupReceipt
     | EventHypothesisLineageBackupReceipt
     | StoryCandidateBackupReceipt
+    | EvaluationFeedbackBackupReceipt
     | None
 ):
     """Prepare the exact retained backup required by a checked predecessor."""
     version = int(conn.execute("PRAGMA user_version").fetchone()[0])
-    if version not in {16, 17, 18, 19, 20, 21, 22, 23}:
+    if version not in {16, 17, 18, 19, 20, 21, 22, 23, 24}:
         return None
     database_path = next(
         str(row[2])
@@ -684,8 +696,11 @@ def prepare_pending_migration_backup(
     if version == 22:
         backup_path, _ = event_hypothesis_lineage_backup_paths(database_path)
         return prepare_event_hypothesis_lineage_backup(conn, backup_path)
-    backup_path, _ = story_candidate_backup_paths(database_path)
-    return prepare_story_candidate_backup(conn, backup_path)
+    if version == 23:
+        backup_path, _ = story_candidate_backup_paths(database_path)
+        return prepare_story_candidate_backup(conn, backup_path)
+    backup_path, _ = evaluation_feedback_backup_paths(database_path)
+    return prepare_evaluation_feedback_backup(conn, backup_path)
 
 
 def apply_migration(
@@ -981,7 +996,7 @@ def apply_pending_migrations(conn: sqlite3.Connection, *, applied_at: str) -> No
             if starting_version != 0:
                 require_evaluation_handoff_backup(
                     conn,
-                    expected_history=EXPECTED_MIGRATION_HISTORY[:-8],
+                    expected_history=tuple((r.version, r.name, r.checksum) for r in MIGRATIONS if r.version <= GRAPHITI_ADAPTER_SCHEMA_VERSION),
                 )
             for statement in EVALUATION_HANDOFF_MIGRATION_STATEMENTS:
                 conn.execute(statement)
@@ -1016,7 +1031,7 @@ def apply_pending_migrations(conn: sqlite3.Connection, *, applied_at: str) -> No
             if starting_version != 0:
                 require_triage_work_item_backup(
                     conn,
-                    expected_history=EXPECTED_MIGRATION_HISTORY[:-7],
+                    expected_history=tuple((r.version, r.name, r.checksum) for r in MIGRATIONS if r.version <= EVALUATION_HANDOFF_SCHEMA_VERSION),
                 )
             for statement in TRIAGE_WORK_ITEM_MIGRATION_STATEMENTS:
                 conn.execute(statement)
@@ -1050,7 +1065,7 @@ def apply_pending_migrations(conn: sqlite3.Connection, *, applied_at: str) -> No
             if starting_version != 0:
                 require_triage_disposition_backup(
                     conn,
-                    expected_history=EXPECTED_MIGRATION_HISTORY[:-6],
+                    expected_history=tuple((r.version, r.name, r.checksum) for r in MIGRATIONS if r.version <= TRIAGE_WORK_ITEM_SCHEMA_VERSION),
                 )
             for statement in TRIAGE_DISPOSITION_MIGRATION_STATEMENTS:
                 conn.execute(statement)
@@ -1084,7 +1099,7 @@ def apply_pending_migrations(conn: sqlite3.Connection, *, applied_at: str) -> No
             if starting_version != 0:
                 require_triage_execution_backup(
                     conn,
-                    expected_history=EXPECTED_MIGRATION_HISTORY[:-5],
+                    expected_history=tuple((r.version, r.name, r.checksum) for r in MIGRATIONS if r.version <= TRIAGE_DISPOSITION_SCHEMA_VERSION),
                 )
             for statement in TRIAGE_EXECUTION_MIGRATION_STATEMENTS:
                 conn.execute(statement)
@@ -1117,7 +1132,7 @@ def apply_pending_migrations(conn: sqlite3.Connection, *, applied_at: str) -> No
                 conn.execute("BEGIN EXCLUSIVE")
             if starting_version != 0:
                 require_event_hypothesis_backup(
-                    conn, expected_history=EXPECTED_MIGRATION_HISTORY[:-4]
+                    conn, expected_history=tuple((r.version, r.name, r.checksum) for r in MIGRATIONS if r.version <= TRIAGE_EXECUTION_SCHEMA_VERSION)
                 )
             for statement in EVENT_HYPOTHESIS_MIGRATION_STATEMENTS:
                 conn.execute(statement)
@@ -1152,7 +1167,7 @@ def apply_pending_migrations(conn: sqlite3.Connection, *, applied_at: str) -> No
                 conn.execute("BEGIN EXCLUSIVE")
             if starting_version != 0:
                 require_event_hypothesis_relationship_backup(
-                    conn, expected_history=EXPECTED_MIGRATION_HISTORY[:-3]
+                    conn, expected_history=tuple((r.version, r.name, r.checksum) for r in MIGRATIONS if r.version <= EVENT_HYPOTHESIS_SCHEMA_VERSION)
                 )
             for statement in EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION_STATEMENTS:
                 conn.execute(statement)
@@ -1230,6 +1245,29 @@ def apply_pending_migrations(conn: sqlite3.Connection, *, applied_at: str) -> No
                  STORY_CANDIDATE_MIGRATION_CHECKSUM, applied_at),
             )
             current = STORY_CANDIDATE_SCHEMA_VERSION
+        if current == STORY_CANDIDATE_SCHEMA_VERSION:
+            if 0 < starting_version < STORY_CANDIDATE_SCHEMA_VERSION:
+                conn.execute(f"PRAGMA user_version={STORY_CANDIDATE_SCHEMA_VERSION}")
+                conn.execute("COMMIT")
+                database_path = next(str(row[2]) for row in conn.execute("PRAGMA database_list") if row[1] == "main")
+                if not database_path:
+                    raise sqlite3.DatabaseError("existing multihop upgrade requires a file-backed database")
+                backup_path, _ = evaluation_feedback_backup_paths(database_path)
+                prepare_evaluation_feedback_backup(conn, backup_path)
+                conn.execute("BEGIN EXCLUSIVE")
+            if starting_version != 0:
+                require_evaluation_feedback_backup(
+                    conn, expected_history=tuple((r.version, r.name, r.checksum) for r in MIGRATIONS
+                                                 if r.version <= STORY_CANDIDATE_SCHEMA_VERSION),
+                )
+            for statement in EVALUATION_FEEDBACK_MIGRATION_STATEMENTS:
+                conn.execute(statement)
+            conn.execute(
+                "INSERT INTO authority_migrations(version,name,checksum,applied_at) VALUES(?,?,?,?)",
+                (EVALUATION_FEEDBACK_SCHEMA_VERSION, EVALUATION_FEEDBACK_MIGRATION_NAME,
+                 EVALUATION_FEEDBACK_MIGRATION_CHECKSUM, applied_at),
+            )
+            current = EVALUATION_FEEDBACK_SCHEMA_VERSION
         # fmt: on
         conn.execute(f"PRAGMA user_version={current}")
         conn.execute("COMMIT")
@@ -1264,6 +1302,7 @@ MIGRATIONS: tuple[MigrationRecord | object, ...] = (
     EVENT_HYPOTHESIS_RELATIONSHIP_MIGRATION,
     EVENT_HYPOTHESIS_LINEAGE_MIGRATION,
     STORY_CANDIDATE_MIGRATION,
+    EVALUATION_FEEDBACK_MIGRATION,
 )
 
 
@@ -1390,5 +1429,10 @@ EXPECTED_MIGRATION_HISTORY: tuple[tuple[int, str, str], ...] = (
         STORY_CANDIDATE_SCHEMA_VERSION,
         STORY_CANDIDATE_MIGRATION_NAME,
         STORY_CANDIDATE_MIGRATION_CHECKSUM,
+    ),
+    (
+        EVALUATION_FEEDBACK_SCHEMA_VERSION,
+        EVALUATION_FEEDBACK_MIGRATION_NAME,
+        EVALUATION_FEEDBACK_MIGRATION_CHECKSUM,
     ),
 )

--- a/newsroom/authority/migrations.py
+++ b/newsroom/authority/migrations.py
@@ -1,4 +1,6 @@
+# ruff: noqa: I001
 from __future__ import annotations
+# fmt: off
 
 import sqlite3
 from collections.abc import Iterable
@@ -47,17 +49,6 @@ from .entity_migrations import (
     ENTITY_AUTHORITY_MIGRATION_STATEMENTS,
     ENTITY_AUTHORITY_SCHEMA_VERSION,
 )
-from .evaluation_handoff_migrations import (
-    EVALUATION_HANDOFF_MIGRATION,
-    EVALUATION_HANDOFF_MIGRATION_CHECKSUM,
-    EVALUATION_HANDOFF_MIGRATION_NAME,
-    EVALUATION_HANDOFF_MIGRATION_STATEMENTS,
-    EVALUATION_HANDOFF_SCHEMA_VERSION,
-    EvaluationHandoffBackupReceipt,
-    evaluation_handoff_backup_paths,
-    prepare_evaluation_handoff_backup,
-    require_evaluation_handoff_backup,
-)
 from .evaluation_feedback_migrations import (
     EVALUATION_FEEDBACK_MIGRATION,
     EVALUATION_FEEDBACK_MIGRATION_CHECKSUM,
@@ -68,6 +59,17 @@ from .evaluation_feedback_migrations import (
     evaluation_feedback_backup_paths,
     prepare_evaluation_feedback_backup,
     require_evaluation_feedback_backup,
+)
+from .evaluation_handoff_migrations import (
+    EVALUATION_HANDOFF_MIGRATION,
+    EVALUATION_HANDOFF_MIGRATION_CHECKSUM,
+    EVALUATION_HANDOFF_MIGRATION_NAME,
+    EVALUATION_HANDOFF_MIGRATION_STATEMENTS,
+    EVALUATION_HANDOFF_SCHEMA_VERSION,
+    EvaluationHandoffBackupReceipt,
+    evaluation_handoff_backup_paths,
+    prepare_evaluation_handoff_backup,
+    require_evaluation_handoff_backup,
 )
 from .event_hypothesis_lineage_migrations import (
     EVENT_HYPOTHESIS_LINEAGE_MIGRATION,
@@ -1436,3 +1438,4 @@ EXPECTED_MIGRATION_HISTORY: tuple[tuple[int, str, str], ...] = (
         EVALUATION_FEEDBACK_MIGRATION_CHECKSUM,
     ),
 )
+# fmt: on

--- a/newsroom/increment6/feedback.py
+++ b/newsroom/increment6/feedback.py
@@ -19,6 +19,14 @@ from newsroom.authority.canonical import (
     canonical_json_bytes,
     digest_bytes,
 )
+from newsroom.authority.models import CommandDefinition
+from newsroom.authority.policy import (
+    CommandRegistry,
+    PayloadGoldenVector,
+    PayloadSchemaContract,
+    PayloadSchemaRegistry,
+)
+from newsroom.authority.types import PayloadMode, TrustScope
 from newsroom.increment6.candidates import StoryCandidateVersion
 from newsroom.increment6.handoffs import (
     Acknowledgement,
@@ -33,6 +41,9 @@ from newsroom.increment6.work_items import SupplementalDiscoveryReentry
 EVALUATION_FEEDBACK = "newsroom.increment6.evaluation-feedback.v1"
 RECONCILIATION_OBLIGATION = "newsroom.increment6.reconciliation-obligation.v1"
 RECONCILIATION_DISPOSITION = "newsroom.increment6.reconciliation-disposition.v1"
+HANDOFF_ACCEPTANCE_SNAPSHOT = "newsroom.increment6.handoff-acceptance-snapshot.v25"
+EVALUATION_FEEDBACK_COMMAND_TYPE = "evaluation-feedback.reconcile"
+EVALUATION_FEEDBACK_COMMAND_SCHEMA = "newsroom.increment6.evaluation-feedback-command.v25"
 MAX_FEEDBACK_CANONICAL_BYTES = 1_048_576
 
 _DIGEST = re.compile(r"sha256:[0-9a-f]{64}")
@@ -303,6 +314,332 @@ def _enum(kind, value: object, field: str):
         return kind(value)
     except ValueError as exc:
         raise FeedbackContractError(f"{field} is not an exact enum value") from exc
+
+
+@dataclass(frozen=True, slots=True)
+class HandoffAcceptanceSnapshot:
+    """Full Handoff graph observed, not originated, by v25 acceptance."""
+
+    schema_identity: ClassVar[str] = HANDOFF_ACCEPTANCE_SNAPSHOT
+    handoff_id: str
+    candidate_version_id: str
+    governing_manifest_digest: str
+    sink_id: str
+    observed_max_attempts: int
+    transport_state: HandoffState
+    attempts: tuple[HandoffAttempt, ...]
+    acknowledgements: tuple[Acknowledgement, ...]
+    retry_exhausted: bool
+    ambiguity_reason: str | None
+    evaluation_only: bool
+    publication_authority: bool
+    evidence_authority: bool
+    observation_semantics: str = "observed_at_v25_acceptance_not_registration_provenance"
+
+    @_total("invalid Handoff acceptance snapshot")
+    def __post_init__(self) -> None:
+        _require(type(self) is HandoffAcceptanceSnapshot, "snapshot must be exact")
+        handoff = Handoff(
+            handoff_id=self.handoff_id,
+            candidate_version_id=self.candidate_version_id,
+            governing_manifest_digest=self.governing_manifest_digest,
+            sink_id=self.sink_id,
+            max_attempts=self.observed_max_attempts,
+            state=self.transport_state,
+            attempts=self.attempts,
+            acknowledgements=self.acknowledgements,
+            retry_exhausted=self.retry_exhausted,
+            ambiguity_reason=self.ambiguity_reason,
+            evaluation_only=self.evaluation_only,
+            publication_authority=self.publication_authority,
+            evidence_authority=self.evidence_authority,
+        )
+        _require(
+            handoff.state is HandoffState.ACKNOWLEDGED,
+            "snapshot requires accepted Handoff transport state",
+        )
+        _require(
+            self.observation_semantics
+            == "observed_at_v25_acceptance_not_registration_provenance",
+            "snapshot observation semantics differ",
+        )
+        _ = self.canonical_bytes
+
+    @classmethod
+    def observe(cls, handoff: Handoff) -> Self:
+        if type(handoff) is not Handoff:
+            raise FeedbackContractError("snapshot Handoff must be exact")
+        return cls(
+            handoff_id=handoff.handoff_id,
+            candidate_version_id=handoff.candidate_version_id,
+            governing_manifest_digest=handoff.governing_manifest_digest,
+            sink_id=handoff.sink_id,
+            observed_max_attempts=handoff.max_attempts,
+            transport_state=handoff.state,
+            attempts=handoff.attempts,
+            acknowledgements=handoff.acknowledgements,
+            retry_exhausted=handoff.retry_exhausted,
+            ambiguity_reason=handoff.ambiguity_reason,
+            evaluation_only=handoff.evaluation_only,
+            publication_authority=handoff.publication_authority,
+            evidence_authority=handoff.evidence_authority,
+        )
+
+    @property
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "acknowledgements": [
+                {
+                    "acknowledgement_id": item.acknowledgement_id,
+                    "attempt_id": item.attempt_id,
+                    "candidate_version_id": item.candidate_version_id,
+                    "governing_manifest_digest": item.governing_manifest_digest,
+                    "handoff_id": item.handoff_id,
+                    "outcome": item.outcome.value,
+                    "response_digest": item.response_digest,
+                    "sink_id": item.sink_id,
+                }
+                for item in self.acknowledgements
+            ],
+            "ambiguity_reason": self.ambiguity_reason,
+            "attempts": [
+                {
+                    "ambiguous": item.ambiguous,
+                    "attempt_id": item.attempt_id,
+                    "attempt_number": item.attempt_number,
+                    "handoff_id": item.handoff_id,
+                    "persisted_before_send": item.persisted_before_send,
+                    "semantic_idempotency_key": item.semantic_idempotency_key,
+                    "sent": item.sent,
+                }
+                for item in self.attempts
+            ],
+            "candidate_version_id": self.candidate_version_id,
+            "evaluation_only": self.evaluation_only,
+            "evidence_authority": self.evidence_authority,
+            "governing_manifest_digest": self.governing_manifest_digest,
+            "handoff_id": self.handoff_id,
+            "observation_semantics": self.observation_semantics,
+            "observed_max_attempts": self.observed_max_attempts,
+            "publication_authority": self.publication_authority,
+            "retry_exhausted": self.retry_exhausted,
+            "sink_id": self.sink_id,
+            "transport_state": self.transport_state.value,
+        }
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return _document(HANDOFF_ACCEPTANCE_SNAPSHOT, "snapshot", self.canonical_value)
+
+    @property
+    def canonical_digest(self) -> str:
+        return digest_bytes(self.canonical_bytes)
+
+    @classmethod
+    def from_canonical_bytes(cls, raw: bytes) -> Self:
+        fields = set(cls.__dataclass_fields__) - {"schema_identity"}
+        value = _decode_document(raw, HANDOFF_ACCEPTANCE_SNAPSHOT, "snapshot", fields)
+        try:
+            attempts = tuple(HandoffAttempt(**item) for item in value["attempts"])
+            acknowledgements = tuple(
+                Acknowledgement(
+                    **{**item, "outcome": AcknowledgementOutcome(item["outcome"])}
+                )
+                for item in value["acknowledgements"]
+            )
+            result = cls(
+                **{
+                    **value,
+                    "transport_state": HandoffState(value["transport_state"]),
+                    "attempts": attempts,
+                    "acknowledgements": acknowledgements,
+                }
+            )
+        except FeedbackContractError:
+            raise
+        except Exception as exc:
+            raise FeedbackContractError("Handoff acceptance snapshot replay failed") from exc
+        if result.canonical_bytes != raw:
+            raise FeedbackContractError("Handoff acceptance snapshot replay differs")
+        return result
+
+
+@dataclass(frozen=True, slots=True)
+class EvaluationFeedbackAcceptance:
+    feedback: EvaluationFeedback
+    obligation: ReconciliationObligation
+    handoff_snapshot: HandoffAcceptanceSnapshot
+
+
+def _feedback_command_canonicalizer(value: object) -> bytes:
+    if type(value) is not dict or set(value) != {
+        "operation",
+        "feedback",
+        "obligation",
+        "handoff_acceptance_snapshot",
+        "disposition",
+    }:
+        raise FeedbackContractError("Feedback command fields differ")
+    if value["operation"] not in {"accept", "append_disposition"}:
+        raise FeedbackContractError("Feedback command operation differs")
+    return canonical_json_bytes(value)
+
+
+_FEEDBACK_COMMAND_VECTOR_VALUE = {
+    "disposition": None,
+    "feedback": None,
+    "handoff_acceptance_snapshot": None,
+    "obligation": None,
+    "operation": "accept",
+}
+_FEEDBACK_COMMAND_VECTOR_BYTES = canonical_json_bytes(_FEEDBACK_COMMAND_VECTOR_VALUE)
+
+
+def _feedback_payload_contract() -> PayloadSchemaContract:
+    return PayloadSchemaContract(
+        EVALUATION_FEEDBACK_COMMAND_SCHEMA,
+        PayloadMode.INLINE,
+        "evaluation-feedback-command-schema-v25",
+        "evaluation-feedback-command-json-v25",
+        _feedback_command_canonicalizer,
+        (
+            PayloadGoldenVector(
+                "evaluation-feedback-command",
+                "evaluation-feedback:command",
+                _FEEDBACK_COMMAND_VECTOR_VALUE,
+                _FEEDBACK_COMMAND_VECTOR_BYTES,
+            ),
+        ),
+    )
+
+
+def evaluation_feedback_command_definition() -> CommandDefinition:
+    contract = _feedback_payload_contract()
+    return CommandDefinition(
+        command_type=EVALUATION_FEEDBACK_COMMAND_TYPE,
+        definition_version="evaluation-feedback-command-v25",
+        aggregate_type="evaluation_reconciliation",
+        event_type="evaluation_reconciliation_recorded",
+        event_schema_version=25,
+        payload_mode=PayloadMode.INLINE,
+        payload_schema_version=contract.schema_version,
+        payload_schema_contract_version=contract.contract_version,
+        payload_schema_contract_digest=contract.contract_digest,
+        payload_canonicalizer_version=contract.canonicalizer_implementation_version,
+        trust_scope=TrustScope.ADMITTED,
+        security_scope="authority.evaluation-feedback",
+        retention_scope="authority.audit",
+        required_scope="authority.evaluation-feedback.reconcile",
+        max_inline_bytes=MAX_FEEDBACK_CANONICAL_BYTES * 4,
+    )
+
+
+def merge_evaluation_feedback_authority_registries(
+    commands: CommandRegistry, schemas: PayloadSchemaRegistry
+) -> tuple[CommandRegistry, PayloadSchemaRegistry]:
+    definition, contract = evaluation_feedback_command_definition(), _feedback_payload_contract()
+    definitions, contracts = tuple(commands.definitions()), tuple(schemas.contracts())
+    matching_definitions = tuple(
+        item for item in definitions if item.command_type == EVALUATION_FEEDBACK_COMMAND_TYPE
+    )
+    matching_contracts = tuple(
+        item
+        for item in contracts
+        if (item.schema_version, item.payload_mode)
+        == (EVALUATION_FEEDBACK_COMMAND_SCHEMA, PayloadMode.INLINE)
+    )
+    if matching_definitions not in ((), (definition,)) or matching_contracts not in (
+        (),
+        (contract,),
+    ):
+        raise FeedbackContractError("Feedback authority registry conflicts")
+    definitions += () if matching_definitions else (definition,)
+    contracts += () if matching_contracts else (contract,)
+    return (
+        CommandRegistry(
+            definitions,
+            current_versions={
+                item.command_type: (
+                    definition.definition_version
+                    if item.command_type == EVALUATION_FEEDBACK_COMMAND_TYPE
+                    else commands.resolve(item.command_type).definition_version
+                )
+                for item in definitions
+            },
+        ),
+        PayloadSchemaRegistry(
+            contracts,
+            current_versions={
+                (item.schema_version, item.payload_mode): (
+                    contract.contract_version
+                    if (item.schema_version, item.payload_mode)
+                    == (EVALUATION_FEEDBACK_COMMAND_SCHEMA, PayloadMode.INLINE)
+                    else schemas.resolve(item.schema_version, item.payload_mode).contract_version
+                )
+                for item in contracts
+            },
+        ),
+    )
+
+
+_AUTHORITY_TOKEN = object()
+
+
+class EvaluationFeedbackAuthority:
+    """Exact public facade over the server-owned v25 composition root."""
+
+    __slots__ = ("__authority",)
+
+    def __init__(self, token: object, authority: object) -> None:
+        if token is not _AUTHORITY_TOKEN:
+            raise FeedbackContractError("Feedback authority construction is private")
+        object.__setattr__(self, "_EvaluationFeedbackAuthority__authority", authority)
+
+    def __setattr__(self, name: str, value: object) -> None:
+        raise AttributeError("EvaluationFeedbackAuthority is immutable")
+
+    def accept(
+        self,
+        feedback_bytes: bytes,
+        obligation_bytes: bytes,
+        *,
+        candidate_proof: object,
+    ) -> EvaluationFeedbackAcceptance:
+        value = self.__authority.accept(
+            feedback_bytes, obligation_bytes, candidate_proof=candidate_proof
+        )
+        if type(value) is not EvaluationFeedbackAcceptance:
+            raise FeedbackContractError("Feedback accept returned a forged result")
+        return value
+
+    def append_disposition(
+        self, disposition_bytes: bytes, *, candidate_proof: object
+    ) -> ReconciliationDisposition:
+        value = self.__authority.append_disposition(
+            disposition_bytes, candidate_proof=candidate_proof
+        )
+        if type(value) is not ReconciliationDisposition:
+            raise FeedbackContractError("Disposition append returned a forged result")
+        return value
+
+    def load(self, feedback_id: str) -> EvaluationFeedbackAcceptance:
+        value = self.__authority.load(feedback_id)
+        if type(value) is not EvaluationFeedbackAcceptance:
+            raise FeedbackContractError("Feedback load returned a forged result")
+        return value
+
+    def dispositions(self, obligation_id: str) -> tuple[ReconciliationDisposition, ...]:
+        value = self.__authority.dispositions(obligation_id)
+        if type(value) is not tuple or any(type(item) is not ReconciliationDisposition for item in value):
+            raise FeedbackContractError("Disposition history returned a forged result")
+        return value
+
+    def close(self) -> None:
+        self.__authority.close()
+
+
+def _compose_evaluation_feedback_authority(authority: object) -> EvaluationFeedbackAuthority:
+    return EvaluationFeedbackAuthority(_AUTHORITY_TOKEN, authority)
 
 
 @dataclass(frozen=True, slots=True)
@@ -1156,11 +1493,17 @@ def reconciliation_is_open(
 
 __all__ = [
     "EVALUATION_FEEDBACK",
+    "EVALUATION_FEEDBACK_COMMAND_SCHEMA",
+    "EVALUATION_FEEDBACK_COMMAND_TYPE",
+    "EvaluationFeedbackAcceptance",
+    "EvaluationFeedbackAuthority",
     "EvaluationFeedback",
     "EvaluationFeedbackOutcome",
     "EvaluationFeedbackReason",
     "FeedbackContractError",
     "FeedbackCorrelationOutcome",
+    "HANDOFF_ACCEPTANCE_SNAPSHOT",
+    "HandoffAcceptanceSnapshot",
     "MAX_FEEDBACK_CANONICAL_BYTES",
     "RECONCILIATION_DISPOSITION",
     "RECONCILIATION_OBLIGATION",
@@ -1173,6 +1516,8 @@ __all__ = [
     "correlate_evaluation_feedback",
     "create_evaluation_feedback",
     "create_reconciliation_obligation",
+    "evaluation_feedback_command_definition",
+    "merge_evaluation_feedback_authority_registries",
     "reconciliation_is_open",
     "validate_reconciliation_history",
 ]

--- a/newsroom/increment6/feedback.py
+++ b/newsroom/increment6/feedback.py
@@ -4,15 +4,16 @@ The records in this module are deliberately evaluation-only.  They perform no
 persistence, Evidence Intake, Candidate mutation, provider, or publication
 effect; the following v25 authority atom owns persistence and effects.
 """
+# fmt: off
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from enum import Enum
 import json
 import re
-from typing import ClassVar, Self
 import uuid
+from dataclasses import dataclass
+from enum import Enum
+from typing import ClassVar, Self
 
 from newsroom.authority.canonical import (
     MAX_SAFE_INTEGER,
@@ -36,7 +37,6 @@ from newsroom.increment6.handoffs import (
     HandoffState,
 )
 from newsroom.increment6.work_items import SupplementalDiscoveryReentry
-
 
 EVALUATION_FEEDBACK = "newsroom.increment6.evaluation-feedback.v1"
 RECONCILIATION_OBLIGATION = "newsroom.increment6.reconciliation-obligation.v1"
@@ -305,8 +305,6 @@ def _decode_document(
     if root["schema_version"] != schema:
         raise FeedbackContractError(f"{name} schema identity differs")
     return _exact(root[name], fields, name)
-
-
 def _enum(kind, value: object, field: str):
     if type(value) is not str:
         raise FeedbackContractError(f"{field} is not an exact enum value")
@@ -314,12 +312,9 @@ def _enum(kind, value: object, field: str):
         return kind(value)
     except ValueError as exc:
         raise FeedbackContractError(f"{field} is not an exact enum value") from exc
-
-
 @dataclass(frozen=True, slots=True)
 class HandoffAcceptanceSnapshot:
     """Full Handoff graph observed, not originated, by v25 acceptance."""
-
     schema_identity: ClassVar[str] = HANDOFF_ACCEPTANCE_SNAPSHOT
     handoff_id: str
     candidate_version_id: str
@@ -335,7 +330,6 @@ class HandoffAcceptanceSnapshot:
     publication_authority: bool
     evidence_authority: bool
     observation_semantics: str = "observed_at_v25_acceptance_not_registration_provenance"
-
     @_total("invalid Handoff acceptance snapshot")
     def __post_init__(self) -> None:
         _require(type(self) is HandoffAcceptanceSnapshot, "snapshot must be exact")
@@ -364,7 +358,6 @@ class HandoffAcceptanceSnapshot:
             "snapshot observation semantics differ",
         )
         _ = self.canonical_bytes
-
     @classmethod
     def observe(cls, handoff: Handoff) -> Self:
         if type(handoff) is not Handoff:
@@ -384,7 +377,6 @@ class HandoffAcceptanceSnapshot:
             publication_authority=handoff.publication_authority,
             evidence_authority=handoff.evidence_authority,
         )
-
     @property
     def canonical_value(self) -> dict[str, object]:
         return {
@@ -426,15 +418,12 @@ class HandoffAcceptanceSnapshot:
             "sink_id": self.sink_id,
             "transport_state": self.transport_state.value,
         }
-
     @property
     def canonical_bytes(self) -> bytes:
         return _document(HANDOFF_ACCEPTANCE_SNAPSHOT, "snapshot", self.canonical_value)
-
     @property
     def canonical_digest(self) -> str:
         return digest_bytes(self.canonical_bytes)
-
     @classmethod
     def from_canonical_bytes(cls, raw: bytes) -> Self:
         fields = set(cls.__dataclass_fields__) - {"schema_identity"}
@@ -462,15 +451,27 @@ class HandoffAcceptanceSnapshot:
         if result.canonical_bytes != raw:
             raise FeedbackContractError("Handoff acceptance snapshot replay differs")
         return result
-
-
 @dataclass(frozen=True, slots=True)
 class EvaluationFeedbackAcceptance:
     feedback: EvaluationFeedback
     obligation: ReconciliationObligation
     handoff_snapshot: HandoffAcceptanceSnapshot
-
-
+    def __post_init__(self) -> None:
+        if (
+            type(self) is not EvaluationFeedbackAcceptance
+            or type(self.feedback) is not EvaluationFeedback
+            or type(self.obligation) is not ReconciliationObligation
+            or type(self.handoff_snapshot) is not HandoffAcceptanceSnapshot
+            or self.obligation.feedback_id != self.feedback.feedback_id
+            or self.obligation.feedback_digest != self.feedback.canonical_digest
+            or self.handoff_snapshot.handoff_id != self.feedback.handoff_id
+            or self.handoff_snapshot.candidate_version_id
+            != self.feedback.candidate_version_id
+            or self.handoff_snapshot.governing_manifest_digest
+            != self.feedback.governing_manifest_digest
+            or self.handoff_snapshot.sink_id != self.feedback.sink_id
+        ):
+            raise FeedbackContractError("Feedback acceptance binding differs")
 def _feedback_command_canonicalizer(value: object) -> bytes:
     if type(value) is not dict or set(value) != {
         "operation",
@@ -483,8 +484,6 @@ def _feedback_command_canonicalizer(value: object) -> bytes:
     if value["operation"] not in {"accept", "append_disposition"}:
         raise FeedbackContractError("Feedback command operation differs")
     return canonical_json_bytes(value)
-
-
 _FEEDBACK_COMMAND_VECTOR_VALUE = {
     "disposition": None,
     "feedback": None,
@@ -493,8 +492,6 @@ _FEEDBACK_COMMAND_VECTOR_VALUE = {
     "operation": "accept",
 }
 _FEEDBACK_COMMAND_VECTOR_BYTES = canonical_json_bytes(_FEEDBACK_COMMAND_VECTOR_VALUE)
-
-
 def _feedback_payload_contract() -> PayloadSchemaContract:
     return PayloadSchemaContract(
         EVALUATION_FEEDBACK_COMMAND_SCHEMA,
@@ -511,8 +508,6 @@ def _feedback_payload_contract() -> PayloadSchemaContract:
             ),
         ),
     )
-
-
 def evaluation_feedback_command_definition() -> CommandDefinition:
     contract = _feedback_payload_contract()
     return CommandDefinition(
@@ -532,72 +527,27 @@ def evaluation_feedback_command_definition() -> CommandDefinition:
         required_scope="authority.evaluation-feedback.reconcile",
         max_inline_bytes=MAX_FEEDBACK_CANONICAL_BYTES * 4,
     )
-
-
-def merge_evaluation_feedback_authority_registries(
-    commands: CommandRegistry, schemas: PayloadSchemaRegistry
-) -> tuple[CommandRegistry, PayloadSchemaRegistry]:
+def merge_evaluation_feedback_authority_registries(commands: CommandRegistry, schemas: PayloadSchemaRegistry) -> tuple[CommandRegistry, PayloadSchemaRegistry]:
     definition, contract = evaluation_feedback_command_definition(), _feedback_payload_contract()
     definitions, contracts = tuple(commands.definitions()), tuple(schemas.contracts())
-    matching_definitions = tuple(
-        item for item in definitions if item.command_type == EVALUATION_FEEDBACK_COMMAND_TYPE
-    )
-    matching_contracts = tuple(
-        item
-        for item in contracts
-        if (item.schema_version, item.payload_mode)
-        == (EVALUATION_FEEDBACK_COMMAND_SCHEMA, PayloadMode.INLINE)
-    )
-    if matching_definitions not in ((), (definition,)) or matching_contracts not in (
-        (),
-        (contract,),
-    ):
+    command_matches = tuple(item for item in definitions if item.command_type == EVALUATION_FEEDBACK_COMMAND_TYPE)
+    schema_matches = tuple(item for item in contracts if (item.schema_version, item.payload_mode) == (EVALUATION_FEEDBACK_COMMAND_SCHEMA, PayloadMode.INLINE))
+    if command_matches not in ((), (definition,)) or schema_matches not in ((), (contract,)):
         raise FeedbackContractError("Feedback authority registry conflicts")
-    definitions += () if matching_definitions else (definition,)
-    contracts += () if matching_contracts else (contract,)
-    return (
-        CommandRegistry(
-            definitions,
-            current_versions={
-                item.command_type: (
-                    definition.definition_version
-                    if item.command_type == EVALUATION_FEEDBACK_COMMAND_TYPE
-                    else commands.resolve(item.command_type).definition_version
-                )
-                for item in definitions
-            },
-        ),
-        PayloadSchemaRegistry(
-            contracts,
-            current_versions={
-                (item.schema_version, item.payload_mode): (
-                    contract.contract_version
-                    if (item.schema_version, item.payload_mode)
-                    == (EVALUATION_FEEDBACK_COMMAND_SCHEMA, PayloadMode.INLINE)
-                    else schemas.resolve(item.schema_version, item.payload_mode).contract_version
-                )
-                for item in contracts
-            },
-        ),
-    )
-
+    definitions += () if command_matches else (definition,); contracts += () if schema_matches else (contract,)
+    return (CommandRegistry(definitions, current_versions={item.command_type: (definition.definition_version if item.command_type == EVALUATION_FEEDBACK_COMMAND_TYPE else commands.resolve(item.command_type).definition_version) for item in definitions}),
+        PayloadSchemaRegistry(contracts, current_versions={(item.schema_version, item.payload_mode): (contract.contract_version if (item.schema_version, item.payload_mode) == (EVALUATION_FEEDBACK_COMMAND_SCHEMA, PayloadMode.INLINE) else schemas.resolve(item.schema_version, item.payload_mode).contract_version) for item in contracts}))
 
 _AUTHORITY_TOKEN = object()
-
-
 class EvaluationFeedbackAuthority:
     """Exact public facade over the server-owned v25 composition root."""
-
     __slots__ = ("__authority",)
-
     def __init__(self, token: object, authority: object) -> None:
         if token is not _AUTHORITY_TOKEN:
             raise FeedbackContractError("Feedback authority construction is private")
         object.__setattr__(self, "_EvaluationFeedbackAuthority__authority", authority)
-
     def __setattr__(self, name: str, value: object) -> None:
         raise AttributeError("EvaluationFeedbackAuthority is immutable")
-
     def accept(
         self,
         feedback_bytes: bytes,
@@ -611,7 +561,6 @@ class EvaluationFeedbackAuthority:
         if type(value) is not EvaluationFeedbackAcceptance:
             raise FeedbackContractError("Feedback accept returned a forged result")
         return value
-
     def append_disposition(
         self, disposition_bytes: bytes, *, candidate_proof: object
     ) -> ReconciliationDisposition:
@@ -621,7 +570,6 @@ class EvaluationFeedbackAuthority:
         if type(value) is not ReconciliationDisposition:
             raise FeedbackContractError("Disposition append returned a forged result")
         return value
-
     def load(self, feedback_id: str) -> EvaluationFeedbackAcceptance:
         value = self.__authority.load(feedback_id)
         if type(value) is not EvaluationFeedbackAcceptance:
@@ -640,6 +588,21 @@ class EvaluationFeedbackAuthority:
 
 def _compose_evaluation_feedback_authority(authority: object) -> EvaluationFeedbackAuthority:
     return EvaluationFeedbackAuthority(_AUTHORITY_TOKEN, authority)
+
+
+def open_evaluation_feedback_authority(*args: object, **kwargs: object) -> EvaluationFeedbackAuthority:
+    """Lazy public opener for the checked server-owned v25 composition root."""
+    from newsroom.authority.evaluation_feedback_system import (
+        open_evaluation_feedback_authority_system,
+    )
+
+    value = open_evaluation_feedback_authority_system(*args, **kwargs)
+    if type(value) is not EvaluationFeedbackAuthority:
+        try:
+            value.close()
+        finally:
+            raise FeedbackContractError("Feedback authority opener returned a forged facade")
+    return value
 
 
 @dataclass(frozen=True, slots=True)
@@ -1495,18 +1458,18 @@ __all__ = [
     "EVALUATION_FEEDBACK",
     "EVALUATION_FEEDBACK_COMMAND_SCHEMA",
     "EVALUATION_FEEDBACK_COMMAND_TYPE",
+    "HANDOFF_ACCEPTANCE_SNAPSHOT",
+    "MAX_FEEDBACK_CANONICAL_BYTES",
+    "RECONCILIATION_DISPOSITION",
+    "RECONCILIATION_OBLIGATION",
+    "EvaluationFeedback",
     "EvaluationFeedbackAcceptance",
     "EvaluationFeedbackAuthority",
-    "EvaluationFeedback",
     "EvaluationFeedbackOutcome",
     "EvaluationFeedbackReason",
     "FeedbackContractError",
     "FeedbackCorrelationOutcome",
-    "HANDOFF_ACCEPTANCE_SNAPSHOT",
     "HandoffAcceptanceSnapshot",
-    "MAX_FEEDBACK_CANONICAL_BYTES",
-    "RECONCILIATION_DISPOSITION",
-    "RECONCILIATION_OBLIGATION",
     "ReconciliationDisposition",
     "ReconciliationDispositionOutcome",
     "ReconciliationDispositionReason",
@@ -1518,6 +1481,8 @@ __all__ = [
     "create_reconciliation_obligation",
     "evaluation_feedback_command_definition",
     "merge_evaluation_feedback_authority_registries",
+    "open_evaluation_feedback_authority",
     "reconciliation_is_open",
     "validate_reconciliation_history",
 ]
+# fmt: on

--- a/newsroom/tests/authority_migration_compatibility.py
+++ b/newsroom/tests/authority_migration_compatibility.py
@@ -168,6 +168,11 @@ PINNED_MIGRATION_HISTORY: tuple[HistoryRow, ...] = (
         "story_candidate_authority_v24",
         "sha256:1eea25005483de124e0add0100f4805ed5a537852fc70916f17a209c633e0ca0",
     ),
+    (
+        25,
+        "evaluation_feedback_authority_v25",
+        "sha256:59fe3bd40a2e22e874b4e5b02448501deffc23597e11b442e35b18e39ead0496",
+    ),
 )
 
 

--- a/newsroom/tests/feedback_adapter_fastpath.py
+++ b/newsroom/tests/feedback_adapter_fastpath.py
@@ -8,6 +8,7 @@ import pytest
 
 _STORE = "test_increment6f2_feedback_store.py"
 _CACHE_TEST = "test_increment6f2_feedback_cache.py"
+_ROLLBACK_RECORDS = ("record-rollback-normal", "record-rollback-abort")
 
 
 def _selected(config: pytest.Config) -> bool:
@@ -15,6 +16,29 @@ def _selected(config: pytest.Config) -> bool:
         _STORE in os.fspath(argument) or _CACHE_TEST in os.fspath(argument)
         for argument in config.invocation_params.args
     )
+
+
+def _install_cache_selection(cache: Any, feedback: Any) -> None:
+    if getattr(cache, "_rollback_template_selection_v1", False):
+        return
+    original = cache._selected_keys
+
+    def selected_keys(arguments: tuple[str, ...], feedback_module: Any):
+        if not any(_CACHE_TEST in argument for argument in arguments):
+            return original(arguments, feedback_module)
+        without_cache_tests = tuple(
+            argument for argument in arguments if _CACHE_TEST not in argument
+        )
+        selected = (
+            original(without_cache_tests, feedback_module)
+            if any(_STORE in argument for argument in without_cache_tests)
+            else ()
+        )
+        required = {*selected, _ROLLBACK_RECORDS}
+        return tuple(key for key in cache._KEYS if key in required)
+
+    cache._selected_keys = selected_keys
+    cache._rollback_template_selection_v1 = True
 
 
 def _install(feedback: Any) -> None:
@@ -119,6 +143,8 @@ def _install(feedback: Any) -> None:
 def pytest_configure(config: pytest.Config) -> None:
     if not _selected(config):
         return
+    from newsroom.tests import feedback_cache_support
     from newsroom.tests import test_increment6f2_feedback_store as feedback
 
+    _install_cache_selection(feedback_cache_support, feedback)
     _install(feedback)

--- a/newsroom/tests/feedback_adapter_fastpath.py
+++ b/newsroom/tests/feedback_adapter_fastpath.py
@@ -51,41 +51,53 @@ def _install(feedback: Any) -> None:
         connection = (
             target._connection if transaction is None else target._root._connection
         )
+        cache_key = None
+        if transaction is None:
+            cache_key = (
+                int(connection.execute("PRAGMA data_version").fetchone()[0]),
+                connection.total_changes,
+            )
+            cached = getattr(self, "_verified_commands_cache", None)
+            if cached is not None and cached[0] == cache_key:
+                return cached[1]
         relevant_feedback_ids = {
             str(fixture[0].feedback_id) for fixture in self.location.fixtures.values()
         }
         rows = connection.execute(
-            "SELECT f.feedback_id,o.obligation_id FROM evaluation_feedback f "
+            "SELECT f.feedback_id,o.obligation_id,EXISTS("
+            "SELECT 1 FROM evaluation_reconciliation_dispositions d "
+            "WHERE d.obligation_id=o.obligation_id) FROM evaluation_feedback f "
             "JOIN evaluation_reconciliation_obligations o "
             "ON o.feedback_id=f.feedback_id ORDER BY f.feedback_id"
         ).fetchall()
         values: list[Any] = []
         verified = False
-        for feedback_id, obligation_id in rows:
+        for feedback_id, obligation_id, has_dispositions in rows:
             feedback_id = str(feedback_id)
             obligation_id = str(obligation_id)
             if feedback_id in relevant_feedback_ids:
                 accepted = target.load(feedback_id)
                 values.append(feedback._decoded(accepted.feedback.source_feedback_id))
                 verified = True
-            has_dispositions = connection.execute(
-                "SELECT 1 FROM evaluation_reconciliation_dispositions "
-                "WHERE obligation_id=? LIMIT 1",
-                (obligation_id,),
-            ).fetchone()
-            if has_dispositions is not None:
+            if has_dispositions:
                 for disposition in target.dispositions(obligation_id):
                     try:
-                        values.append(
-                            feedback._decoded(disposition.idempotency_key)
-                        )
+                        values.append(feedback._decoded(disposition.idempotency_key))
                     except KeyError:
                         pass
                 verified = True
         if not verified:
             base_feedback = self.location.base[0]
             target.load(base_feedback.feedback_id)
-        return tuple(values)
+        commands = tuple(values)
+        if transaction is None:
+            post_key = (
+                int(connection.execute("PRAGMA data_version").fetchone()[0]),
+                connection.total_changes,
+            )
+            if post_key == cache_key:
+                self._verified_commands_cache = (post_key, commands)
+        return commands
 
     def submit(self: Any, command: Any, *, lose_response: bool = False) -> Any:
         try:

--- a/newsroom/tests/feedback_adapter_fastpath.py
+++ b/newsroom/tests/feedback_adapter_fastpath.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import os
+import sqlite3
+from typing import Any
+
+import pytest
+
+_STORE = "test_increment6f2_feedback_store.py"
+_CACHE_TEST = "test_increment6f2_feedback_cache.py"
+
+
+def _selected(config: pytest.Config) -> bool:
+    return any(
+        _STORE in os.fspath(argument) or _CACHE_TEST in os.fspath(argument)
+        for argument in config.invocation_params.args
+    )
+
+
+def _install(feedback: Any) -> None:
+    handle = feedback._Handle
+    if getattr(handle, "_verified_result_fastpath_v1", False):
+        return
+
+    def _commands(self: Any, transaction: Any = None) -> tuple[Any, ...]:
+        target = transaction or self._opened()
+        connection = (
+            target._connection if transaction is None else target._root._connection
+        )
+        relevant_feedback_ids = {
+            str(fixture[0].feedback_id) for fixture in self.location.fixtures.values()
+        }
+        rows = connection.execute(
+            "SELECT f.feedback_id,o.obligation_id FROM evaluation_feedback f "
+            "JOIN evaluation_reconciliation_obligations o "
+            "ON o.feedback_id=f.feedback_id ORDER BY f.feedback_id"
+        ).fetchall()
+        values: list[Any] = []
+        verified = False
+        for feedback_id, obligation_id in rows:
+            feedback_id = str(feedback_id)
+            obligation_id = str(obligation_id)
+            if feedback_id in relevant_feedback_ids:
+                accepted = target.load(feedback_id)
+                values.append(feedback._decoded(accepted.feedback.source_feedback_id))
+                verified = True
+            has_dispositions = connection.execute(
+                "SELECT 1 FROM evaluation_reconciliation_dispositions "
+                "WHERE obligation_id=? LIMIT 1",
+                (obligation_id,),
+            ).fetchone()
+            if has_dispositions is not None:
+                for disposition in target.dispositions(obligation_id):
+                    try:
+                        values.append(
+                            feedback._decoded(disposition.idempotency_key)
+                        )
+                    except KeyError:
+                        pass
+                verified = True
+        if not verified:
+            base_feedback = self.location.base[0]
+            target.load(base_feedback.feedback_id)
+        return tuple(values)
+
+    def submit(self: Any, command: Any, *, lose_response: bool = False) -> Any:
+        try:
+            if command.record_id in self.location.competing:
+                proposed = self.location.competing[command.record_id]
+                retained_disposition = self._opened().append_disposition(
+                    proposed.canonical_bytes,
+                    candidate_proof=self.location.proof,
+                )
+                retained = feedback._decoded(retained_disposition.idempotency_key)
+            else:
+                proposed_feedback, obligation = feedback._submission(
+                    self.location, command
+                )
+                accepted = self._opened().accept(
+                    proposed_feedback.canonical_bytes,
+                    obligation.canonical_bytes,
+                    candidate_proof=self.location.proof,
+                )
+                retained = feedback._decoded(accepted.feedback.source_feedback_id)
+        except (
+            KeyError,
+            feedback.FeedbackContractError,
+            sqlite3.OperationalError,
+        ) as exc:
+            if feedback._database_locked(exc):
+                raise feedback.BindingConflict(command.record_id) from exc
+            try:
+                retained = next(
+                    (
+                        item
+                        for item in self._commands()
+                        if item.record_id == command.record_id
+                    ),
+                    None,
+                )
+            except Exception as integrity:
+                raise feedback.IntegrityViolation(command.record_id) from integrity
+            if retained is not None:
+                raise feedback.BindingConflict(command.record_id) from exc
+            raise feedback.IntegrityViolation(command.record_id) from exc
+        except Exception as exc:
+            raise feedback.IntegrityViolation(command.record_id) from exc
+        if retained != command:
+            raise feedback.IntegrityViolation(command.record_id)
+        if lose_response:
+            raise feedback.LostResponse(command.record_id)
+        return feedback.AuthorityValue.from_command(retained)
+
+    handle._commands = _commands
+    handle.submit = submit
+    handle._verified_result_fastpath_v1 = True
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    if not _selected(config):
+        return
+    from newsroom.tests import test_increment6f2_feedback_store as feedback
+
+    _install(feedback)

--- a/newsroom/tests/feedback_cache_support.py
+++ b/newsroom/tests/feedback_cache_support.py
@@ -9,6 +9,7 @@ import re
 import sqlite3
 import stat
 import uuid
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -17,6 +18,7 @@ import pytest
 _FORMAT = "newsroom.feedback-conformance-cache.v1"
 _STORE = "test_increment6f2_feedback_store.py"
 _CACHE_TEST = "test_increment6f2_feedback_cache.py"
+_SYSTEM = "test_increment6f2_feedback_system.py"
 _PROBE = "test_real_feedback_store_passes_required_conformance_probe"
 _KEYS = (
     ("record-1",),
@@ -60,6 +62,19 @@ def _safe_file(path: Path) -> os.stat_result:
     return metadata
 
 
+def _safe_source_file(path: Path) -> os.stat_result:
+    metadata = path.lstat()
+    mode = stat.S_IMODE(metadata.st_mode)
+    if (
+        stat.S_ISLNK(metadata.st_mode)
+        or not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_uid != os.getuid()
+        or mode & 0o022
+    ):
+        raise ValueError(f"unsafe feedback template source: {path.name}")
+    return metadata
+
+
 def _atomic_write(path: Path, payload: bytes) -> None:
     stage = path.with_name(f"{path.name}.{uuid.uuid4().hex}.stage")
     flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0)
@@ -85,7 +100,9 @@ def _deepcopy(value: object) -> object:
 
 def _selected(config: pytest.Config) -> bool:
     return any(
-        _STORE in os.fspath(argument) or _CACHE_TEST in os.fspath(argument)
+        _STORE in os.fspath(argument)
+        or _CACHE_TEST in os.fspath(argument)
+        or _SYSTEM in os.fspath(argument)
         for argument in config.invocation_params.args
     )
 
@@ -96,6 +113,8 @@ def _selected_keys(arguments: tuple[str, ...], feedback: Any):
     conservative = False
     found = False
     for argument in arguments:
+        if _SYSTEM in argument:
+            found = True
         if _CACHE_TEST in argument:
             found = True
             selected.add(("record-1",))
@@ -124,6 +143,8 @@ def _selected_keys(arguments: tuple[str, ...], feedback: Any):
         raise ValueError("feedback conformance selection missing")
     if conservative:
         return _KEYS
+    if not selected:
+        return ()
     ordered = tuple(key for key in _KEYS if key in selected)
     return ordered or (("record-1",),)
 
@@ -139,7 +160,7 @@ def _snapshot(location: Any) -> dict[str, object]:
     retrieval = seed_tail[0][1]
     source = retrieval._path
     if not isinstance(source, Path):
-        raise ValueError("feedback retrieval source path")
+        raise TypeError("feedback retrieval source path")
     retrieval_bytes = source.read_bytes()
     retrieval._path = _SENTINEL
     return {
@@ -153,14 +174,93 @@ def _snapshot(location: Any) -> dict[str, object]:
     }
 
 
+@dataclass(frozen=True)
+class _SystemSeedSnapshot:
+    database_bytes: bytes
+    retrieval_bytes: bytes
+    seed_tail: tuple
+    feedback: object
+    obligation: object
+
+    def clone(self, root: Path):
+        from newsroom.tests import (
+            test_increment6e2_candidate_store as candidate_fixture,
+        )
+
+        seed_tail, feedback, obligation = _deepcopy(
+            (self.seed_tail, self.feedback, self.obligation)
+        )
+        collaborators = seed_tail[0]
+        retrieval = collaborators[1]
+        if retrieval._path != _SENTINEL:
+            raise ValueError("feedback system seed retrieval sentinel differs")
+        database = root / "feedback-system-seed.sqlite3"
+        retrieval_path = root / "retrieval-context.sqlite3"
+        _write_private(database, self.database_bytes)
+        _write_private(retrieval_path, self.retrieval_bytes)
+        retrieval._path = retrieval_path
+        seed = (collaborators, database, *seed_tail[1:])
+        location = candidate_fixture._Location(seed, root / "candidate-collisions")
+        args = candidate_fixture._collaborators(seed)
+        args["authorizer"] = _authorizer(args)
+        return location, args, feedback, obligation
+
+
+def _system_seed_snapshot(value: tuple[object, ...]) -> _SystemSeedSnapshot:
+    if len(value) != 4:
+        raise ValueError("feedback system seed shape differs")
+    location, _, feedback, obligation = value
+    seed = location.seed
+    connection = sqlite3.connect(seed[1], isolation_level=None)
+    try:
+        connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    finally:
+        connection.close()
+    seed_tail = _deepcopy((seed[0], *seed[2:]))
+    retrieval = seed_tail[0][1]
+    source = retrieval._path
+    if not isinstance(source, Path):
+        raise TypeError("feedback system seed retrieval path")
+    _safe_source_file(source)
+    retrieval_bytes = source.read_bytes()
+    retrieval._path = _SENTINEL
+    return _SystemSeedSnapshot(
+        Path(seed[1]).read_bytes(),
+        retrieval_bytes,
+        seed_tail,
+        feedback,
+        obligation,
+    )
+
+
 def _build(selected: tuple[tuple[str, ...], ...], feedback: Any, root: Path):
+    from newsroom.tests import test_increment6e2_candidate_store as candidate_fixture
+    from newsroom.tests import test_increment6f2_feedback_system as system_fixture
+
     feedback._LOCATION_SNAPSHOTS.clear()
+    _safe_directory(root, create=True)
+    candidate_seed_snapshot = candidate_fixture._seed_snapshot(root / "candidate-seed")
+    system_root = root / "system-seed"
+    system_root.mkdir(mode=0o700)
+    system_seed = system_fixture._seed(
+        system_root, candidate_seed_snapshot=candidate_seed_snapshot
+    )
+    system_seed_snapshot = _system_seed_snapshot(system_seed)
     templates = {}
     for index, records in enumerate(selected):
-        location = feedback._build_location(root / f"template-{index}", records)
+        location_args = (
+            {"system_seed": system_seed}
+            if len(selected) == 1
+            else {"system_seed_snapshot": system_seed_snapshot}
+        )
+        location = feedback._build_location(
+            root / f"template-{index}", records, **location_args
+        )
         templates[records] = _snapshot(location)
     return {
+        "candidate_seed": candidate_seed_snapshot,
         "format": _FORMAT,
+        "system_seed": system_seed_snapshot,
         "template_keys": selected,
         "templates": templates,
     }
@@ -177,9 +277,9 @@ def _publish(root: Path, selected, feedback: Any, build_root: Path) -> None:
         "format": _FORMAT,
         "template_keys": [list(key) for key in selected],
     }
-    rendered = json.dumps(
-        manifest, sort_keys=True, separators=(",", ":")
-    ).encode() + b"\n"
+    rendered = (
+        json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode() + b"\n"
+    )
     _atomic_write(root / "manifest.json", rendered)
 
 
@@ -190,9 +290,9 @@ def _load(root: Path, selected):
     _safe_file(bundle_path)
     raw = manifest_path.read_bytes()
     manifest = json.loads(raw)
-    canonical = json.dumps(
-        manifest, sort_keys=True, separators=(",", ":")
-    ).encode() + b"\n"
+    canonical = (
+        json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode() + b"\n"
+    )
     if raw != canonical or set(manifest) != {
         "bundle_digest",
         "bundle_size",
@@ -210,7 +310,7 @@ def _load(root: Path, selected):
         raise ValueError("feedback cache bundle identity differs")
     value = pickle.loads(bundle)
     if not isinstance(value, dict):
-        raise ValueError("feedback cache bundle malformed")
+        raise TypeError("feedback cache bundle malformed")
     return value
 
 
@@ -252,9 +352,9 @@ def _install_clone(feedback: Any) -> None:
         retrieval = collaborators[1]
         source = retrieval._path
         if not isinstance(source, Path):
-            raise ValueError("feedback retrieval template path")
+            raise TypeError("feedback retrieval template path")
         retrieval_path = root / "retrieval-context.sqlite3"
-        _safe_file(source)
+        _safe_source_file(source)
         _write_private(retrieval_path, source.read_bytes())
         retrieval._path = retrieval_path
         seed = (collaborators, database, *seed_tail[1:])
@@ -267,7 +367,13 @@ def _install_clone(feedback: Any) -> None:
 
 
 def _install(value, selected, feedback: Any, hydrate_root: Path) -> None:
-    if set(value) != {"format", "template_keys", "templates"}:
+    if set(value) != {
+        "candidate_seed",
+        "format",
+        "system_seed",
+        "template_keys",
+        "templates",
+    }:
         raise ValueError("feedback cache fields differ")
     if value["format"] != _FORMAT or value["template_keys"] != selected:
         raise ValueError("feedback cache contract differs")
@@ -276,7 +382,22 @@ def _install(value, selected, feedback: Any, hydrate_root: Path) -> None:
         raise ValueError("feedback cache templates differ")
     hydrate_root.mkdir(mode=0o700)
     feedback._LOCATION_SNAPSHOTS.clear()
+    system_seed = value["system_seed"]
+    if not isinstance(system_seed, _SystemSeedSnapshot):
+        raise TypeError("feedback system seed differs")
+    from newsroom.tests import test_increment6f2_feedback_system as system_fixture
+
+    def clone_system_seed(root: Path, *, candidate_seed_snapshot=None):
+        del candidate_seed_snapshot
+        return system_seed.clone(root)
+
+    system_fixture._seed = clone_system_seed
     from newsroom.tests import test_increment6e2_candidate_store as candidate_fixture
+
+    candidate_seed = value["candidate_seed"]
+    if not isinstance(candidate_seed, candidate_fixture._SeedSnapshot):
+        raise TypeError("feedback candidate seed differs")
+    candidate_fixture._SHARED_SEED_SNAPSHOT = candidate_seed
 
     for index, records in enumerate(selected):
         template = templates[records]
@@ -294,7 +415,7 @@ def _install(value, selected, feedback: Any, hydrate_root: Path) -> None:
         if not isinstance(template["database_bytes"], bytes) or not isinstance(
             template["retrieval_bytes"], bytes
         ):
-            raise ValueError("feedback cache template bytes differ")
+            raise TypeError("feedback cache template bytes differ")
         seed_tail = template["seed_tail"]
         if not isinstance(seed_tail, tuple) or not seed_tail:
             raise ValueError("feedback cache seed tail differs")
@@ -356,9 +477,9 @@ def pytest_sessionstart(session: pytest.Session) -> None:
 
     _install_clone(feedback)
     worker = getattr(config, "workerinput", None)
-    if not isinstance(worker, dict) or not str(
-        worker.get("workerid", "")
-    ).startswith("gw"):
+    if not isinstance(worker, dict) or not str(worker.get("workerid", "")).startswith(
+        "gw"
+    ):
         return
     run_uid = worker.get("testrunuid")
     if not isinstance(run_uid, str) or _RUN_UID.fullmatch(run_uid) is None:

--- a/newsroom/tests/feedback_cache_support.py
+++ b/newsroom/tests/feedback_cache_support.py
@@ -1,0 +1,379 @@
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import os
+import pickle
+import re
+import sqlite3
+import stat
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_FORMAT = "newsroom.feedback-conformance-cache.v1"
+_STORE = "test_increment6f2_feedback_store.py"
+_CACHE_TEST = "test_increment6f2_feedback_cache.py"
+_PROBE = "test_real_feedback_store_passes_required_conformance_probe"
+_KEYS = (
+    ("record-1",),
+    ("record-1", "record-2"),
+    ("record-a", "record-b"),
+    ("record-rollback-normal", "record-rollback-abort"),
+)
+_RUN_UID = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}")
+_SENTINEL = Path("/__newsroom_feedback_cache__/retrieval.sqlite3")
+
+
+def _digest(payload: bytes) -> str:
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def _safe_directory(path: Path, *, create: bool = False) -> None:
+    if create:
+        try:
+            path.mkdir(mode=0o700)
+        except FileExistsError:
+            pass
+    metadata = path.lstat()
+    if (
+        stat.S_ISLNK(metadata.st_mode)
+        or not stat.S_ISDIR(metadata.st_mode)
+        or metadata.st_uid != os.getuid()
+        or stat.S_IMODE(metadata.st_mode) != 0o700
+    ):
+        raise ValueError(f"unsafe feedback cache directory: {path.name}")
+
+
+def _safe_file(path: Path) -> os.stat_result:
+    metadata = path.lstat()
+    if (
+        stat.S_ISLNK(metadata.st_mode)
+        or not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_uid != os.getuid()
+        or stat.S_IMODE(metadata.st_mode) != 0o600
+    ):
+        raise ValueError(f"unsafe feedback cache file: {path.name}")
+    return metadata
+
+
+def _atomic_write(path: Path, payload: bytes) -> None:
+    stage = path.with_name(f"{path.name}.{uuid.uuid4().hex}.stage")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0)
+    descriptor = os.open(stage, flags, 0o600)
+    try:
+        with os.fdopen(descriptor, "wb", closefd=False) as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+    finally:
+        os.close(descriptor)
+    os.replace(stage, path)
+    directory = os.open(path.parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(directory)
+    finally:
+        os.close(directory)
+
+
+def _deepcopy(value: object) -> object:
+    return pickle.loads(pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL))
+
+
+def _selected(config: pytest.Config) -> bool:
+    return any(
+        _STORE in os.fspath(argument) or _CACHE_TEST in os.fspath(argument)
+        for argument in config.invocation_params.args
+    )
+
+
+def _selected_keys(arguments: tuple[str, ...], feedback: Any):
+    probes = {probe.probe_id: probe for probe in feedback._CONFORMANCE_PROBES}
+    selected: set[tuple[str, ...]] = set()
+    conservative = False
+    found = False
+    for argument in arguments:
+        if _CACHE_TEST in argument:
+            found = True
+            selected.add(("record-1",))
+        if _STORE not in argument:
+            continue
+        found = True
+        tail = argument.split(_STORE, 1)[1]
+        if not tail.startswith("::"):
+            conservative = True
+            continue
+        node = tail[2:]
+        if not node.startswith(_PROBE):
+            selected.add(("record-1",))
+            continue
+        suffix = node[len(_PROBE) :]
+        if not suffix:
+            conservative = True
+            continue
+        if not suffix.startswith("[") or not suffix.endswith("]"):
+            raise ValueError("unknown exact feedback conformance probe")
+        probe = probes.get(suffix[1:-1])
+        if probe is None:
+            raise ValueError("unknown exact feedback conformance probe")
+        selected.add(feedback._RECORDS_BY_CASE.get(probe.case, ("record-1",)))
+    if not found:
+        raise ValueError("feedback conformance selection missing")
+    if conservative:
+        return _KEYS
+    ordered = tuple(key for key in _KEYS if key in selected)
+    return ordered or (("record-1",),)
+
+
+def _snapshot(location: Any) -> dict[str, object]:
+    seed = location.candidate.seed
+    connection = sqlite3.connect(seed[1], isolation_level=None)
+    try:
+        connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    finally:
+        connection.close()
+    seed_tail = _deepcopy((seed[0], *seed[2:]))
+    retrieval = seed_tail[0][1]
+    source = retrieval._path
+    if not isinstance(source, Path):
+        raise ValueError("feedback retrieval source path")
+    retrieval_bytes = source.read_bytes()
+    retrieval._path = _SENTINEL
+    return {
+        "base": location.base,
+        "competing": location.competing,
+        "database_bytes": Path(seed[1]).read_bytes(),
+        "fixtures": location.fixtures,
+        "proof": location.proof,
+        "retrieval_bytes": retrieval_bytes,
+        "seed_tail": seed_tail,
+    }
+
+
+def _build(selected: tuple[tuple[str, ...], ...], feedback: Any, root: Path):
+    feedback._LOCATION_SNAPSHOTS.clear()
+    templates = {}
+    for index, records in enumerate(selected):
+        location = feedback._build_location(root / f"template-{index}", records)
+        templates[records] = _snapshot(location)
+    return {
+        "format": _FORMAT,
+        "template_keys": selected,
+        "templates": templates,
+    }
+
+
+def _publish(root: Path, selected, feedback: Any, build_root: Path) -> None:
+    bundle = pickle.dumps(
+        _build(selected, feedback, build_root), protocol=pickle.HIGHEST_PROTOCOL
+    )
+    _atomic_write(root / "bundle.pickle", bundle)
+    manifest = {
+        "bundle_digest": _digest(bundle),
+        "bundle_size": len(bundle),
+        "format": _FORMAT,
+        "template_keys": [list(key) for key in selected],
+    }
+    rendered = json.dumps(
+        manifest, sort_keys=True, separators=(",", ":")
+    ).encode() + b"\n"
+    _atomic_write(root / "manifest.json", rendered)
+
+
+def _load(root: Path, selected):
+    manifest_path = root / "manifest.json"
+    bundle_path = root / "bundle.pickle"
+    _safe_file(manifest_path)
+    _safe_file(bundle_path)
+    raw = manifest_path.read_bytes()
+    manifest = json.loads(raw)
+    canonical = json.dumps(
+        manifest, sort_keys=True, separators=(",", ":")
+    ).encode() + b"\n"
+    if raw != canonical or set(manifest) != {
+        "bundle_digest",
+        "bundle_size",
+        "format",
+        "template_keys",
+    }:
+        raise ValueError("feedback cache manifest differs")
+    bundle = bundle_path.read_bytes()
+    if (
+        manifest["format"] != _FORMAT
+        or manifest["template_keys"] != [list(key) for key in selected]
+        or manifest["bundle_size"] != len(bundle)
+        or manifest["bundle_digest"] != _digest(bundle)
+    ):
+        raise ValueError("feedback cache bundle identity differs")
+    value = pickle.loads(bundle)
+    if not isinstance(value, dict):
+        raise ValueError("feedback cache bundle malformed")
+    return value
+
+
+def _authorizer(args: dict[str, object]) -> object:
+    from newsroom.authority.auth import StaticAuthorizer
+
+    registry = args["command_registry"]
+    scopes = {item.required_scope for item in registry.definitions()} | {
+        "authority.evaluation-feedback.reconcile"
+    }
+    return StaticAuthorizer(
+        policy_version="feedback-test-v1",
+        grants_by_principal={"editor": frozenset(scopes)},
+    )
+
+
+def _write_private(path: Path, payload: bytes) -> None:
+    path.write_bytes(payload)
+    path.chmod(0o600)
+
+
+def _install_clone(feedback: Any) -> None:
+    from newsroom.tests import test_increment6e2_candidate_store as candidate_fixture
+
+    def clone(snapshot: Any, root: Path) -> Any:
+        root.mkdir(mode=0o700)
+        database = root / "feedback-authority.sqlite3"
+        _write_private(database, snapshot.database_bytes)
+        seed_tail, fixtures, proof, base, competing = _deepcopy(
+            (
+                snapshot.seed_tail,
+                snapshot.fixtures,
+                snapshot.proof,
+                snapshot.base,
+                snapshot.competing,
+            )
+        )
+        collaborators = seed_tail[0]
+        retrieval = collaborators[1]
+        source = retrieval._path
+        if not isinstance(source, Path):
+            raise ValueError("feedback retrieval template path")
+        retrieval_path = root / "retrieval-context.sqlite3"
+        _safe_file(source)
+        _write_private(retrieval_path, source.read_bytes())
+        retrieval._path = retrieval_path
+        seed = (collaborators, database, *seed_tail[1:])
+        candidate = candidate_fixture._Location(seed, root / "candidate-collisions")
+        args = candidate_fixture._collaborators(seed)
+        args["authorizer"] = _authorizer(args)
+        return feedback._Location(candidate, args, fixtures, proof, base, competing)
+
+    feedback._LocationSnapshot.clone = clone
+
+
+def _install(value, selected, feedback: Any, hydrate_root: Path) -> None:
+    if set(value) != {"format", "template_keys", "templates"}:
+        raise ValueError("feedback cache fields differ")
+    if value["format"] != _FORMAT or value["template_keys"] != selected:
+        raise ValueError("feedback cache contract differs")
+    templates = value["templates"]
+    if not isinstance(templates, dict) or tuple(templates) != selected:
+        raise ValueError("feedback cache templates differ")
+    hydrate_root.mkdir(mode=0o700)
+    feedback._LOCATION_SNAPSHOTS.clear()
+    from newsroom.tests import test_increment6e2_candidate_store as candidate_fixture
+
+    for index, records in enumerate(selected):
+        template = templates[records]
+        expected = {
+            "base",
+            "competing",
+            "database_bytes",
+            "fixtures",
+            "proof",
+            "retrieval_bytes",
+            "seed_tail",
+        }
+        if not isinstance(template, dict) or set(template) != expected:
+            raise ValueError("feedback cache template fields differ")
+        if not isinstance(template["database_bytes"], bytes) or not isinstance(
+            template["retrieval_bytes"], bytes
+        ):
+            raise ValueError("feedback cache template bytes differ")
+        seed_tail = template["seed_tail"]
+        if not isinstance(seed_tail, tuple) or not seed_tail:
+            raise ValueError("feedback cache seed tail differs")
+        retrieval = seed_tail[0][1]
+        if retrieval._path != _SENTINEL:
+            raise ValueError("feedback cache retrieval sentinel differs")
+        hydrated = hydrate_root / f"retrieval-{index}.sqlite3"
+        _write_private(hydrated, template["retrieval_bytes"])
+        retrieval._path = hydrated
+        seed = (
+            seed_tail[0],
+            hydrate_root / f"template-{index}.sqlite3",
+            *seed_tail[1:],
+        )
+        args = candidate_fixture._collaborators(seed)
+        args["authorizer"] = _authorizer(args)
+        feedback._LOCATION_SNAPSHOTS[records] = feedback._LocationSnapshot(
+            template["database_bytes"],
+            seed_tail,
+            args,
+            template["fixtures"],
+            template["proof"],
+            template["base"],
+            template["competing"],
+        )
+    _install_clone(feedback)
+
+
+def _ensure(root: Path, run_uid: str, selected, feedback: Any, hydrate_root: Path):
+    if _RUN_UID.fullmatch(run_uid) is None:
+        raise ValueError("invalid feedback cache run uid")
+    _safe_directory(root, create=True)
+    lock_path = root / "producer.lock"
+    flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(lock_path, flags, 0o600)
+    try:
+        metadata = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_uid != os.getuid()
+            or stat.S_IMODE(metadata.st_mode) != 0o600
+        ):
+            raise ValueError("unsafe feedback cache lock")
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        if not (root / "manifest.json").exists():
+            _publish(root, selected, feedback, root / f"build-{run_uid}")
+        value = _load(root, selected)
+    finally:
+        os.close(descriptor)
+    _install(value, selected, feedback, hydrate_root)
+
+
+def pytest_sessionstart(session: pytest.Session) -> None:
+    config = session.config
+    if not _selected(config):
+        return
+    from newsroom.tests import test_increment6f2_feedback_store as feedback
+
+    _install_clone(feedback)
+    worker = getattr(config, "workerinput", None)
+    if not isinstance(worker, dict) or not str(
+        worker.get("workerid", "")
+    ).startswith("gw"):
+        return
+    run_uid = worker.get("testrunuid")
+    if not isinstance(run_uid, str) or _RUN_UID.fullmatch(run_uid) is None:
+        raise pytest.UsageError("invalid xdist testrunuid for feedback cache")
+    basetemp = config._tmp_path_factory.getbasetemp()
+    selected = _selected_keys(
+        tuple(os.fspath(item) for item in config.invocation_params.args), feedback
+    )
+    try:
+        _ensure(
+            basetemp.parent / f"newsroom-feedback-{run_uid}",
+            run_uid,
+            selected,
+            feedback,
+            basetemp / "feedback-hydrated",
+        )
+    except Exception as exc:
+        raise pytest.UsageError(f"feedback shared cache invalid: {exc}") from exc

--- a/newsroom/tests/graphiti_adapter_4d_migration_helpers.py
+++ b/newsroom/tests/graphiti_adapter_4d_migration_helpers.py
@@ -56,6 +56,9 @@ def _drop_empty_v23_lineage_schema(connection: sqlite3.Connection) -> None:
             EVALUATION_FEEDBACK_MIGRATION_STATEMENTS,
         )
 
+        def normalise_sql(value: str) -> str:
+            return " ".join(value.split()).replace(" IF NOT EXISTS", "")
+
         objects = connection.execute(
             "SELECT type,name,sql FROM sqlite_master WHERE "
             "tbl_name IN ('evaluation_feedback','evaluation_reconciliation_obligations',"
@@ -77,10 +80,20 @@ def _drop_empty_v23_lineage_schema(connection: sqlite3.Connection) -> None:
             connection.execute(
                 "SELECT name,checksum FROM authority_migrations WHERE version=25"
             ).fetchone()
-            != (EVALUATION_FEEDBACK_MIGRATION_NAME, EVALUATION_FEEDBACK_MIGRATION_CHECKSUM)
+            != (
+                EVALUATION_FEEDBACK_MIGRATION_NAME,
+                EVALUATION_FEEDBACK_MIGRATION_CHECKSUM,
+            )
             or {str(row[1]) for row in objects} != expected_names
+            or {normalise_sql(str(row[2])) for row in objects}
+            != {
+                normalise_sql(statement)
+                for statement in EVALUATION_FEEDBACK_MIGRATION_STATEMENTS
+            }
         ):
-            raise sqlite3.DatabaseError("downgrade requires exact empty v25 Feedback schema")
+            raise sqlite3.DatabaseError(
+                "downgrade requires exact empty v25 Feedback schema"
+            )
         for table in (
             "evaluation_feedback",
             "evaluation_reconciliation_obligations",

--- a/newsroom/tests/graphiti_adapter_4d_migration_helpers.py
+++ b/newsroom/tests/graphiti_adapter_4d_migration_helpers.py
@@ -49,6 +49,62 @@ def drop_empty_v23_lineage_schema(connection: sqlite3.Connection) -> None:
 
 def _drop_empty_v23_lineage_schema(connection: sqlite3.Connection) -> None:
     """Remove an exact, empty v23 lineage schema atomically."""
+    if int(connection.execute("PRAGMA user_version").fetchone()[0]) == 25:
+        from newsroom.authority.evaluation_feedback_migrations import (
+            EVALUATION_FEEDBACK_MIGRATION_CHECKSUM,
+            EVALUATION_FEEDBACK_MIGRATION_NAME,
+            EVALUATION_FEEDBACK_MIGRATION_STATEMENTS,
+        )
+
+        objects = connection.execute(
+            "SELECT type,name,sql FROM sqlite_master WHERE "
+            "tbl_name IN ('evaluation_feedback','evaluation_reconciliation_obligations',"
+            "'evaluation_reconciliation_dispositions') AND type IN ('table','trigger')"
+        ).fetchall()
+        expected_names = {
+            "evaluation_feedback",
+            "evaluation_reconciliation_obligations",
+            "evaluation_reconciliation_dispositions",
+            "immutable_evaluation_feedback",
+            "retained_evaluation_feedback",
+            "immutable_evaluation_obligation",
+            "retained_evaluation_obligation",
+            "immutable_evaluation_disposition",
+            "retained_evaluation_disposition",
+            "evaluation_disposition_predecessor_guard",
+        }
+        if (
+            connection.execute(
+                "SELECT name,checksum FROM authority_migrations WHERE version=25"
+            ).fetchone()
+            != (EVALUATION_FEEDBACK_MIGRATION_NAME, EVALUATION_FEEDBACK_MIGRATION_CHECKSUM)
+            or {str(row[1]) for row in objects} != expected_names
+        ):
+            raise sqlite3.DatabaseError("downgrade requires exact empty v25 Feedback schema")
+        for table in (
+            "evaluation_feedback",
+            "evaluation_reconciliation_obligations",
+            "evaluation_reconciliation_dispositions",
+        ):
+            if connection.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone() != (0,):
+                raise sqlite3.DatabaseError("v25 Feedback tables must be empty")
+        guard = connection.execute(
+            "SELECT sql FROM sqlite_master WHERE type='trigger' "
+            "AND name='immutable_authority_migrations_delete'"
+        ).fetchone()[0]
+        connection.execute("DROP TRIGGER immutable_authority_migrations_delete")
+        for object_type, name, _ in objects:
+            if object_type == "trigger":
+                connection.execute(f'DROP TRIGGER "{name}"')
+        for table in (
+            "evaluation_reconciliation_dispositions",
+            "evaluation_reconciliation_obligations",
+            "evaluation_feedback",
+        ):
+            connection.execute(f'DROP TABLE "{table}"')
+        connection.execute("DELETE FROM authority_migrations WHERE version=25")
+        connection.execute(guard)
+        connection.execute("PRAGMA user_version=24")
     if int(connection.execute("PRAGMA user_version").fetchone()[0]) == 24:
         candidate_tables = (
             "story_candidate_heads",

--- a/newsroom/tests/test_authority_migration_compatibility.py
+++ b/newsroom/tests/test_authority_migration_compatibility.py
@@ -44,6 +44,7 @@ _EXPECTED_NAMES = {
     22: "event_hypothesis_relationship_authority_v22",
     23: "event_hypothesis_lineage_authority_v23",
     24: "story_candidate_authority_v24",
+    25: "evaluation_feedback_authority_v25",
 }
 _EXPECTED_CHECKSUMS = {
     13: "sha256:c3e5ae627dda1c04bebc50952786413d977bd399e67b7f5b87452794f08f49ab",
@@ -58,6 +59,7 @@ _EXPECTED_CHECKSUMS = {
     22: "sha256:e59eb222a95e2901ccaae29ce1b9e8eded797306e9796718a6d2c4fa505a6636",
     23: "sha256:6c24d402f246f4e82a49a9772d70677d922282aae3b6dde93c62c0ef9b1b7a72",
     24: "sha256:1eea25005483de124e0add0100f4805ed5a537852fc70916f17a209c633e0ca0",
+    25: "sha256:59fe3bd40a2e22e874b4e5b02448501deffc23597e11b442e35b18e39ead0496",
 }
 
 _EXPECTED_MATRIX = """version | migration | objects | history fingerprint | schema fingerprint | object fingerprint
@@ -74,6 +76,7 @@ v21 | event_hypothesis_authority_v21 | 1170 | sha256:7404a1b6ffb14aacff8d3e9bb1d
 v22 | event_hypothesis_relationship_authority_v22 | 1179 | sha256:69acb590abbd8cbb3e6acdad8e6a0c0f31e13e1ed0a718098b64d545c343c1ed | sha256:2118fa893fb7fd2911bbde3056b79b1d0e26ccd6903e1c4228616f342898eaad | sha256:117392ff7fd1160034ec0792ab9f0d94e3a4643dc6fc280b44855ac67efff77a
 v23 | event_hypothesis_lineage_authority_v23 | 1192 | sha256:cd4750c9e0c44e3a91b6e6ecbb45ba382dc96fa77fbf2d87d3670801fb6bc9bc | sha256:c341333cf54d724bb4d2092bb9da81e9f3a434ddb03e6ddc14a51fdf2c6c1b52 | sha256:a23a710567b0cdf97f753e4412f1ca0a16b2d85c939a82f32a181f8efa583cce
 v24 | story_candidate_authority_v24 | 1221 | sha256:87fbc9d10bfea4239e9105cf851827404afb12012cc91ccf358ae9def233f6ff | sha256:abf8430bfd676a9b0e574847cde9375d90aa1e32680725a08b30c0657d567a7c | sha256:42452161bfddc32e5553bb0aab38c325dda223ec811f47cfae195d642fe06926
+v25 | evaluation_feedback_authority_v25 | 1253 | sha256:bea793377d065d3073e6dfa8d40139fedfd377d5e24d9812d12cdb1ad52e9a0f | sha256:353900bf5804f0b770489982541f3cff4fd30ea36fc75d19b9c63315d1b6ec06 | sha256:002a7c3cb59690568a8779e05c46a751ef57f91ee9070dc9095b0bfb953cf3f8
 """
 
 

--- a/newsroom/tests/test_graphiti_adapter_4d_migration_helpers.py
+++ b/newsroom/tests/test_graphiti_adapter_4d_migration_helpers.py
@@ -12,6 +12,7 @@ from newsroom.authority.migrations import apply_pending_migrations
 
 from .graphiti_adapter_4d_migration_helpers import (
     drop_empty_v22_relationship_schema,
+    drop_empty_v23_lineage_schema,
 )
 
 RELATIONSHIP_TRIGGERS = (
@@ -54,6 +55,21 @@ def test_v22_downgrade_preflight_preserves_state_when_trigger_is_missing(
 
     with pytest.raises(sqlite3.DatabaseError, match="exact v22 relationship schema"):
         drop_empty_v22_relationship_schema(connection)
+
+    assert _retained_state(connection) == before
+
+
+def test_v25_downgrade_preflight_preserves_state_when_trigger_sql_differs() -> None:
+    connection = _fresh()
+    connection.execute("DROP TRIGGER immutable_evaluation_feedback")
+    connection.execute(
+        "CREATE TRIGGER immutable_evaluation_feedback BEFORE UPDATE ON evaluation_feedback "
+        "WHEN 1=1 BEGIN SELECT RAISE(ABORT,'immutable Evaluation Feedback'); END"
+    )
+    before = _retained_state(connection)
+
+    with pytest.raises(sqlite3.DatabaseError, match="exact empty v25 Feedback schema"):
+        drop_empty_v23_lineage_schema(connection)
 
     assert _retained_state(connection) == before
 

--- a/newsroom/tests/test_increment6d1_hypothesis_migrations.py
+++ b/newsroom/tests/test_increment6d1_hypothesis_migrations.py
@@ -91,7 +91,7 @@ def _history(connection: sqlite3.Connection) -> list[tuple[int, str, str]]:
 
 def test_fresh_v21_has_exact_allocation_history_and_integrity() -> None:
     connection = _fresh()
-    assert SCHEMA_VERSION == 24
+    assert SCHEMA_VERSION == 25
     assert next(item for item in EXPECTED_MIGRATION_HISTORY if item[0] == 21) == (
         21,
         EVENT_HYPOTHESIS_MIGRATION_NAME,

--- a/newsroom/tests/test_increment6d2_relationship_migrations.py
+++ b/newsroom/tests/test_increment6d2_relationship_migrations.py
@@ -70,7 +70,7 @@ def test_fresh_v22_has_exact_single_table_history_and_pins() -> None:
     )
     assert (
         EXPECTED_SCHEMA_FINGERPRINT
-        == "sha256:abf8430bfd676a9b0e574847cde9375d90aa1e32680725a08b30c0657d567a7c"
+        == "sha256:353900bf5804f0b770489982541f3cff4fd30ea36fc75d19b9c63315d1b6ec06"
     )
     assert next(item for item in EXPECTED_MIGRATION_HISTORY if item[0] == 22) == (
         22,

--- a/newsroom/tests/test_increment6d3_lineage_store.py
+++ b/newsroom/tests/test_increment6d3_lineage_store.py
@@ -393,9 +393,15 @@ def test_v22_to_v23_preserves_retained_relationship_before_lineage_use(
         path.unlink(missing_ok=True)
     for path in story_candidate_backup_paths(seed[1]):
         path.unlink(missing_ok=True)
+    from newsroom.authority.evaluation_feedback_migrations import (
+        evaluation_feedback_backup_paths,
+    )
+
+    for path in evaluation_feedback_backup_paths(seed[1]):
+        path.unlink(missing_ok=True)
     assert prepare_pending_migration_backup(connection) is not None
     apply_pending_migrations(connection, applied_at="2042-01-03T00:00:00.000000Z")
-    assert connection.execute("PRAGMA user_version").fetchone() == (24,)
+    assert connection.execute("PRAGMA user_version").fetchone() == (25,)
     assert (
         connection.execute(
             "SELECT * FROM event_hypothesis_relationship_decisions ORDER BY decision_id"
@@ -1421,10 +1427,10 @@ class _LineageAdapter:
                 apply_pending_migrations(
                     connection, applied_at="2042-01-03T00:00:00.000000Z"
                 )
-                assert connection.execute("PRAGMA user_version").fetchone() == (24,)
+                assert connection.execute("PRAGMA user_version").fetchone() == (25,)
                 assert connection.execute(
                     "SELECT MAX(version) FROM authority_migrations"
-                ).fetchone() == (24,)
+                ).fetchone() == (25,)
             finally:
                 connection.close()
         return _ConformanceHandle(location)

--- a/newsroom/tests/test_increment6e2_candidate_authority.py
+++ b/newsroom/tests/test_increment6e2_candidate_authority.py
@@ -83,7 +83,7 @@ def test_v24_allocates_only_exact_candidate_tables(tmp_path: Path) -> None:
     migrations.apply_pending_migrations(
         connection, applied_at="2042-01-01T00:00:00.000000Z"
     )
-    assert connection.execute("PRAGMA user_version").fetchone() == (24,)
+    assert connection.execute("PRAGMA user_version").fetchone() == (migrations.SCHEMA_VERSION,)
     assert connection.execute(
         "SELECT name FROM authority_migrations WHERE version=24"
     ).fetchone() == (STORY_CANDIDATE_MIGRATION_NAME,)
@@ -156,7 +156,7 @@ def test_v24_downgrade_preflight_is_non_mutating(tmp_path: Path, failure: str) -
             ("sha256:" + "f" * 64,),
         )
     else:
-        connection.execute("PRAGMA user_version=25")
+        connection.execute("PRAGMA user_version=26")
     damaged = (
         connection.execute("PRAGMA user_version").fetchone(),
         tuple(connection.iterdump()),

--- a/newsroom/tests/test_increment6e2_candidate_store.py
+++ b/newsroom/tests/test_increment6e2_candidate_store.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import pickle
 import sqlite3
 import uuid
 from collections.abc import Callable
@@ -65,14 +66,15 @@ from newsroom.increment6.relationships import (
     ComparatorSetManifest,
     HypothesisVersionBinding,
     assess_relationships,
+    merge_relationship_authority_registries,
     open_event_hypothesis_relationship_authority,
     relationship_command_definition,
-    merge_relationship_authority_registries,
 )
 from newsroom.tests import test_increment6d1_hypothesis_store as d1
 from newsroom.tests import test_increment6d2_relationship_store as d2
 from newsroom.tests import test_increment6d3_lineage as d3
 from newsroom.tests.authority_store_conformance import (
+    _SCENARIOS,
     CASE_INVENTORY,
     Applicability,
     AuthorityValue,
@@ -84,7 +86,6 @@ from newsroom.tests.authority_store_conformance import (
     StoredAuthorityState,
     TamperKind,
     WriteCommand,
-    _SCENARIOS,
     run_conformance,
 )
 from newsroom.tests.test_increment5c2_named_tool_authority_execution import (
@@ -97,7 +98,6 @@ from newsroom.tests.test_increment5c2_named_tool_authority_execution import (
     executor,
 )
 from newsroom.tests.test_increment6e1_collision import _trusted_context
-
 
 _RECORDS = (
     ("record-1", "alpha"),
@@ -277,12 +277,24 @@ class _SeedSnapshot:
     database_bytes: bytes
     tail: tuple
 
+    def fork(self) -> _SeedSnapshot:
+        return pickle.loads(pickle.dumps(self, protocol=pickle.HIGHEST_PROTOCOL))
+
     def clone(self, root: Path) -> tuple:
         root.mkdir(mode=0o700)
         database = root / "candidate-authority.sqlite3"
         database.write_bytes(self.database_bytes)
         os.chmod(database, 0o600)
-        return (self.tail[0], database, *self.tail[1:])
+        collaborators = pickle.loads(
+            pickle.dumps(self.tail[0], protocol=pickle.HIGHEST_PROTOCOL)
+        )
+        tail = (collaborators, *self.tail[1:])
+        retrieval = tail[0][1]
+        retrieval_path = root / "retrieval-context.sqlite3"
+        retrieval_path.write_bytes(Path(retrieval._path).read_bytes())
+        os.chmod(retrieval_path, 0o600)
+        retrieval._path = retrieval_path
+        return (tail[0], database, *tail[1:])
 
 
 def _seed_snapshot(root: Path) -> _SeedSnapshot:
@@ -298,6 +310,9 @@ def _seed_snapshot(root: Path) -> _SeedSnapshot:
         d2._SEED_CACHE = global_cache
         if d2._seed_cache_state(d2._SEED_CACHE) != global_state:
             raise AssertionError("global relationship seed cache changed")
+
+
+_SHARED_SEED_SNAPSHOT: _SeedSnapshot | None = None
 
 
 def _named_snapshot(
@@ -942,7 +957,9 @@ class _Adapter:
 
     def __init__(self, root: Path) -> None:
         self.root = root
-        self.snapshot = _seed_snapshot(root / "capacity-2-seed")
+        self.snapshot = _SHARED_SEED_SNAPSHOT or _seed_snapshot(
+            root / "capacity-2-seed"
+        )
 
     def create_location(self) -> _Location:
         root = self.root / str(uuid.uuid4())

--- a/newsroom/tests/test_increment6f2_feedback_cache.py
+++ b/newsroom/tests/test_increment6f2_feedback_cache.py
@@ -4,7 +4,11 @@ import sqlite3
 import stat
 from pathlib import Path
 
+import pytest
+
+from newsroom.tests import feedback_adapter_fastpath
 from newsroom.tests import test_increment6f2_feedback_store as feedback
+from newsroom.tests.authority_store_conformance import AuthorityValue
 
 
 def test_feedback_template_clones_are_file_and_object_isolated(tmp_path: Path) -> None:
@@ -47,3 +51,35 @@ def test_feedback_template_clones_are_file_and_object_isolated(tmp_path: Path) -
     assert snapshot.database_bytes == template_database_bytes
     assert template_retrieval.read_bytes() == template_retrieval_bytes
     assert second_retrieval.read_bytes() == second_retrieval_bytes
+
+
+def test_feedback_submit_uses_verified_result_and_reads_still_use_facade(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    feedback_adapter_fastpath._install(feedback)
+    command = feedback.candidate_fixture._generic("record-1")
+    location = feedback._location(tmp_path / "fastpath", ("record-1",))
+    handle = feedback._Handle(location)
+    root = handle._opened()
+    original_load = root.load
+
+    def reject_redundant_read(*args: object, **kwargs: object) -> object:
+        raise AssertionError("write result performed a redundant facade read")
+
+    monkeypatch.setattr(root, "load", reject_redundant_read)
+    monkeypatch.setattr(root, "dispositions", reject_redundant_read)
+    try:
+        assert handle.submit(command) == AuthorityValue.from_command(command)
+
+        calls = 0
+
+        def observed_load(*args: object, **kwargs: object) -> object:
+            nonlocal calls
+            calls += 1
+            return original_load(*args, **kwargs)
+
+        monkeypatch.setattr(root, "load", observed_load)
+        assert handle.observe(command.record_id) is not None
+        assert calls == 1
+    finally:
+        handle.close()

--- a/newsroom/tests/test_increment6f2_feedback_cache.py
+++ b/newsroom/tests/test_increment6f2_feedback_cache.py
@@ -3,27 +3,43 @@ from __future__ import annotations
 import sqlite3
 import stat
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
-from newsroom.tests import feedback_adapter_fastpath
-from newsroom.tests import feedback_cache_support
+from newsroom.tests import feedback_adapter_fastpath, feedback_cache_support
 from newsroom.tests import test_increment6f2_feedback_store as feedback
 from newsroom.tests.authority_store_conformance import AuthorityValue
 
 _ROLLBACK_RECORDS = ("record-rollback-normal", "record-rollback-abort")
 
 
-def test_feedback_template_clones_are_file_and_object_isolated(tmp_path: Path) -> None:
+def test_feedback_template_clones_are_file_and_object_isolated(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     selection = (
-        "newsroom/tests/test_increment6f2_feedback_cache.py::"
-        "test_feedback_template_clones_are_file_and_object_isolated",
-        "newsroom/tests/test_increment6f2_feedback_store.py::"
-        "test_real_feedback_store_passes_required_conformance_probe"
-        "[transaction_rollback-abort]",
+        (
+            "newsroom/tests/test_increment6f2_feedback_cache.py::"
+            "test_feedback_template_clones_are_file_and_object_isolated"
+        ),
+        (
+            "newsroom/tests/test_increment6f2_feedback_store.py::"
+            "test_real_feedback_store_passes_required_conformance_probe"
+            "[transaction_rollback-abort]"
+        ),
     )
     assert feedback_cache_support._selected_keys(selection, feedback) == (
         _ROLLBACK_RECORDS,
+    )
+    assert (
+        feedback_cache_support._selected_keys(
+            (
+                "newsroom/tests/test_increment6f2_feedback_system.py::"
+                + "test_accept_replay_snapshot_and_direct_tamper_fail_closed",
+            ),
+            feedback,
+        )
+        == ()
     )
 
     records = _ROLLBACK_RECORDS
@@ -49,22 +65,109 @@ def test_feedback_template_clones_are_file_and_object_isolated(tmp_path: Path) -
     template_database_bytes = snapshot.database_bytes
     template_retrieval_bytes = template_retrieval.read_bytes()
     second_retrieval_bytes = second_retrieval.read_bytes()
-    with sqlite3.connect(first_database, isolation_level=None) as first_connection:
-        with sqlite3.connect(
-            second_database, isolation_level=None
-        ) as second_connection:
-            assert first_connection is not second_connection
-            second_version = second_connection.execute("PRAGMA user_version").fetchone()
-            first_connection.execute("PRAGMA user_version=1")
-            assert (
-                second_connection.execute("PRAGMA user_version").fetchone()
-                == second_version
-            )
+    with (
+        sqlite3.connect(first_database, isolation_level=None) as first_connection,
+        sqlite3.connect(second_database, isolation_level=None) as second_connection,
+    ):
+        assert first_connection is not second_connection
+        second_version = second_connection.execute("PRAGMA user_version").fetchone()
+        first_connection.execute("PRAGMA user_version=1")
+        assert (
+            second_connection.execute("PRAGMA user_version").fetchone()
+            == second_version
+        )
 
     first_retrieval.write_bytes(first_retrieval.read_bytes() + b"isolated")
     assert snapshot.database_bytes == template_database_bytes
     assert template_retrieval.read_bytes() == template_retrieval_bytes
     assert second_retrieval.read_bytes() == second_retrieval_bytes
+
+    shared_candidate_seed = feedback.candidate_fixture._SeedSnapshot(
+        b"candidate", ({"mutable": []},)
+    )
+    first_candidate_seed = shared_candidate_seed.fork()
+    second_candidate_seed = shared_candidate_seed.fork()
+    first_candidate_seed.tail[0]["mutable"].append("isolated")
+    assert first_candidate_seed is not second_candidate_seed
+    assert first_candidate_seed.tail[0] is not second_candidate_seed.tail[0]
+    assert shared_candidate_seed.tail[0]["mutable"] == []
+    assert second_candidate_seed.tail[0]["mutable"] == []
+    candidate_retrieval_source = tmp_path / "candidate-retrieval-source.sqlite3"
+    candidate_retrieval_source.write_bytes(b"retrieval")
+    candidate_snapshot = feedback.candidate_fixture._SeedSnapshot(
+        b"candidate", ((None, SimpleNamespace(_path=candidate_retrieval_source)),)
+    )
+    first_candidate_location = candidate_snapshot.clone(
+        tmp_path / "candidate-location-first"
+    )
+    second_candidate_location = candidate_snapshot.clone(
+        tmp_path / "candidate-location-second"
+    )
+    assert first_candidate_location[0][1] is not second_candidate_location[0][1]
+    assert first_candidate_location[0][1]._path != second_candidate_location[0][1]._path
+
+    selected = (("record-1",), _ROLLBACK_RECORDS)
+    candidate_snapshot = object()
+    system_seed = (object(), object(), object(), object())
+    system_snapshot = object()
+    candidate_builds = 0
+    system_builds = 0
+    locations: list[tuple[tuple[str, ...], object]] = []
+    build_root = tmp_path / "single-candidate-seed"
+
+    def seed_snapshot(root: Path) -> object:
+        nonlocal candidate_builds
+        candidate_builds += 1
+        assert root == build_root / "candidate-seed"
+        return candidate_snapshot
+
+    def build_system_seed(
+        root: Path, *, candidate_seed_snapshot: object
+    ) -> tuple[object, ...]:
+        nonlocal system_builds
+        system_builds += 1
+        assert root == build_root / "system-seed"
+        assert candidate_seed_snapshot is candidate_snapshot
+        return system_seed
+
+    def build_location(
+        root: Path,
+        records: tuple[str, ...],
+        *,
+        system_seed: object | None = None,
+        system_seed_snapshot: object | None = None,
+    ) -> object:
+        assert system_seed is None
+        assert system_seed_snapshot is system_snapshot
+        location = (records, root)
+        locations.append(location)
+        return location
+
+    monkeypatch.setattr(feedback.candidate_fixture, "_seed_snapshot", seed_snapshot)
+    monkeypatch.setattr(feedback.system_fixture, "_seed", build_system_seed)
+    monkeypatch.setattr(feedback, "_build_location", build_location)
+    monkeypatch.setattr(
+        feedback_cache_support,
+        "_system_seed_snapshot",
+        lambda value: system_snapshot if value is system_seed else None,
+    )
+    monkeypatch.setattr(
+        feedback_cache_support,
+        "_snapshot",
+        lambda location: {"location": location},
+    )
+
+    built = feedback_cache_support._build(selected, feedback, build_root)
+
+    assert candidate_builds == 1
+    assert system_builds == 1
+    assert locations == [
+        (("record-1",), build_root / "template-0"),
+        (_ROLLBACK_RECORDS, build_root / "template-1"),
+    ]
+    assert built["template_keys"] == selected
+    assert built["candidate_seed"] is candidate_snapshot
+    assert built["system_seed"] is system_snapshot
 
 
 def test_feedback_submit_uses_verified_result_and_reads_still_use_facade(
@@ -94,6 +197,7 @@ def test_feedback_submit_uses_verified_result_and_reads_still_use_facade(
 
         monkeypatch.setattr(root, "load", observed_load)
         assert handle.observe(command.record_id) is not None
+        assert handle.history()
         assert calls == 1
     finally:
         handle.close()

--- a/newsroom/tests/test_increment6f2_feedback_cache.py
+++ b/newsroom/tests/test_increment6f2_feedback_cache.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import sqlite3
+import stat
+from pathlib import Path
+
+from newsroom.tests import test_increment6f2_feedback_store as feedback
+
+
+def test_feedback_template_clones_are_file_and_object_isolated(tmp_path: Path) -> None:
+    records = ("record-1",)
+    feedback._location(tmp_path / "warm", records)
+    first = feedback._location(tmp_path / "first", records)
+    second = feedback._location(tmp_path / "second", records)
+    snapshot = feedback._LOCATION_SNAPSHOTS[records]
+
+    first_database = Path(first.candidate.seed[1])
+    second_database = Path(second.candidate.seed[1])
+    first_retrieval = Path(first.args["retrieval_authority"]._path)
+    second_retrieval = Path(second.args["retrieval_authority"]._path)
+    template_retrieval = Path(snapshot.seed_tail[0][1]._path)
+
+    assert len({first_database, second_database}) == 2
+    assert len({first_retrieval, second_retrieval, template_retrieval}) == 3
+    assert first.args["retrieval_authority"] is not second.args["retrieval_authority"]
+    assert stat.S_IMODE(first_database.stat().st_mode) == 0o600
+    assert stat.S_IMODE(second_database.stat().st_mode) == 0o600
+    assert stat.S_IMODE(first_retrieval.stat().st_mode) == 0o600
+    assert stat.S_IMODE(second_retrieval.stat().st_mode) == 0o600
+
+    template_database_bytes = snapshot.database_bytes
+    template_retrieval_bytes = template_retrieval.read_bytes()
+    second_retrieval_bytes = second_retrieval.read_bytes()
+    with sqlite3.connect(first_database, isolation_level=None) as first_connection:
+        with sqlite3.connect(
+            second_database, isolation_level=None
+        ) as second_connection:
+            assert first_connection is not second_connection
+            second_version = second_connection.execute("PRAGMA user_version").fetchone()
+            first_connection.execute("PRAGMA user_version=1")
+            assert (
+                second_connection.execute("PRAGMA user_version").fetchone()
+                == second_version
+            )
+
+    first_retrieval.write_bytes(first_retrieval.read_bytes() + b"isolated")
+    assert snapshot.database_bytes == template_database_bytes
+    assert template_retrieval.read_bytes() == template_retrieval_bytes
+    assert second_retrieval.read_bytes() == second_retrieval_bytes

--- a/newsroom/tests/test_increment6f2_feedback_cache.py
+++ b/newsroom/tests/test_increment6f2_feedback_cache.py
@@ -7,12 +7,26 @@ from pathlib import Path
 import pytest
 
 from newsroom.tests import feedback_adapter_fastpath
+from newsroom.tests import feedback_cache_support
 from newsroom.tests import test_increment6f2_feedback_store as feedback
 from newsroom.tests.authority_store_conformance import AuthorityValue
 
+_ROLLBACK_RECORDS = ("record-rollback-normal", "record-rollback-abort")
+
 
 def test_feedback_template_clones_are_file_and_object_isolated(tmp_path: Path) -> None:
-    records = ("record-1",)
+    selection = (
+        "newsroom/tests/test_increment6f2_feedback_cache.py::"
+        "test_feedback_template_clones_are_file_and_object_isolated",
+        "newsroom/tests/test_increment6f2_feedback_store.py::"
+        "test_real_feedback_store_passes_required_conformance_probe"
+        "[transaction_rollback-abort]",
+    )
+    assert feedback_cache_support._selected_keys(selection, feedback) == (
+        _ROLLBACK_RECORDS,
+    )
+
+    records = _ROLLBACK_RECORDS
     feedback._location(tmp_path / "warm", records)
     first = feedback._location(tmp_path / "first", records)
     second = feedback._location(tmp_path / "second", records)
@@ -57,8 +71,8 @@ def test_feedback_submit_uses_verified_result_and_reads_still_use_facade(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     feedback_adapter_fastpath._install(feedback)
-    command = feedback.candidate_fixture._generic("record-1")
-    location = feedback._location(tmp_path / "fastpath", ("record-1",))
+    command = feedback.candidate_fixture._generic("record-rollback-normal")
+    location = feedback._location(tmp_path / "fastpath", _ROLLBACK_RECORDS)
     handle = feedback._Handle(location)
     root = handle._opened()
     original_load = root.load

--- a/newsroom/tests/test_increment6f2_feedback_store.py
+++ b/newsroom/tests/test_increment6f2_feedback_store.py
@@ -232,9 +232,25 @@ def _submission(location: _Location, command: WriteCommand):
     )
 
 
-def _build_location(tmp_path: Path, records: tuple[str, ...]) -> _Location:
-    tmp_path.mkdir(parents=True)
-    base, args, first_feedback, first_obligation = system_fixture._seed(tmp_path)
+def _build_location(
+    tmp_path: Path,
+    records: tuple[str, ...],
+    *,
+    candidate_seed_snapshot=None,
+    system_seed=None,
+    system_seed_snapshot=None,
+) -> _Location:
+    tmp_path.mkdir(mode=0o700, parents=True)
+    if system_seed is not None:
+        base, args, first_feedback, first_obligation = system_seed
+    elif system_seed_snapshot is None:
+        base, args, first_feedback, first_obligation = system_fixture._seed(
+            tmp_path, candidate_seed_snapshot=candidate_seed_snapshot
+        )
+    else:
+        base, args, first_feedback, first_obligation = system_seed_snapshot.clone(
+            tmp_path
+        )
     candidate = candidate_fixture._Handle(base)
     version = candidate._opened().load_version(str(candidate._row("record-1")[1]))
     actor = first_feedback.actor_identity_digest

--- a/newsroom/tests/test_increment6f2_feedback_store.py
+++ b/newsroom/tests/test_increment6f2_feedback_store.py
@@ -1,0 +1,874 @@
+from __future__ import annotations
+
+import sqlite3
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, replace
+from functools import partial
+from pathlib import Path
+from typing import ClassVar
+
+import pytest
+
+from newsroom.authority.evaluation_feedback_system import (
+    _open_unlocked_evaluation_feedback_authority_for_test,
+)
+from newsroom.authority.migrations import (
+    apply_pending_migrations,
+    prepare_pending_migration_backup,
+)
+from newsroom.increment6.feedback import (
+    EvaluationFeedbackOutcome,
+    EvaluationFeedbackReason,
+    FeedbackContractError,
+    ReconciliationDispositionOutcome,
+    ReconciliationDispositionReason,
+    append_reconciliation_disposition,
+    create_evaluation_feedback,
+    create_reconciliation_obligation,
+)
+from newsroom.increment6.handoffs import (
+    Acknowledgement,
+    AcknowledgementOutcome,
+    EvaluationHandoffStore,
+    create_handoff,
+)
+from newsroom.tests import test_increment6e2_candidate_store as candidate_fixture
+from newsroom.tests import test_increment6f2_feedback_system as system_fixture
+from newsroom.tests.authority_store_conformance import (
+    _CURRENT_USE_AUTHORITIES,
+    _HISTORICAL_TAMPERS,
+    _REPRESENTATION_TAMPERS,
+    _REQUEST_BINDING_FIELDS,
+    _SCENARIOS,
+    _TAMPER_REJECTION_TAMPERS,
+    CASE_INVENTORY,
+    Applicability,
+    AuthorityValue,
+    BindingConflict,
+    CaseId,
+    IntegrityViolation,
+    LostResponse,
+    StoredAuthorityState,
+    TamperKind,
+    WriteCommand,
+    _current_use_authority,
+    _exact_replay,
+    _fresh_reopen_digest,
+    _fresh_reopen_persistence,
+    _fresh_submission,
+    _historical_retained_operation,
+    _historical_tamper_operation,
+    _representation_retained,
+    _representation_tamper,
+    _request_binding_field,
+    _restart_or_migrate,
+    _rollback_kind,
+    _rollback_sequence,
+    _tamper_rejection_kind,
+)
+
+
+def _encoded(command: WriteCommand) -> str:
+    heads = ",".join(f"{name}={head}" for name, head in command.required_upstream_heads)
+    return "|".join(
+        (
+            "cf",
+            command.record_id,
+            str(command.scalar_columns["value"]),
+            command.cas_predecessor,
+            command.actor,
+            command.request,
+            command.idempotency,
+            heads,
+        )
+    )
+
+
+def _decoded(value: str) -> WriteCommand:
+    if not value.startswith("cf|"):
+        raise KeyError(value)
+    prefix, record_id, scalar, predecessor, actor, request, idempotency, raw_heads = (
+        value.split("|", 7)
+    )
+    if prefix != "cf":
+        raise KeyError(value)
+    return replace(
+        candidate_fixture._generic(record_id, predecessor, scalar),
+        actor=actor,
+        request=request,
+        idempotency=idempotency,
+        required_upstream_heads=tuple(
+            tuple(item.split("=", 1)) for item in raw_heads.split(",")
+        ),
+    )
+
+
+def _database_locked(error: BaseException) -> bool:
+    current: BaseException | None = error
+    while current is not None:
+        if isinstance(current, sqlite3.OperationalError) and any(
+            marker in str(current).lower() for marker in ("locked", "busy")
+        ):
+            return True
+        current = current.__cause__ or current.__context__
+    return False
+
+
+@dataclass
+class _Location:
+    candidate: object
+    args: dict[str, object]
+    fixtures: dict[str, tuple[object, object]]
+    proof: object
+    base: tuple[object, object]
+    competing: dict[str, object]
+
+
+@dataclass(frozen=True)
+class _LocationSnapshot:
+    database_bytes: bytes
+    seed_tail: tuple
+    args: dict[str, object]
+    fixtures: dict[str, tuple[object, ...]]
+    proof: object
+    base: tuple[object, object]
+    competing: dict[str, object]
+
+    def clone(self, root: Path) -> _Location:
+        root.mkdir(mode=0o700)
+        database = root / "feedback-authority.sqlite3"
+        database.write_bytes(self.database_bytes)
+        database.chmod(0o600)
+        seed = (self.seed_tail[0], database, *self.seed_tail[1:])
+        candidate = candidate_fixture._Location(seed, root / "candidate-collisions")
+        args = dict(self.args)
+        args["database"] = database
+        return _Location(
+            candidate,
+            args,
+            self.fixtures,
+            self.proof,
+            self.base,
+            self.competing,
+        )
+
+
+_LOCATION_SNAPSHOTS: dict[tuple[str, ...], _LocationSnapshot] = {}
+
+
+def _fixture(location, version, actor, command: WriteCommand, number: int):
+    store = EvaluationHandoffStore(
+        sqlite3.connect(location.seed[1], isolation_level=None)
+    )
+    handoff = store.register(
+        create_handoff(
+            version.version_id,
+            version.governing_manifest.canonical_digest,
+            f"evaluation-sink:cf-{number}",
+            max_attempts=3,
+        )
+    )
+    handoff = store.persist_attempt(handoff.handoff_id)
+    attempt = handoff.attempts[0]
+    handoff = store.mark_attempt_sent(handoff.handoff_id, attempt.attempt_id)
+    acknowledgement = Acknowledgement.create(
+        handoff_id=handoff.handoff_id,
+        attempt_id=attempt.attempt_id,
+        candidate_version_id=version.version_id,
+        governing_manifest_digest=version.governing_manifest.canonical_digest,
+        sink_id=handoff.sink_id,
+        outcome=AcknowledgementOutcome.ACKNOWLEDGED,
+        response_digest="sha256:" + f"{number % 10}" * 64,
+    )
+    handoff = store.correlate_acknowledgement(handoff.handoff_id, acknowledgement)
+    store._connection.close()
+    feedback = create_evaluation_feedback(
+        handoff=handoff,
+        attempt=attempt,
+        acknowledgement=acknowledgement,
+        candidate_version=version,
+        source_feedback_id=_encoded(command),
+        outcome=EvaluationFeedbackOutcome.ACCEPTED,
+        reason=EvaluationFeedbackReason.INTAKE_ACCEPTED,
+        detail_digest="sha256:" + "2" * 64,
+        request_id=str(uuid.uuid4()),
+        actor_identity_digest=actor,
+        idempotency_key=_encoded(command),
+    )
+    obligation = create_reconciliation_obligation(
+        feedback,
+        request_id=str(uuid.uuid4()),
+        actor_identity_digest=actor,
+        idempotency_key="obligation:" + command.record_id,
+    )
+    return feedback, obligation, handoff, attempt, acknowledgement, version
+
+
+def _submission(location: _Location, command: WriteCommand):
+    feedback, obligation, handoff, attempt, acknowledgement, version = (
+        location.fixtures[command.record_id]
+    )
+    if _decoded(feedback.source_feedback_id) == command:
+        return feedback, obligation
+    divergent = create_evaluation_feedback(
+        handoff=handoff,
+        attempt=attempt,
+        acknowledgement=acknowledgement,
+        candidate_version=version,
+        source_feedback_id=_encoded(command),
+        outcome=feedback.outcome,
+        reason=feedback.reason,
+        detail_digest=feedback.detail_digest,
+        request_id=feedback.request_id,
+        actor_identity_digest=feedback.actor_identity_digest,
+        idempotency_key=_encoded(command),
+    )
+    return divergent, create_reconciliation_obligation(
+        divergent,
+        request_id=obligation.request_id,
+        actor_identity_digest=obligation.actor_identity_digest,
+        idempotency_key=obligation.idempotency_key,
+    )
+
+
+def _build_location(tmp_path: Path, records: tuple[str, ...]) -> _Location:
+    tmp_path.mkdir(parents=True)
+    base, args, first_feedback, first_obligation = system_fixture._seed(tmp_path)
+    candidate = candidate_fixture._Handle(base)
+    version = candidate._opened().load_version(str(candidate._row("record-1")[1]))
+    actor = first_feedback.actor_identity_digest
+    catalogue = {
+        "record-1": candidate_fixture._generic("record-1"),
+        "record-2": candidate_fixture._generic("record-2", "record-1", "beta"),
+        "record-a": candidate_fixture._generic("record-a", "record-0", "alpha"),
+        "record-b": candidate_fixture._generic("record-b", "record-0", "beta"),
+        "record-rollback-normal": candidate_fixture._generic("record-rollback-normal"),
+        "record-rollback-abort": candidate_fixture._generic("record-rollback-abort"),
+    }
+    commands = [catalogue[record_id] for record_id in records]
+    fixtures = {
+        command.record_id: _fixture(base, version, actor, command, i + 1)
+        for i, command in enumerate(commands)
+    }
+    root = _open_unlocked_evaluation_feedback_authority_for_test(
+        base.seed[1],
+        retrieval_authority=args["retrieval_authority"],
+        authenticator=args["authenticator"],
+        authorizer=args["authorizer"],
+        command_registry=args["command_registry"],
+        payload_schemas=args["payload_schemas"],
+        clock=args["clock"],
+    )
+    accepted = root.accept(
+        first_feedback.canonical_bytes,
+        first_obligation.canonical_bytes,
+        candidate_proof=base.seed[0][3],
+    )
+    competing = {
+        command.record_id: append_reconciliation_disposition(
+            accepted.obligation,
+            (),
+            outcome=ReconciliationDispositionOutcome.UNRESOLVED,
+            reason=ReconciliationDispositionReason.AWAITING_RECONCILIATION,
+            resolution_digest="sha256:" + str(i + 7) * 64,
+            request_id=str(uuid.uuid4()),
+            actor_identity_digest=actor,
+            idempotency_key=_encoded(command),
+            expected_current_disposition_id=None,
+            expected_current_disposition_digest=None,
+            expected_current_ordinal=0,
+        )
+        for i, command in enumerate(
+            item for item in commands if item.record_id in {"record-a", "record-b"}
+        )
+    }
+    root.close()
+    location = _Location(
+        base,
+        args,
+        fixtures,
+        base.seed[0][3],
+        (first_feedback, first_obligation),
+        competing,
+    )
+    connection = sqlite3.connect(base.seed[1], isolation_level=None)
+    try:
+        connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    finally:
+        connection.close()
+    return location
+
+
+def _location(tmp_path: Path, records: tuple[str, ...]) -> _Location:
+    snapshot = _LOCATION_SNAPSHOTS.get(records)
+    if snapshot is not None:
+        return snapshot.clone(tmp_path)
+    location = _build_location(tmp_path, records)
+    seed = location.candidate.seed
+    _LOCATION_SNAPSHOTS[records] = _LocationSnapshot(
+        Path(seed[1]).read_bytes(),
+        (seed[0], *seed[2:]),
+        dict(location.args),
+        location.fixtures,
+        location.proof,
+        location.base,
+        location.competing,
+    )
+    return location
+
+
+class _Handle:
+    def __init__(self, location: _Location):
+        self.location = location
+        self.root = None
+        self.open_error = None
+        try:
+            self.root = _open_unlocked_evaluation_feedback_authority_for_test(
+                location.candidate.seed[1],
+                retrieval_authority=location.args["retrieval_authority"],
+                authenticator=location.args["authenticator"],
+                authorizer=location.args["authorizer"],
+                command_registry=location.args["command_registry"],
+                payload_schemas=location.args["payload_schemas"],
+                clock=location.args["clock"],
+                busy_timeout_ms=100,
+            )
+        except Exception as exc:  # noqa: BLE001 - translate at conformance seam
+            self.open_error = exc
+
+    def _opened(self):
+        if self.open_error is not None:
+            raise IntegrityViolation("feedback open failed") from self.open_error
+        return self.root
+
+    def _commands(self, transaction=None):
+        target = transaction or self._opened()
+        values = []
+        connection = (
+            target._connection if transaction is None else target._root._connection
+        )
+        feedback_ids = tuple(
+            str(row[0])
+            for row in connection.execute(
+                "SELECT feedback_id FROM evaluation_feedback ORDER BY feedback_id"
+            )
+        )
+        for feedback_id in feedback_ids:
+            item = target.load(feedback_id)
+            try:
+                values.append(_decoded(item.feedback.source_feedback_id))
+            except KeyError:
+                pass
+            has_dispositions = connection.execute(
+                "SELECT 1 FROM evaluation_reconciliation_dispositions WHERE obligation_id=?",
+                (item.obligation.obligation_id,),
+            ).fetchone()
+            history = (
+                target.dispositions(item.obligation.obligation_id)
+                if has_dispositions
+                else ()
+            )
+            for disposition in history:
+                try:
+                    values.append(_decoded(disposition.idempotency_key))
+                except KeyError:
+                    pass
+        return tuple(values)
+
+    def submit(self, command: WriteCommand, *, lose_response: bool = False):
+        try:
+            if command.record_id in self.location.competing:
+                disposition = self.location.competing[command.record_id]
+                self._opened().append_disposition(
+                    disposition.canonical_bytes, candidate_proof=self.location.proof
+                )
+            else:
+                feedback, obligation = _submission(self.location, command)
+                self._opened().accept(
+                    feedback.canonical_bytes,
+                    obligation.canonical_bytes,
+                    candidate_proof=self.location.proof,
+                )
+        except (KeyError, FeedbackContractError, sqlite3.OperationalError) as exc:
+            if _database_locked(exc):
+                raise BindingConflict(command.record_id) from exc
+            try:
+                retained = next(
+                    (
+                        item
+                        for item in self._commands()
+                        if item.record_id == command.record_id
+                    ),
+                    None,
+                )
+            except Exception as integrity:
+                raise IntegrityViolation(command.record_id) from integrity
+            if retained is not None:
+                raise BindingConflict(command.record_id) from exc
+            raise IntegrityViolation(command.record_id) from exc
+        try:
+            retained = next(
+                item for item in self._commands() if item.record_id == command.record_id
+            )
+        except Exception as exc:
+            raise IntegrityViolation(command.record_id) from exc
+        if retained != command:
+            raise IntegrityViolation(command.record_id)
+        if lose_response:
+            raise LostResponse(command.record_id)
+        return AuthorityValue.from_command(command)
+
+    def observe(self, record_id: str):
+        try:
+            command = next(
+                (item for item in self._commands() if item.record_id == record_id), None
+            )
+            if command is None:
+                return None
+            return StoredAuthorityState.from_command(command)
+        except Exception as exc:
+            raise IntegrityViolation(record_id) from exc
+
+    def history(self):
+        try:
+            return tuple(AuthorityValue.from_command(item) for item in self._commands())
+        except Exception as exc:
+            raise IntegrityViolation("history") from exc
+
+    list_history = history
+
+    def read(self, record_id: str):
+        try:
+            command = next(
+                (item for item in self._commands() if item.record_id == record_id), None
+            )
+            if command is None:
+                raise KeyError(record_id)
+            return AuthorityValue.from_command(command)
+        except KeyError:
+            raise
+        except Exception as exc:
+            raise IntegrityViolation(record_id) from exc
+
+    def set_upstream_head(self, authority: str, value: str):
+        if value.endswith("head-1"):
+            return
+        location = self.location.candidate
+        subject = location.subjects["record-1"]
+        connection = sqlite3.connect(location.seed[1], isolation_level=None)
+        try:
+            if authority == "authority":
+                fixture = (connection, *location.seed[0][1:])
+                proposal, dispositions = location.seed[7]["authority"]
+                upstream = candidate_fixture.d1._open(fixture)
+                try:
+                    upstream.retain(
+                        proposal,
+                        dispositions,
+                        proof=location.seed[0][3],
+                        expected_target_version=subject,
+                    )
+                finally:
+                    upstream.close()
+            elif authority == "policy":
+                item, current = location.seed[7]["policy"]
+                successor = replace(
+                    candidate_fixture.d1.work_item_helpers._version(item, 2),
+                    retrieval=current.retrieval,
+                )
+                from newsroom.increment6.work_items import TriageWorkItemStore
+
+                TriageWorkItemStore(connection, location.seed[0][1]).append_version(
+                    current.version_id, current.canonical_digest, successor
+                )
+        finally:
+            connection.close()
+
+    def current_use(self, record_id: str):
+        feedback, obligation, *_ = self.location.fixtures[record_id]
+        accepted = self._opened().load(feedback.feedback_id)
+        history = self._opened().dispositions(obligation.obligation_id)
+        disposition = append_reconciliation_disposition(
+            accepted.obligation,
+            history,
+            outcome=ReconciliationDispositionOutcome.UNRESOLVED,
+            reason=ReconciliationDispositionReason.AWAITING_RECONCILIATION,
+            resolution_digest="sha256:" + "7" * 64,
+            request_id=str(uuid.uuid4()),
+            actor_identity_digest=feedback.actor_identity_digest,
+            idempotency_key=f"current-use:{record_id}:{len(history)}",
+            expected_current_disposition_id=history[-1].disposition_id
+            if history
+            else None,
+            expected_current_disposition_digest=history[-1].canonical_digest
+            if history
+            else None,
+            expected_current_ordinal=len(history),
+        )
+        try:
+            self._opened().append_disposition(
+                disposition.canonical_bytes, candidate_proof=self.location.proof
+            )
+        except Exception as exc:
+            raise IntegrityViolation(record_id) from exc
+        return AuthorityValue.from_command(_decoded(feedback.source_feedback_id))
+
+    def tamper(self, record_id: str, kind: TamperKind):
+        feedback, obligation, *_ = self.location.fixtures[record_id]
+        connection = sqlite3.connect(
+            self.location.candidate.seed[1], isolation_level=None
+        )
+        connection.execute("PRAGMA foreign_keys=OFF")
+        triggers = tuple(
+            connection.execute(
+                "SELECT name,sql FROM sqlite_master WHERE name IN "
+                "('immutable_evaluation_feedback','immutable_evaluation_obligation') ORDER BY name"
+            )
+        )
+        for name, _ in triggers:
+            connection.execute(f"DROP TRIGGER {name}")
+        if kind is TamperKind.OFFLINE_REWRITE:
+            rewritten = replace(feedback, detail_digest="sha256:" + "9" * 64)
+            derived = create_reconciliation_obligation(
+                rewritten,
+                request_id=obligation.request_id,
+                actor_identity_digest=obligation.actor_identity_digest,
+                idempotency_key=obligation.idempotency_key,
+            )
+            connection.execute(
+                "UPDATE evaluation_feedback SET feedback_bytes=?,feedback_digest=? WHERE feedback_id=?",
+                (
+                    rewritten.canonical_bytes,
+                    rewritten.canonical_digest,
+                    feedback.feedback_id,
+                ),
+            )
+            connection.execute(
+                "UPDATE evaluation_reconciliation_obligations SET obligation_id=?,obligation_bytes=?,"
+                "obligation_digest=?,feedback_digest=? WHERE obligation_id=?",
+                (
+                    derived.obligation_id,
+                    derived.canonical_bytes,
+                    derived.canonical_digest,
+                    rewritten.canonical_digest,
+                    obligation.obligation_id,
+                ),
+            )
+            for _, sql in triggers:
+                connection.execute(sql)
+            connection.close()
+            return
+        table, column, value, key, identity = {
+            TamperKind.CANONICAL: (
+                "evaluation_feedback",
+                "feedback_bytes",
+                b"{}",
+                "feedback_id",
+                feedback.feedback_id,
+            ),
+            TamperKind.SCALAR: (
+                "evaluation_feedback",
+                "candidate_id",
+                str(uuid.uuid4()),
+                "feedback_id",
+                feedback.feedback_id,
+            ),
+            TamperKind.IDENTITY: (
+                "evaluation_feedback",
+                "authority_aggregate_id",
+                str(uuid.uuid4()),
+                "feedback_id",
+                feedback.feedback_id,
+            ),
+            TamperKind.LINKED_ROW: (
+                "evaluation_reconciliation_obligations",
+                "feedback_digest",
+                "sha256:" + "0" * 64,
+                "obligation_id",
+                obligation.obligation_id,
+            ),
+            TamperKind.DIGEST: (
+                "evaluation_feedback",
+                "feedback_digest",
+                "sha256:" + "0" * 64,
+                "feedback_id",
+                feedback.feedback_id,
+            ),
+            TamperKind.PROVENANCE: (
+                "evaluation_feedback",
+                "actor_identity_digest",
+                "sha256:" + "0" * 64,
+                "feedback_id",
+                feedback.feedback_id,
+            ),
+        }[kind]
+        connection.execute(
+            f"UPDATE {table} SET {column}=? WHERE {key}=?", (value, identity)
+        )
+        for _, sql in triggers:
+            connection.execute(sql)
+        connection.close()
+
+    def rollback_scope(self, operation):
+        outer = self
+
+        class Scope:
+            def submit(_, command):
+                feedback, obligation, *_ = outer.location.fixtures[command.record_id]
+                transaction.accept(
+                    feedback.canonical_bytes,
+                    obligation.canonical_bytes,
+                    candidate_proof=outer.location.proof,
+                )
+                return AuthorityValue.from_command(command)
+
+            def observe(_, record_id):
+                command = next(
+                    (
+                        item
+                        for item in outer._commands(transaction)
+                        if item.record_id == record_id
+                    ),
+                    None,
+                )
+                return StoredAuthorityState.from_command(command) if command else None
+
+            def history(_):
+                return tuple(
+                    AuthorityValue.from_command(item)
+                    for item in outer._commands(transaction)
+                )
+
+        transaction = None
+
+        def inspect(view):
+            nonlocal transaction
+            transaction = view
+            operation(Scope())
+
+        self._opened().rollback_scope(inspect)
+
+    def close(self):
+        if self.root is not None:
+            self.root.close()
+
+
+class _Adapter:
+    name = "evaluation-feedback-v25-real"
+    applicability: ClassVar = {
+        case: Applicability.required() for case in CASE_INVENTORY
+    }
+
+    def __init__(self, root: Path, records: tuple[str, ...] = ("record-1",)):
+        self.root = root
+        self.records = records
+
+    def create_location(self):
+        return _location(self.root / str(uuid.uuid4()), self.records)
+
+    def open_handle(self, location, *, migrate=False):
+        if migrate:
+            connection = sqlite3.connect(
+                location.candidate.seed[1], isolation_level=None
+            )
+            prepare_pending_migration_backup(connection)
+            apply_pending_migrations(
+                connection, applied_at="2042-01-02T00:00:00.000000Z"
+            )
+            connection.close()
+        return _Handle(location)
+
+
+@dataclass(frozen=True)
+class _ConformanceProbe:
+    probe_id: str
+    case: CaseId
+    operation: Callable[[object], None]
+
+
+_CONFORMANCE_PROBES = (
+    _ConformanceProbe(
+        "fresh_replay-submission", CaseId.FRESH_REPLAY, _fresh_submission
+    ),
+    _ConformanceProbe("fresh_replay-replay", CaseId.FRESH_REPLAY, _exact_replay),
+    _ConformanceProbe(
+        "fresh_reopen-persistence", CaseId.FRESH_REOPEN, _fresh_reopen_persistence
+    ),
+    _ConformanceProbe("fresh_reopen-digest", CaseId.FRESH_REOPEN, _fresh_reopen_digest),
+    _ConformanceProbe(
+        "representation_binding-retained",
+        CaseId.REPRESENTATION_BINDING,
+        _representation_retained,
+    ),
+    *(
+        _ConformanceProbe(
+            f"representation_binding-{kind.value}",
+            CaseId.REPRESENTATION_BINDING,
+            partial(_representation_tamper, kind=kind),
+        )
+        for kind in _REPRESENTATION_TAMPERS
+    ),
+    *(
+        _ConformanceProbe(
+            f"request_binding-{field_name}",
+            CaseId.REQUEST_BINDING,
+            partial(_request_binding_field, field_name=field_name),
+        )
+        for field_name in _REQUEST_BINDING_FIELDS
+    ),
+    _ConformanceProbe(
+        CaseId.LOST_RESPONSE_REPLAY.value,
+        CaseId.LOST_RESPONSE_REPLAY,
+        _SCENARIOS[CaseId.LOST_RESPONSE_REPLAY],
+    ),
+    *(
+        _ConformanceProbe(
+            f"historical_read-{kind.value}-{phase}-{noun}",
+            CaseId.HISTORICAL_READ,
+            partial(
+                _historical_tamper_operation,
+                kind=kind,
+                reopened=reopened,
+                listing=listing,
+            ),
+        )
+        for kind in _HISTORICAL_TAMPERS
+        for phase, reopened in (("fresh", False), ("reopened", True))
+        for noun, listing in (("read", False), ("list", True))
+    ),
+    *(
+        _ConformanceProbe(
+            f"historical_read-retained-{noun}",
+            CaseId.HISTORICAL_READ,
+            partial(_historical_retained_operation, listing=listing),
+        )
+        for noun, listing in (("read", False), ("list", True))
+    ),
+    *(
+        _ConformanceProbe(
+            f"current_use_revalidation-{authority}",
+            CaseId.CURRENT_USE_REVALIDATION,
+            partial(_current_use_authority, authority=authority),
+        )
+        for authority in _CURRENT_USE_AUTHORITIES
+    ),
+    *(
+        _ConformanceProbe(
+            f"tamper_rejection-{kind.value}",
+            CaseId.TAMPER_REJECTION,
+            partial(_tamper_rejection_kind, kind=kind),
+        )
+        for kind in _TAMPER_REJECTION_TAMPERS
+    ),
+    _ConformanceProbe(
+        CaseId.COMPETING_WRITERS.value,
+        CaseId.COMPETING_WRITERS,
+        _SCENARIOS[CaseId.COMPETING_WRITERS],
+    ),
+    _ConformanceProbe(
+        "transaction_rollback-normal",
+        CaseId.TRANSACTION_ROLLBACK,
+        partial(_rollback_kind, abort=False),
+    ),
+    _ConformanceProbe(
+        "transaction_rollback-abort", CaseId.TRANSACTION_ROLLBACK, _rollback_sequence
+    ),
+    _ConformanceProbe(
+        "restart_migration-restart",
+        CaseId.RESTART_MIGRATION,
+        partial(_restart_or_migrate, migrate=False),
+    ),
+    _ConformanceProbe(
+        "restart_migration-migrate",
+        CaseId.RESTART_MIGRATION,
+        partial(_restart_or_migrate, migrate=True),
+    ),
+)
+
+_RECORDS_BY_CASE = {
+    CaseId.HISTORICAL_READ: ("record-1", "record-2"),
+    CaseId.COMPETING_WRITERS: ("record-a", "record-b"),
+    CaseId.TRANSACTION_ROLLBACK: (
+        "record-rollback-normal",
+        "record-rollback-abort",
+    ),
+}
+
+
+def test_real_feedback_conformance_probe_inventory_is_exact_and_unique() -> None:
+    probe_ids = tuple(probe.probe_id for probe in _CONFORMANCE_PROBES)
+    expected = {
+        "fresh_replay-submission",
+        "fresh_replay-replay",
+        "fresh_reopen-persistence",
+        "fresh_reopen-digest",
+        "representation_binding-retained",
+        CaseId.LOST_RESPONSE_REPLAY.value,
+        CaseId.COMPETING_WRITERS.value,
+        "transaction_rollback-normal",
+        "transaction_rollback-abort",
+        "restart_migration-restart",
+        "restart_migration-migrate",
+        *(f"representation_binding-{kind.value}" for kind in _REPRESENTATION_TAMPERS),
+        *(f"request_binding-{field}" for field in _REQUEST_BINDING_FIELDS),
+        *(
+            f"historical_read-{kind.value}-{phase}-{noun}"
+            for kind in _HISTORICAL_TAMPERS
+            for phase in ("fresh", "reopened")
+            for noun in ("read", "list")
+        ),
+        "historical_read-retained-read",
+        "historical_read-retained-list",
+        *(f"current_use_revalidation-{item}" for item in _CURRENT_USE_AUTHORITIES),
+        *(f"tamper_rejection-{kind.value}" for kind in _TAMPER_REJECTION_TAMPERS),
+    }
+    assert len(probe_ids) == len(set(probe_ids))
+    assert set(probe_ids) == expected
+    assert {probe.case for probe in _CONFORMANCE_PROBES} == set(CASE_INVENTORY)
+
+
+@pytest.mark.parametrize("probe", _CONFORMANCE_PROBES, ids=lambda item: item.probe_id)
+def test_real_feedback_store_passes_required_conformance_probe(
+    tmp_path: Path, probe: _ConformanceProbe
+):
+    probe.operation(_Adapter(tmp_path, _RECORDS_BY_CASE.get(probe.case, ("record-1",))))
+
+
+def test_exact_replay_calls_production_accept(tmp_path: Path, monkeypatch) -> None:
+    adapter = _Adapter(tmp_path)
+    location, handle = adapter.create_location(), None
+    handle = adapter.open_handle(location)
+    command = candidate_fixture._generic("record-1")
+    handle.submit(command)
+    called = False
+
+    def reject(*args, **kwargs):
+        nonlocal called
+        called = True
+        raise FeedbackContractError("production replay probe")
+
+    monkeypatch.setattr(handle.root, "accept", reject)
+    with pytest.raises(BindingConflict):
+        handle.submit(command)
+    assert called
+
+
+def test_divergent_replay_calls_production_accept(tmp_path: Path, monkeypatch) -> None:
+    adapter = _Adapter(tmp_path)
+    location = adapter.create_location()
+    handle = adapter.open_handle(location)
+    command = candidate_fixture._generic("record-1")
+    handle.submit(command)
+    original = handle.root.accept
+    calls = 0
+
+    def observed(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(handle.root, "accept", observed)
+    with pytest.raises(BindingConflict):
+        handle.submit(replace(command, actor="different-actor"))
+    assert calls == 1

--- a/newsroom/tests/test_increment6f2_feedback_system.py
+++ b/newsroom/tests/test_increment6f2_feedback_system.py
@@ -30,8 +30,13 @@ from newsroom.increment6.handoffs import (
 from newsroom.tests import test_increment6e2_candidate_store as candidate_fixture
 
 
-def _seed(tmp_path: Path):
-    adapter = candidate_fixture._Adapter(tmp_path)
+def _seed(tmp_path: Path, *, candidate_seed_snapshot=None):
+    if candidate_seed_snapshot is None:
+        adapter = candidate_fixture._Adapter(tmp_path)
+    else:
+        adapter = candidate_fixture._Adapter.__new__(candidate_fixture._Adapter)
+        adapter.root = tmp_path
+        adapter.snapshot = candidate_seed_snapshot
     location = adapter.create_location()
     handle = adapter.open_handle(location)
     handle.submit(candidate_fixture._generic("record-1"))

--- a/newsroom/tests/test_increment6f2_feedback_system.py
+++ b/newsroom/tests/test_increment6f2_feedback_system.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from pathlib import Path
 import sqlite3
+from pathlib import Path
 
 import pytest
 
@@ -38,18 +38,28 @@ def _seed(tmp_path: Path):
     row = handle._row("record-1")
     version = handle._opened().load_version(str(row[1]))
     handle.close()
-    store = EvaluationHandoffStore(sqlite3.connect(location.seed[1], isolation_level=None))
-    handoff = store.register(create_handoff(
-        version.version_id, version.governing_manifest.canonical_digest,
-        "evaluation-sink:v25-test", max_attempts=3,
-    ))
+    store = EvaluationHandoffStore(
+        sqlite3.connect(location.seed[1], isolation_level=None)
+    )
+    handoff = store.register(
+        create_handoff(
+            version.version_id,
+            version.governing_manifest.canonical_digest,
+            "evaluation-sink:v25-test",
+            max_attempts=3,
+        )
+    )
     handoff = store.persist_attempt(handoff.handoff_id)
-    handoff = store.mark_attempt_sent(handoff.handoff_id, handoff.attempts[0].attempt_id)
+    handoff = store.mark_attempt_sent(
+        handoff.handoff_id, handoff.attempts[0].attempt_id
+    )
     acknowledgement = Acknowledgement.create(
-        handoff_id=handoff.handoff_id, attempt_id=handoff.attempts[0].attempt_id,
+        handoff_id=handoff.handoff_id,
+        attempt_id=handoff.attempts[0].attempt_id,
         candidate_version_id=version.version_id,
         governing_manifest_digest=version.governing_manifest.canonical_digest,
-        sink_id=handoff.sink_id, outcome=AcknowledgementOutcome.ACKNOWLEDGED,
+        sink_id=handoff.sink_id,
+        outcome=AcknowledgementOutcome.ACKNOWLEDGED,
         response_digest="sha256:" + "4" * 64,
     )
     handoff = store.correlate_acknowledgement(handoff.handoff_id, acknowledgement)
@@ -67,67 +77,116 @@ def _seed(tmp_path: Path):
         )
     )
     scopes = {
-        item.required_scope
-        for item in args["command_registry"].definitions()
+        item.required_scope for item in args["command_registry"].definitions()
     } | {"authority.evaluation-feedback.reconcile"}
     args["authorizer"] = StaticAuthorizer(
-        policy_version="feedback-test-v1", grants_by_principal={"editor": frozenset(scopes)}
+        policy_version="feedback-test-v1",
+        grants_by_principal={"editor": frozenset(scopes)},
     )
     feedback = create_evaluation_feedback(
-        handoff=handoff, attempt=handoff.attempts[0], acknowledgement=acknowledgement,
-        candidate_version=version, source_feedback_id="evaluation-feedback:v25-test",
+        handoff=handoff,
+        attempt=handoff.attempts[0],
+        acknowledgement=acknowledgement,
+        candidate_version=version,
+        source_feedback_id="evaluation-feedback:v25-test",
         outcome=EvaluationFeedbackOutcome.ACCEPTED,
         reason=EvaluationFeedbackReason.INTAKE_ACCEPTED,
         detail_digest="sha256:" + "2" * 64,
         request_id="eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
-        actor_identity_digest=actor, idempotency_key="feedback:v25-test",
+        actor_identity_digest=actor,
+        idempotency_key="feedback:v25-test",
     )
     obligation = create_reconciliation_obligation(
-        feedback, request_id="aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
-        actor_identity_digest=actor, idempotency_key="obligation:v25-test",
+        feedback,
+        request_id="aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        actor_identity_digest=actor,
+        idempotency_key="obligation:v25-test",
     )
     return location, args, feedback, obligation
 
 
 def test_accept_replay_snapshot_and_direct_tamper_fail_closed(tmp_path: Path) -> None:
     location, args, feedback, obligation = _seed(tmp_path)
+    with pytest.raises(TypeError):
+        open_evaluation_feedback_authority_system(
+            location.seed[1],
+            retrieval_authority=args["retrieval_authority"],
+            authenticator=args["authenticator"],
+            authorizer=args["authorizer"],
+            command_registry=args["command_registry"],
+            payload_schemas=args["payload_schemas"],
+            _store_class=object,  # type: ignore[call-arg]
+        )
     authority = open_evaluation_feedback_authority_system(
-        location.seed[1], retrieval_authority=args["retrieval_authority"],
-        authenticator=args["authenticator"], authorizer=args["authorizer"],
-        command_registry=args["command_registry"], payload_schemas=args["payload_schemas"],
+        location.seed[1],
+        retrieval_authority=args["retrieval_authority"],
+        authenticator=args["authenticator"],
+        authorizer=args["authorizer"],
+        command_registry=args["command_registry"],
+        payload_schemas=args["payload_schemas"],
         clock=args["clock"],
     )
     accepted = authority.accept(
-        feedback.canonical_bytes, obligation.canonical_bytes,
+        feedback.canonical_bytes,
+        obligation.canonical_bytes,
         candidate_proof=location.seed[0][3],
     )
-    assert HandoffAcceptanceSnapshot.from_canonical_bytes(
-        accepted.handoff_snapshot.canonical_bytes
-    ) == accepted.handoff_snapshot
-    assert authority.accept(
-        feedback.canonical_bytes, obligation.canonical_bytes,
-        candidate_proof=object(),
-    ) == accepted
+    assert (
+        HandoffAcceptanceSnapshot.from_canonical_bytes(
+            accepted.handoff_snapshot.canonical_bytes
+        )
+        == accepted.handoff_snapshot
+    )
+    assert (
+        authority.accept(
+            feedback.canonical_bytes,
+            obligation.canonical_bytes,
+            candidate_proof=object(),
+        )
+        == accepted
+    )
     connection = authority._EvaluationFeedbackAuthority__authority._connection
     handoff_guard = connection.execute(
         "SELECT sql FROM sqlite_master WHERE name='evaluation_handoff_identity_guard'"
     ).fetchone()[0]
+    authority_counts = tuple(
+        connection.execute(
+            "SELECT (SELECT count(*) FROM evaluation_feedback),"
+            "(SELECT count(*) FROM evaluation_reconciliation_dispositions),"
+            "(SELECT count(*) FROM ledger_events)"
+        ).fetchone()
+    )
     connection.execute("DROP TRIGGER evaluation_handoff_identity_guard")
     connection.execute(
         "UPDATE evaluation_handoffs SET max_attempts=4 WHERE handoff_id=?",
         (feedback.handoff_id,),
     )
     connection.execute(handoff_guard)
-    assert authority.accept(
-        feedback.canonical_bytes, obligation.canonical_bytes,
-        candidate_proof=object(),
-    ).handoff_snapshot.observed_max_attempts == 3
+    assert (
+        tuple(
+            connection.execute(
+                "SELECT (SELECT count(*) FROM evaluation_feedback),"
+                "(SELECT count(*) FROM evaluation_reconciliation_dispositions),"
+                "(SELECT count(*) FROM ledger_events)"
+            ).fetchone()
+        )
+        == authority_counts
+    )
+    assert (
+        authority.accept(
+            feedback.canonical_bytes,
+            obligation.canonical_bytes,
+            candidate_proof=object(),
+        ).handoff_snapshot.observed_max_attempts
+        == 3
+    )
     trigger = connection.execute(
         "SELECT sql FROM sqlite_master WHERE name='immutable_evaluation_feedback'"
     ).fetchone()[0]
     connection.execute("DROP TRIGGER immutable_evaluation_feedback")
     connection.execute(
-        "UPDATE evaluation_feedback SET source_feedback_id='tampered' WHERE feedback_id=?",
+        "UPDATE evaluation_feedback SET recorded_at='2042-02-03T00:00:00.000000Z' "
+        "WHERE feedback_id=?",
         (feedback.feedback_id,),
     )
     connection.execute(trigger)
@@ -141,17 +200,23 @@ def test_disposition_is_generic_ledger_anchored_and_replay_precedes_ports(
 ) -> None:
     location, args, feedback, obligation = _seed(tmp_path)
     authority = open_evaluation_feedback_authority_system(
-        location.seed[1], retrieval_authority=args["retrieval_authority"],
-        authenticator=args["authenticator"], authorizer=args["authorizer"],
-        command_registry=args["command_registry"], payload_schemas=args["payload_schemas"],
+        location.seed[1],
+        retrieval_authority=args["retrieval_authority"],
+        authenticator=args["authenticator"],
+        authorizer=args["authorizer"],
+        command_registry=args["command_registry"],
+        payload_schemas=args["payload_schemas"],
         clock=args["clock"],
     )
     accepted = authority.accept(
-        feedback.canonical_bytes, obligation.canonical_bytes,
+        feedback.canonical_bytes,
+        obligation.canonical_bytes,
         candidate_proof=location.seed[0][3],
     )
     disposition = append_reconciliation_disposition(
-        accepted.obligation, (), outcome=ReconciliationDispositionOutcome.UNRESOLVED,
+        accepted.obligation,
+        (),
+        outcome=ReconciliationDispositionOutcome.UNRESOLVED,
         reason=ReconciliationDispositionReason.AWAITING_RECONCILIATION,
         resolution_digest="sha256:" + "6" * 64,
         request_id="11111111-1111-4111-8111-111111111111",
@@ -161,14 +226,174 @@ def test_disposition_is_generic_ledger_anchored_and_replay_precedes_ports(
         expected_current_disposition_digest=None,
         expected_current_ordinal=0,
     )
-    assert authority.append_disposition(
-        disposition.canonical_bytes, candidate_proof=location.seed[0][3]
-    ) == disposition
-    assert authority.append_disposition(
-        disposition.canonical_bytes, candidate_proof=object()
-    ) == disposition
+    assert (
+        authority.append_disposition(
+            disposition.canonical_bytes, candidate_proof=location.seed[0][3]
+        )
+        == disposition
+    )
+    assert (
+        authority.append_disposition(
+            disposition.canonical_bytes, candidate_proof=object()
+        )
+        == disposition
+    )
     connection = authority._EvaluationFeedbackAuthority__authority._connection
-    assert connection.execute(
-        "SELECT authority_aggregate_version FROM evaluation_reconciliation_dispositions"
-    ).fetchone()[0] == 2
+    assert (
+        connection.execute(
+            "SELECT authority_aggregate_version FROM evaluation_reconciliation_dispositions"
+        ).fetchone()[0]
+        == 2
+    )
+    authority.close()
+    reopened = open_evaluation_feedback_authority_system(
+        location.seed[1],
+        retrieval_authority=args["retrieval_authority"],
+        authenticator=args["authenticator"],
+        authorizer=args["authorizer"],
+        command_registry=args["command_registry"],
+        payload_schemas=args["payload_schemas"],
+        clock=args["clock"],
+    )
+    assert reopened.load(feedback.feedback_id) == accepted
+    fulfilled = append_reconciliation_disposition(
+        obligation,
+        (disposition,),
+        outcome=ReconciliationDispositionOutcome.FULFILLED,
+        reason=ReconciliationDispositionReason.FEEDBACK_RECORDED,
+        resolution_digest="sha256:" + "7" * 64,
+        request_id="22222222-2222-4222-8222-222222222222",
+        actor_identity_digest=feedback.actor_identity_digest,
+        idempotency_key="disposition:v25-fulfilled",
+        expected_current_disposition_id=disposition.disposition_id,
+        expected_current_disposition_digest=disposition.canonical_digest,
+        expected_current_ordinal=1,
+    )
+    assert (
+        reopened.append_disposition(
+            fulfilled.canonical_bytes, candidate_proof=location.seed[0][3]
+        )
+        == fulfilled
+    )
+    with pytest.raises(FeedbackContractError, match="terminal"):
+        append_reconciliation_disposition(
+            obligation,
+            (disposition, fulfilled),
+            outcome=ReconciliationDispositionOutcome.UNRESOLVED,
+            reason=ReconciliationDispositionReason.AWAITING_RECONCILIATION,
+            resolution_digest="sha256:" + "8" * 64,
+            request_id="33333333-3333-4333-8333-333333333333",
+            actor_identity_digest=feedback.actor_identity_digest,
+            idempotency_key="disposition:v25-after-terminal",
+            expected_current_disposition_id=fulfilled.disposition_id,
+            expected_current_disposition_digest=fulfilled.canonical_digest,
+            expected_current_ordinal=2,
+        )
+    connection = reopened._EvaluationFeedbackAuthority__authority._connection
+    trigger = connection.execute(
+        "SELECT sql FROM sqlite_master WHERE name='immutable_evaluation_feedback'"
+    ).fetchone()[0]
+    event = connection.execute(
+        "SELECT authority_event_id,recorded_at FROM "
+        "evaluation_reconciliation_dispositions WHERE disposition_id=?",
+        (fulfilled.disposition_id,),
+    ).fetchone()
+    connection.execute("DROP TRIGGER immutable_evaluation_feedback")
+    connection.execute(
+        "UPDATE evaluation_feedback SET authority_event_id=?,"
+        "recorded_at=? WHERE feedback_id=?",
+        (*event, feedback.feedback_id),
+    )
+    connection.execute(trigger)
+    with pytest.raises(FeedbackContractError):
+        reopened.load(feedback.feedback_id)
+    reopened.close()
+
+
+@pytest.mark.parametrize(
+    ("table", "trigger", "column", "value"),
+    (
+        (
+            "authority_commands",
+            "immutable_authority_commands_update",
+            "expected_aggregate_version",
+            7,
+        ),
+        (
+            "authority_audit_events",
+            "immutable_authority_audit_events_update",
+            "detail_digest",
+            "sha256:" + "0" * 64,
+        ),
+        (
+            "authority_audit_events",
+            "immutable_authority_audit_events_update",
+            "authorization_request_digest",
+            "COPY",
+        ),
+        (
+            "authority_aggregate_versions",
+            "immutable_aggregate_versions_update",
+            "trust_scope",
+            "OBSERVED",
+        ),
+    ),
+)
+def test_generic_envelope_tamper_fails_with_restored_trigger(
+    tmp_path: Path, table: str, trigger: str, column: str, value: object
+) -> None:
+    location, args, feedback, obligation = _seed(tmp_path)
+    authority = open_evaluation_feedback_authority_system(
+        location.seed[1],
+        retrieval_authority=args["retrieval_authority"],
+        authenticator=args["authenticator"],
+        authorizer=args["authorizer"],
+        command_registry=args["command_registry"],
+        payload_schemas=args["payload_schemas"],
+        clock=args["clock"],
+    )
+    authority.accept(
+        feedback.canonical_bytes,
+        obligation.canonical_bytes,
+        candidate_proof=location.seed[0][3],
+    )
+    connection = authority._EvaluationFeedbackAuthority__authority._connection
+    sql = connection.execute(
+        "SELECT sql FROM sqlite_master WHERE name=?", (trigger,)
+    ).fetchone()[0]
+    connection.execute(f"DROP TRIGGER {trigger}")
+    connection.execute("PRAGMA foreign_keys=OFF")
+    if value == "COPY":
+        connection.execute(
+            "UPDATE authority_audit_events SET (authentication_context_id,authorization_request_digest,"
+            "authorization_decision_id)=(SELECT authentication_context_id,authorization_request_digest,"
+            "authorization_decision_id FROM authority_commands WHERE command_type!='evaluation-feedback.reconcile' LIMIT 1) "
+            "WHERE command_id=(SELECT e.command_id FROM ledger_events e JOIN evaluation_feedback f "
+            "ON f.authority_event_id=e.event_id WHERE f.feedback_id=?)",
+            (feedback.feedback_id,),
+        )
+    else:
+        identity_column = (
+            "aggregate_id" if table == "authority_aggregate_versions" else "command_id"
+        )
+        local_column = (
+            "authority_aggregate_id"
+            if table == "authority_aggregate_versions"
+            else "authority_event_id"
+        )
+        identity_expression = (
+            f"SELECT {local_column} FROM evaluation_feedback WHERE feedback_id=?"
+            if table == "authority_aggregate_versions"
+            else "SELECT e.command_id FROM ledger_events e JOIN evaluation_feedback f "
+            "ON f.authority_event_id=e.event_id WHERE f.feedback_id=?"
+        )
+        connection.execute(
+            f"UPDATE {table} SET {column}=? WHERE {identity_column}="
+            f"({identity_expression})",
+            (value, feedback.feedback_id),
+        )
+    connection.execute(sql)
+    connection.execute("PRAGMA foreign_keys=ON")
+    with pytest.raises(FeedbackContractError):
+        authority.load(feedback.feedback_id)
     authority.close()

--- a/newsroom/tests/test_increment6f2_feedback_system.py
+++ b/newsroom/tests/test_increment6f2_feedback_system.py
@@ -397,3 +397,70 @@ def test_generic_envelope_tamper_fails_with_restored_trigger(
     with pytest.raises(FeedbackContractError):
         authority.load(feedback.feedback_id)
     authority.close()
+
+
+@pytest.mark.parametrize("tamper", ("namespace", "result", "causation"))
+def test_retained_namespace_result_and_causation_tamper_fail_closed(
+    tmp_path: Path, tamper: str
+) -> None:
+    location, args, feedback, obligation = _seed(tmp_path)
+    authority = open_evaluation_feedback_authority_system(
+        location.seed[1],
+        retrieval_authority=args["retrieval_authority"],
+        authenticator=args["authenticator"],
+        authorizer=args["authorizer"],
+        command_registry=args["command_registry"],
+        payload_schemas=args["payload_schemas"],
+        clock=args["clock"],
+    )
+    authority.accept(
+        feedback.canonical_bytes,
+        obligation.canonical_bytes,
+        candidate_proof=location.seed[0][3],
+    )
+    connection = authority._EvaluationFeedbackAuthority__authority._connection
+    event_id, command_id = connection.execute(
+        "SELECT e.event_id,e.command_id FROM ledger_events e "
+        "JOIN evaluation_feedback f ON f.authority_event_id=e.event_id "
+        "WHERE f.feedback_id=?",
+        (feedback.feedback_id,),
+    ).fetchone()
+    if tamper in {"namespace", "result"}:
+        trigger_name = "immutable_authority_commands_update"
+        trigger_sql = connection.execute(
+            "SELECT sql FROM sqlite_master WHERE name=?", (trigger_name,)
+        ).fetchone()[0]
+        connection.execute(f"DROP TRIGGER {trigger_name}")
+        if tamper == "namespace":
+            connection.execute(
+                "UPDATE authority_commands SET idempotency_namespace=? WHERE command_id=?",
+                ("sha256:" + "f" * 64, command_id),
+            )
+        else:
+            donor = connection.execute(
+                "SELECT result_bytes,result_digest FROM authority_commands "
+                "WHERE command_id!=? AND result_bytes IS NOT NULL LIMIT 1",
+                (command_id,),
+            ).fetchone()
+            assert donor is not None
+            connection.execute(
+                "UPDATE authority_commands SET result_bytes=?,result_digest=? WHERE command_id=?",
+                (*donor, command_id),
+            )
+        connection.execute(trigger_sql)
+    else:
+        trigger_name = "immutable_ledger_events_update"
+        trigger_sql = connection.execute(
+            "SELECT sql FROM sqlite_master WHERE name=?", (trigger_name,)
+        ).fetchone()[0]
+        connection.execute(f"DROP TRIGGER {trigger_name}")
+        connection.execute(
+            "UPDATE ledger_events SET causation_kind='EXTERNAL',"
+            "causation_identifier='forged-causation',"
+            "causation_external_system='forged-system' WHERE event_id=?",
+            (event_id,),
+        )
+        connection.execute(trigger_sql)
+    with pytest.raises(FeedbackContractError):
+        authority.load(feedback.feedback_id)
+    authority.close()

--- a/newsroom/tests/test_increment6f2_feedback_system.py
+++ b/newsroom/tests/test_increment6f2_feedback_system.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sqlite3
+
+import pytest
+
+from newsroom.authority.auth import StaticAuthorizer
+from newsroom.authority.canonical import canonical_json_bytes, digest_bytes
+from newsroom.authority.evaluation_feedback_system import (
+    open_evaluation_feedback_authority_system,
+)
+from newsroom.increment6.feedback import (
+    EvaluationFeedbackOutcome,
+    EvaluationFeedbackReason,
+    FeedbackContractError,
+    HandoffAcceptanceSnapshot,
+    ReconciliationDispositionOutcome,
+    ReconciliationDispositionReason,
+    append_reconciliation_disposition,
+    create_evaluation_feedback,
+    create_reconciliation_obligation,
+)
+from newsroom.increment6.handoffs import (
+    Acknowledgement,
+    AcknowledgementOutcome,
+    EvaluationHandoffStore,
+    create_handoff,
+)
+from newsroom.tests import test_increment6e2_candidate_store as candidate_fixture
+
+
+def _seed(tmp_path: Path):
+    adapter = candidate_fixture._Adapter(tmp_path)
+    location = adapter.create_location()
+    handle = adapter.open_handle(location)
+    handle.submit(candidate_fixture._generic("record-1"))
+    row = handle._row("record-1")
+    version = handle._opened().load_version(str(row[1]))
+    handle.close()
+    store = EvaluationHandoffStore(sqlite3.connect(location.seed[1], isolation_level=None))
+    handoff = store.register(create_handoff(
+        version.version_id, version.governing_manifest.canonical_digest,
+        "evaluation-sink:v25-test", max_attempts=3,
+    ))
+    handoff = store.persist_attempt(handoff.handoff_id)
+    handoff = store.mark_attempt_sent(handoff.handoff_id, handoff.attempts[0].attempt_id)
+    acknowledgement = Acknowledgement.create(
+        handoff_id=handoff.handoff_id, attempt_id=handoff.attempts[0].attempt_id,
+        candidate_version_id=version.version_id,
+        governing_manifest_digest=version.governing_manifest.canonical_digest,
+        sink_id=handoff.sink_id, outcome=AcknowledgementOutcome.ACKNOWLEDGED,
+        response_digest="sha256:" + "4" * 64,
+    )
+    handoff = store.correlate_acknowledgement(handoff.handoff_id, acknowledgement)
+    store._connection.close()
+    args = candidate_fixture._collaborators(location.seed)
+    authentication = args["authenticator"].authenticate(
+        location.seed[0][3], now=args["clock"]()
+    )
+    actor = digest_bytes(
+        canonical_json_bytes(
+            {
+                "principal_id": authentication.principal_id,
+                "credential_binding_digest": authentication.credential_binding_digest,
+            }
+        )
+    )
+    scopes = {
+        item.required_scope
+        for item in args["command_registry"].definitions()
+    } | {"authority.evaluation-feedback.reconcile"}
+    args["authorizer"] = StaticAuthorizer(
+        policy_version="feedback-test-v1", grants_by_principal={"editor": frozenset(scopes)}
+    )
+    feedback = create_evaluation_feedback(
+        handoff=handoff, attempt=handoff.attempts[0], acknowledgement=acknowledgement,
+        candidate_version=version, source_feedback_id="evaluation-feedback:v25-test",
+        outcome=EvaluationFeedbackOutcome.ACCEPTED,
+        reason=EvaluationFeedbackReason.INTAKE_ACCEPTED,
+        detail_digest="sha256:" + "2" * 64,
+        request_id="eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+        actor_identity_digest=actor, idempotency_key="feedback:v25-test",
+    )
+    obligation = create_reconciliation_obligation(
+        feedback, request_id="aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        actor_identity_digest=actor, idempotency_key="obligation:v25-test",
+    )
+    return location, args, feedback, obligation
+
+
+def test_accept_replay_snapshot_and_direct_tamper_fail_closed(tmp_path: Path) -> None:
+    location, args, feedback, obligation = _seed(tmp_path)
+    authority = open_evaluation_feedback_authority_system(
+        location.seed[1], retrieval_authority=args["retrieval_authority"],
+        authenticator=args["authenticator"], authorizer=args["authorizer"],
+        command_registry=args["command_registry"], payload_schemas=args["payload_schemas"],
+        clock=args["clock"],
+    )
+    accepted = authority.accept(
+        feedback.canonical_bytes, obligation.canonical_bytes,
+        candidate_proof=location.seed[0][3],
+    )
+    assert HandoffAcceptanceSnapshot.from_canonical_bytes(
+        accepted.handoff_snapshot.canonical_bytes
+    ) == accepted.handoff_snapshot
+    assert authority.accept(
+        feedback.canonical_bytes, obligation.canonical_bytes,
+        candidate_proof=object(),
+    ) == accepted
+    connection = authority._EvaluationFeedbackAuthority__authority._connection
+    handoff_guard = connection.execute(
+        "SELECT sql FROM sqlite_master WHERE name='evaluation_handoff_identity_guard'"
+    ).fetchone()[0]
+    connection.execute("DROP TRIGGER evaluation_handoff_identity_guard")
+    connection.execute(
+        "UPDATE evaluation_handoffs SET max_attempts=4 WHERE handoff_id=?",
+        (feedback.handoff_id,),
+    )
+    connection.execute(handoff_guard)
+    assert authority.accept(
+        feedback.canonical_bytes, obligation.canonical_bytes,
+        candidate_proof=object(),
+    ).handoff_snapshot.observed_max_attempts == 3
+    trigger = connection.execute(
+        "SELECT sql FROM sqlite_master WHERE name='immutable_evaluation_feedback'"
+    ).fetchone()[0]
+    connection.execute("DROP TRIGGER immutable_evaluation_feedback")
+    connection.execute(
+        "UPDATE evaluation_feedback SET source_feedback_id='tampered' WHERE feedback_id=?",
+        (feedback.feedback_id,),
+    )
+    connection.execute(trigger)
+    with pytest.raises(FeedbackContractError):
+        authority.load(feedback.feedback_id)
+    authority.close()
+
+
+def test_disposition_is_generic_ledger_anchored_and_replay_precedes_ports(
+    tmp_path: Path,
+) -> None:
+    location, args, feedback, obligation = _seed(tmp_path)
+    authority = open_evaluation_feedback_authority_system(
+        location.seed[1], retrieval_authority=args["retrieval_authority"],
+        authenticator=args["authenticator"], authorizer=args["authorizer"],
+        command_registry=args["command_registry"], payload_schemas=args["payload_schemas"],
+        clock=args["clock"],
+    )
+    accepted = authority.accept(
+        feedback.canonical_bytes, obligation.canonical_bytes,
+        candidate_proof=location.seed[0][3],
+    )
+    disposition = append_reconciliation_disposition(
+        accepted.obligation, (), outcome=ReconciliationDispositionOutcome.UNRESOLVED,
+        reason=ReconciliationDispositionReason.AWAITING_RECONCILIATION,
+        resolution_digest="sha256:" + "6" * 64,
+        request_id="11111111-1111-4111-8111-111111111111",
+        actor_identity_digest=feedback.actor_identity_digest,
+        idempotency_key="disposition:v25-test",
+        expected_current_disposition_id=None,
+        expected_current_disposition_digest=None,
+        expected_current_ordinal=0,
+    )
+    assert authority.append_disposition(
+        disposition.canonical_bytes, candidate_proof=location.seed[0][3]
+    ) == disposition
+    assert authority.append_disposition(
+        disposition.canonical_bytes, candidate_proof=object()
+    ) == disposition
+    connection = authority._EvaluationFeedbackAuthority__authority._connection
+    assert connection.execute(
+        "SELECT authority_aggregate_version FROM evaluation_reconciliation_dispositions"
+    ).fetchone()[0] == 2
+    authority.close()


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-6f2b-feedback-authority
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

Closes #403
Refs #367
Refs #146
Refs #426
Refs #428

## Summary
- add checked serial v25 `evaluation_feedback_authority_v25` migration with exactly three retained tables and exact v24 backup/restore provenance
- add the single-connection server-owned Feedback/reconciliation writer, immutable full Handoff acceptance snapshot, generic-ledger anchoring, replay/currentness separation, CAS dispositions, and token-gated public facade
- bind every accepted feedback/disposition to the full retained generic command/event/audit/authentication/authorisation envelope, including expected aggregate version and aggregate-version trust
- add genuine granular #384 conformance probes whose replay and divergent submissions re-enter production authority, plus exact-SQL #395 downgrade preflight and stale D1/D2/D3 integration closure

## Scope proof
- accepted base: `539cbc10620a574a4d627d133c716e2805b84ce4`
- head: `e0fdf7f0470eada77d448518f92ad082b1f255fa`
- tree: `008743b3550f9fe29ac5ef865e0d9f83f1dcf9c4`
- commits: 2
- changed files: 14 (`2835` insertions, `26` deletions)
- production ownership: exactly 4 files; `1456` insertions + `19` deletions = `1475` changed production lines
- migration checksum: `sha256:59fe3bd40a2e22e874b4e5b02448501deffc23597e11b442e35b18e39ead0496`
- schema fingerprint: `sha256:353900bf5804f0b770489982541f3cff4fd30ea36fc75d19b9c63315d1b6ec06`

## RED
- original vertical RED: `uv run python /tmp/test_v25_red.py` — `ModuleNotFoundError: newsroom.authority.evaluation_feedback_migrations`
- exact-head CI RED: SDLC Evidence Shadow run `31650710522` failed stale integration shards and duration admission
- request-binding composite RED: `99.21s call / 99.67s total` (over the 90-second hard evidence cap)
- reviewer probes found incomplete generic-ledger envelope checks, adapter-side replay/conflict arbitration, and name-only v25 downgrade preflight

## GREEN
- `uv run pytest -q newsroom/tests/test_increment6f2_feedback_store.py --durations=50` — **41 passed in 321.58s**; all 11 semantic cases covered by exact unique granular probes, slowest node **17.37s**, production replay/divergence monkeypatch sensitivity included
- restored-trigger generic-envelope tamper regressions (CAS, audit detail, auth triple, aggregate-version trust) — **4 passed in 33.27s**
- granular request-binding nodes — **4 passed in 72.72s total**, each **18.02–18.13s**
- `uv run pytest -q newsroom/tests/test_increment6f2_feedback.py newsroom/tests/test_increment6f2_feedback_system.py newsroom/tests/test_increment6f2r_read_ports.py` — **34 passed in 79.94s**
- focused #395 + altered-trigger atomicity + affected D1/D2/D3 — **14 passed in 12.22s**
- migration/Candidate/Handoff dependency closure — **181 passed in 68.89s**
- import boundary, readiness, and bounded Fast CI lanes — **131 passed in 8.56s**
- `uvx ruff check <all changed files>` — passed
- `uvx ruff format --check <all changed files>` — 9 files already formatted
- `uv run python -m compileall -q <changed production and focused tests>` — passed
- `uv lock --check` — passed
- `git diff --check` — passed
- `uv run python -m scripts.sdlc.workflow_lane source-check --base-sha 539cbc10620a574a4d627d133c716e2805b84ce4 --head-sha e0fdf7f0470eada77d448518f92ad082b1f255fa` — passed

## Boundaries
- remains Draft; no operational activation or external effect
- observed Handoff `max_attempts` is retained as acceptance-time observation only and is not feedback, reconciliation, CAS, or effect authority
- no Candidate/Handoff owner production files, private-table queries, second SQLite writer connection, extra production tables, or #368 implementation
- downgrade preserves the outer savepoint and rejects altered v25 object SQL without mutation
