### PR TITLE
Increment 6: add retained-head closeout evidence

### DIFF
--- a/.github/workflows/evidence.yml
+++ b/.github/workflows/evidence.yml
@@ -873,7 +873,7 @@ jobs:
               or {lane.get('lane_id') for lane in increment6_lanes}
               != {'core', 'service'}
               or type(increment6_count) is not int
-              or increment6_count != 58
+              or increment6_count != 59
               or not isinstance(increment6_cases, list)
               or len(increment6_cases) != increment6_count
               or not all(isinstance(item, dict) for item in increment6_cases)
@@ -883,7 +883,7 @@ jobs:
               or len({item.get('test_id') for item in increment6_cases})
               != increment6_count
               or increment6_inventory.get('digest')
-              != 'sha256:cb051e71025a2387aa6bdc4e4fca0bc76b414aabaeb2d192b2aa1dd48c81e011'
+              != 'sha256:afc556ba5785f84eb691af903f24c81ac43d50bbe6c02a3ad23eb08dca8dff5f'
               or increment6_inventory.get('schema_version') != 25
               or increment6_inventory.get('schema_fingerprint')
               != 'sha256:353900bf5804f0b770489982541f3cff4fd30ea36fc75d19b9c63315d1b6ec06'
@@ -891,6 +891,55 @@ jobs:
               != 'sha256:bea793377d065d3073e6dfa8d40139fedfd377d5e24d9812d12cdb1ad52e9a0f'
           ):
               raise SystemExit('increment6 closeout inventory differs')
+          canonical_increment6_cases = []
+          expected_case_fields = {
+              'case_id',
+              'category',
+              'lane',
+              'outcome',
+              'requirements',
+              'test_id',
+          }
+          for item in increment6_cases:
+              requirements = item.get('requirements')
+              if (
+                  set(item) != expected_case_fields
+                  or not isinstance(item.get('category'), str)
+                  or not item.get('category')
+                  or not isinstance(item.get('lane'), str)
+                  or not item.get('lane')
+                  or not isinstance(requirements, list)
+                  or not requirements
+                  or not all(
+                      isinstance(requirement, str) and requirement
+                      for requirement in requirements
+                  )
+                  or requirements != sorted(set(requirements))
+              ):
+                  raise SystemExit('increment6 selected case differs')
+              canonical_increment6_cases.append(
+                  {
+                      'case_id': item['case_id'],
+                      'category': item['category'],
+                      'lane': item['lane'],
+                      'requirements': requirements,
+                      'test_id': item['test_id'],
+                  }
+              )
+          selected_inventory_digest = (
+              'sha256:'
+              + hashlib.sha256(
+                  json.dumps(
+                      canonical_increment6_cases,
+                      ensure_ascii=False,
+                      allow_nan=False,
+                      sort_keys=True,
+                      separators=(',', ':'),
+                  ).encode('utf-8')
+              ).hexdigest()
+          )
+          if selected_inventory_digest != increment6_inventory.get('digest'):
+              raise SystemExit('increment6 selected inventory digest differs')
           increment6_claimed = increment6.get('receipt_identity')
           increment6_unsigned = dict(increment6)
           increment6_unsigned.pop('receipt_identity', None)

--- a/docs/traceability/increment-6g-final-closeout.md
+++ b/docs/traceability/increment-6g-final-closeout.md
@@ -6,11 +6,11 @@
 - **Entry main:** `c52574afcc9725b7ee14edcc8f4aa608a2593ecc`
 - **Entry tree:** `91754aeb76f05fac41b38ad8ef90715b7fe11ba4`
 - **Inventory source:** `newsroom/increment6/closeout.py`
-- **Inventory digest:** `sha256:cb051e71025a2387aa6bdc4e4fca0bc76b414aabaeb2d192b2aa1dd48c81e011`
+- **Inventory digest:** `sha256:afc556ba5785f84eb691af903f24c81ac43d50bbe6c02a3ad23eb08dca8dff5f`
 
 ## Closed boundary
 
-The machine inventory reconciles 58 exact permanent pytest node identities. It
+The machine inventory reconciles 59 exact permanent pytest node identities. It
 binds the complete Increment 6 fixture path from retained Source Revision,
 Signal and Lead authority through Work Item, Retrieval Context, Proposal,
 Disposition, Hypothesis, Relationship, Lineage, Candidate Admission,
@@ -45,7 +45,9 @@ The selected authority cases retain the real public paths:
 - concurrent claim/admission and evaluation Handoff loss, delay, ambiguity and
   retry;
 - mandatory Feedback obligations and reconciliation dispositions which remain
-  visible until a governed terminal state; and
+  visible until a governed terminal state, including the exact sequence where
+  feedback is accepted on Candidate Version N, the Candidate authority advances
+  to N+1, and the retained N obligation is then dispositioned; and
 - Watch Condition and supplemental-discovery re-entry through a new governed
   Work Item.
 
@@ -72,11 +74,13 @@ JUnit properties. Wrong projector credentials and actual tombstone removal are
 separate selected actual-service cases.
 
 `scripts/sdlc/increment6g_closeout_receipt.py` replays the immutable core and
-service transport bundles, validates the PASS decision, checks all 58 selected
+service transport bundles, validates the PASS decision, checks all 59 selected
 outcomes, rejects any lane failure/error, and binds the raw JUnit, lane receipt,
 envelope, transport, replay, selected-test manifest and service identities to
-one exact source head and tree. It checks the tracked checkout before consuming
-evidence and again before emission.
+one exact source head and tree. The isolated signer reconstructs the canonical
+selected-case inventory and its digest before attestation, so the declared
+digest cannot stand in for a changed case mapping. It checks the tracked
+checkout before consuming evidence and again before emission.
 
 The final receipt is included with the decision evidence. Only a successful
 service-required manual run on `refs/heads/main` advances to `signed-closeout`.

--- a/newsroom/increment6/closeout.py
+++ b/newsroom/increment6/closeout.py
@@ -399,6 +399,15 @@ INCREMENT6G_FINAL_CLOSEOUT_CASES = tuple(
                 _FAILURE,
             ),
             _case(
+                "F04_RETAINED_AFTER_HEAD_ADVANCE",
+                _F,
+                _D,
+                "test_increment6f2_feedback_system",
+                "test_disposition_is_generic_ledger_anchored_and_replay_precedes_ports",
+                _FEEDBACK,
+                _CANDIDATE,
+            ),
+            _case(
                 "R01_WATCH_EXPIRY",
                 _R,
                 _D,

--- a/newsroom/tests/test_increment6g_closeout_receipt.py
+++ b/newsroom/tests/test_increment6g_closeout_receipt.py
@@ -9,7 +9,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from newsroom.authority.canonical import canonical_json_bytes
+from newsroom.authority.canonical import canonical_json_bytes, digest_bytes
 from newsroom.authority.migrations import (
     EXPECTED_MIGRATION_HISTORY,
 )
@@ -214,6 +214,41 @@ def test_final_receipt_binds_exact_decision_transports_inventory_and_service(
     )
     unsigned = dict(receipt)
     assert unsigned.pop("receipt_identity") == sha256_identity(unsigned)
+
+
+def test_selected_case_mapping_reconstructs_the_declared_inventory_digest() -> None:
+    selected = [
+        {**case.canonical_value(), "outcome": "passed"}
+        for case in INCREMENT6G_FINAL_CLOSEOUT_CASES
+    ]
+
+    def reconstructed_digest(cases: list[dict[str, object]]) -> str:
+        return digest_bytes(
+            canonical_json_bytes(
+                [
+                    {
+                        "case_id": item["case_id"],
+                        "category": item["category"],
+                        "lane": item["lane"],
+                        "requirements": item["requirements"],
+                        "test_id": item["test_id"],
+                    }
+                    for item in cases
+                ]
+            )
+        )
+
+    assert reconstructed_digest(selected) == INCREMENT6G_FINAL_CLOSEOUT_INVENTORY_DIGEST
+    retained = next(
+        item
+        for item in selected
+        if item["case_id"] == "F04_RETAINED_AFTER_HEAD_ADVANCE"
+    )
+    retained["test_id"] = (
+        "newsroom.tests.test_increment6f2_feedback_system::"
+        "test_accept_replay_snapshot_and_direct_tamper_fail_closed"
+    )
+    assert reconstructed_digest(selected) != INCREMENT6G_FINAL_CLOSEOUT_INVENTORY_DIGEST
 
 
 def test_service_identity_rejects_changed_history_service_and_inventory() -> None:

--- a/newsroom/tests/test_increment6g_final_closeout.py
+++ b/newsroom/tests/test_increment6g_final_closeout.py
@@ -30,9 +30,9 @@ ROOT = Path(__file__).resolve().parents[2]
 
 def test_final_closeout_inventory_is_content_addressed_and_exact() -> None:
     validate_increment6g_final_closeout_inventory()
-    assert len(INCREMENT6G_FINAL_CLOSEOUT_CASES) == 58
+    assert len(INCREMENT6G_FINAL_CLOSEOUT_CASES) == 59
     assert INCREMENT6G_FINAL_CLOSEOUT_INVENTORY_DIGEST == (
-        "sha256:cb051e71025a2387aa6bdc4e4fca0bc76b414aabaeb2d192b2aa1dd48c81e011"
+        "sha256:afc556ba5785f84eb691af903f24c81ac43d50bbe6c02a3ad23eb08dca8dff5f"
     )
     assert {
         requirement
@@ -54,6 +54,19 @@ def test_final_closeout_inventory_is_content_addressed_and_exact() -> None:
         "newsroom.tests.test_increment6f2_feedback_system::"
         "test_accept_replay_snapshot_and_direct_tamper_fail_closed"
     )
+    retained_after_head_advance = next(
+        case
+        for case in INCREMENT6G_FINAL_CLOSEOUT_CASES
+        if case.case_id == "F04_RETAINED_AFTER_HEAD_ADVANCE"
+    )
+    assert retained_after_head_advance.test_id == (
+        "newsroom.tests.test_increment6f2_feedback_system::"
+        "test_disposition_is_generic_ledger_anchored_and_replay_precedes_ports"
+    )
+    assert set(retained_after_head_advance.requirements) == {
+        "COLLISION_CANDIDATE_EQUIVALENT_DISTINCT_ADMISSION",
+        "FEEDBACK_OBLIGATION_RECONCILIATION_VISIBILITY",
+    }
     assert INCREMENT6G_FINAL_NON_EFFECTS == tuple(sorted(INCREMENT6G_FINAL_NON_EFFECTS))
 
 


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-6g-retained-head-closeout
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

Supports #368 after #432/#433.

## Summary

- add the previously omitted explicit `F04_RETAINED_AFTER_HEAD_ADVANCE` selected case
- bind the 59-case inventory to the permanent real-authority regression which accepts feedback on Candidate N, advances the same Candidate to N+1, rejects fresh stale-N feedback, then disposes and replays N's retained obligation
- rotate the content-addressed inventory digest and signed-closeout verifier from 58 to 59 cases

## Scope

- migration-free closeout inventory and verifier only
- no production authority, migration, schema, table, writer, credential, external egress or runtime effect
- the selected regression already merged through #433 and passed its corrective exact-head gate

## Local evidence

- final closeout and receipt tests: 12 passed
- explicit selected regression: 1 passed
- collection proves 12 closeout/service targets
- Ruff check/format, diff check and source integrity: passed

## Final gate

This PR does not itself close #368. After merge, #368 still requires one new signed exact-main SDLC run with authenticated Neo4j service, all core shards, the 59-case receipt, three independently verified subjects in one signed attestation bundle, and zero P1/material-P2/unresolved threads.