### PR TITLE
Increment 7A1: add Planned Agenda contracts

### DIFF
--- a/newsroom/increment7/agenda.py
+++ b/newsroom/increment7/agenda.py
@@ -418,7 +418,11 @@ class PlannedAgendaVersion(_NoEffect):
             or self.expectation_path.kind is not AgendaPathKind.EXPECTATION
         ):
             raise AgendaContractError("expectation_path must be an expectation path")
-        paths = tuple(self.occurrence_confirmation_paths)
+        if type(self.occurrence_confirmation_paths) is not tuple:
+            raise AgendaContractError(
+                "occurrence_confirmation_paths must be bounded confirmation paths"
+            )
+        paths = self.occurrence_confirmation_paths
         if (
             not paths
             or len(paths) > MAX_PATHS
@@ -444,12 +448,12 @@ class PlannedAgendaVersion(_NoEffect):
             ("relationship_references", self.relationship_references, MAX_REFERENCES),
             ("uncertainties", self.uncertainties, MAX_UNCERTAINTIES),
         ):
-            normal = tuple(values)
-            if len(normal) > maximum or tuple(sorted(set(normal))) != normal:
+            if type(values) is not tuple or len(values) > maximum:
                 raise AgendaContractError(f"{field} must be unique, sorted and bounded")
-            for value in normal:
+            for value in values:
                 (_digest if field == "relationship_references" else _text)(value, field)
-            object.__setattr__(self, field, normal)
+            if tuple(sorted(set(values))) != values:
+                raise AgendaContractError(f"{field} must be unique, sorted and bounded")
         _timestamp(self.recorded_at, "recorded_at")
 
     def _validate_time(self) -> None:
@@ -483,7 +487,10 @@ class PlannedAgendaVersion(_NoEffect):
                         "exact window requires an ordered UTC end"
                     )
         elif precision is AgendaTimePrecision.DATE_ONLY:
-            if start is None or _DATE.fullmatch(start) is None or end is not None:
+            if start is None or end is not None:
+                raise AgendaContractError("date-only schedule must remain date-only")
+            start = _text(start, "asserted_start", maximum=10)
+            if _DATE.fullmatch(start) is None:
                 raise AgendaContractError("date-only schedule must remain date-only")
             try:
                 datetime.strptime(start, "%Y-%m-%d")

--- a/newsroom/increment7/agenda.py
+++ b/newsroom/increment7/agenda.py
@@ -1,0 +1,614 @@
+"""Strict, effect-free Planned Agenda contracts for Increment 7A1.
+
+Agenda values are immutable expectations.  Constructing, parsing, opening a
+window, or observing clock passage grants no Signal, Lead, Candidate, evidence,
+publication, provider, scheduling, or other runtime authority.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+from typing import Self
+
+from newsroom.authority.canonical import (
+    CanonicalizationError,
+    canonical_json_bytes,
+    digest_bytes,
+    validate_sha256_digest,
+)
+
+PLANNED_AGENDA_ITEM = "newsroom.increment7.planned-agenda-item.v1"
+PLANNED_AGENDA_VERSION = "newsroom.increment7.planned-agenda-version.v1"
+AGENDA_TIME_PRECISION = "EXPLICIT_AND_UNWIDENED"
+AGENDA_RESOLUTION_VOCABULARY = "newsroom.increment7.agenda-resolution-vocabulary.v1"
+NO_CLOCK_GENERATED_EDITORIAL_RECORD = (
+    "CLOCK_PASSAGE_CREATES_NO_SIGNAL_LEAD_CANDIDATE_OR_EVIDENCE"
+)
+MAX_AGENDA_CANONICAL_BYTES = 1_048_576
+MAX_TEXT_BYTES = 2_048
+MAX_PATHS = 16
+MAX_REFERENCES = 32
+MAX_UNCERTAINTIES = 32
+
+_UUID = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z"
+)
+_TOKEN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:\-]{0,255}\Z")
+_DATE = re.compile(r"[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])\Z")
+_UTC = re.compile(
+    r"[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T(?:[01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]\.[0-9]{6}Z\Z"
+)
+
+
+class AgendaContractError(ValueError):
+    """Untrusted Agenda bytes or values failed the exact v1 contract."""
+
+
+class AgendaKind(StrEnum):
+    RELEASE = "RELEASE"
+    PROCEEDING = "PROCEEDING"
+    EFFECTIVE_DATE = "EFFECTIVE_DATE"
+    DEADLINE = "DEADLINE"
+    EXPECTED_DEVELOPMENT = "EXPECTED_DEVELOPMENT"
+
+
+class AgendaScheduleStatus(StrEnum):
+    PROVISIONAL = "PROVISIONAL"
+    CONFIRMED = "CONFIRMED"
+    POSTPONED_WITHOUT_DATE = "POSTPONED_WITHOUT_DATE"
+    CANCELLED = "CANCELLED"
+    WITHDRAWN = "WITHDRAWN"
+
+
+class AgendaTimePrecision(StrEnum):
+    EXACT_INSTANT = "EXACT_INSTANT"
+    EXACT_WINDOW = "EXACT_WINDOW"
+    DATE_ONLY = "DATE_ONLY"
+    APPROXIMATE = "APPROXIMATE"
+    TIME_ZONE_AMBIGUOUS = "TIME_ZONE_AMBIGUOUS"
+    UNKNOWN = "UNKNOWN"
+
+
+class AgendaResolutionKind(StrEnum):
+    OCCURRENCE_CONFIRMED = "OCCURRENCE_CONFIRMED"
+    MISSED_NOT_OBSERVED = "MISSED_NOT_OBSERVED"
+    LATE_OCCURRENCE = "LATE_OCCURRENCE"
+    RESCHEDULED = "RESCHEDULED"
+    CANCELLED_WITH_SOURCE_EVIDENCE = "CANCELLED_WITH_SOURCE_EVIDENCE"
+    POSTPONED_WITH_SOURCE_EVIDENCE = "POSTPONED_WITH_SOURCE_EVIDENCE"
+    WITHDRAWN_WITH_SOURCE_EVIDENCE = "WITHDRAWN_WITH_SOURCE_EVIDENCE"
+    CHECK_FAILED = "CHECK_FAILED"
+    CHECK_PARTIAL = "CHECK_PARTIAL"
+    CHECK_UNAVAILABLE = "CHECK_UNAVAILABLE"
+    AMBIGUOUS = "AMBIGUOUS"
+
+
+class CoverageBasis(StrEnum):
+    ORIGINATING_AUTHORITY = "ORIGINATING_AUTHORITY"
+    RESPONSIBLE_OPERATOR = "RESPONSIBLE_OPERATOR"
+    PLANNED_AGENDA = "PLANNED_AGENDA"
+    ESTABLISHED_MEDIA_RADAR = "ESTABLISHED_MEDIA_RADAR"
+    SPECIALIST_OR_LOCAL_RADAR = "SPECIALIST_OR_LOCAL_RADAR"
+    MANUAL_EDITOR_OR_READER = "MANUAL_EDITOR_OR_READER"
+
+
+class AgendaPathKind(StrEnum):
+    EXPECTATION = "EXPECTATION"
+    OCCURRENCE_CONFIRMATION = "OCCURRENCE_CONFIRMATION"
+
+
+class AgendaUrgency(StrEnum):
+    IMMEDIATE = "IMMEDIATE"
+    TIME_SENSITIVE = "TIME_SENSITIVE"
+    ROUTINE = "ROUTINE"
+    UNKNOWN = "UNKNOWN"
+
+
+class _NoEffect:
+    authorises_authority = False
+    authorises_persistence = False
+    authorises_external_effect = False
+    authorises_publication = False
+    authorises_evidence = False
+    authorises_egress = False
+    authorises_provider = False
+    authorises_schedule = False
+    production_activation_authorised = False
+    creates_signal = False
+    creates_lead = False
+    creates_candidate = False
+    creates_occurrence = False
+
+
+def _exact_dict(
+    value: object, fields: tuple[str, ...], label: str
+) -> dict[str, object]:
+    if type(value) is not dict or tuple(value) != tuple(sorted(fields)):
+        raise AgendaContractError(f"{label} fields are not exact and ordered")
+    return value
+
+
+def _text(value: object, field: str, *, maximum: int = MAX_TEXT_BYTES) -> str:
+    try:
+        encoded_size = len(value.encode()) if type(value) is str else 0
+    except UnicodeEncodeError as exc:
+        raise AgendaContractError(f"{field} must be bounded canonical text") from exc
+    if (
+        type(value) is not str
+        or not value
+        or value != value.strip()
+        or encoded_size > maximum
+    ):
+        raise AgendaContractError(f"{field} must be bounded canonical text")
+    return value
+
+
+def _enum[T: StrEnum](enum_type: type[T], value: object, field: str) -> T:
+    if type(value) is not str and type(value) is not enum_type:
+        raise AgendaContractError(f"{field} must be a closed vocabulary value")
+    try:
+        return enum_type(value)
+    except ValueError as exc:
+        raise AgendaContractError(f"{field} must be a closed vocabulary value") from exc
+
+
+def _token(value: object, field: str) -> str:
+    value = _text(value, field, maximum=256)
+    if _TOKEN.fullmatch(value) is None:
+        raise AgendaContractError(f"{field} must be a canonical token")
+    return value
+
+
+def _uuid(value: object, field: str) -> str:
+    if type(value) is not str or _UUID.fullmatch(value) is None:
+        raise AgendaContractError(f"{field} must be a canonical UUID")
+    try:
+        if str(uuid.UUID(value)) != value:
+            raise ValueError
+    except ValueError as exc:
+        raise AgendaContractError(f"{field} must be a canonical UUID") from exc
+    return value
+
+
+def _digest(value: object, field: str) -> str:
+    try:
+        return validate_sha256_digest(value, field=field)
+    except (CanonicalizationError, TypeError, ValueError) as exc:
+        raise AgendaContractError(
+            f"{field} must be a canonical SHA-256 digest"
+        ) from exc
+
+
+def _timestamp(value: object, field: str) -> str:
+    value = _text(value, field, maximum=27)
+    if _UTC.fullmatch(value) is None:
+        raise AgendaContractError(f"{field} must be an exact UTC timestamp")
+    try:
+        datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ")
+    except ValueError as exc:
+        raise AgendaContractError(f"{field} must be an exact UTC timestamp") from exc
+    return value
+
+
+def _strings(value: object, field: str, maximum: int) -> tuple[str, ...]:
+    if type(value) is not list or len(value) > maximum:
+        raise AgendaContractError(f"{field} must be a bounded array")
+    result = tuple(_text(item, field) for item in value)
+    if tuple(sorted(set(result))) != result:
+        raise AgendaContractError(f"{field} must be unique and sorted")
+    return result
+
+
+def _load(raw: bytes, schema: str, fields: tuple[str, ...]) -> dict[str, object]:
+    if type(raw) is not bytes or not raw or len(raw) > MAX_AGENDA_CANONICAL_BYTES:
+        raise AgendaContractError("Agenda bytes are not bounded")
+    try:
+        value = json.loads(raw.decode("utf-8"), object_pairs_hook=_pairs)
+        canonical = canonical_json_bytes(value)
+    except AgendaContractError:
+        raise
+    except (UnicodeError, json.JSONDecodeError, CanonicalizationError) as exc:
+        raise AgendaContractError("Agenda bytes are not canonical JSON") from exc
+    if raw != canonical:
+        raise AgendaContractError("Agenda bytes are not exact canonical JSON")
+    record = _exact_dict(value, fields, "Agenda record")
+    if record["schema_version"] != schema:
+        raise AgendaContractError("Agenda schema version differs")
+    return record
+
+
+def _pairs(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for name, value in pairs:
+        if name in result:
+            raise AgendaContractError(f"duplicate object name: {name}")
+        result[name] = value
+    return result
+
+
+@dataclass(frozen=True, slots=True)
+class AgendaPathReference(_NoEffect):
+    kind: AgendaPathKind
+    source_definition_version_id: str
+    path_policy_version: str
+    rights_reference: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "kind",
+            _enum(AgendaPathKind, self.kind, "kind"),
+        )
+        _uuid(self.source_definition_version_id, "source_definition_version_id")
+        _token(self.path_policy_version, "path_policy_version")
+        _token(self.rights_reference, "rights_reference")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "kind": self.kind.value,
+            "source_definition_version_id": self.source_definition_version_id,
+            "path_policy_version": self.path_policy_version,
+            "rights_reference": self.rights_reference,
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> Self:
+        fields = (
+            "kind",
+            "source_definition_version_id",
+            "path_policy_version",
+            "rights_reference",
+        )
+        raw = _exact_dict(value, fields, "Agenda path")
+        return cls(**raw)  # type: ignore[arg-type]
+
+
+_ITEM_FIELDS = (
+    "schema_version",
+    "agenda_item_id",
+    "agenda_kind",
+    "stable_subject_key",
+    "created_from_source_revision_id",
+    "created_at",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PlannedAgendaItem(_NoEffect):
+    agenda_item_id: str
+    agenda_kind: AgendaKind
+    stable_subject_key: str
+    created_from_source_revision_id: str
+    created_at: str
+    schema_version: str = PLANNED_AGENDA_ITEM
+
+    def __post_init__(self) -> None:
+        if self.schema_version != PLANNED_AGENDA_ITEM:
+            raise AgendaContractError("Agenda Item schema version differs")
+        _uuid(self.agenda_item_id, "agenda_item_id")
+        object.__setattr__(
+            self,
+            "agenda_kind",
+            _enum(AgendaKind, self.agenda_kind, "agenda_kind"),
+        )
+        _token(self.stable_subject_key, "stable_subject_key")
+        _uuid(self.created_from_source_revision_id, "created_from_source_revision_id")
+        _timestamp(self.created_at, "created_at")
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return canonical_json_bytes(
+            {
+                name: getattr(self, name).value
+                if isinstance(getattr(self, name), StrEnum)
+                else getattr(self, name)
+                for name in _ITEM_FIELDS
+            }
+        )
+
+    @property
+    def digest(self) -> str:
+        return digest_bytes(self.canonical_bytes)
+
+    @classmethod
+    def from_canonical_bytes(cls, raw: bytes) -> Self:
+        return cls(**_load(raw, PLANNED_AGENDA_ITEM, _ITEM_FIELDS))  # type: ignore[arg-type]
+
+
+_VERSION_FIELDS = (
+    "schema_version",
+    "agenda_version_id",
+    "agenda_item_id",
+    "version_ordinal",
+    "predecessor_version_digest",
+    "source_revision_id",
+    "coverage_basis",
+    "expected_subject",
+    "time_precision",
+    "asserted_start",
+    "asserted_end",
+    "time_zone",
+    "schedule_status",
+    "expectation_path",
+    "occurrence_confirmation_paths",
+    "geography",
+    "urgency",
+    "relationship_references",
+    "uncertainties",
+    "recorded_at",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PlannedAgendaVersion(_NoEffect):
+    agenda_version_id: str
+    agenda_item_id: str
+    version_ordinal: int
+    predecessor_version_digest: str | None
+    source_revision_id: str
+    coverage_basis: CoverageBasis
+    expected_subject: str
+    time_precision: AgendaTimePrecision
+    asserted_start: str | None
+    asserted_end: str | None
+    time_zone: str | None
+    schedule_status: AgendaScheduleStatus
+    expectation_path: AgendaPathReference
+    occurrence_confirmation_paths: tuple[AgendaPathReference, ...]
+    geography: str | None
+    urgency: AgendaUrgency
+    relationship_references: tuple[str, ...]
+    uncertainties: tuple[str, ...]
+    recorded_at: str
+    schema_version: str = PLANNED_AGENDA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.schema_version != PLANNED_AGENDA_VERSION:
+            raise AgendaContractError("Agenda Version schema version differs")
+        _uuid(self.agenda_version_id, "agenda_version_id")
+        _uuid(self.agenda_item_id, "agenda_item_id")
+        if (
+            type(self.version_ordinal) is not int
+            or not 1 <= self.version_ordinal <= 1_000_000
+        ):
+            raise AgendaContractError(
+                "version_ordinal must be a bounded positive integer"
+            )
+        if self.version_ordinal == 1:
+            if self.predecessor_version_digest is not None:
+                raise AgendaContractError(
+                    "first Agenda Version cannot have a predecessor"
+                )
+        elif self.predecessor_version_digest is None:
+            raise AgendaContractError(
+                "successor Agenda Version requires predecessor digest"
+            )
+        else:
+            _digest(self.predecessor_version_digest, "predecessor_version_digest")
+        _uuid(self.source_revision_id, "source_revision_id")
+        object.__setattr__(
+            self,
+            "coverage_basis",
+            _enum(CoverageBasis, self.coverage_basis, "coverage_basis"),
+        )
+        _text(self.expected_subject, "expected_subject")
+        object.__setattr__(
+            self,
+            "time_precision",
+            _enum(AgendaTimePrecision, self.time_precision, "time_precision"),
+        )
+        object.__setattr__(
+            self,
+            "schedule_status",
+            _enum(AgendaScheduleStatus, self.schedule_status, "schedule_status"),
+        )
+        object.__setattr__(
+            self,
+            "urgency",
+            _enum(AgendaUrgency, self.urgency, "urgency"),
+        )
+        self._validate_time()
+        if (
+            type(self.expectation_path) is not AgendaPathReference
+            or self.expectation_path.kind is not AgendaPathKind.EXPECTATION
+        ):
+            raise AgendaContractError("expectation_path must be an expectation path")
+        paths = tuple(self.occurrence_confirmation_paths)
+        if (
+            not paths
+            or len(paths) > MAX_PATHS
+            or any(
+                type(path) is not AgendaPathReference
+                or path.kind is not AgendaPathKind.OCCURRENCE_CONFIRMATION
+                for path in paths
+            )
+        ):
+            raise AgendaContractError(
+                "occurrence_confirmation_paths must be bounded confirmation paths"
+            )
+        if tuple(
+            sorted({canonical_json_bytes(path.to_dict()) for path in paths})
+        ) != tuple(canonical_json_bytes(path.to_dict()) for path in paths):
+            raise AgendaContractError(
+                "occurrence_confirmation_paths must be unique and sorted"
+            )
+        object.__setattr__(self, "occurrence_confirmation_paths", paths)
+        if self.geography is not None:
+            _text(self.geography, "geography")
+        for field, values, maximum in (
+            ("relationship_references", self.relationship_references, MAX_REFERENCES),
+            ("uncertainties", self.uncertainties, MAX_UNCERTAINTIES),
+        ):
+            normal = tuple(values)
+            if len(normal) > maximum or tuple(sorted(set(normal))) != normal:
+                raise AgendaContractError(f"{field} must be unique, sorted and bounded")
+            for value in normal:
+                (_digest if field == "relationship_references" else _text)(value, field)
+            object.__setattr__(self, field, normal)
+        _timestamp(self.recorded_at, "recorded_at")
+
+    def _validate_time(self) -> None:
+        start, end, zone, precision = (
+            self.asserted_start,
+            self.asserted_end,
+            self.time_zone,
+            self.time_precision,
+        )
+        if zone is not None:
+            _text(zone, "time_zone", maximum=128)
+        if precision in {
+            AgendaTimePrecision.EXACT_INSTANT,
+            AgendaTimePrecision.EXACT_WINDOW,
+        }:
+            if start is None or zone is None:
+                raise AgendaContractError(
+                    "exact time requires UTC start and explicit time zone"
+                )
+            _timestamp(start, "asserted_start")
+            if precision is AgendaTimePrecision.EXACT_INSTANT and end is not None:
+                raise AgendaContractError("exact instant cannot have an end")
+            if precision is AgendaTimePrecision.EXACT_WINDOW:
+                if end is None:
+                    raise AgendaContractError(
+                        "exact window requires an ordered UTC end"
+                    )
+                _timestamp(end, "asserted_end")
+                if end <= start:
+                    raise AgendaContractError(
+                        "exact window requires an ordered UTC end"
+                    )
+        elif precision is AgendaTimePrecision.DATE_ONLY:
+            if start is None or _DATE.fullmatch(start) is None or end is not None:
+                raise AgendaContractError("date-only schedule must remain date-only")
+            try:
+                datetime.strptime(start, "%Y-%m-%d")
+            except ValueError as exc:
+                raise AgendaContractError(
+                    "date-only schedule must remain date-only"
+                ) from exc
+        elif precision is AgendaTimePrecision.TIME_ZONE_AMBIGUOUS:
+            if start is None or zone is not None:
+                raise AgendaContractError(
+                    "time-zone-ambiguous schedule cannot invent a zone"
+                )
+            _text(start, "asserted_start", maximum=128)
+            if end is not None:
+                _text(end, "asserted_end", maximum=128)
+        elif precision is AgendaTimePrecision.APPROXIMATE:
+            if start is None:
+                raise AgendaContractError(
+                    "approximate schedule requires its asserted text"
+                )
+            _text(start, "asserted_start", maximum=128)
+            if end is not None:
+                _text(end, "asserted_end", maximum=128)
+        elif any(value is not None for value in (start, end, zone)):
+            raise AgendaContractError(
+                "unknown schedule cannot contain invented time fields"
+            )
+        if (
+            self.schedule_status
+            in {
+                AgendaScheduleStatus.CANCELLED,
+                AgendaScheduleStatus.WITHDRAWN,
+                AgendaScheduleStatus.POSTPONED_WITHOUT_DATE,
+            }
+            and not self.uncertainties
+        ):
+            raise AgendaContractError(
+                "non-active status requires attributed source uncertainty"
+            )
+
+    def _dict(self) -> dict[str, object]:
+        result: dict[str, object] = {}
+        for name in _VERSION_FIELDS:
+            value = getattr(self, name)
+            if isinstance(value, StrEnum):
+                value = value.value
+            elif isinstance(value, AgendaPathReference):
+                value = value.to_dict()
+            elif name == "occurrence_confirmation_paths":
+                value = [path.to_dict() for path in value]
+            elif isinstance(value, tuple):
+                value = list(value)
+            result[name] = value
+        return result
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return canonical_json_bytes(self._dict())
+
+    @property
+    def digest(self) -> str:
+        return digest_bytes(self.canonical_bytes)
+
+    @classmethod
+    def from_canonical_bytes(cls, raw: bytes) -> Self:
+        value = _load(raw, PLANNED_AGENDA_VERSION, _VERSION_FIELDS)
+        value["expectation_path"] = AgendaPathReference.from_dict(
+            value["expectation_path"]
+        )
+        paths = value["occurrence_confirmation_paths"]
+        if type(paths) is not list:
+            raise AgendaContractError("occurrence_confirmation_paths must be an array")
+        value["occurrence_confirmation_paths"] = tuple(
+            AgendaPathReference.from_dict(path) for path in paths
+        )
+        for field in ("relationship_references", "uncertainties"):
+            raw_values = value[field]
+            if type(raw_values) is not list:
+                raise AgendaContractError(f"{field} must be an array")
+            value[field] = tuple(raw_values)
+        return cls(**value)  # type: ignore[arg-type]
+
+
+def validate_agenda_successor(
+    prior: PlannedAgendaVersion, successor: PlannedAgendaVersion
+) -> None:
+    """Validate immutable adjacency without allocating or retaining a Version."""
+    if (
+        type(prior) is not PlannedAgendaVersion
+        or type(successor) is not PlannedAgendaVersion
+    ):
+        raise AgendaContractError(
+            "Agenda successor values must be exact typed Versions"
+        )
+    if (
+        successor.agenda_item_id != prior.agenda_item_id
+        or successor.version_ordinal != prior.version_ordinal + 1
+        or successor.predecessor_version_digest != prior.digest
+    ):
+        raise AgendaContractError(
+            "Agenda successor does not extend the exact prior Version"
+        )
+    if successor.canonical_bytes == prior.canonical_bytes:
+        raise AgendaContractError(
+            "Agenda successor must record a substantive source assertion"
+        )
+
+
+__all__ = [
+    "AGENDA_RESOLUTION_VOCABULARY",
+    "AGENDA_TIME_PRECISION",
+    "MAX_AGENDA_CANONICAL_BYTES",
+    "NO_CLOCK_GENERATED_EDITORIAL_RECORD",
+    "PLANNED_AGENDA_ITEM",
+    "PLANNED_AGENDA_VERSION",
+    "AgendaContractError",
+    "AgendaKind",
+    "AgendaPathKind",
+    "AgendaPathReference",
+    "AgendaResolutionKind",
+    "AgendaScheduleStatus",
+    "AgendaTimePrecision",
+    "AgendaUrgency",
+    "CoverageBasis",
+    "PlannedAgendaItem",
+    "PlannedAgendaVersion",
+    "validate_agenda_successor",
+]

--- a/newsroom/increment7/agenda.py
+++ b/newsroom/increment7/agenda.py
@@ -599,7 +599,8 @@ def validate_agenda_successor(
             "Agenda successor values must be exact typed Versions"
         )
     if (
-        successor.agenda_item_id != prior.agenda_item_id
+        successor.agenda_version_id == prior.agenda_version_id
+        or successor.agenda_item_id != prior.agenda_item_id
         or successor.version_ordinal != prior.version_ordinal + 1
         or successor.predecessor_version_digest != prior.digest
     ):

--- a/newsroom/increment7/agenda.py
+++ b/newsroom/increment7/agenda.py
@@ -539,6 +539,19 @@ class PlannedAgendaVersion(_NoEffect):
             result[name] = value
         return result
 
+    def _assertion_dict(self) -> dict[str, object]:
+        lineage_fields = {
+            "agenda_version_id",
+            "version_ordinal",
+            "predecessor_version_digest",
+            "recorded_at",
+        }
+        return {
+            name: value
+            for name, value in self._dict().items()
+            if name not in lineage_fields
+        }
+
     @property
     def canonical_bytes(self) -> bytes:
         return canonical_json_bytes(self._dict())
@@ -586,7 +599,7 @@ def validate_agenda_successor(
         raise AgendaContractError(
             "Agenda successor does not extend the exact prior Version"
         )
-    if successor.canonical_bytes == prior.canonical_bytes:
+    if successor._assertion_dict() == prior._assertion_dict():
         raise AgendaContractError(
             "Agenda successor must record a substantive source assertion"
         )

--- a/newsroom/increment7/agenda.py
+++ b/newsroom/increment7/agenda.py
@@ -143,6 +143,7 @@ def _text(value: object, field: str, *, maximum: int = MAX_TEXT_BYTES) -> str:
         or not value
         or value != value.strip()
         or encoded_size > maximum
+        or any(ord(character) < 32 or ord(character) == 127 for character in value)
     ):
         raise AgendaContractError(f"{field} must be bounded canonical text")
     return value
@@ -212,7 +213,12 @@ def _load(raw: bytes, schema: str, fields: tuple[str, ...]) -> dict[str, object]
         canonical = canonical_json_bytes(value)
     except AgendaContractError:
         raise
-    except (UnicodeError, json.JSONDecodeError, CanonicalizationError) as exc:
+    except (
+        UnicodeError,
+        json.JSONDecodeError,
+        CanonicalizationError,
+        RecursionError,
+    ) as exc:
         raise AgendaContractError("Agenda bytes are not canonical JSON") from exc
     if raw != canonical:
         raise AgendaContractError("Agenda bytes are not exact canonical JSON")

--- a/newsroom/increment7/agenda.py
+++ b/newsroom/increment7/agenda.py
@@ -218,6 +218,7 @@ def _load(raw: bytes, schema: str, fields: tuple[str, ...]) -> dict[str, object]
         json.JSONDecodeError,
         CanonicalizationError,
         RecursionError,
+        ValueError,
     ) as exc:
         raise AgendaContractError("Agenda bytes are not canonical JSON") from exc
     if raw != canonical:

--- a/newsroom/tests/test_increment7a1_agenda_authority_precision_lifecycle.py
+++ b/newsroom/tests/test_increment7a1_agenda_authority_precision_lifecycle.py
@@ -184,6 +184,15 @@ def test_reschedule_is_an_exact_successor_and_preserves_prior_bytes() -> None:
     assert prior.canonical_bytes == prior_bytes
     assert successor.predecessor_version_digest == prior.digest
 
+    bookkeeping_only = _version(
+        agenda_version_id=_id(22),
+        version_ordinal=2,
+        predecessor_version_digest=prior.digest,
+        recorded_at="2026-08-15T00:00:00.000000Z",
+    )
+    with pytest.raises(AgendaContractError, match="substantive source assertion"):
+        validate_agenda_successor(prior, bookkeeping_only)
+
 
 def test_successor_rejects_cross_item_gap_and_wrong_predecessor() -> None:
     prior = _version()

--- a/newsroom/tests/test_increment7a1_agenda_authority_precision_lifecycle.py
+++ b/newsroom/tests/test_increment7a1_agenda_authority_precision_lifecycle.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+
+from newsroom.authority.canonical import canonical_json_bytes
+from newsroom.increment7.agenda import (
+    NO_CLOCK_GENERATED_EDITORIAL_RECORD,
+    AgendaContractError,
+    AgendaKind,
+    AgendaPathKind,
+    AgendaPathReference,
+    AgendaResolutionKind,
+    AgendaScheduleStatus,
+    AgendaTimePrecision,
+    AgendaUrgency,
+    CoverageBasis,
+    PlannedAgendaItem,
+    PlannedAgendaVersion,
+    validate_agenda_successor,
+)
+
+
+def _id(value: int) -> str:
+    return str(uuid.UUID(int=value, version=4))
+
+
+def _path(kind: AgendaPathKind, value: int) -> AgendaPathReference:
+    return AgendaPathReference(
+        kind=kind,
+        source_definition_version_id=_id(value),
+        path_policy_version="agenda-path-v1",
+        rights_reference="rights-fixture-v1",
+    )
+
+
+def _version(**changes: object) -> PlannedAgendaVersion:
+    values: dict[str, object] = {
+        "agenda_version_id": _id(11),
+        "agenda_item_id": _id(10),
+        "version_ordinal": 1,
+        "predecessor_version_digest": None,
+        "source_revision_id": _id(12),
+        "coverage_basis": CoverageBasis.PLANNED_AGENDA,
+        "expected_subject": "Monetary Policy Committee decision",
+        "time_precision": AgendaTimePrecision.EXACT_WINDOW,
+        "asserted_start": "2026-09-01T11:00:00.000000Z",
+        "asserted_end": "2026-09-01T12:00:00.000000Z",
+        "time_zone": "Europe/London",
+        "schedule_status": AgendaScheduleStatus.CONFIRMED,
+        "expectation_path": _path(AgendaPathKind.EXPECTATION, 13),
+        "occurrence_confirmation_paths": (
+            _path(AgendaPathKind.OCCURRENCE_CONFIRMATION, 14),
+            _path(AgendaPathKind.OCCURRENCE_CONFIRMATION, 15),
+        ),
+        "geography": "United Kingdom",
+        "urgency": AgendaUrgency.TIME_SENSITIVE,
+        "relationship_references": (),
+        "uncertainties": (),
+        "recorded_at": "2026-08-14T00:00:00.000000Z",
+    }
+    values.update(changes)
+    return PlannedAgendaVersion(**values)  # type: ignore[arg-type]
+
+
+def test_item_and_version_are_canonical_stable_and_round_trip() -> None:
+    item = PlannedAgendaItem(
+        agenda_item_id=_id(10),
+        agenda_kind=AgendaKind.RELEASE,
+        stable_subject_key="uk.mpc.decision.2026-09",
+        created_from_source_revision_id=_id(12),
+        created_at="2026-08-14T00:00:00.000000Z",
+    )
+    version = _version()
+
+    assert PlannedAgendaItem.from_canonical_bytes(item.canonical_bytes) == item
+    assert PlannedAgendaVersion.from_canonical_bytes(version.canonical_bytes) == version
+    assert item.digest.startswith("sha256:")
+    assert version.digest.startswith("sha256:")
+    assert version.canonical_bytes == canonical_json_bytes(
+        json.loads(version.canonical_bytes)
+    )
+
+
+@pytest.mark.parametrize(
+    ("precision", "start", "end", "zone"),
+    [
+        (
+            AgendaTimePrecision.EXACT_INSTANT,
+            "2026-09-01T11:00:00.000000Z",
+            None,
+            "Europe/London",
+        ),
+        (AgendaTimePrecision.DATE_ONLY, "2026-09-01", None, "Europe/London"),
+        (AgendaTimePrecision.APPROXIMATE, "early September 2026", None, None),
+        (AgendaTimePrecision.TIME_ZONE_AMBIGUOUS, "2026-09-01 11:00", None, None),
+        (AgendaTimePrecision.UNKNOWN, None, None, None),
+    ],
+)
+def test_time_precision_preserves_the_exact_asserted_uncertainty(
+    precision: AgendaTimePrecision,
+    start: str | None,
+    end: str | None,
+    zone: str | None,
+) -> None:
+    value = _version(
+        time_precision=precision,
+        asserted_start=start,
+        asserted_end=end,
+        time_zone=zone,
+    )
+    assert value.time_precision is precision
+    assert value.asserted_start == start
+    assert value.time_zone == zone
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {
+            "time_precision": AgendaTimePrecision.EXACT_INSTANT,
+            "asserted_end": "2026-09-01T12:00:00.000000Z",
+        },
+        {
+            "time_precision": AgendaTimePrecision.EXACT_WINDOW,
+            "asserted_end": "2026-09-01T10:00:00.000000Z",
+        },
+        {
+            "time_precision": AgendaTimePrecision.DATE_ONLY,
+            "asserted_start": "2026-09-01T11:00:00.000000Z",
+            "asserted_end": None,
+        },
+        {
+            "time_precision": AgendaTimePrecision.TIME_ZONE_AMBIGUOUS,
+            "time_zone": "Europe/London",
+            "asserted_end": None,
+        },
+        {
+            "time_precision": AgendaTimePrecision.UNKNOWN,
+            "asserted_start": "soon",
+            "asserted_end": None,
+            "time_zone": None,
+        },
+    ],
+)
+def test_time_precision_cannot_be_silently_widened(changes: dict[str, object]) -> None:
+    with pytest.raises(AgendaContractError):
+        _version(**changes)
+
+
+def test_active_version_has_dual_distinct_paths_and_no_editorial_effect() -> None:
+    version = _version()
+    assert version.expectation_path.kind is AgendaPathKind.EXPECTATION
+    assert all(
+        path.kind is AgendaPathKind.OCCURRENCE_CONFIRMATION
+        for path in version.occurrence_confirmation_paths
+    )
+    assert NO_CLOCK_GENERATED_EDITORIAL_RECORD.endswith(
+        "NO_SIGNAL_LEAD_CANDIDATE_OR_EVIDENCE"
+    )
+    for value in (version, version.expectation_path):
+        assert value.creates_signal is False
+        assert value.creates_lead is False
+        assert value.creates_candidate is False
+        assert value.authorises_evidence is False
+        assert value.authorises_schedule is False
+        assert value.authorises_external_effect is False
+
+
+def test_reschedule_is_an_exact_successor_and_preserves_prior_bytes() -> None:
+    prior = _version()
+    prior_bytes = prior.canonical_bytes
+    successor = _version(
+        agenda_version_id=_id(21),
+        version_ordinal=2,
+        predecessor_version_digest=prior.digest,
+        asserted_start="2026-09-02T11:00:00.000000Z",
+        asserted_end="2026-09-02T12:00:00.000000Z",
+        recorded_at="2026-08-15T00:00:00.000000Z",
+    )
+    validate_agenda_successor(prior, successor)
+    assert prior.canonical_bytes == prior_bytes
+    assert successor.predecessor_version_digest == prior.digest
+
+
+def test_successor_rejects_cross_item_gap_and_wrong_predecessor() -> None:
+    prior = _version()
+    for changes in (
+        {"agenda_item_id": _id(99)},
+        {"version_ordinal": 3},
+        {"predecessor_version_digest": "sha256:" + "0" * 64},
+    ):
+        values: dict[str, object] = {
+            "agenda_version_id": _id(21),
+            "version_ordinal": 2,
+            "predecessor_version_digest": prior.digest,
+        }
+        values.update(changes)
+        successor = _version(**values)
+        with pytest.raises(AgendaContractError, match="exact prior"):
+            validate_agenda_successor(prior, successor)
+
+
+def test_cancellation_postponement_and_withdrawal_require_source_uncertainty() -> None:
+    for status in (
+        AgendaScheduleStatus.CANCELLED,
+        AgendaScheduleStatus.POSTPONED_WITHOUT_DATE,
+        AgendaScheduleStatus.WITHDRAWN,
+    ):
+        with pytest.raises(AgendaContractError, match="source uncertainty"):
+            _version(schedule_status=status)
+        value = _version(
+            schedule_status=status,
+            uncertainties=("source-revision-asserted-status",),
+        )
+        assert value.schedule_status is status
+
+
+def test_resolution_vocabulary_keeps_miss_failure_and_late_occurrence_distinct() -> (
+    None
+):
+    assert {
+        AgendaResolutionKind.MISSED_NOT_OBSERVED,
+        AgendaResolutionKind.LATE_OCCURRENCE,
+        AgendaResolutionKind.CHECK_FAILED,
+        AgendaResolutionKind.CHECK_PARTIAL,
+        AgendaResolutionKind.CHECK_UNAVAILABLE,
+        AgendaResolutionKind.CANCELLED_WITH_SOURCE_EVIDENCE,
+    } <= set(AgendaResolutionKind)
+    assert (
+        AgendaResolutionKind.MISSED_NOT_OBSERVED.value
+        != AgendaResolutionKind.CANCELLED_WITH_SOURCE_EVIDENCE.value
+    )
+
+
+def test_parser_rejects_noncanonical_duplicate_unknown_and_oversized_values() -> None:
+    version = _version()
+    pretty = json.dumps(json.loads(version.canonical_bytes), indent=2).encode()
+    with pytest.raises(AgendaContractError, match="exact canonical JSON"):
+        PlannedAgendaVersion.from_canonical_bytes(pretty)
+    duplicate = (
+        version.canonical_bytes.decode()
+        .replace(
+            '"agenda_item_id":',
+            '"agenda_item_id":"' + _id(99) + '","agenda_item_id":',
+            1,
+        )
+        .encode()
+    )
+    with pytest.raises(AgendaContractError, match="duplicate object name"):
+        PlannedAgendaVersion.from_canonical_bytes(duplicate)
+    unknown = json.loads(version.canonical_bytes)
+    unknown["creates_candidate"] = False
+    with pytest.raises(AgendaContractError, match="fields are not exact"):
+        PlannedAgendaVersion.from_canonical_bytes(canonical_json_bytes(unknown))
+    with pytest.raises(AgendaContractError, match="bounded canonical text"):
+        _version(expected_subject="x" * 2049)
+    with pytest.raises(AgendaContractError, match="closed vocabulary"):
+        _version(time_precision="WIDENED")
+    with pytest.raises(AgendaContractError, match="date-only"):
+        _version(
+            time_precision=AgendaTimePrecision.DATE_ONLY,
+            asserted_start="2026-02-30",
+            asserted_end=None,
+        )
+    with pytest.raises(AgendaContractError, match="exact UTC timestamp"):
+        _version(asserted_start="2026-02-30T11:00:00.000000Z")
+    with pytest.raises(AgendaContractError, match="expectation path"):
+        _version(expectation_path=object())
+
+
+def test_occurrence_paths_are_nonempty_unique_sorted_and_do_not_create_occurrence() -> (
+    None
+):
+    with pytest.raises(AgendaContractError, match="bounded confirmation paths"):
+        _version(occurrence_confirmation_paths=())
+    path = _path(AgendaPathKind.OCCURRENCE_CONFIRMATION, 14)
+    with pytest.raises(AgendaContractError, match="unique and sorted"):
+        _version(occurrence_confirmation_paths=(path, path))
+    version = _version()
+    assert version.creates_occurrence is False

--- a/newsroom/tests/test_increment7a1_agenda_authority_precision_lifecycle.py
+++ b/newsroom/tests/test_increment7a1_agenda_authority_precision_lifecycle.py
@@ -197,6 +197,7 @@ def test_reschedule_is_an_exact_successor_and_preserves_prior_bytes() -> None:
 def test_successor_rejects_cross_item_gap_and_wrong_predecessor() -> None:
     prior = _version()
     for changes in (
+        {"agenda_version_id": prior.agenda_version_id},
         {"agenda_item_id": _id(99)},
         {"version_ordinal": 3},
         {"predecessor_version_digest": "sha256:" + "0" * 64},

--- a/newsroom/tests/test_increment7a1_agenda_authority_precision_lifecycle.py
+++ b/newsroom/tests/test_increment7a1_agenda_authority_precision_lifecycle.py
@@ -267,6 +267,8 @@ def test_parser_rejects_noncanonical_duplicate_unknown_and_oversized_values() ->
         PlannedAgendaVersion.from_canonical_bytes(canonical_json_bytes(unknown))
     with pytest.raises(AgendaContractError, match="bounded canonical text"):
         _version(expected_subject="x" * 2049)
+    with pytest.raises(AgendaContractError, match="bounded canonical text"):
+        _version(expected_subject="embedded\ncontrol")
     with pytest.raises(AgendaContractError, match="closed vocabulary"):
         _version(time_precision="WIDENED")
     with pytest.raises(AgendaContractError, match="date-only"):

--- a/newsroom/tests/test_increment7a1_agenda_authority_precision_lifecycle.py
+++ b/newsroom/tests/test_increment7a1_agenda_authority_precision_lifecycle.py
@@ -276,6 +276,18 @@ def test_parser_rejects_noncanonical_duplicate_unknown_and_oversized_values() ->
         )
     with pytest.raises(AgendaContractError, match="exact UTC timestamp"):
         _version(asserted_start="2026-02-30T11:00:00.000000Z")
+    malformed_references = json.loads(version.canonical_bytes)
+    malformed_references["relationship_references"] = [{}]
+    with pytest.raises(AgendaContractError, match="canonical SHA-256 digest"):
+        PlannedAgendaVersion.from_canonical_bytes(
+            canonical_json_bytes(malformed_references)
+        )
+    with pytest.raises(AgendaContractError, match="bounded canonical text"):
+        _version(
+            time_precision=AgendaTimePrecision.DATE_ONLY,
+            asserted_start=7,
+            asserted_end=None,
+        )
     with pytest.raises(AgendaContractError, match="expectation path"):
         _version(expectation_path=object())
 

--- a/newsroom/tests/test_increment7a1_agenda_authority_precision_lifecycle.py
+++ b/newsroom/tests/test_increment7a1_agenda_authority_precision_lifecycle.py
@@ -261,6 +261,11 @@ def test_parser_rejects_noncanonical_duplicate_unknown_and_oversized_values() ->
     )
     with pytest.raises(AgendaContractError, match="duplicate object name"):
         PlannedAgendaVersion.from_canonical_bytes(duplicate)
+    oversized_integer = version.canonical_bytes.replace(
+        b'"version_ordinal":1', b'"version_ordinal":' + b"9" * 5_000
+    )
+    with pytest.raises(AgendaContractError, match="canonical JSON"):
+        PlannedAgendaVersion.from_canonical_bytes(oversized_integer)
     unknown = json.loads(version.canonical_bytes)
     unknown["creates_candidate"] = False
     with pytest.raises(AgendaContractError, match="fields are not exact"):


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-7a1-agenda-contracts
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

## Summary
- define immutable Planned Agenda Item and Version contracts with exact canonical serialisation
- preserve asserted time precision, time-zone ambiguity, expectation and occurrence-confirmation paths
- define explicit miss, late, cancellation and check-resolution vocabulary without granting editorial authority
- reject duplicate, unknown, non-canonical and oversized input while keeping construction effect-free

## Non-effects
No persistence, clock runner, source access, Signal, Lead, Candidate, evidence, publication, provider or external effect.

## Evidence
- `uvx ruff@0.12.0 check newsroom/increment7/agenda.py newsroom/tests/test_increment7a1_agenda_authority_precision_lifecycle.py`
- `uv run pytest -q newsroom/tests/test_increment7a1_agenda_authority_precision_lifecycle.py newsroom/tests/test_increment7_head_migration_ownership.py newsroom/tests/test_increment6g_final_closeout.py` — 34 passed
- `git diff --check`

Closes #436
