### PR TITLE
Increment 6F2c: retain reconciliation after Candidate advance

### DIFF
--- a/newsroom/authority/evaluation_feedback_system.py
+++ b/newsroom/authority/evaluation_feedback_system.py
@@ -556,14 +556,19 @@ class _EvaluationFeedbackAuthorityRoot:
     def _current_correlation(
         self, feedback: EvaluationFeedback, *, candidate_proof: object
     ) -> tuple[object, object, FeedbackCorrelationOutcome]:
-        version = self._candidate.require_retained_version_in_transaction(
-            feedback.candidate_version_id
-        )
+        version, handoff, outcome = self._retained_correlation(feedback)
         current = self._candidate.require_current_head_in_transaction(
             feedback.candidate_id, proof=candidate_proof
         )
         if current.version_id != version.version_id:
             raise FeedbackContractError("fresh feedback requires current Candidate head")
+        return version, handoff, outcome
+    def _retained_correlation(
+        self, feedback: EvaluationFeedback
+    ) -> tuple[object, object, FeedbackCorrelationOutcome]:
+        version = self._candidate.require_retained_version_in_transaction(
+            feedback.candidate_version_id
+        )
         handoff = self._handoff.require_retained_handoff_in_transaction(feedback.handoff_id)
         outcome = correlate_evaluation_feedback(handoff, version, feedback, ())
         return version, handoff, outcome
@@ -695,8 +700,9 @@ class _EvaluationFeedbackAuthorityRoot:
         )
         if rebuilt.canonical_bytes != proposed.canonical_bytes:
             raise FeedbackContractError("disposition derivation differs")
-        _, _, outcome = self._current_correlation(
-            parent.feedback, candidate_proof=candidate_proof
+        _, _, outcome = self._retained_correlation(parent.feedback)
+        self._candidate.require_current_head_in_transaction(
+            parent.feedback.candidate_id, proof=candidate_proof
         )
         if outcome not in {
             FeedbackCorrelationOutcome.READY,

--- a/newsroom/tests/test_increment6e2_candidate_store.py
+++ b/newsroom/tests/test_increment6e2_candidate_store.py
@@ -422,14 +422,15 @@ def _actor_digest(seed: tuple, actor: str) -> str:
     )
 
 
-def _manifest(location: _Location, version, collision):
+def _manifest(location: _Location, version, collision, registry_extender=None):
     connection = sqlite3.connect(location.seed[1], isolation_level=None)
     connection.row_factory = sqlite3.Row
     connection.execute("PRAGMA foreign_keys=ON")
     connection.execute("PRAGMA journal_mode=WAL")
-    commands, schemas = merge_relationship_authority_registries(
-        location.seed[4], location.seed[5]
-    )
+    commands, schemas = location.seed[4], location.seed[5]
+    if registry_extender is not None:
+        commands, schemas = registry_extender(commands, schemas)
+    commands, schemas = merge_relationship_authority_registries(commands, schemas)
     commands, schemas = merge_lineage_authority_registries(commands, schemas)
     commands, schemas = merge_candidate_authority_registries(commands, schemas)
     lineage = _create_event_hypothesis_lineage_read_port(
@@ -553,7 +554,7 @@ def _admission(location: _Location, command: WriteCommand):
     return admission, collision_request_value
 
 
-def _advance_record_one(location: _Location):
+def _advance_record_one(location: _Location, registry_extender=None):
     previous = location.subjects["record-1"]
     connection = sqlite3.connect(location.seed[1], isolation_level=None)
     try:
@@ -579,6 +580,10 @@ def _advance_record_one(location: _Location):
     )
     assert assessment.decision is CanonicalOutcome.REL_DEVELOPMENT_OF
     args = _collaborators(location.seed)
+    if registry_extender is not None:
+        args["command_registry"], args["payload_schemas"] = registry_extender(
+            args["command_registry"], args["payload_schemas"]
+        )
     commands, schemas = merge_relationship_authority_registries(
         args["command_registry"], args["payload_schemas"]
     )
@@ -601,13 +606,18 @@ def _advance_record_one(location: _Location):
 
 
 class _Handle:
-    def __init__(self, location: _Location) -> None:
+    def __init__(self, location: _Location, registry_extender=None) -> None:
         self.location = location
         self.authority = None
         self.open_error: Exception | None = None
         try:
+            args = _collaborators(location.seed)
+            if registry_extender is not None:
+                args["command_registry"], args["payload_schemas"] = registry_extender(
+                    args["command_registry"], args["payload_schemas"]
+                )
             self.authority = _open_unlocked_story_candidate_authority_for_test(
-                **_collaborators(location.seed), collision_enforcer=_enforcer(location)
+                **args, collision_enforcer=_enforcer(location)
             )
         except Exception as exc:
             if not isinstance(exc, (AuthoritySchemaError, CandidateContractError)):

--- a/newsroom/tests/test_increment6f2_feedback_system.py
+++ b/newsroom/tests/test_increment6f2_feedback_system.py
@@ -43,6 +43,29 @@ def _seed(tmp_path: Path, *, candidate_seed_snapshot=None):
     row = handle._row("record-1")
     version = handle._opened().load_version(str(row[1]))
     handle.close()
+    args = candidate_fixture._collaborators(location.seed)
+    feedback, obligation = _feedback_for_version(
+        location,
+        args,
+        version,
+        suffix="v25-test",
+        response_character="4",
+        feedback_request_id="eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+        obligation_request_id="aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    )
+    return location, args, feedback, obligation
+
+
+def _feedback_for_version(
+    location,
+    args,
+    version,
+    *,
+    suffix: str,
+    response_character: str,
+    feedback_request_id: str,
+    obligation_request_id: str,
+):
     store = EvaluationHandoffStore(
         sqlite3.connect(location.seed[1], isolation_level=None)
     )
@@ -50,7 +73,7 @@ def _seed(tmp_path: Path, *, candidate_seed_snapshot=None):
         create_handoff(
             version.version_id,
             version.governing_manifest.canonical_digest,
-            "evaluation-sink:v25-test",
+            f"evaluation-sink:{suffix}",
             max_attempts=3,
         )
     )
@@ -65,11 +88,10 @@ def _seed(tmp_path: Path, *, candidate_seed_snapshot=None):
         governing_manifest_digest=version.governing_manifest.canonical_digest,
         sink_id=handoff.sink_id,
         outcome=AcknowledgementOutcome.ACKNOWLEDGED,
-        response_digest="sha256:" + "4" * 64,
+        response_digest="sha256:" + response_character * 64,
     )
     handoff = store.correlate_acknowledgement(handoff.handoff_id, acknowledgement)
     store._connection.close()
-    args = candidate_fixture._collaborators(location.seed)
     authentication = args["authenticator"].authenticate(
         location.seed[0][3], now=args["clock"]()
     )
@@ -93,21 +115,91 @@ def _seed(tmp_path: Path, *, candidate_seed_snapshot=None):
         attempt=handoff.attempts[0],
         acknowledgement=acknowledgement,
         candidate_version=version,
-        source_feedback_id="evaluation-feedback:v25-test",
+        source_feedback_id=f"evaluation-feedback:{suffix}",
         outcome=EvaluationFeedbackOutcome.ACCEPTED,
         reason=EvaluationFeedbackReason.INTAKE_ACCEPTED,
         detail_digest="sha256:" + "2" * 64,
-        request_id="eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+        request_id=feedback_request_id,
         actor_identity_digest=actor,
-        idempotency_key="feedback:v25-test",
+        idempotency_key=f"feedback:{suffix}",
     )
     obligation = create_reconciliation_obligation(
         feedback,
-        request_id="aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        request_id=obligation_request_id,
         actor_identity_digest=actor,
-        idempotency_key="obligation:v25-test",
+        idempotency_key=f"obligation:{suffix}",
     )
-    return location, args, feedback, obligation
+    return feedback, obligation
+
+
+def _advance_candidate_head(location, version):
+    from newsroom.increment6.feedback import (
+        merge_evaluation_feedback_authority_registries,
+    )
+
+    previous, advanced_hypothesis = candidate_fixture._advance_record_one(
+        location, merge_evaluation_feedback_authority_registries
+    )
+    assert advanced_hypothesis.previous_version_id == previous.version_id
+    binding = candidate_fixture.CandidateUseCollisionBinding(
+        advanced_hypothesis.hypothesis_id,
+        advanced_hypothesis.version_id,
+        advanced_hypothesis.canonical_digest,
+        candidate_fixture.CandidateUseOperation.USE_CURRENT_CANDIDATE,
+        version.candidate_id,
+        version.governing_manifest.collision_namespace,
+        version.governing_manifest.collision_key_digest,
+        "retrieval-generation-v2",
+        candidate_fixture.QUERY_VALID,
+        candidate_fixture.SERVING,
+        42,
+    )
+    collision_request, collision = candidate_fixture._named_snapshot(
+        location, binding, occupied_candidate_id=version.candidate_id
+    )
+    manifest = candidate_fixture._manifest(
+        location,
+        advanced_hypothesis,
+        collision,
+        merge_evaluation_feedback_authority_registries,
+    )
+    request = candidate_fixture.CandidateAdmissionRequest(
+        "44444444-4444-4444-8444-444444444444",
+        candidate_fixture._actor_digest(location.seed, "actor-1"),
+        "candidate:feedback-head-advance",
+        version.version_id,
+        version.canonical_digest,
+        version.ordinal,
+        manifest.semantic_scope_digest,
+        collision_request.request_digest,
+        manifest.governing_state_binding.canonical_digest,
+        None,
+    )
+    admission = candidate_fixture.evaluate_candidate_admission(
+        request=request,
+        manifest=manifest,
+        collision=collision,
+        current_version=version,
+        governing_state=candidate_fixture.CandidateGoverningState(
+            candidate_fixture.CandidateGoverningStateStatus.COMPLETE,
+            manifest.governing_state_binding,
+        ),
+    )
+    successor = candidate_fixture._Handle(
+        location, merge_evaluation_feedback_authority_registries
+    )
+    try:
+        advanced = successor._opened().admit(
+            admission.canonical_bytes,
+            collision_request=collision_request,
+            proof=location.seed[0][3],
+        )
+    finally:
+        successor.close()
+    assert advanced.candidate_id == version.candidate_id
+    assert advanced.previous_version_id == version.version_id
+    assert advanced.ordinal == version.ordinal + 1
+    return advanced
 
 
 def test_accept_replay_snapshot_and_direct_tamper_fail_closed(tmp_path: Path) -> None:
@@ -218,6 +310,44 @@ def test_disposition_is_generic_ledger_anchored_and_replay_precedes_ports(
         obligation.canonical_bytes,
         candidate_proof=location.seed[0][3],
     )
+    authority.close()
+    from newsroom.increment6.feedback import (
+        merge_evaluation_feedback_authority_registries,
+    )
+
+    candidate = candidate_fixture._Handle(
+        location, merge_evaluation_feedback_authority_registries
+    )
+    version = candidate._opened().load_version(feedback.candidate_version_id)
+    candidate.close()
+    advanced = _advance_candidate_head(location, version)
+    assert advanced.version_id != feedback.candidate_version_id
+    stale_feedback, stale_obligation = _feedback_for_version(
+        location,
+        args,
+        version,
+        suffix="stale-candidate-version",
+        response_character="5",
+        feedback_request_id="55555555-5555-4555-8555-555555555555",
+        obligation_request_id="66666666-6666-4666-8666-666666666666",
+    )
+    authority = open_evaluation_feedback_authority_system(
+        location.seed[1],
+        retrieval_authority=args["retrieval_authority"],
+        authenticator=args["authenticator"],
+        authorizer=args["authorizer"],
+        command_registry=args["command_registry"],
+        payload_schemas=args["payload_schemas"],
+        clock=args["clock"],
+    )
+    with pytest.raises(
+        FeedbackContractError, match="fresh feedback requires current Candidate head"
+    ):
+        authority.accept(
+            stale_feedback.canonical_bytes,
+            stale_obligation.canonical_bytes,
+            candidate_proof=location.seed[0][3],
+        )
     disposition = append_reconciliation_disposition(
         accepted.obligation,
         (),
@@ -261,18 +391,41 @@ def test_disposition_is_generic_ledger_anchored_and_replay_precedes_ports(
         clock=args["clock"],
     )
     assert reopened.load(feedback.feedback_id) == accepted
-    fulfilled = append_reconciliation_disposition(
+    blocked = append_reconciliation_disposition(
         obligation,
         (disposition,),
-        outcome=ReconciliationDispositionOutcome.FULFILLED,
-        reason=ReconciliationDispositionReason.FEEDBACK_RECORDED,
+        outcome=ReconciliationDispositionOutcome.BLOCKED,
+        reason=ReconciliationDispositionReason.DEPENDENCY_UNAVAILABLE,
         resolution_digest="sha256:" + "7" * 64,
         request_id="22222222-2222-4222-8222-222222222222",
         actor_identity_digest=feedback.actor_identity_digest,
-        idempotency_key="disposition:v25-fulfilled",
+        idempotency_key="disposition:v25-blocked",
         expected_current_disposition_id=disposition.disposition_id,
         expected_current_disposition_digest=disposition.canonical_digest,
         expected_current_ordinal=1,
+    )
+    assert (
+        reopened.append_disposition(
+            blocked.canonical_bytes, candidate_proof=location.seed[0][3]
+        )
+        == blocked
+    )
+    assert (
+        reopened.append_disposition(blocked.canonical_bytes, candidate_proof=object())
+        == blocked
+    )
+    fulfilled = append_reconciliation_disposition(
+        obligation,
+        (disposition, blocked),
+        outcome=ReconciliationDispositionOutcome.FULFILLED,
+        reason=ReconciliationDispositionReason.FEEDBACK_RECORDED,
+        resolution_digest="sha256:" + "8" * 64,
+        request_id="33333333-3333-4333-8333-333333333333",
+        actor_identity_digest=feedback.actor_identity_digest,
+        idempotency_key="disposition:v25-fulfilled",
+        expected_current_disposition_id=blocked.disposition_id,
+        expected_current_disposition_digest=blocked.canonical_digest,
+        expected_current_ordinal=2,
     )
     assert (
         reopened.append_disposition(
@@ -280,19 +433,23 @@ def test_disposition_is_generic_ledger_anchored_and_replay_precedes_ports(
         )
         == fulfilled
     )
+    assert (
+        reopened.append_disposition(fulfilled.canonical_bytes, candidate_proof=object())
+        == fulfilled
+    )
     with pytest.raises(FeedbackContractError, match="terminal"):
         append_reconciliation_disposition(
             obligation,
-            (disposition, fulfilled),
+            (disposition, blocked, fulfilled),
             outcome=ReconciliationDispositionOutcome.UNRESOLVED,
             reason=ReconciliationDispositionReason.AWAITING_RECONCILIATION,
-            resolution_digest="sha256:" + "8" * 64,
-            request_id="33333333-3333-4333-8333-333333333333",
+            resolution_digest="sha256:" + "9" * 64,
+            request_id="77777777-7777-4777-8777-777777777777",
             actor_identity_digest=feedback.actor_identity_digest,
             idempotency_key="disposition:v25-after-terminal",
             expected_current_disposition_id=fulfilled.disposition_id,
             expected_current_disposition_digest=fulfilled.canonical_digest,
-            expected_current_ordinal=2,
+            expected_current_ordinal=3,
         )
     connection = reopened._EvaluationFeedbackAuthority__authority._connection
     trigger = connection.execute(


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-6f2c-retained-reconciliation
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

Closes #432

## Summary

- split retained Candidate/Handoff correlation from the fresh-feedback current-head identity gate
- keep current Candidate authority revalidation for every new disposition without requiring the historical feedback-bound Version to remain the head
- prove Candidate Version N obligations remain appendable and exactly replayable after the real Candidate authority advances to N+1
- retain fresh stale-Version rejection and both Candidate-advance/disposition race orderings

## Production scope

- `newsroom/authority/evaluation_feedback_system.py` only
- no migration, schema, checksum, fingerprint, table, second connection or new authority effect

## Local evidence

- RED before fix: `test_retained_obligation_remains_disposable_after_candidate_head_advance` failed with `fresh feedback requires current Candidate head`
- focused #402/#403/#384 closure: 81 passed
- source integrity: passed for `8ff90ebe56b416f3acd2c81d1a583d48f8386f2a..6c86cf433d25fb08e8eb06cd51aafea9cf4d0aa9`
- Ruff check/format and `git diff --check`: passed

## Required semantics retained

- exact feedback replay remains replay-before-ports
- genuinely fresh feedback bound to historical Version N still fails the current-head gate
- every new disposition still revalidates authenticated current Candidate authority and the exact retained Version N, Handoff, feedback, obligation, snapshot and generic ledger
- CAS, actor, request, idempotency, lost-response, terminality and contiguous history are unchanged




## Exact-head runtime correction

The first exact-head route on `306208632f10e60d585346ec78d59bd6cef8e331` isolated one non-product shard-5 lifecycle timeout. Three separate Candidate-advance nodes added 91 seconds across shards. The amended head preserves the existing Candidate successor node unchanged and runs the explicit correction inside the existing reconciliation disposition authority node using the already published immutable system seed under xdist. It does not change node selection, topology, timeouts or product semantics; cloned paths, connections and mutable objects remain isolated. The focused closure remains 81 passing tests.



