### PR TITLE
Increment 6G: add final closed-world closeout receipt

### DIFF
--- a/.github/workflows/evidence.yml
+++ b/.github/workflows/evidence.yml
@@ -649,6 +649,18 @@ jobs:
             --decision .sdlc-run/decision.json \
             --output .sdlc-run/increment5e2-final-closeout.json
 
+      - name: Build Increment 6G final closeout receipt
+        if: needs.route.outputs.service_required == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run --no-sync python -m scripts.sdlc.increment6g_closeout_receipt \
+            --repo-root . \
+            --core-transport-bundle-root .sdlc-run/decision-input/core-transport \
+            --service-transport-bundle-root .sdlc-run/decision-input/service-transport \
+            --decision .sdlc-run/decision.json \
+            --output .sdlc-run/increment6g-final-closeout.json
+
       - name: Upload final decision evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -659,6 +671,7 @@ jobs:
             .sdlc-run/decision-input/collection.json
             .sdlc-run/decision.json
             .sdlc-run/increment5e2-final-closeout.json
+            .sdlc-run/increment6g-final-closeout.json
           if-no-files-found: error
           retention-days: 30
           compression-level: 0
@@ -720,6 +733,10 @@ jobs:
           )
           decision_subject = Path(
               '.sdlc-run/signed-closeout-input/decision.json'
+          )
+          increment6_subject = Path(
+              '.sdlc-run/signed-closeout-input/'
+              'increment6g-final-closeout.json'
           )
 
           def unique_object(pairs):
@@ -829,6 +846,65 @@ jobs:
           if claimed_identity != actual_identity:
               raise SystemExit('closeout receipt self-hash mismatch')
 
+          increment6 = load_subject(increment6_subject, 'increment6 closeout')
+          if (
+              not isinstance(increment6, dict)
+              or increment6.get('schema_version')
+              != 'newsroom.increment6g.final-closeout-receipt.v1'
+              or increment6.get('evaluated_sha') != expected_head
+              or increment6.get('evaluated_tree_sha')
+              != value.get('evaluated_tree_sha')
+              or increment6.get('decision_identity')
+              != value.get('decision_identity')
+          ):
+              raise SystemExit('increment6 closeout identity differs')
+          increment6_lanes = increment6.get('lanes')
+          increment6_inventory = increment6.get('inventory')
+          increment6_cases = increment6.get('selected_cases')
+          increment6_count = (
+              increment6_inventory.get('case_count')
+              if isinstance(increment6_inventory, dict)
+              else None
+          )
+          if (
+              not isinstance(increment6_lanes, list)
+              or len(increment6_lanes) != 2
+              or not all(isinstance(lane, dict) for lane in increment6_lanes)
+              or {lane.get('lane_id') for lane in increment6_lanes}
+              != {'core', 'service'}
+              or type(increment6_count) is not int
+              or increment6_count != 58
+              or not isinstance(increment6_cases, list)
+              or len(increment6_cases) != increment6_count
+              or not all(isinstance(item, dict) for item in increment6_cases)
+              or any(item.get('outcome') != 'passed' for item in increment6_cases)
+              or len({item.get('case_id') for item in increment6_cases})
+              != increment6_count
+              or len({item.get('test_id') for item in increment6_cases})
+              != increment6_count
+              or increment6_inventory.get('digest')
+              != 'sha256:67ae4fdba2d9bda2280896a2e2de38a95a211cfe1f80dd505ccd646cdc2b4b4f'
+              or increment6_inventory.get('schema_version') != 25
+              or increment6_inventory.get('schema_fingerprint')
+              != 'sha256:353900bf5804f0b770489982541f3cff4fd30ea36fc75d19b9c63315d1b6ec06'
+          ):
+              raise SystemExit('increment6 closeout inventory differs')
+          increment6_claimed = increment6.get('receipt_identity')
+          increment6_unsigned = dict(increment6)
+          increment6_unsigned.pop('receipt_identity', None)
+          increment6_canonical = json.dumps(
+              increment6_unsigned,
+              ensure_ascii=False,
+              allow_nan=False,
+              sort_keys=True,
+              separators=(',', ':'),
+          ).encode('utf-8')
+          increment6_actual = (
+              'sha256:' + hashlib.sha256(increment6_canonical).hexdigest()
+          )
+          if increment6_claimed != increment6_actual:
+              raise SystemExit('increment6 closeout self-hash mismatch')
+
           decision = load_subject(decision_subject, 'decision')
           if (
               not isinstance(decision, dict)
@@ -858,6 +934,7 @@ jobs:
           subject-path: |
             .sdlc-run/signed-closeout-input/decision.json
             .sdlc-run/signed-closeout-input/increment5e2-final-closeout.json
+            .sdlc-run/signed-closeout-input/increment6g-final-closeout.json
 
       - name: Retain attestation bundle
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/evidence.yml
+++ b/.github/workflows/evidence.yml
@@ -883,7 +883,7 @@ jobs:
               or len({item.get('test_id') for item in increment6_cases})
               != increment6_count
               or increment6_inventory.get('digest')
-              != 'sha256:67ae4fdba2d9bda2280896a2e2de38a95a211cfe1f80dd505ccd646cdc2b4b4f'
+              != 'sha256:cb051e71025a2387aa6bdc4e4fca0bc76b414aabaeb2d192b2aa1dd48c81e011'
               or increment6_inventory.get('schema_version') != 25
               or increment6_inventory.get('schema_fingerprint')
               != 'sha256:353900bf5804f0b770489982541f3cff4fd30ea36fc75d19b9c63315d1b6ec06'

--- a/.github/workflows/evidence.yml
+++ b/.github/workflows/evidence.yml
@@ -887,6 +887,8 @@ jobs:
               or increment6_inventory.get('schema_version') != 25
               or increment6_inventory.get('schema_fingerprint')
               != 'sha256:353900bf5804f0b770489982541f3cff4fd30ea36fc75d19b9c63315d1b6ec06'
+              or increment6_inventory.get('migration_history_digest')
+              != 'sha256:bea793377d065d3073e6dfa8d40139fedfd377d5e24d9812d12cdb1ad52e9a0f'
           ):
               raise SystemExit('increment6 closeout inventory differs')
           increment6_claimed = increment6.get('receipt_identity')

--- a/.github/workflows/projection-b2-neo4j.yml
+++ b/.github/workflows/projection-b2-neo4j.yml
@@ -158,6 +158,7 @@ jobs:
             newsroom/tests/test_increment_2d_neo4j_service.py \
             newsroom/tests/test_increment4e_neo4j_service.py \
             newsroom/tests/test_increment5b4_neo4j_service.py \
+            newsroom/tests/test_increment6g_neo4j_service.py \
             --junitxml=projection-b2-b3-c1-complete-retrieval-neo4j-results.xml
 
       - name: Remove disposable credential files

--- a/docs/traceability/increment-6g-final-closeout.md
+++ b/docs/traceability/increment-6g-final-closeout.md
@@ -6,7 +6,7 @@
 - **Entry main:** `c52574afcc9725b7ee14edcc8f4aa608a2593ecc`
 - **Entry tree:** `91754aeb76f05fac41b38ad8ef90715b7fe11ba4`
 - **Inventory source:** `newsroom/increment6/closeout.py`
-- **Inventory digest:** `sha256:67ae4fdba2d9bda2280896a2e2de38a95a211cfe1f80dd505ccd646cdc2b4b4f`
+- **Inventory digest:** `sha256:cb051e71025a2387aa6bdc4e4fca0bc76b414aabaeb2d192b2aa1dd48c81e011`
 
 ## Closed boundary
 
@@ -48,6 +48,16 @@ The selected authority cases retain the real public paths:
 
 Rights withdrawal, exact tombstone removal, tamper, unavailable, degraded and
 no-false-success outcomes are retained as explicit fail-closed evidence.
+
+The inherited v17 Handoff record does not immutably prove its original
+registration-time `max_attempts`; #428 owns that later hardening and blocks
+production-equivalent Handoff use. Increment 6 does not use that unanchored
+scalar as authority. The selected feedback-authority case retains the exact
+v25 Handoff acceptance snapshot in the same transaction as accepted feedback,
+then changes only the underlying `max_attempts` value and proves that no new
+feedback, reconciliation disposition or ledger effect is created. Exact replay
+continues to return the retained snapshot. This known limitation therefore
+cannot authorise an Increment 6 effect and is not hidden by the closeout.
 
 ## Actual service and retained receipt
 

--- a/docs/traceability/increment-6g-final-closeout.md
+++ b/docs/traceability/increment-6g-final-closeout.md
@@ -1,0 +1,80 @@
+# Increment 6G final closeout traceability
+
+- **Issue:** #368
+- **Parent:** #146
+- **Gate:** Tier M
+- **Entry main:** `c52574afcc9725b7ee14edcc8f4aa608a2593ecc`
+- **Entry tree:** `91754aeb76f05fac41b38ad8ef90715b7fe11ba4`
+- **Inventory source:** `newsroom/increment6/closeout.py`
+- **Inventory digest:** `sha256:67ae4fdba2d9bda2280896a2e2de38a95a211cfe1f80dd505ccd646cdc2b4b4f`
+
+## Closed boundary
+
+The machine inventory reconciles 58 exact permanent pytest node identities. It
+binds the complete Increment 6 fixture path from retained Source Revision,
+Signal and Lead authority through Work Item, Retrieval Context, Proposal,
+Disposition, Hypothesis, Relationship, Lineage, Candidate Admission,
+evaluation-only Handoff, Feedback and mandatory Reconciliation Disposition.
+
+The inventory is evidence only when the signed SDLC receipt finds every exact
+node once in the retained core or authenticated-service JUnit reports and each
+selected node passed without a skip. The receipt rejects any failure or error
+in either complete lane, including a failure outside the selected inventory.
+
+## Migration and authority boundary
+
+The closeout adds no migration, table, product writer or product authority. The
+retained migration inventory proves the literal v1-v25 history, every supported
+exact predecessor upgrade, multihop backup identities, exclusive rollback and
+restore/re-upgrade. The actual-service target binds that same current history,
+schema version and schema fingerprint to the evaluated source head and tree.
+
+The selected authority cases retain the real public paths:
+
+- Work Item claim ownership, stale recovery, urgent/degraded visibility and
+  starvation protection;
+- Proposal route/disposition matrices, inspectable holds and no-authority
+  boundaries;
+- Hypothesis create/append, relationship uncertainty/correction and retained
+  receipt replay;
+- consolidation, split and reversal lineage without predecessor rewrite;
+- current collision recheck and equivalent/distinct Candidate admission;
+- concurrent claim/admission and evaluation Handoff loss, delay, ambiguity and
+  retry;
+- mandatory Feedback obligations and reconciliation dispositions which remain
+  visible until a governed terminal state; and
+- Watch Condition and supplemental-discovery re-entry through a new governed
+  Work Item.
+
+Rights withdrawal, exact tombstone removal, tamper, unavailable, degraded and
+no-false-success outcomes are retained as explicit fail-closed evidence.
+
+## Actual service and retained receipt
+
+`newsroom/tests/test_increment6g_neo4j_service.py` runs only with the permanent
+authenticated Neo4j service lane. It verifies the pinned image, server,
+edition, driver, database and projector identity through authenticated
+transport, then records the exact source, migration and inventory identities as
+JUnit properties. Wrong projector credentials and actual tombstone removal are
+separate selected actual-service cases.
+
+`scripts/sdlc/increment6g_closeout_receipt.py` replays the immutable core and
+service transport bundles, validates the PASS decision, checks all 58 selected
+outcomes, rejects any lane failure/error, and binds the raw JUnit, lane receipt,
+envelope, transport, replay, selected-test manifest and service identities to
+one exact source head and tree. It checks the tracked checkout before consuming
+evidence and again before emission.
+
+The final receipt is included with the decision evidence. Only a successful
+service-required manual run on `refs/heads/main` advances to `signed-closeout`.
+That isolated job independently checks its schema, exact-main identity, lane
+set, inventory, decision binding and content hash, then attests the decision,
+the retained Increment 5E2 receipt and the Increment 6G receipt together.
+
+## Non-effects
+
+Closeout performs no evidence acquisition, live provider/model call, product
+runtime egress, product authority mutation, publication, production activation,
+shadow or canary action. Disposable authenticated Neo4j is CI infrastructure;
+it does not change the product non-effect boundary. Increment 7 remains outside
+this work.

--- a/newsroom/increment6/__init__.py
+++ b/newsroom/increment6/__init__.py
@@ -1,5 +1,15 @@
 """Increment 6 contracts, initially limited to reviewed 6R readiness."""
 
+from .closeout import (
+    INCREMENT6_FINAL_REQUIREMENTS,
+    INCREMENT6G_FINAL_CLOSEOUT_CASES,
+    INCREMENT6G_FINAL_CLOSEOUT_INVENTORY_DIGEST,
+    INCREMENT6G_FINAL_NON_EFFECTS,
+    Increment6CloseoutCase,
+    Increment6CloseoutCategory,
+    Increment6CloseoutLane,
+    validate_increment6g_final_closeout_inventory,
+)
 from .readiness import (
     EXPECTED_READINESS_DIGEST,
     INCREMENT_6_READINESS,
@@ -17,6 +27,10 @@ from .readiness import (
 
 __all__ = [
     "EXPECTED_READINESS_DIGEST",
+    "INCREMENT6_FINAL_REQUIREMENTS",
+    "INCREMENT6G_FINAL_CLOSEOUT_CASES",
+    "INCREMENT6G_FINAL_CLOSEOUT_INVENTORY_DIGEST",
+    "INCREMENT6G_FINAL_NON_EFFECTS",
     "INCREMENT_6_READINESS",
     "INCREMENT_6_READINESS_DIGEST",
     "READINESS_CONTRACT_PATH",
@@ -24,8 +38,12 @@ __all__ = [
     "GateTier",
     "Increment6ReadinessContract",
     "Increment6ReadinessError",
+    "Increment6CloseoutCase",
+    "Increment6CloseoutCategory",
+    "Increment6CloseoutLane",
     "InterfaceCompanion",
     "InterfaceInventoryItem",
     "load_increment6_readiness_contract",
+    "validate_increment6g_final_closeout_inventory",
     "validate_interface_inventory",
 ]

--- a/newsroom/increment6/closeout.py
+++ b/newsroom/increment6/closeout.py
@@ -370,8 +370,9 @@ INCREMENT6G_FINAL_CLOSEOUT_CASES = tuple(
                 _F,
                 _D,
                 "test_increment6f2_feedback_system",
-                "test_disposition_is_generic_ledger_anchored_and_replay_precedes_ports",
+                "test_accept_replay_snapshot_and_direct_tamper_fail_closed",
                 _FEEDBACK,
+                _FAILURE,
             ),
             _case(
                 "R01_WATCH_EXPIRY",

--- a/newsroom/increment6/closeout.py
+++ b/newsroom/increment6/closeout.py
@@ -1,0 +1,527 @@
+"""Closed-world evidence inventory for the final Increment 6 Tier-M gate.
+
+The inventory names permanent repository tests which exercise the public
+Increment 6 authority facades. It introduces no writer or product effect: the
+SDLC receipt reconciles their retained JUnit outcomes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from newsroom.authority.canonical import canonical_json_bytes, digest_bytes
+
+
+class Increment6CloseoutLane(StrEnum):
+    DETERMINISTIC = "DETERMINISTIC"
+    ACTUAL_NEO4J = "ACTUAL_NEO4J"
+
+
+class Increment6CloseoutCategory(StrEnum):
+    MIGRATION_LIFECYCLE = "MIGRATION_LIFECYCLE"
+    WORK_CONTROL = "WORK_CONTROL"
+    PROPOSAL_AUTHORITY = "PROPOSAL_AUTHORITY"
+    HYPOTHESIS_AND_RELATIONSHIP = "HYPOTHESIS_AND_RELATIONSHIP"
+    LINEAGE = "LINEAGE"
+    CANDIDATE_ADMISSION = "CANDIDATE_ADMISSION"
+    HANDOFF_TRANSPORT = "HANDOFF_TRANSPORT"
+    FEEDBACK_RECONCILIATION = "FEEDBACK_RECONCILIATION"
+    DISCOVERY_REENTRY = "DISCOVERY_REENTRY"
+    RIGHTS_AND_FAILURE = "RIGHTS_AND_FAILURE"
+    ACTUAL_SERVICE_SECURITY = "ACTUAL_SERVICE_SECURITY"
+    CLOSEOUT_INTEGRITY = "CLOSEOUT_INTEGRITY"
+
+
+INCREMENT6_FINAL_REQUIREMENTS = frozenset(
+    {
+        "ACTUAL_SERVICE_IDENTITY_AUTHENTICATED_TRANSPORT",
+        "CLOSED_WORLD_RECEIPT_SIGNED_EXACT_MAIN",
+        "COLLISION_CANDIDATE_EQUIVALENT_DISTINCT_ADMISSION",
+        "CONCURRENT_CLAIM_ADMISSION_HANDOFF_ACK_RETRY",
+        "FEEDBACK_OBLIGATION_RECONCILIATION_VISIBILITY",
+        "HYPOTHESIS_CREATE_APPEND_RELATIONSHIP_CORRECTION_REVERSAL",
+        "LINEAGE_CONSOLIDATION_SPLIT_REVERSAL_SAFETY",
+        "MIGRATION_V1_V25_HISTORY_UPGRADE_ROLLBACK_RESTART_REPLAY",
+        "PROPOSAL_REJECT_HOLD_ESCALATE_NO_AUTHORITY",
+        "RIGHTS_TOMBSTONE_NO_FALSE_SUCCESS_TAMPER_UNAVAILABLE_DEGRADED",
+        "SUPPLEMENTAL_DISCOVERY_WATCH_REENTRY",
+        "WORK_ITEM_OWNERSHIP_URGENT_DEGRADED_FAIRNESS_STALE",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class Increment6CloseoutCase:
+    case_id: str
+    category: Increment6CloseoutCategory
+    lane: Increment6CloseoutLane
+    test_id: str
+    requirements: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if not self.case_id or not self.case_id.isascii():
+            raise RuntimeError("closeout case identity differs")
+        if (
+            not self.test_id.startswith("newsroom.tests.test_")
+            or "::test_" not in self.test_id
+            or len(self.test_id) > 512
+        ):
+            raise RuntimeError("closeout test identity is not canonical")
+        if (
+            not self.requirements
+            or self.requirements != tuple(sorted(set(self.requirements)))
+            or not set(self.requirements) <= INCREMENT6_FINAL_REQUIREMENTS
+        ):
+            raise RuntimeError("closeout requirement inventory differs")
+
+    def canonical_value(self) -> dict[str, object]:
+        return {
+            "case_id": self.case_id,
+            "category": self.category.value,
+            "lane": self.lane.value,
+            "requirements": list(self.requirements),
+            "test_id": self.test_id,
+        }
+
+
+def _case(
+    case_id: str,
+    category: Increment6CloseoutCategory,
+    lane: Increment6CloseoutLane,
+    module: str,
+    test_name: str,
+    *requirements: str,
+) -> Increment6CloseoutCase:
+    return Increment6CloseoutCase(
+        case_id=case_id,
+        category=category,
+        lane=lane,
+        test_id=f"newsroom.tests.{module}::{test_name}",
+        requirements=tuple(sorted(requirements)),
+    )
+
+
+_D = Increment6CloseoutLane.DETERMINISTIC
+_A = Increment6CloseoutLane.ACTUAL_NEO4J
+_M = Increment6CloseoutCategory.MIGRATION_LIFECYCLE
+_W = Increment6CloseoutCategory.WORK_CONTROL
+_P = Increment6CloseoutCategory.PROPOSAL_AUTHORITY
+_H = Increment6CloseoutCategory.HYPOTHESIS_AND_RELATIONSHIP
+_L = Increment6CloseoutCategory.LINEAGE
+_C = Increment6CloseoutCategory.CANDIDATE_ADMISSION
+_T = Increment6CloseoutCategory.HANDOFF_TRANSPORT
+_F = Increment6CloseoutCategory.FEEDBACK_RECONCILIATION
+_R = Increment6CloseoutCategory.DISCOVERY_REENTRY
+_X = Increment6CloseoutCategory.RIGHTS_AND_FAILURE
+_S = Increment6CloseoutCategory.ACTUAL_SERVICE_SECURITY
+_Z = Increment6CloseoutCategory.CLOSEOUT_INTEGRITY
+
+_MIGRATION = "MIGRATION_V1_V25_HISTORY_UPGRADE_ROLLBACK_RESTART_REPLAY"
+_WORK = "WORK_ITEM_OWNERSHIP_URGENT_DEGRADED_FAIRNESS_STALE"
+_PROPOSAL = "PROPOSAL_REJECT_HOLD_ESCALATE_NO_AUTHORITY"
+_HYPOTHESIS = "HYPOTHESIS_CREATE_APPEND_RELATIONSHIP_CORRECTION_REVERSAL"
+_LINEAGE = "LINEAGE_CONSOLIDATION_SPLIT_REVERSAL_SAFETY"
+_CANDIDATE = "COLLISION_CANDIDATE_EQUIVALENT_DISTINCT_ADMISSION"
+_HANDOFF = "CONCURRENT_CLAIM_ADMISSION_HANDOFF_ACK_RETRY"
+_FEEDBACK = "FEEDBACK_OBLIGATION_RECONCILIATION_VISIBILITY"
+_REENTRY = "SUPPLEMENTAL_DISCOVERY_WATCH_REENTRY"
+_FAILURE = "RIGHTS_TOMBSTONE_NO_FALSE_SUCCESS_TAMPER_UNAVAILABLE_DEGRADED"
+_SERVICE = "ACTUAL_SERVICE_IDENTITY_AUTHENTICATED_TRANSPORT"
+_CLOSEOUT = "CLOSED_WORLD_RECEIPT_SIGNED_EXACT_MAIN"
+
+
+INCREMENT6G_FINAL_CLOSEOUT_CASES = tuple(
+    sorted(
+        (
+            _case(
+                "M01_HISTORY",
+                _M,
+                _D,
+                "test_authority_migration_compatibility",
+                "test_registry_history_and_statement_pins_are_complete_and_named",
+                _MIGRATION,
+            ),
+            *tuple(
+                _case(
+                    f"M02_PREDECESSOR_{version}",
+                    _M,
+                    _D,
+                    "test_authority_migration_compatibility",
+                    f"test_exact_predecessors_upgrade_to_current[{version}]",
+                    _MIGRATION,
+                )
+                for version in range(13, 25)
+            ),
+            _case(
+                "M03_MULTIHOP",
+                _M,
+                _D,
+                "test_authority_migration_compatibility",
+                "test_multihop_upgrade_retains_each_exact_backup_and_digest",
+                _MIGRATION,
+            ),
+            _case(
+                "M04_ROLLBACK",
+                _M,
+                _D,
+                "test_authority_migration_compatibility",
+                "test_failed_upgrade_rolls_back_to_exact_predecessor",
+                _MIGRATION,
+            ),
+            _case(
+                "M05_RESTORE_REUPGRADE",
+                _M,
+                _D,
+                "test_authority_migration_compatibility",
+                "test_successful_upgrade_can_restore_exact_backup_then_reupgrade",
+                _MIGRATION,
+            ),
+            _case(
+                "W01_CLAIM",
+                _W,
+                _D,
+                "test_increment6b1_execution_store",
+                "test_two_connections_converge_on_one_claim_and_reopen_detects_tamper",
+                _WORK,
+                _HANDOFF,
+            ),
+            _case(
+                "W02_STALE",
+                _W,
+                _D,
+                "test_increment6b1_execution_store",
+                "test_different_worker_can_expire_a_stale_work_item_at_the_boundary",
+                _WORK,
+            ),
+            _case(
+                "W03_FAIRNESS",
+                _W,
+                _D,
+                "test_increment6b2_scheduling",
+                "test_revalidated_starved_routine_gets_next_ordinary_grant_before_fresh_inflow",
+                _WORK,
+            ),
+            _case(
+                "W04_DEGRADED_URGENT",
+                _W,
+                _D,
+                "test_increment6b2_scheduling",
+                "test_degraded_urgent_is_exact_visible_hold_and_never_downgraded",
+                _WORK,
+                _FAILURE,
+            ),
+            _case(
+                "P01_MATRIX",
+                _P,
+                _D,
+                "test_increment6c2_dispositions",
+                "test_exact_route_outcome_reason_action_matrix_and_cross_route_rejection",
+                _PROPOSAL,
+            ),
+            _case(
+                "P02_HOLD",
+                _P,
+                _D,
+                "test_increment6c1_proposals",
+                "test_operational_hold_requires_an_inspectable_action_boundary",
+                _PROPOSAL,
+            ),
+            _case(
+                "P03_NO_AUTHORITY",
+                _P,
+                _D,
+                "test_increment6c1_proposals",
+                "test_content_identity_and_no_authority_boundary_fail_closed",
+                _PROPOSAL,
+            ),
+            _case(
+                "H01_CREATE_APPEND",
+                _H,
+                _D,
+                "test_increment6d1_hypotheses",
+                "test_version_identity_and_create_append_topology_fail_closed",
+                _HYPOTHESIS,
+            ),
+            _case(
+                "H02_RELATIONSHIP",
+                _H,
+                _D,
+                "test_increment6d2_relationships",
+                "test_false_merge_split_and_temporal_correction_precedence",
+                _HYPOTHESIS,
+            ),
+            _case(
+                "H03_RETAINED",
+                _H,
+                _D,
+                "test_increment6d2_relationship_store",
+                "test_retained_receipt_requires_exact_canonical_evidence_and_policy_replay",
+                _HYPOTHESIS,
+            ),
+            _case(
+                "L01_CONSOLIDATE",
+                _L,
+                _D,
+                "test_increment6d3_lineage",
+                "test_valid_consolidation_consumes_heads_without_mutating_predecessors",
+                _LINEAGE,
+            ),
+            _case(
+                "L02_SPLIT",
+                _L,
+                _D,
+                "test_increment6d3_lineage",
+                "test_valid_split_and_exact_32_way_pair_coverage_envelope",
+                _LINEAGE,
+            ),
+            _case(
+                "L03_REVERSAL",
+                _L,
+                _D,
+                "test_increment6d3_lineage",
+                "test_valid_reversal_restores_exact_hypothesis_identities_with_new_versions",
+                _LINEAGE,
+            ),
+            _case(
+                "C01_EQUIVALENT_DISTINCT",
+                _C,
+                _D,
+                "test_increment6e2_candidates",
+                "test_distinct_and_blocked_collision_results_remain_typed",
+                _CANDIDATE,
+            ),
+            _case(
+                "C02_ADMISSION",
+                _C,
+                _D,
+                "test_increment6e2_candidate_authority",
+                "test_real_new_candidate_admission_commits_and_exact_replay_skips_providers",
+                _CANDIDATE,
+                _HANDOFF,
+            ),
+            _case(
+                "C03_COMMIT_RECHECK",
+                _C,
+                _D,
+                "test_increment6e1_collision",
+                "test_commit_time_recheck_blocks_current_candidate_drift",
+                _CANDIDATE,
+            ),
+            _case(
+                "T01_LOST_DELAYED",
+                _T,
+                _D,
+                "test_increment6f1_handoff_migrations",
+                "test_store_correlates_delayed_ack_after_lost_response_and_retry",
+                _HANDOFF,
+            ),
+            _case(
+                "T02_AMBIGUOUS",
+                _T,
+                _D,
+                "test_increment6f1_handoffs",
+                "test_conflicting_acknowledgement_arrival_orders_remain_ambiguous",
+                _HANDOFF,
+            ),
+            _case(
+                "T03_CONCURRENT",
+                _T,
+                _D,
+                "test_increment6f1_handoff_migrations",
+                "test_concurrent_replay_allocates_one_logical_handoff_and_attempt",
+                _HANDOFF,
+            ),
+            *tuple(
+                _case(
+                    f"F01_OBLIGATION_{index:02d}",
+                    _F,
+                    _D,
+                    "test_increment6f2_feedback",
+                    "test_every_feedback_reason_creates_one_stable_mandatory_obligation["
+                    + suffix
+                    + "]",
+                    _FEEDBACK,
+                )
+                for index, suffix in enumerate(
+                    (
+                        "accepted-intake_accepted-record_intake_acceptance",
+                        "inconclusive-insufficient_public_evidence-review_insufficient_public_evidence",
+                        "inconclusive-supplemental_discovery_requested-govern_supplemental_discovery",
+                        "rejected-candidate_closed-record_candidate_closed",
+                        "rejected-duplicate_or_merged_candidate-record_duplicate_or_merge",
+                        "rejected-out_of_scope-record_out_of_scope",
+                        "rejected-rights_block-record_rights_block",
+                        "rejected-stale_candidate-record_stale_candidate",
+                    ),
+                    start=1,
+                )
+            ),
+            _case(
+                "F02_DISPOSITION",
+                _F,
+                _D,
+                "test_increment6f2_feedback",
+                "test_disposition_history_is_contiguous_cas_bound_replayable_and_terminal",
+                _FEEDBACK,
+            ),
+            _case(
+                "F03_AUTHORITY",
+                _F,
+                _D,
+                "test_increment6f2_feedback_system",
+                "test_disposition_is_generic_ledger_anchored_and_replay_precedes_ports",
+                _FEEDBACK,
+            ),
+            _case(
+                "R01_WATCH_EXPIRY",
+                _R,
+                _D,
+                "test_increment6a2_work_items",
+                "test_watch_reentry_requires_exact_causal_successor_and_matching_condition[EXPIRY-2042-03-14T10:00:00.000000Z]",
+                _REENTRY,
+            ),
+            _case(
+                "R01_WATCH_REVIEW",
+                _R,
+                _D,
+                "test_increment6a2_work_items",
+                "test_watch_reentry_requires_exact_causal_successor_and_matching_condition[REVIEW-2100-01-01T00:00:00.000000Z]",
+                _REENTRY,
+            ),
+            _case(
+                "R02_SUPPLEMENTAL",
+                _R,
+                _D,
+                "test_increment6a2_work_items",
+                "test_actual_supplemental_lineage_persists_replays_and_restarts",
+                _REENTRY,
+            ),
+            _case(
+                "R03_FEEDBACK_REENTRY",
+                _R,
+                _D,
+                "test_increment6f2_feedback",
+                "test_supplemental_fulfilment_requires_exact_governed_reentry",
+                _REENTRY,
+                _FEEDBACK,
+            ),
+            _case(
+                "X01_RIGHTS",
+                _X,
+                _D,
+                "test_increment6a2_work_items",
+                "test_actual_retrieval_journal_is_exact_indexed_and_tamper_or_purge_fails",
+                _FAILURE,
+            ),
+            _case(
+                "X02_UNAVAILABLE",
+                _X,
+                _D,
+                "test_increment6e1_collision",
+                "test_missing_retained_authority_bytes_fail_closed_as_unavailable",
+                _FAILURE,
+            ),
+            *tuple(
+                _case(
+                    f"X03_TAMPER_{field.upper()}",
+                    _X,
+                    _D,
+                    "test_increment6f2_feedback_system",
+                    "test_retained_namespace_result_and_causation_tamper_fail_closed["
+                    + field
+                    + "]",
+                    _FAILURE,
+                )
+                for field in ("causation", "namespace", "result")
+            ),
+            _case(
+                "S01_IDENTITY",
+                _S,
+                _A,
+                "test_increment6g_neo4j_service",
+                "test_actual_service_increment6g_identity_and_closeout_inventory",
+                _SERVICE,
+                _CLOSEOUT,
+            ),
+            _case(
+                "S02_AUTH",
+                _S,
+                _A,
+                "test_projection_b2_neo4j_service",
+                "test_actual_service_wrong_projector_credential_fails_closed_without_secret",
+                _SERVICE,
+                _FAILURE,
+            ),
+            _case(
+                "S03_TOMBSTONE",
+                _S,
+                _A,
+                "test_complete_projection_2b_neo4j_service",
+                "test_actual_service_revocation_and_tombstone_remove_current_derivatives",
+                _SERVICE,
+                _FAILURE,
+            ),
+            _case(
+                "Z01_INVENTORY",
+                _Z,
+                _D,
+                "test_increment6g_final_closeout",
+                "test_final_closeout_inventory_is_content_addressed_and_exact",
+                _CLOSEOUT,
+            ),
+        ),
+        key=lambda item: item.case_id,
+    )
+)
+
+
+INCREMENT6G_FINAL_NON_EFFECTS = tuple(
+    sorted(
+        {
+            "EVIDENCE_ACQUISITION",
+            "EXTERNAL_EGRESS",
+            "LIVE_MODEL_OR_PROVIDER",
+            "PRODUCT_AUTHORITY_MUTATION",
+            "PRODUCTION_ACTIVATION",
+            "PUBLICATION_OR_PUBLIC_EFFECT",
+            "SHADOW_OR_CANARY",
+        }
+    )
+)
+
+
+def _inventory_values() -> list[dict[str, object]]:
+    return [case.canonical_value() for case in INCREMENT6G_FINAL_CLOSEOUT_CASES]
+
+
+INCREMENT6G_FINAL_CLOSEOUT_INVENTORY_DIGEST = digest_bytes(
+    canonical_json_bytes(_inventory_values())
+)
+
+
+def validate_increment6g_final_closeout_inventory() -> None:
+    cases = INCREMENT6G_FINAL_CLOSEOUT_CASES
+    if not cases or tuple(case.case_id for case in cases) != tuple(
+        sorted(case.case_id for case in cases)
+    ):
+        raise RuntimeError("closeout inventory order differs")
+    if len({case.case_id for case in cases}) != len(cases):
+        raise RuntimeError("duplicate closeout case identity")
+    if len({case.test_id for case in cases}) != len(cases):
+        raise RuntimeError("duplicate closeout test identity")
+    if {requirement for case in cases for requirement in case.requirements} != (
+        INCREMENT6_FINAL_REQUIREMENTS
+    ):
+        raise RuntimeError("closeout requirements are incomplete")
+    if {case.lane for case in cases} != set(Increment6CloseoutLane):
+        raise RuntimeError("closeout lanes are incomplete")
+    if {case.category for case in cases} != set(Increment6CloseoutCategory):
+        raise RuntimeError("closeout categories are incomplete")
+    if INCREMENT6G_FINAL_CLOSEOUT_INVENTORY_DIGEST != digest_bytes(
+        canonical_json_bytes(_inventory_values())
+    ):
+        raise RuntimeError("closeout inventory digest differs")
+
+
+validate_increment6g_final_closeout_inventory()

--- a/newsroom/tests/test_increment6g_closeout_receipt.py
+++ b/newsroom/tests/test_increment6g_closeout_receipt.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import hashlib
+import subprocess
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from newsroom.authority.canonical import canonical_json_bytes
+from newsroom.authority.migrations import (
+    EXPECTED_MIGRATION_HISTORY,
+    EXPECTED_SCHEMA_FINGERPRINT,
+    SCHEMA_VERSION,
+)
+from newsroom.increment6.closeout import (
+    INCREMENT6G_FINAL_CLOSEOUT_CASES,
+    INCREMENT6G_FINAL_CLOSEOUT_INVENTORY_DIGEST,
+    INCREMENT6G_FINAL_NON_EFFECTS,
+    Increment6CloseoutLane,
+)
+from newsroom.projection.neo4j import (
+    NEO4J_B2_DRIVER_VERSION,
+    NEO4J_B2_IMAGE,
+    NEO4J_B2_SERVER_VERSION,
+)
+from scripts.sdlc.emit_evidence import sha256_identity
+from scripts.sdlc.increment5e2_closeout_receipt import _parse_junit
+from scripts.sdlc.increment6g_closeout_receipt import (
+    Increment6GCloseoutReceiptError,
+    _selected_cases,
+    _service_identities,
+    build_final_receipt,
+)
+from scripts.sdlc.workflow_lane import service_compatibility_digest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _clean_clone(tmp_path: Path) -> Path:
+    clone = tmp_path / "clean-repository"
+    subprocess.run(
+        ["git", "clone", "--quiet", "--no-hardlinks", str(ROOT), str(clone)],
+        check=True,
+    )
+    return clone
+
+
+def _git(root: Path, expression: str) -> str:
+    return subprocess.check_output(
+        ["git", "rev-parse", expression], cwd=root, text=True
+    ).strip()
+
+
+def _target_properties(head: str, tree: str) -> dict[str, str]:
+    return {
+        "increment6g_closeout_case_count": str(len(INCREMENT6G_FINAL_CLOSEOUT_CASES)),
+        "increment6g_closeout_inventory_digest": (
+            INCREMENT6G_FINAL_CLOSEOUT_INVENTORY_DIGEST
+        ),
+        "increment6g_migration_history_json": canonical_json_bytes(
+            [list(item) for item in EXPECTED_MIGRATION_HISTORY]
+        ).decode("utf-8"),
+        "increment6g_neo4j_database": "neo4j",
+        "increment6g_neo4j_driver_version": NEO4J_B2_DRIVER_VERSION,
+        "increment6g_neo4j_edition": "community",
+        "increment6g_neo4j_image": NEO4J_B2_IMAGE,
+        "increment6g_neo4j_projector_username": "newsroom_projector",
+        "increment6g_neo4j_server_version": NEO4J_B2_SERVER_VERSION,
+        "increment6g_non_effects": ",".join(INCREMENT6G_FINAL_NON_EFFECTS),
+        "increment6g_schema_fingerprint": EXPECTED_SCHEMA_FINGERPRINT,
+        "increment6g_schema_version": str(SCHEMA_VERSION),
+        "increment6g_service_compatibility_digest": service_compatibility_digest(),
+        "increment6g_source_head_sha": head,
+        "increment6g_source_tree_sha": tree,
+    }
+
+
+def _junit(
+    path: Path,
+    lane: Increment6CloseoutLane,
+    properties: dict[str, str],
+    *,
+    skipped: str | None = None,
+) -> Path:
+    suite = ET.Element("testsuite")
+    for item in INCREMENT6G_FINAL_CLOSEOUT_CASES:
+        if item.lane is not lane:
+            continue
+        owner, name = item.test_id.split("::", 1)
+        case = ET.SubElement(suite, "testcase", classname=owner, name=name)
+        if item.test_id == skipped:
+            ET.SubElement(case, "skipped")
+        if item.test_id.endswith(
+            "::test_actual_service_increment6g_identity_and_closeout_inventory"
+        ):
+            container = ET.SubElement(case, "properties")
+            for key, value in properties.items():
+                ET.SubElement(container, "property", name=key, value=value)
+    path.write_bytes(ET.tostring(suite, encoding="utf-8", xml_declaration=True))
+    return path
+
+
+@dataclass(frozen=True)
+class _RawReport:
+    path: str
+    size_bytes: int
+    digest: str
+
+
+def _final_stubs(
+    tmp_path: Path, repo: Path
+) -> tuple[SimpleNamespace, dict[str, SimpleNamespace]]:
+    head, tree = _git(repo, "HEAD"), _git(repo, "HEAD^{tree}")
+    lanes = []
+    transports: dict[str, SimpleNamespace] = {}
+    properties = _target_properties(head, tree)
+    for lane_id, inventory_lane in (
+        ("core", Increment6CloseoutLane.DETERMINISTIC),
+        ("service", Increment6CloseoutLane.ACTUAL_NEO4J),
+    ):
+        artifact = tmp_path / lane_id
+        artifact.mkdir()
+        report = _junit(artifact / "report.xml", inventory_lane, properties)
+        payload = report.read_bytes()
+        replay = SimpleNamespace(
+            head_sha=head, replay_identity="sha256:" + lane_id[0] * 64
+        )
+        receipt = SimpleNamespace(
+            envelope_identity="sha256:" + "e" * 64,
+            evaluated_sha=head,
+            evaluated_tree_sha=tree,
+            raw_reports=(
+                _RawReport(
+                    "report.xml",
+                    len(payload),
+                    "sha256:" + hashlib.sha256(payload).hexdigest(),
+                ),
+            ),
+            receipt_identity="sha256:" + "r" * 64,
+            route=SimpleNamespace(selected_test_manifest_digest="sha256:" + "a" * 64),
+        )
+        lane = SimpleNamespace(
+            lane_id=lane_id,
+            lane_identity="sha256:" + "l" * 64,
+            receipt=receipt,
+            replay=replay,
+        )
+        lanes.append(lane)
+        transports[lane_id] = SimpleNamespace(
+            artifact_root=artifact,
+            bundle=SimpleNamespace(transport_identity="sha256:" + "t" * 64),
+            replay=replay,
+        )
+    decision = SimpleNamespace(
+        context=SimpleNamespace(evaluated_sha=head, evaluated_tree_sha=tree),
+        decision_identity="sha256:" + "d" * 64,
+        lanes=tuple(lanes),
+        result="PASS",
+    )
+    return decision, transports
+
+
+def _patch_inputs(
+    monkeypatch: pytest.MonkeyPatch,
+    decision: SimpleNamespace,
+    transports: dict[str, SimpleNamespace],
+) -> None:
+    monkeypatch.setattr(
+        "scripts.sdlc.increment6g_closeout_receipt.load_contract",
+        lambda _root: object(),
+    )
+    monkeypatch.setattr(
+        "scripts.sdlc.increment6g_closeout_receipt.validate_shadow_decision",
+        lambda _value, contract: decision,
+    )
+    monkeypatch.setattr(
+        "scripts.sdlc.increment6g_closeout_receipt.load_verified_transport",
+        lambda path: transports[Path(path).name],
+    )
+
+
+def test_final_receipt_binds_exact_decision_transports_inventory_and_service(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _clean_clone(tmp_path)
+    decision, transports = _final_stubs(tmp_path, repo)
+    _patch_inputs(monkeypatch, decision, transports)
+    decision_path = tmp_path / "decision.json"
+    decision_path.write_text("{}", encoding="utf-8")
+
+    receipt = build_final_receipt(
+        repo_root=repo,
+        core_transport_bundle_root=tmp_path / "core",
+        service_transport_bundle_root=tmp_path / "service",
+        decision_path=decision_path,
+    )
+
+    assert receipt["schema_version"] == (
+        "newsroom.increment6g.final-closeout-receipt.v1"
+    )
+    assert len(receipt["selected_cases"]) == len(INCREMENT6G_FINAL_CLOSEOUT_CASES)
+    assert {lane["lane_id"] for lane in receipt["lanes"]} == {"core", "service"}
+    assert receipt["inventory"]["digest"] == (
+        INCREMENT6G_FINAL_CLOSEOUT_INVENTORY_DIGEST
+    )
+    unsigned = dict(receipt)
+    assert unsigned.pop("receipt_identity") == sha256_identity(unsigned)
+
+
+def test_service_identity_rejects_changed_history_service_and_inventory() -> None:
+    properties = _target_properties("a" * 40, "b" * 40)
+    identity = _service_identities(properties, "a" * 40, "b" * 40)
+    assert identity["migration"]["schema_version"] == 25
+
+    mutations = {
+        "increment6g_schema_version": "24",
+        "increment6g_source_head_sha": "c" * 40,
+        "increment6g_closeout_case_count": "0",
+    }
+    for field, changed in mutations.items():
+        tampered = dict(properties)
+        tampered[field] = changed
+        with pytest.raises(Increment6GCloseoutReceiptError):
+            _service_identities(tampered, "a" * 40, "b" * 40)
+
+
+def test_selected_case_must_be_present_and_pass_without_skip(tmp_path: Path) -> None:
+    properties = _target_properties("a" * 40, "b" * 40)
+    target = next(
+        case
+        for case in INCREMENT6G_FINAL_CLOSEOUT_CASES
+        if case.lane is Increment6CloseoutLane.ACTUAL_NEO4J
+    )
+    report = _parse_junit(
+        _junit(
+            tmp_path / "service.xml",
+            Increment6CloseoutLane.ACTUAL_NEO4J,
+            properties,
+            skipped=target.test_id,
+        )
+    )
+    with pytest.raises(Increment6GCloseoutReceiptError, match="not_passed"):
+        _selected_cases((report,), Increment6CloseoutLane.ACTUAL_NEO4J)
+
+
+def test_final_receipt_rechecks_clean_checkout_before_emission(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _clean_clone(tmp_path)
+    decision, transports = _final_stubs(tmp_path, repo)
+    _patch_inputs(monkeypatch, decision, transports)
+    decision_path = tmp_path / "decision.json"
+    decision_path.write_text("{}", encoding="utf-8")
+    (repo / "README.md").write_text(
+        (repo / "README.md").read_text(encoding="utf-8") + "\ntracked drift\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(Increment6GCloseoutReceiptError, match="validated_input"):
+        build_final_receipt(
+            repo_root=repo,
+            core_transport_bundle_root=tmp_path / "core",
+            service_transport_bundle_root=tmp_path / "service",
+            decision_path=decision_path,
+        )

--- a/newsroom/tests/test_increment6g_final_closeout.py
+++ b/newsroom/tests/test_increment6g_final_closeout.py
@@ -15,6 +15,7 @@ from newsroom.increment6.closeout import (
 )
 from scripts.sdlc.workflow_lane import (
     _OPTIONAL_CORE_TEST_IDS,
+    _core_node_shards,
     _repository_service_tests,
 )
 
@@ -47,6 +48,25 @@ def test_closeout_test_functions_are_permanent_repository_tests() -> None:
         function_name = function_name.split("[", 1)[0]
         module = importlib.import_module(module_name)
         assert callable(getattr(module, function_name))
+
+
+def test_expensive_lineage_cases_concentration_is_bounded() -> None:
+    from newsroom.tests.test_increment6d3_lineage_store import (
+        _EXPECTED_PROBE_IDS,
+        _bound_or_collected_core_inventory,
+    )
+
+    prefix = (
+        "newsroom/tests/test_increment6d3_lineage_store.py::"
+        "test_real_v23_store_passes_required_conformance_probe["
+    )
+    shards = _core_node_shards(_bound_or_collected_core_inventory())
+    counts = tuple(
+        sum(node_id.startswith(prefix) for node_id in shard) for shard in shards
+    )
+
+    assert sum(counts) == len(_EXPECTED_PROBE_IDS)
+    assert max(counts) <= 7
 
 
 def test_actual_service_case_is_in_both_permanent_service_routes() -> None:

--- a/newsroom/tests/test_increment6g_final_closeout.py
+++ b/newsroom/tests/test_increment6g_final_closeout.py
@@ -26,7 +26,7 @@ def test_final_closeout_inventory_is_content_addressed_and_exact() -> None:
     validate_increment6g_final_closeout_inventory()
     assert len(INCREMENT6G_FINAL_CLOSEOUT_CASES) == 58
     assert INCREMENT6G_FINAL_CLOSEOUT_INVENTORY_DIGEST == (
-        "sha256:67ae4fdba2d9bda2280896a2e2de38a95a211cfe1f80dd505ccd646cdc2b4b4f"
+        "sha256:cb051e71025a2387aa6bdc4e4fca0bc76b414aabaeb2d192b2aa1dd48c81e011"
     )
     assert {
         requirement
@@ -38,6 +38,15 @@ def test_final_closeout_inventory_is_content_addressed_and_exact() -> None:
     )
     assert {case.lane for case in INCREMENT6G_FINAL_CLOSEOUT_CASES} == set(
         Increment6CloseoutLane
+    )
+    inherited_handoff_boundary = next(
+        case
+        for case in INCREMENT6G_FINAL_CLOSEOUT_CASES
+        if case.case_id == "F03_AUTHORITY"
+    )
+    assert inherited_handoff_boundary.test_id == (
+        "newsroom.tests.test_increment6f2_feedback_system::"
+        "test_accept_replay_snapshot_and_direct_tamper_fail_closed"
     )
     assert INCREMENT6G_FINAL_NON_EFFECTS == tuple(sorted(INCREMENT6G_FINAL_NON_EFFECTS))
 

--- a/newsroom/tests/test_increment6g_final_closeout.py
+++ b/newsroom/tests/test_increment6g_final_closeout.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import importlib
+import re
+from pathlib import Path
+
+from newsroom.increment6.closeout import (
+    INCREMENT6_FINAL_REQUIREMENTS,
+    INCREMENT6G_FINAL_CLOSEOUT_CASES,
+    INCREMENT6G_FINAL_CLOSEOUT_INVENTORY_DIGEST,
+    INCREMENT6G_FINAL_NON_EFFECTS,
+    Increment6CloseoutCategory,
+    Increment6CloseoutLane,
+    validate_increment6g_final_closeout_inventory,
+)
+from scripts.sdlc.workflow_lane import (
+    _OPTIONAL_CORE_TEST_IDS,
+    _repository_service_tests,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_final_closeout_inventory_is_content_addressed_and_exact() -> None:
+    validate_increment6g_final_closeout_inventory()
+    assert len(INCREMENT6G_FINAL_CLOSEOUT_CASES) == 58
+    assert INCREMENT6G_FINAL_CLOSEOUT_INVENTORY_DIGEST == (
+        "sha256:67ae4fdba2d9bda2280896a2e2de38a95a211cfe1f80dd505ccd646cdc2b4b4f"
+    )
+    assert {
+        requirement
+        for case in INCREMENT6G_FINAL_CLOSEOUT_CASES
+        for requirement in case.requirements
+    } == INCREMENT6_FINAL_REQUIREMENTS
+    assert {case.category for case in INCREMENT6G_FINAL_CLOSEOUT_CASES} == set(
+        Increment6CloseoutCategory
+    )
+    assert {case.lane for case in INCREMENT6G_FINAL_CLOSEOUT_CASES} == set(
+        Increment6CloseoutLane
+    )
+    assert INCREMENT6G_FINAL_NON_EFFECTS == tuple(sorted(INCREMENT6G_FINAL_NON_EFFECTS))
+
+
+def test_closeout_test_functions_are_permanent_repository_tests() -> None:
+    for case in INCREMENT6G_FINAL_CLOSEOUT_CASES:
+        module_name, function_name = case.test_id.split("::", 1)
+        function_name = function_name.split("[", 1)[0]
+        module = importlib.import_module(module_name)
+        assert callable(getattr(module, function_name))
+
+
+def test_actual_service_case_is_in_both_permanent_service_routes() -> None:
+    actual = {
+        case.test_id
+        for case in INCREMENT6G_FINAL_CLOSEOUT_CASES
+        if case.lane is Increment6CloseoutLane.ACTUAL_NEO4J
+    }
+    assert actual <= set(_OPTIONAL_CORE_TEST_IDS)
+
+    selected_files = set(_repository_service_tests(ROOT))
+    for test_id in actual:
+        module_name = test_id.split("::", 1)[0]
+        assert module_name.replace(".", "/") + ".py" in selected_files
+
+    workflow = (ROOT / ".github" / "workflows" / "projection-b2-neo4j.yml").read_text(
+        encoding="utf-8"
+    )
+    patterns = set(re.findall(r"newsroom/tests/test_[^\\\s]+\.py", workflow))
+    selected = {
+        path.relative_to(ROOT).as_posix()
+        for pattern in patterns
+        for path in ROOT.glob(pattern)
+    }
+    required = {
+        case.test_id.split("::", 1)[0].replace(".", "/") + ".py"
+        for case in INCREMENT6G_FINAL_CLOSEOUT_CASES
+        if case.lane is Increment6CloseoutLane.ACTUAL_NEO4J
+    }
+    assert required <= selected
+
+
+def test_actual_service_target_binds_every_frozen_identity() -> None:
+    source = (
+        ROOT / "newsroom" / "tests" / "test_increment6g_neo4j_service.py"
+    ).read_text(encoding="utf-8")
+    for identity in (
+        "increment6g_source_head_sha",
+        "increment6g_source_tree_sha",
+        "increment6g_schema_version",
+        "increment6g_schema_fingerprint",
+        "increment6g_migration_history_json",
+        "increment6g_closeout_inventory_digest",
+        "increment6g_closeout_case_count",
+        "increment6g_non_effects",
+        "increment6g_neo4j_image",
+        "increment6g_neo4j_server_version",
+        "increment6g_neo4j_edition",
+        "increment6g_neo4j_driver_version",
+        "increment6g_neo4j_database",
+        "increment6g_neo4j_projector_username",
+        "increment6g_service_compatibility_digest",
+    ):
+        assert identity in source

--- a/newsroom/tests/test_increment6g_neo4j_service.py
+++ b/newsroom/tests/test_increment6g_neo4j_service.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import os
+import subprocess
+
+import pytest
+
+from newsroom.authority.canonical import canonical_json_bytes
+from newsroom.authority.migrations import (
+    EXPECTED_MIGRATION_HISTORY,
+    EXPECTED_SCHEMA_FINGERPRINT,
+    SCHEMA_VERSION,
+)
+from newsroom.increment6.closeout import (
+    INCREMENT6G_FINAL_CLOSEOUT_CASES,
+    INCREMENT6G_FINAL_CLOSEOUT_INVENTORY_DIGEST,
+    INCREMENT6G_FINAL_NON_EFFECTS,
+)
+from newsroom.projection.neo4j import (
+    NEO4J_B2_DRIVER_VERSION,
+    NEO4J_B2_IMAGE,
+    NEO4J_B2_SERVER_VERSION,
+    Neo4jProjectorConfig,
+)
+from newsroom.projection.neo4j._adapter import _open_neo4j_adapter
+from scripts.sdlc.workflow_lane import service_compatibility_digest
+
+
+def test_actual_service_increment6g_identity_and_closeout_inventory(
+    record_property,
+) -> None:
+    if os.environ.get("NEWSROOM_NEO4J_SERVICE_REQUIRED") != "1":
+        pytest.skip("authenticated Neo4j service is not required")
+
+    config = Neo4jProjectorConfig.from_environment()
+    adapter = _open_neo4j_adapter(config)
+    try:
+        compatibility = adapter.verify_compatibility()
+    finally:
+        adapter.close()
+
+    assert compatibility.server_version == NEO4J_B2_SERVER_VERSION
+    assert compatibility.edition == "community"
+    assert compatibility.driver_version == NEO4J_B2_DRIVER_VERSION
+    assert SCHEMA_VERSION == 25
+    assert len(EXPECTED_MIGRATION_HISTORY) == 25
+    assert tuple(item[0] for item in EXPECTED_MIGRATION_HISTORY) == tuple(range(1, 26))
+
+    head = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+    tree = subprocess.check_output(
+        ["git", "rev-parse", "HEAD^{tree}"], text=True
+    ).strip()
+    history = canonical_json_bytes(
+        [list(item) for item in EXPECTED_MIGRATION_HISTORY]
+    ).decode("utf-8")
+
+    record_property("increment6g_source_head_sha", head)
+    record_property("increment6g_source_tree_sha", tree)
+    record_property("increment6g_schema_version", str(SCHEMA_VERSION))
+    record_property("increment6g_schema_fingerprint", EXPECTED_SCHEMA_FINGERPRINT)
+    record_property("increment6g_migration_history_json", history)
+    record_property(
+        "increment6g_closeout_inventory_digest",
+        INCREMENT6G_FINAL_CLOSEOUT_INVENTORY_DIGEST,
+    )
+    record_property(
+        "increment6g_closeout_case_count",
+        str(len(INCREMENT6G_FINAL_CLOSEOUT_CASES)),
+    )
+    record_property(
+        "increment6g_non_effects",
+        ",".join(INCREMENT6G_FINAL_NON_EFFECTS),
+    )
+    record_property("increment6g_neo4j_image", NEO4J_B2_IMAGE)
+    record_property("increment6g_neo4j_server_version", compatibility.server_version)
+    record_property("increment6g_neo4j_edition", compatibility.edition)
+    record_property("increment6g_neo4j_driver_version", compatibility.driver_version)
+    record_property("increment6g_neo4j_database", config.database)
+    record_property("increment6g_neo4j_projector_username", config.username)
+    record_property(
+        "increment6g_service_compatibility_digest",
+        service_compatibility_digest(),
+    )

--- a/newsroom/tests/test_integrated_c1_sdlc_contract.py
+++ b/newsroom/tests/test_integrated_c1_sdlc_contract.py
@@ -38,6 +38,7 @@ def test_increment_1c_native_graph_paths_require_actual_service_evidence() -> No
         "newsroom/tests/test_complete_projection_2b_neo4j_service.py",
         "newsroom/tests/test_increment4e_neo4j_service.py",
         "newsroom/tests/test_increment5b4_neo4j_service.py",
+        "newsroom/tests/test_increment6g_neo4j_service.py",
         "newsroom/tests/test_increment_2d_neo4j_service.py",
         _INTEGRATED_SERVICE_TEST,
         "newsroom/tests/test_projection_b2_increment5e2_neo4j_service.py",
@@ -117,13 +118,17 @@ def test_complete_actual_service_cases_are_optional_only_in_core() -> None:
         "newsroom.tests.test_projection_b2_increment5e2_neo4j_service::"
         "test_actual_service_increment5e2_target_and_report"
     ) in optional
+    assert (
+        "newsroom.tests.test_increment6g_neo4j_service::"
+        "test_actual_service_increment6g_identity_and_closeout_inventory"
+    ) in optional
     assert {
         "newsroom.tests.test_projection_b3_neo4j_service::test_actual_service_3e_projects_complete_lineage_and_recovers_graph_loss",
         "newsroom.tests.test_projection_b3_neo4j_service::test_actual_service_3e_replacement_generation_becomes_only_active_lineage",
     } <= set(optional)
     assert complete <= set(optional)
     assert optional == tuple(sorted(optional))
-    assert len(optional) == 41
+    assert len(optional) == 42
 
     route = _route("newsroom/projection/neo4j/_complete_adapter.py")
     assert route["service_required"] is True

--- a/newsroom/tests/test_integrated_c1_workflow_contract.py
+++ b/newsroom/tests/test_integrated_c1_workflow_contract.py
@@ -61,6 +61,7 @@ def test_permanent_neo4j_gate_retains_increment5e2_closed_world_receipt() -> Non
     required = (
         "newsroom/tests/test_projection_b2_*.py",
         "newsroom/tests/test_increment5b4_neo4j_service.py",
+        "newsroom/tests/test_increment6g_neo4j_service.py",
         "scripts.sdlc.increment5e2_closeout_receipt actual-service",
         "--service-junit-report projection-b2-b3-c1-complete-retrieval-neo4j-results.xml",
         "--output increment5e2-actual-service-closeout.json",

--- a/newsroom/tests/test_sdlc_classifier.py
+++ b/newsroom/tests/test_sdlc_classifier.py
@@ -93,7 +93,8 @@ def test_classifier_source_tests_policy_and_workflows_require_service() -> None:
         assert route["service_tests"] == [
             "newsroom/tests/test_complete_projection_2b_neo4j_service.py",
             "newsroom/tests/test_increment4e_neo4j_service.py",
-        "newsroom/tests/test_increment5b4_neo4j_service.py",
+            "newsroom/tests/test_increment5b4_neo4j_service.py",
+            "newsroom/tests/test_increment6g_neo4j_service.py",
             "newsroom/tests/test_increment_2d_neo4j_service.py",
             "newsroom/tests/test_integrated_c1_neo4j_service.py",
             "newsroom/tests/test_projection_b2_increment5e2_neo4j_service.py",

--- a/newsroom/tests/test_sdlc_evidence_workflow.py
+++ b/newsroom/tests/test_sdlc_evidence_workflow.py
@@ -327,6 +327,7 @@ def test_lane_and_decision_artifacts_are_compact_immutable_and_attempt_scoped() 
                 ".sdlc-run/decision-input/collection.json",
                 ".sdlc-run/decision.json",
                 ".sdlc-run/increment5e2-final-closeout.json",
+                ".sdlc-run/increment6g-final-closeout.json",
             ]
 
 
@@ -392,6 +393,7 @@ def test_signed_closeout_attests_only_the_validated_exact_main_receipt() -> None
     validation = validate["run"]
     for expected in (
         "newsroom.increment5e2.final-closeout-receipt.v1",
+        "newsroom.increment6g.final-closeout-receipt.v1",
         "receipt_identity",
         "evaluated_sha",
         "EXPECTED_HEAD_SHA",
@@ -413,6 +415,7 @@ def test_signed_closeout_attests_only_the_validated_exact_main_receipt() -> None
     assert attest["with"]["subject-path"].splitlines() == [
         ".sdlc-run/signed-closeout-input/decision.json",
         (".sdlc-run/signed-closeout-input/increment5e2-final-closeout.json"),
+        ".sdlc-run/signed-closeout-input/increment6g-final-closeout.json",
     ]
     upload = _step("signed-closeout", "Retain attestation bundle")
     assert upload["uses"] == UPLOAD

--- a/newsroom/tests/test_sdlc_workflow_lane.py
+++ b/newsroom/tests/test_sdlc_workflow_lane.py
@@ -677,6 +677,7 @@ def test_optional_core_skips_are_exact_actual_service_cases() -> None:
         'newsroom.tests.test_increment4e_neo4j_service::test_actual_service_increment4_tombstone_purges_and_never_resurrects',
         'newsroom.tests.test_increment5b4_neo4j_service::test_increment5b4_fixed_port_excludes_future_observations',
         'newsroom.tests.test_increment5b4_neo4j_service::test_increment5b4_fixed_port_reads_only_exact_generation_and_allowed_state',
+        'newsroom.tests.test_increment6g_neo4j_service::test_actual_service_increment6g_identity_and_closeout_inventory',
         'newsroom.tests.test_increment_2d_neo4j_service::test_actual_service_complete_increment_2_proof_admits_replays_and_restarts',
         'newsroom.tests.test_increment_2d_neo4j_service::test_actual_service_complete_proof_fails_closed_when_required_surface_is_lost[fulltext]',
         'newsroom.tests.test_increment_2d_neo4j_service::test_actual_service_complete_proof_fails_closed_when_required_surface_is_lost[relation]',

--- a/scripts/sdlc/increment6g_closeout_receipt.py
+++ b/scripts/sdlc/increment6g_closeout_receipt.py
@@ -6,7 +6,7 @@ import sys
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 
-from newsroom.authority.canonical import canonical_json_bytes
+from newsroom.authority.canonical import canonical_json_bytes, digest_bytes
 from newsroom.authority.migrations import (
     EXPECTED_MIGRATION_HISTORY,
     EXPECTED_SCHEMA_FINGERPRINT,
@@ -73,11 +73,15 @@ class Increment6GCloseoutReceiptError(ValueError):
 
 
 def _inventory() -> dict[str, object]:
+    migration_history_digest = digest_bytes(
+        canonical_json_bytes([list(item) for item in EXPECTED_MIGRATION_HISTORY])
+    )
     return {
         "case_count": len(INCREMENT6G_FINAL_CLOSEOUT_CASES),
         "digest": INCREMENT6G_FINAL_CLOSEOUT_INVENTORY_DIGEST,
         "non_effects": list(INCREMENT6G_FINAL_NON_EFFECTS),
         "requirements": sorted(INCREMENT6_FINAL_REQUIREMENTS),
+        "migration_history_digest": migration_history_digest,
         "schema_version": SCHEMA_VERSION,
         "schema_fingerprint": EXPECTED_SCHEMA_FINGERPRINT,
     }
@@ -165,6 +169,7 @@ def _service_identities(
     return {
         "migration": {
             "history": expected_history,
+            "history_digest": digest_bytes(canonical_json_bytes(expected_history)),
             "schema_fingerprint": EXPECTED_SCHEMA_FINGERPRINT,
             "schema_version": SCHEMA_VERSION,
         },

--- a/scripts/sdlc/increment6g_closeout_receipt.py
+++ b/scripts/sdlc/increment6g_closeout_receipt.py
@@ -1,0 +1,309 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+from newsroom.authority.canonical import canonical_json_bytes
+from newsroom.authority.migrations import (
+    EXPECTED_MIGRATION_HISTORY,
+    EXPECTED_SCHEMA_FINGERPRINT,
+    SCHEMA_VERSION,
+)
+from newsroom.increment6.closeout import (
+    INCREMENT6_FINAL_REQUIREMENTS,
+    INCREMENT6G_FINAL_CLOSEOUT_CASES,
+    INCREMENT6G_FINAL_CLOSEOUT_INVENTORY_DIGEST,
+    INCREMENT6G_FINAL_NON_EFFECTS,
+    Increment6CloseoutLane,
+)
+from newsroom.projection.neo4j import (
+    NEO4J_B2_DRIVER_VERSION,
+    NEO4J_B2_IMAGE,
+    NEO4J_B2_SERVER_VERSION,
+)
+from scripts.sdlc.contracts import ContractError, load_contract
+from scripts.sdlc.emit_evidence import sha256_identity
+from scripts.sdlc.increment5e2_closeout_receipt import (
+    Increment5E2CloseoutReceiptError,
+    _decision_payload,
+    _git_identity,
+    _lane_reports,
+    _require_git_identity,
+    _write_output,
+)
+from scripts.sdlc.shadow_decision import (
+    ShadowDecisionError,
+    validate_shadow_decision,
+)
+from scripts.sdlc.transport_replay import (
+    TransportReplayError,
+    load_verified_transport,
+)
+from scripts.sdlc.workflow_lane import service_compatibility_digest
+
+FINAL_SCHEMA_VERSION = "newsroom.increment6g.final-closeout-receipt.v1"
+_TARGET_TEST_ID = (
+    "newsroom.tests.test_increment6g_neo4j_service::"
+    "test_actual_service_increment6g_identity_and_closeout_inventory"
+)
+_TARGET_PROPERTIES = {
+    "increment6g_closeout_case_count",
+    "increment6g_closeout_inventory_digest",
+    "increment6g_migration_history_json",
+    "increment6g_neo4j_database",
+    "increment6g_neo4j_driver_version",
+    "increment6g_neo4j_edition",
+    "increment6g_neo4j_image",
+    "increment6g_neo4j_projector_username",
+    "increment6g_neo4j_server_version",
+    "increment6g_non_effects",
+    "increment6g_schema_fingerprint",
+    "increment6g_schema_version",
+    "increment6g_service_compatibility_digest",
+    "increment6g_source_head_sha",
+    "increment6g_source_tree_sha",
+}
+
+
+class Increment6GCloseoutReceiptError(ValueError):
+    """Raised when the Increment 6 closed-world evidence is not exact."""
+
+
+def _inventory() -> dict[str, object]:
+    return {
+        "case_count": len(INCREMENT6G_FINAL_CLOSEOUT_CASES),
+        "digest": INCREMENT6G_FINAL_CLOSEOUT_INVENTORY_DIGEST,
+        "non_effects": list(INCREMENT6G_FINAL_NON_EFFECTS),
+        "requirements": sorted(INCREMENT6_FINAL_REQUIREMENTS),
+        "schema_version": SCHEMA_VERSION,
+        "schema_fingerprint": EXPECTED_SCHEMA_FINGERPRINT,
+    }
+
+
+def _selected_cases(
+    reports: Sequence[object], lane: Increment6CloseoutLane
+) -> tuple[list[dict[str, object]], Mapping[str, str]]:
+    observed: dict[str, object] = {}
+    for report in reports:
+        for case in report.cases:
+            if case.test_id in observed:
+                raise Increment6GCloseoutReceiptError("duplicate_test_id")
+            observed[case.test_id] = case
+    selected: list[dict[str, object]] = []
+    properties: Mapping[str, str] = {}
+    for item in INCREMENT6G_FINAL_CLOSEOUT_CASES:
+        if item.lane is not lane:
+            continue
+        case = observed.get(item.test_id)
+        if case is None:
+            raise Increment6GCloseoutReceiptError(
+                f"selected_test_missing:{item.case_id}"
+            )
+        if case.outcome != "passed":
+            raise Increment6GCloseoutReceiptError(
+                f"selected_test_not_passed:{item.case_id}:{case.outcome}"
+            )
+        selected.append({**item.canonical_value(), "outcome": "passed"})
+        if item.test_id == _TARGET_TEST_ID:
+            properties = case.properties
+    return selected, properties
+
+
+def _reject_failures(reports: Sequence[object]) -> None:
+    for report in reports:
+        for case in report.cases:
+            if case.outcome in {"failure", "error"}:
+                raise Increment6GCloseoutReceiptError(
+                    f"test_not_passed:{case.test_id}:{case.outcome}"
+                )
+
+
+def _service_identities(
+    properties: Mapping[str, str], head: str, tree: str
+) -> dict[str, object]:
+    if set(properties) != _TARGET_PROPERTIES:
+        raise Increment6GCloseoutReceiptError("target_properties")
+    try:
+        history = json.loads(properties["increment6g_migration_history_json"])
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        raise Increment6GCloseoutReceiptError("migration_history_json") from exc
+    expected_history = [list(item) for item in EXPECTED_MIGRATION_HISTORY]
+    if (
+        history != expected_history
+        or properties["increment6g_migration_history_json"]
+        != canonical_json_bytes(expected_history).decode("utf-8")
+        or SCHEMA_VERSION != 25
+        or properties["increment6g_schema_version"] != "25"
+        or properties["increment6g_schema_fingerprint"] != EXPECTED_SCHEMA_FINGERPRINT
+    ):
+        raise Increment6GCloseoutReceiptError("migration_identity")
+    if (
+        properties["increment6g_closeout_inventory_digest"]
+        != INCREMENT6G_FINAL_CLOSEOUT_INVENTORY_DIGEST
+        or properties["increment6g_closeout_case_count"]
+        != str(len(INCREMENT6G_FINAL_CLOSEOUT_CASES))
+        or properties["increment6g_non_effects"]
+        != ",".join(INCREMENT6G_FINAL_NON_EFFECTS)
+    ):
+        raise Increment6GCloseoutReceiptError("closeout_inventory")
+    expected = {
+        "increment6g_neo4j_database": "neo4j",
+        "increment6g_neo4j_driver_version": NEO4J_B2_DRIVER_VERSION,
+        "increment6g_neo4j_edition": "community",
+        "increment6g_neo4j_image": NEO4J_B2_IMAGE,
+        "increment6g_neo4j_projector_username": "newsroom_projector",
+        "increment6g_neo4j_server_version": NEO4J_B2_SERVER_VERSION,
+        "increment6g_service_compatibility_digest": service_compatibility_digest(),
+        "increment6g_source_head_sha": head,
+        "increment6g_source_tree_sha": tree,
+    }
+    if any(properties[name] != value for name, value in expected.items()):
+        raise Increment6GCloseoutReceiptError("service_identity")
+    return {
+        "migration": {
+            "history": expected_history,
+            "schema_fingerprint": EXPECTED_SCHEMA_FINGERPRINT,
+            "schema_version": SCHEMA_VERSION,
+        },
+        "service": {
+            "compatibility_digest": service_compatibility_digest(),
+            "database": "neo4j",
+            "driver_version": NEO4J_B2_DRIVER_VERSION,
+            "edition": "community",
+            "image": NEO4J_B2_IMAGE,
+            "projector_username": "newsroom_projector",
+            "server_version": NEO4J_B2_SERVER_VERSION,
+        },
+    }
+
+
+def build_final_receipt(
+    *,
+    repo_root: str | Path,
+    core_transport_bundle_root: str | Path,
+    service_transport_bundle_root: str | Path,
+    decision_path: str | Path,
+) -> dict[str, object]:
+    try:
+        root, head, tree = _git_identity(repo_root)
+        _require_git_identity(root, head, tree)
+        contract = load_contract(root)
+        decision = validate_shadow_decision(
+            _decision_payload(decision_path), contract=contract
+        )
+        transports = {
+            "core": load_verified_transport(core_transport_bundle_root),
+            "service": load_verified_transport(service_transport_bundle_root),
+        }
+    except (
+        ContractError,
+        Increment5E2CloseoutReceiptError,
+        ShadowDecisionError,
+        TransportReplayError,
+    ) as exc:
+        raise Increment6GCloseoutReceiptError("validated_input") from exc
+    if decision.result != "PASS" or {lane.lane_id for lane in decision.lanes} != {
+        "core",
+        "service",
+    }:
+        raise Increment6GCloseoutReceiptError("decision_not_exact_pass")
+    if (
+        decision.context.evaluated_sha != head
+        or decision.context.evaluated_tree_sha != tree
+    ):
+        raise Increment6GCloseoutReceiptError("checkout_identity")
+
+    lane_map = {lane.lane_id: lane for lane in decision.lanes}
+    lane_values: list[dict[str, object]] = []
+    report_values: dict[str, list[dict[str, object]]] = {}
+    selected_all: list[dict[str, object]] = []
+    manifest_digests: set[str] = set()
+    identities: dict[str, object] | None = None
+    try:
+        for lane_id, inventory_lane in (
+            ("core", Increment6CloseoutLane.DETERMINISTIC),
+            ("service", Increment6CloseoutLane.ACTUAL_NEO4J),
+        ):
+            lane = lane_map[lane_id]
+            verified = transports[lane_id]
+            if (
+                lane.receipt.evaluated_sha != head
+                or lane.receipt.evaluated_tree_sha != tree
+                or verified.replay.head_sha != head
+            ):
+                raise Increment6GCloseoutReceiptError("lane_checkout_identity")
+            reports = _lane_reports(verified, lane)
+            _reject_failures(reports)
+            selected, properties = _selected_cases(reports, inventory_lane)
+            selected_all.extend(selected)
+            if inventory_lane is Increment6CloseoutLane.ACTUAL_NEO4J:
+                identities = _service_identities(properties, head, tree)
+            report_values[lane_id] = [
+                {
+                    "digest": raw.digest,
+                    "path": raw.path,
+                    "size_bytes": raw.size_bytes,
+                }
+                for raw in lane.receipt.raw_reports
+            ]
+            manifest_digests.add(lane.receipt.route.selected_test_manifest_digest)
+            lane_values.append(
+                {
+                    "envelope_identity": lane.receipt.envelope_identity,
+                    "lane_id": lane_id,
+                    "lane_identity": lane.lane_identity,
+                    "receipt_identity": lane.receipt.receipt_identity,
+                    "replay_identity": verified.replay.replay_identity,
+                    "transport_identity": verified.bundle.transport_identity,
+                }
+            )
+        _require_git_identity(root, head, tree)
+    except Increment5E2CloseoutReceiptError as exc:
+        raise Increment6GCloseoutReceiptError("validated_input") from exc
+    if identities is None or len(manifest_digests) != 1:
+        raise Increment6GCloseoutReceiptError("selected_test_manifest")
+
+    value = {
+        "decision_identity": decision.decision_identity,
+        "evaluated_sha": head,
+        "evaluated_tree_sha": tree,
+        "inventory": _inventory(),
+        "junit_reports": report_values,
+        "lanes": lane_values,
+        "schema_version": FINAL_SCHEMA_VERSION,
+        "selected_cases": sorted(selected_all, key=lambda item: str(item["case_id"])),
+        "selected_test_manifest_digest": manifest_digests.pop(),
+        **identities,
+    }
+    return {**value, "receipt_identity": sha256_identity(value)}
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Emit the exact Increment 6G closed-world receipt"
+    )
+    parser.add_argument("--repo-root", required=True)
+    parser.add_argument("--core-transport-bundle-root", required=True)
+    parser.add_argument("--service-transport-bundle-root", required=True)
+    parser.add_argument("--decision", required=True)
+    parser.add_argument("--output", required=True)
+    arguments = parser.parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        receipt = build_final_receipt(
+            repo_root=arguments.repo_root,
+            core_transport_bundle_root=arguments.core_transport_bundle_root,
+            service_transport_bundle_root=arguments.service_transport_bundle_root,
+            decision_path=arguments.decision,
+        )
+        _write_output(arguments.output, receipt)
+    except (Increment5E2CloseoutReceiptError, Increment6GCloseoutReceiptError) as exc:
+        print(f"EVIDENCE_MISMATCH:increment6g-closeout:{exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sdlc/workflow_lane.py
+++ b/scripts/sdlc/workflow_lane.py
@@ -89,6 +89,7 @@ _OPTIONAL_CORE_TEST_IDS = (
     "newsroom.tests.test_increment4e_neo4j_service::test_actual_service_increment4_tombstone_purges_and_never_resurrects",
     "newsroom.tests.test_increment5b4_neo4j_service::test_increment5b4_fixed_port_excludes_future_observations",
     "newsroom.tests.test_increment5b4_neo4j_service::test_increment5b4_fixed_port_reads_only_exact_generation_and_allowed_state",
+    "newsroom.tests.test_increment6g_neo4j_service::test_actual_service_increment6g_identity_and_closeout_inventory",
     "newsroom.tests.test_increment_2d_neo4j_service::test_actual_service_complete_increment_2_proof_admits_replays_and_restarts",
     "newsroom.tests.test_increment_2d_neo4j_service::test_actual_service_complete_proof_fails_closed_when_required_surface_is_lost[fulltext]",
     "newsroom.tests.test_increment_2d_neo4j_service::test_actual_service_complete_proof_fails_closed_when_required_surface_is_lost[relation]",


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-6g-final-closeout
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

Refs #368
Parent: #146

## Scope

- adds a migration-free 58-node closed-world Increment 6 evidence inventory over permanent public-facade tests;
- adds an authenticated Neo4j target binding exact source, v1–v25 migration, schema, inventory and service identities;
- adds a fail-closed final receipt over immutable core/service transport bundles and the PASS decision;
- includes that receipt in exact-main `signed-closeout` validation and attestation;
- discloses and proves the inherited v17 Handoff `max_attempts` boundary without claiming the #428 hardening;
- adds no product authority, migration, table, writer, runtime egress, credential or activation.

## Local evidence

- `55` selected deterministic closeout cases passed in `72.87s`;
- closeout/receipt/service unit tests: `8 passed, 1 skipped` outside the authenticated lane;
- final feedback-boundary and closeout set: `30 passed`;
- SDLC/workflow and closeout regression set: `184 passed`;
- Ruff, YAML parsing and diff checks passed.

## Exact-head authoritative evidence

Head `52ce8d1cb7fbd9811ffa55e59085d625fb2f9d21`, tree `6ef6899919b6b8a482d4da74908f0088e4cdc5eb`:

- run `31692606665` passed source, authenticated service, all ten core shards, reducer and decision;
- 3,551 core tests plus 42 authenticated-service tests; zero failures, zero errors, zero required skips;
- decision `sha256:06387fb961f0cc665b6d197691df61a5fb1a1945acc0f8fd7587cec1c97ae1bb`;
- Increment 6 receipt `sha256:d6014f8b71be67bc97fa739e83e8234f10ee826de32a1ecf4bac27f9f5f4840e`;
- final exact-head substantive review: P1 0, material P2 0, unresolved threads 0.

After merge, #368 remains open until the separate signed exact-main manual SDLC decision and attestation pass.
