### PR TITLE
fix: preserve Increment 6 migration prefix

### DIFF
--- a/docs/traceability/increment-6g-final-closeout.md
+++ b/docs/traceability/increment-6g-final-closeout.md
@@ -28,6 +28,9 @@ retained migration inventory proves the literal v1-v25 history, every supported
 exact predecessor upgrade, multihop backup identities, exclusive rollback and
 restore/re-upgrade. The actual-service target binds that same current history,
 schema version and schema fingerprint to the evaluated source head and tree.
+Those Increment 6 identities are dedicated frozen constants: permanent future
+service runs validate the exact v1-v25 prefix and permit a later authorised
+migration suffix rather than freezing the repository's current schema at v25.
 
 The selected authority cases retain the real public paths:
 

--- a/newsroom/increment6/closeout.py
+++ b/newsroom/increment6/closeout.py
@@ -7,6 +7,7 @@ SDLC receipt reconciles their retained JUnit outcomes.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import StrEnum
 
@@ -49,6 +50,29 @@ INCREMENT6_FINAL_REQUIREMENTS = frozenset(
         "WORK_ITEM_OWNERSHIP_URGENT_DEGRADED_FAIRNESS_STALE",
     }
 )
+
+INCREMENT6G_FINAL_SCHEMA_VERSION = 25
+INCREMENT6G_FINAL_SCHEMA_FINGERPRINT = (
+    "sha256:353900bf5804f0b770489982541f3cff4fd30ea36fc75d19b9c63315d1b6ec06"
+)
+INCREMENT6G_FINAL_MIGRATION_HISTORY_DIGEST = (
+    "sha256:bea793377d065d3073e6dfa8d40139fedfd377d5e24d9812d12cdb1ad52e9a0f"
+)
+
+
+def increment6g_final_migration_history(
+    history: Sequence[tuple[int, str, str]],
+) -> tuple[tuple[int, str, str], ...]:
+    prefix = tuple(history[:INCREMENT6G_FINAL_SCHEMA_VERSION])
+    if (
+        len(prefix) != INCREMENT6G_FINAL_SCHEMA_VERSION
+        or tuple(item[0] for item in prefix)
+        != tuple(range(1, INCREMENT6G_FINAL_SCHEMA_VERSION + 1))
+        or digest_bytes(canonical_json_bytes([list(item) for item in prefix]))
+        != INCREMENT6G_FINAL_MIGRATION_HISTORY_DIGEST
+    ):
+        raise RuntimeError("Increment 6 migration history prefix differs")
+    return prefix
 
 
 @dataclass(frozen=True, slots=True)

--- a/newsroom/tests/test_increment6g_closeout_receipt.py
+++ b/newsroom/tests/test_increment6g_closeout_receipt.py
@@ -12,14 +12,15 @@ import pytest
 from newsroom.authority.canonical import canonical_json_bytes
 from newsroom.authority.migrations import (
     EXPECTED_MIGRATION_HISTORY,
-    EXPECTED_SCHEMA_FINGERPRINT,
-    SCHEMA_VERSION,
 )
 from newsroom.increment6.closeout import (
     INCREMENT6G_FINAL_CLOSEOUT_CASES,
     INCREMENT6G_FINAL_CLOSEOUT_INVENTORY_DIGEST,
     INCREMENT6G_FINAL_NON_EFFECTS,
+    INCREMENT6G_FINAL_SCHEMA_FINGERPRINT,
+    INCREMENT6G_FINAL_SCHEMA_VERSION,
     Increment6CloseoutLane,
+    increment6g_final_migration_history,
 )
 from newsroom.projection.neo4j import (
     NEO4J_B2_DRIVER_VERSION,
@@ -61,7 +62,12 @@ def _target_properties(head: str, tree: str) -> dict[str, str]:
             INCREMENT6G_FINAL_CLOSEOUT_INVENTORY_DIGEST
         ),
         "increment6g_migration_history_json": canonical_json_bytes(
-            [list(item) for item in EXPECTED_MIGRATION_HISTORY]
+            [
+                list(item)
+                for item in increment6g_final_migration_history(
+                    EXPECTED_MIGRATION_HISTORY
+                )
+            ]
         ).decode("utf-8"),
         "increment6g_neo4j_database": "neo4j",
         "increment6g_neo4j_driver_version": NEO4J_B2_DRIVER_VERSION,
@@ -70,8 +76,8 @@ def _target_properties(head: str, tree: str) -> dict[str, str]:
         "increment6g_neo4j_projector_username": "newsroom_projector",
         "increment6g_neo4j_server_version": NEO4J_B2_SERVER_VERSION,
         "increment6g_non_effects": ",".join(INCREMENT6G_FINAL_NON_EFFECTS),
-        "increment6g_schema_fingerprint": EXPECTED_SCHEMA_FINGERPRINT,
-        "increment6g_schema_version": str(SCHEMA_VERSION),
+        "increment6g_schema_fingerprint": INCREMENT6G_FINAL_SCHEMA_FINGERPRINT,
+        "increment6g_schema_version": str(INCREMENT6G_FINAL_SCHEMA_VERSION),
         "increment6g_service_compatibility_digest": service_compatibility_digest(),
         "increment6g_source_head_sha": head,
         "increment6g_source_tree_sha": tree,
@@ -225,6 +231,24 @@ def test_service_identity_rejects_changed_history_service_and_inventory() -> Non
         tampered[field] = changed
         with pytest.raises(Increment6GCloseoutReceiptError):
             _service_identities(tampered, "a" * 40, "b" * 40)
+
+
+def test_receipt_preserves_v25_prefix_after_an_authorised_future_migration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import scripts.sdlc.increment6g_closeout_receipt as receipt_module
+
+    appended = (
+        *EXPECTED_MIGRATION_HISTORY,
+        (26, "future_authorised", "sha256:x"),
+    )
+    monkeypatch.setattr(receipt_module, "SCHEMA_VERSION", 26)
+    monkeypatch.setattr(receipt_module, "EXPECTED_MIGRATION_HISTORY", appended)
+
+    properties = _target_properties("a" * 40, "b" * 40)
+    identity = receipt_module._service_identities(properties, "a" * 40, "b" * 40)
+    assert identity["migration"]["schema_version"] == 25
+    assert len(identity["migration"]["history"]) == 25
 
 
 def test_selected_case_must_be_present_and_pass_without_skip(tmp_path: Path) -> None:

--- a/newsroom/tests/test_increment6g_final_closeout.py
+++ b/newsroom/tests/test_increment6g_final_closeout.py
@@ -4,13 +4,19 @@ import importlib
 import re
 from pathlib import Path
 
+import pytest
+
 from newsroom.increment6.closeout import (
     INCREMENT6_FINAL_REQUIREMENTS,
     INCREMENT6G_FINAL_CLOSEOUT_CASES,
     INCREMENT6G_FINAL_CLOSEOUT_INVENTORY_DIGEST,
+    INCREMENT6G_FINAL_MIGRATION_HISTORY_DIGEST,
     INCREMENT6G_FINAL_NON_EFFECTS,
+    INCREMENT6G_FINAL_SCHEMA_FINGERPRINT,
+    INCREMENT6G_FINAL_SCHEMA_VERSION,
     Increment6CloseoutCategory,
     Increment6CloseoutLane,
+    increment6g_final_migration_history,
     validate_increment6g_final_closeout_inventory,
 )
 from scripts.sdlc.workflow_lane import (
@@ -76,6 +82,27 @@ def test_expensive_lineage_cases_concentration_is_bounded() -> None:
 
     assert sum(counts) == len(_EXPECTED_PROBE_IDS)
     assert max(counts) <= 7
+
+
+def test_increment6_closeout_migration_identity_accepts_only_an_exact_prefix() -> None:
+    from newsroom.authority.migrations import EXPECTED_MIGRATION_HISTORY
+
+    prefix = increment6g_final_migration_history(EXPECTED_MIGRATION_HISTORY)
+    assert len(prefix) == INCREMENT6G_FINAL_SCHEMA_VERSION == 25
+    assert INCREMENT6G_FINAL_SCHEMA_FINGERPRINT == (
+        "sha256:353900bf5804f0b770489982541f3cff4fd30ea36fc75d19b9c63315d1b6ec06"
+    )
+    assert INCREMENT6G_FINAL_MIGRATION_HISTORY_DIGEST == (
+        "sha256:bea793377d065d3073e6dfa8d40139fedfd377d5e24d9812d12cdb1ad52e9a0f"
+    )
+
+    appended = (*EXPECTED_MIGRATION_HISTORY, (26, "future_authorised", "sha256:x"))
+    assert increment6g_final_migration_history(appended) == prefix
+
+    changed = list(EXPECTED_MIGRATION_HISTORY)
+    changed[0] = (1, "changed", changed[0][2])
+    with pytest.raises(RuntimeError, match="migration history prefix"):
+        increment6g_final_migration_history(tuple(changed))
 
 
 def test_actual_service_case_is_in_both_permanent_service_routes() -> None:

--- a/newsroom/tests/test_increment6g_neo4j_service.py
+++ b/newsroom/tests/test_increment6g_neo4j_service.py
@@ -8,13 +8,15 @@ import pytest
 from newsroom.authority.canonical import canonical_json_bytes
 from newsroom.authority.migrations import (
     EXPECTED_MIGRATION_HISTORY,
-    EXPECTED_SCHEMA_FINGERPRINT,
     SCHEMA_VERSION,
 )
 from newsroom.increment6.closeout import (
     INCREMENT6G_FINAL_CLOSEOUT_CASES,
     INCREMENT6G_FINAL_CLOSEOUT_INVENTORY_DIGEST,
     INCREMENT6G_FINAL_NON_EFFECTS,
+    INCREMENT6G_FINAL_SCHEMA_FINGERPRINT,
+    INCREMENT6G_FINAL_SCHEMA_VERSION,
+    increment6g_final_migration_history,
 )
 from newsroom.projection.neo4j import (
     NEO4J_B2_DRIVER_VERSION,
@@ -42,22 +44,27 @@ def test_actual_service_increment6g_identity_and_closeout_inventory(
     assert compatibility.server_version == NEO4J_B2_SERVER_VERSION
     assert compatibility.edition == "community"
     assert compatibility.driver_version == NEO4J_B2_DRIVER_VERSION
-    assert SCHEMA_VERSION == 25
-    assert len(EXPECTED_MIGRATION_HISTORY) == 25
-    assert tuple(item[0] for item in EXPECTED_MIGRATION_HISTORY) == tuple(range(1, 26))
+    assert SCHEMA_VERSION >= INCREMENT6G_FINAL_SCHEMA_VERSION
+    history_prefix = increment6g_final_migration_history(
+        EXPECTED_MIGRATION_HISTORY
+    )
 
     head = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
     tree = subprocess.check_output(
         ["git", "rev-parse", "HEAD^{tree}"], text=True
     ).strip()
     history = canonical_json_bytes(
-        [list(item) for item in EXPECTED_MIGRATION_HISTORY]
+        [list(item) for item in history_prefix]
     ).decode("utf-8")
 
     record_property("increment6g_source_head_sha", head)
     record_property("increment6g_source_tree_sha", tree)
-    record_property("increment6g_schema_version", str(SCHEMA_VERSION))
-    record_property("increment6g_schema_fingerprint", EXPECTED_SCHEMA_FINGERPRINT)
+    record_property(
+        "increment6g_schema_version", str(INCREMENT6G_FINAL_SCHEMA_VERSION)
+    )
+    record_property(
+        "increment6g_schema_fingerprint", INCREMENT6G_FINAL_SCHEMA_FINGERPRINT
+    )
     record_property("increment6g_migration_history_json", history)
     record_property(
         "increment6g_closeout_inventory_digest",

--- a/scripts/sdlc/increment6g_closeout_receipt.py
+++ b/scripts/sdlc/increment6g_closeout_receipt.py
@@ -6,18 +6,21 @@ import sys
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 
-from newsroom.authority.canonical import canonical_json_bytes, digest_bytes
+from newsroom.authority.canonical import canonical_json_bytes
 from newsroom.authority.migrations import (
     EXPECTED_MIGRATION_HISTORY,
-    EXPECTED_SCHEMA_FINGERPRINT,
     SCHEMA_VERSION,
 )
 from newsroom.increment6.closeout import (
     INCREMENT6_FINAL_REQUIREMENTS,
     INCREMENT6G_FINAL_CLOSEOUT_CASES,
     INCREMENT6G_FINAL_CLOSEOUT_INVENTORY_DIGEST,
+    INCREMENT6G_FINAL_MIGRATION_HISTORY_DIGEST,
     INCREMENT6G_FINAL_NON_EFFECTS,
+    INCREMENT6G_FINAL_SCHEMA_FINGERPRINT,
+    INCREMENT6G_FINAL_SCHEMA_VERSION,
     Increment6CloseoutLane,
+    increment6g_final_migration_history,
 )
 from newsroom.projection.neo4j import (
     NEO4J_B2_DRIVER_VERSION,
@@ -72,18 +75,25 @@ class Increment6GCloseoutReceiptError(ValueError):
     """Raised when the Increment 6 closed-world evidence is not exact."""
 
 
+def _migration_history_prefix() -> tuple[tuple[int, str, str], ...]:
+    if SCHEMA_VERSION < INCREMENT6G_FINAL_SCHEMA_VERSION:
+        raise Increment6GCloseoutReceiptError("migration_history_prefix")
+    try:
+        return increment6g_final_migration_history(EXPECTED_MIGRATION_HISTORY)
+    except RuntimeError as exc:
+        raise Increment6GCloseoutReceiptError("migration_history_prefix") from exc
+
+
 def _inventory() -> dict[str, object]:
-    migration_history_digest = digest_bytes(
-        canonical_json_bytes([list(item) for item in EXPECTED_MIGRATION_HISTORY])
-    )
+    _migration_history_prefix()
     return {
         "case_count": len(INCREMENT6G_FINAL_CLOSEOUT_CASES),
         "digest": INCREMENT6G_FINAL_CLOSEOUT_INVENTORY_DIGEST,
         "non_effects": list(INCREMENT6G_FINAL_NON_EFFECTS),
         "requirements": sorted(INCREMENT6_FINAL_REQUIREMENTS),
-        "migration_history_digest": migration_history_digest,
-        "schema_version": SCHEMA_VERSION,
-        "schema_fingerprint": EXPECTED_SCHEMA_FINGERPRINT,
+        "migration_history_digest": INCREMENT6G_FINAL_MIGRATION_HISTORY_DIGEST,
+        "schema_version": INCREMENT6G_FINAL_SCHEMA_VERSION,
+        "schema_fingerprint": INCREMENT6G_FINAL_SCHEMA_FINGERPRINT,
     }
 
 
@@ -134,14 +144,15 @@ def _service_identities(
         history = json.loads(properties["increment6g_migration_history_json"])
     except (UnicodeError, json.JSONDecodeError) as exc:
         raise Increment6GCloseoutReceiptError("migration_history_json") from exc
-    expected_history = [list(item) for item in EXPECTED_MIGRATION_HISTORY]
+    expected_history = [list(item) for item in _migration_history_prefix()]
     if (
         history != expected_history
         or properties["increment6g_migration_history_json"]
         != canonical_json_bytes(expected_history).decode("utf-8")
-        or SCHEMA_VERSION != 25
-        or properties["increment6g_schema_version"] != "25"
-        or properties["increment6g_schema_fingerprint"] != EXPECTED_SCHEMA_FINGERPRINT
+        or properties["increment6g_schema_version"]
+        != str(INCREMENT6G_FINAL_SCHEMA_VERSION)
+        or properties["increment6g_schema_fingerprint"]
+        != INCREMENT6G_FINAL_SCHEMA_FINGERPRINT
     ):
         raise Increment6GCloseoutReceiptError("migration_identity")
     if (
@@ -169,9 +180,9 @@ def _service_identities(
     return {
         "migration": {
             "history": expected_history,
-            "history_digest": digest_bytes(canonical_json_bytes(expected_history)),
-            "schema_fingerprint": EXPECTED_SCHEMA_FINGERPRINT,
-            "schema_version": SCHEMA_VERSION,
+            "history_digest": INCREMENT6G_FINAL_MIGRATION_HISTORY_DIGEST,
+            "schema_fingerprint": INCREMENT6G_FINAL_SCHEMA_FINGERPRINT,
+            "schema_version": INCREMENT6G_FINAL_SCHEMA_VERSION,
         },
         "service": {
             "compatibility_digest": service_compatibility_digest(),


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-6g-closeout-forward-compatibility
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

Refs #368
Follow-up to #430

## Finding corrected

Addresses the unresolved P1 on #430: the permanent Increment 6 closeout service target and receipt must preserve the frozen v1–v25 prefix without requiring the repository's current schema to remain exactly v25 after a later authorised migration.

## Scope

- adds dedicated frozen Increment 6 schema version, schema fingerprint and migration-prefix digest constants;
- validates the exact v1–v25 prefix and accepts only an appended later migration suffix;
- keeps the Increment 6 service properties and receipt pinned to v25 identities;
- retains current-schema fail-closed behaviour when the repository is below v25 or the prefix changes;
- changes no migration, schema, product authority, writer, timeout, skip, credential, egress or activation path.

## Local evidence

- red gate: closeout tests initially failed collection because the prefix constants/helper did not exist;
- focused closeout/service tests: `11 passed, 1 skipped` outside the authenticated lane;
- SDLC/workflow regression set: `186 passed, 1 skipped`;
- Ruff, YAML parsing and diff checks passed.

## Required gates

This PR remains Draft until Fast CI, the authenticated service lane, all ten core shards, reducer/decision and exact-head substantive review are green. After merge, the signed exact-main closeout must be rerun before resolving the P1 and closing #368/#146.
