### PR TITLE
Increment 7A2: enforce Agenda resolution chronology

### DIFF
--- a/newsroom/increment7/agenda_authority.py
+++ b/newsroom/increment7/agenda_authority.py
@@ -493,7 +493,8 @@ class PlannedAgendaReadPort(_NoEffect):
         _uuid(agenda_item_id, "agenda_item_id")
         rows = self._connection.execute(
             "SELECT version_bytes,version_digest,recorded_at,agenda_version_id,"
-            "agenda_item_id,version_ordinal,predecessor_version_digest "
+            "agenda_item_id,version_ordinal,predecessor_version_digest,"
+            "source_revision_id,schedule_status "
             "FROM planned_agenda_versions "
             "WHERE agenda_item_id=? ORDER BY version_ordinal",
             (agenda_item_id,),
@@ -510,6 +511,8 @@ class PlannedAgendaReadPort(_NoEffect):
                 or version.agenda_item_id != stored[4]
                 or version.version_ordinal != stored[5]
                 or version.predecessor_version_digest != stored[6]
+                or version.source_revision_id != stored[7]
+                or version.schedule_status.value != stored[8]
             ):
                 raise AgendaAuthorityError("Planned Agenda Version replay differs")
             if ordinal > 1:
@@ -521,7 +524,9 @@ class PlannedAgendaReadPort(_NoEffect):
         _uuid(agenda_item_id, "agenda_item_id")
         rows = self._connection.execute(
             "SELECT r.resolution_bytes,r.resolution_digest,r.agenda_version_id,"
-            "r.agenda_version_digest,v.version_bytes,v.version_digest,v.recorded_at "
+            "r.agenda_version_digest,v.version_bytes,v.version_digest,v.recorded_at,"
+            "r.resolution_kind,r.evidence_digest,r.confirmation_path_digest,"
+            "r.baseline_evidence_digest,r.successor_version_digest,r.observed_at "
             "FROM planned_agenda_resolutions r JOIN planned_agenda_versions v "
             "ON v.agenda_version_id=r.agenda_version_id "
             "AND v.agenda_item_id=r.agenda_item_id "
@@ -547,6 +552,12 @@ class PlannedAgendaReadPort(_NoEffect):
                 or bound_version.digest != stored[5]
                 or bound_version.recorded_at != stored[6]
                 or resolution.observed_at < bound_version.recorded_at
+                or resolution.kind.value != stored[7]
+                or resolution.evidence_digest != stored[8]
+                or resolution.confirmation_path_digest != stored[9]
+                or resolution.baseline_evidence_digest != stored[10]
+                or resolution.successor_version_digest != stored[11]
+                or resolution.observed_at != stored[12]
                 or resolution.previous_resolution_digest
                 != (None if previous is None else previous.digest)
                 or (
@@ -562,27 +573,33 @@ class PlannedAgendaReadPort(_NoEffect):
     def load(self, agenda_item_id: str) -> PlannedAgendaSnapshot:
         _uuid(agenda_item_id, "agenda_item_id")
         row = self._connection.execute(
-            "SELECT i.item_bytes,i.item_digest,h.current_version_id,"
+            "SELECT i.item_bytes,i.item_digest,i.agenda_kind,i.stable_subject_key,"
+            "i.initial_version_id,i.created_at,h.current_version_id,"
             "h.current_version_digest,"
             "h.current_version_ordinal,h.current_resolution_digest,"
-            "h.current_resolution_ordinal FROM planned_agenda_items i "
+            "h.current_resolution_ordinal,h.updated_at FROM planned_agenda_items i "
             "JOIN planned_agenda_heads h USING(agenda_item_id) WHERE i.agenda_item_id=?",
             (agenda_item_id,),
         ).fetchone()
         if row is None:
             raise AgendaAuthorityError("Planned Agenda Item is absent")
         item = PlannedAgendaItem.from_canonical_bytes(bytes(row[0]))
-        if item.digest != row[1]:
+        if (
+            item.digest != row[1]
+            or item.agenda_kind.value != row[2]
+            or item.stable_subject_key != row[3]
+            or item.created_at != row[5]
+        ):
             raise AgendaAuthorityError("Planned Agenda Item replay differs")
         versions = self.versions(agenda_item_id)
         if not versions:
             raise AgendaAuthorityError("Planned Agenda Version history is empty")
         current = versions[-1]
-        if (
+        if versions[0].agenda_version_id != row[4] or (
             current.agenda_version_id,
             current.digest,
             current.version_ordinal,
-        ) != tuple(row[2:5]):
+        ) != tuple(row[6:9]):
             raise AgendaAuthorityError("Planned Agenda head differs")
         resolutions = self.resolutions(agenda_item_id)
         previous = resolutions[-1] if resolutions else None
@@ -590,7 +607,9 @@ class PlannedAgendaReadPort(_NoEffect):
             None if previous is None else previous.digest,
             len(resolutions),
         )
-        if tuple(row[5:7]) != expected_resolution:
+        if tuple(row[9:11]) != expected_resolution or row[11] != (
+            current.recorded_at if previous is None else previous.observed_at
+        ):
             raise AgendaAuthorityError("Agenda Resolution head differs")
         return PlannedAgendaSnapshot(item, current, resolutions)
 

--- a/newsroom/increment7/agenda_authority.py
+++ b/newsroom/increment7/agenda_authority.py
@@ -527,7 +527,7 @@ class PlannedAgendaReadPort(_NoEffect):
             "r.agenda_version_digest,v.version_bytes,v.version_digest,v.recorded_at,"
             "r.resolution_kind,r.evidence_digest,r.confirmation_path_digest,"
             "r.baseline_evidence_digest,r.successor_version_digest,r.observed_at "
-            "FROM planned_agenda_resolutions r JOIN planned_agenda_versions v "
+            "FROM planned_agenda_resolutions r LEFT JOIN planned_agenda_versions v "
             "ON v.agenda_version_id=r.agenda_version_id "
             "AND v.agenda_item_id=r.agenda_item_id "
             "AND v.version_digest=r.agenda_version_digest "
@@ -539,6 +539,8 @@ class PlannedAgendaReadPort(_NoEffect):
         )
         previous: AgendaResolution | None = None
         for ordinal, (resolution, stored) in enumerate(zip(resolutions, rows), 1):
+            if stored[4] is None:
+                raise AgendaAuthorityError("Agenda Resolution replay differs")
             bound_version = PlannedAgendaVersion.from_canonical_bytes(bytes(stored[4]))
             if (
                 resolution.agenda_item_id != agenda_item_id

--- a/newsroom/increment7/agenda_authority.py
+++ b/newsroom/increment7/agenda_authority.py
@@ -510,8 +510,12 @@ class PlannedAgendaReadPort(_NoEffect):
     def resolutions(self, agenda_item_id: str) -> tuple[AgendaResolution, ...]:
         _uuid(agenda_item_id, "agenda_item_id")
         rows = self._connection.execute(
-            "SELECT resolution_bytes,resolution_digest FROM planned_agenda_resolutions "
-            "WHERE agenda_item_id=? ORDER BY resolution_ordinal",
+            "SELECT r.resolution_bytes,r.resolution_digest,v.recorded_at "
+            "FROM planned_agenda_resolutions r JOIN planned_agenda_versions v "
+            "ON v.agenda_version_id=r.agenda_version_id "
+            "AND v.agenda_item_id=r.agenda_item_id "
+            "AND v.version_digest=r.agenda_version_digest "
+            "WHERE r.agenda_item_id=? ORDER BY r.resolution_ordinal",
             (agenda_item_id,),
         ).fetchall()
         resolutions = tuple(
@@ -523,8 +527,13 @@ class PlannedAgendaReadPort(_NoEffect):
                 resolution.agenda_item_id != agenda_item_id
                 or resolution.resolution_ordinal != ordinal
                 or resolution.digest != stored[1]
+                or resolution.observed_at < stored[2]
                 or resolution.previous_resolution_digest
                 != (None if previous is None else previous.digest)
+                or (
+                    previous is not None
+                    and resolution.observed_at < previous.observed_at
+                )
             ):
                 raise AgendaAuthorityError("Agenda Resolution replay differs")
             previous = resolution

--- a/newsroom/increment7/agenda_authority.py
+++ b/newsroom/increment7/agenda_authority.py
@@ -492,7 +492,9 @@ class PlannedAgendaReadPort(_NoEffect):
     def versions(self, agenda_item_id: str) -> tuple[PlannedAgendaVersion, ...]:
         _uuid(agenda_item_id, "agenda_item_id")
         rows = self._connection.execute(
-            "SELECT version_bytes,version_digest FROM planned_agenda_versions "
+            "SELECT version_bytes,version_digest,recorded_at,agenda_version_id,"
+            "agenda_item_id,version_ordinal,predecessor_version_digest "
+            "FROM planned_agenda_versions "
             "WHERE agenda_item_id=? ORDER BY version_ordinal",
             (agenda_item_id,),
         ).fetchall()
@@ -500,7 +502,15 @@ class PlannedAgendaReadPort(_NoEffect):
             PlannedAgendaVersion.from_canonical_bytes(bytes(row[0])) for row in rows
         )
         for ordinal, (version, stored) in enumerate(zip(versions, rows), 1):
-            if version.version_ordinal != ordinal or version.digest != stored[1]:
+            if (
+                version.version_ordinal != ordinal
+                or version.digest != stored[1]
+                or version.recorded_at != stored[2]
+                or version.agenda_version_id != stored[3]
+                or version.agenda_item_id != stored[4]
+                or version.version_ordinal != stored[5]
+                or version.predecessor_version_digest != stored[6]
+            ):
                 raise AgendaAuthorityError("Planned Agenda Version replay differs")
             if ordinal > 1:
                 validate_agenda_successor(versions[ordinal - 2], version)
@@ -511,7 +521,7 @@ class PlannedAgendaReadPort(_NoEffect):
         _uuid(agenda_item_id, "agenda_item_id")
         rows = self._connection.execute(
             "SELECT r.resolution_bytes,r.resolution_digest,r.agenda_version_id,"
-            "r.agenda_version_digest,v.recorded_at "
+            "r.agenda_version_digest,v.version_bytes,v.version_digest,v.recorded_at "
             "FROM planned_agenda_resolutions r JOIN planned_agenda_versions v "
             "ON v.agenda_version_id=r.agenda_version_id "
             "AND v.agenda_item_id=r.agenda_item_id "
@@ -524,13 +534,19 @@ class PlannedAgendaReadPort(_NoEffect):
         )
         previous: AgendaResolution | None = None
         for ordinal, (resolution, stored) in enumerate(zip(resolutions, rows), 1):
+            bound_version = PlannedAgendaVersion.from_canonical_bytes(bytes(stored[4]))
             if (
                 resolution.agenda_item_id != agenda_item_id
                 or resolution.resolution_ordinal != ordinal
                 or resolution.digest != stored[1]
                 or resolution.agenda_version_id != stored[2]
                 or resolution.agenda_version_digest != stored[3]
-                or resolution.observed_at < stored[4]
+                or bound_version.agenda_version_id != resolution.agenda_version_id
+                or bound_version.agenda_item_id != resolution.agenda_item_id
+                or bound_version.digest != resolution.agenda_version_digest
+                or bound_version.digest != stored[5]
+                or bound_version.recorded_at != stored[6]
+                or resolution.observed_at < bound_version.recorded_at
                 or resolution.previous_resolution_digest
                 != (None if previous is None else previous.digest)
                 or (

--- a/newsroom/increment7/agenda_authority.py
+++ b/newsroom/increment7/agenda_authority.py
@@ -31,6 +31,7 @@ from newsroom.authority.migrations import (
 from newsroom.increment7.agenda import (
     AgendaResolutionKind,
     AgendaScheduleStatus,
+    AgendaTimePrecision,
     PlannedAgendaItem,
     PlannedAgendaVersion,
     validate_agenda_successor,
@@ -658,7 +659,7 @@ class PlannedAgendaAuthority(PlannedAgendaReadPort):
             "planned_agenda_resolutions": "resolution_bytes",
         }
         for table, byte_column in byte_columns.items():
-            row = self._connection.execute(
+            rows = self._connection.execute(
                 f"SELECT agenda_item_id,request_id,actor_identity_digest,"
                 f"idempotency_key,command_digest,{byte_column} FROM {table} WHERE request_id=? "
                 "OR (actor_identity_digest=? AND idempotency_key=?)",
@@ -667,9 +668,11 @@ class PlannedAgendaAuthority(PlannedAgendaReadPort):
                     command.actor_identity_digest,
                     command.idempotency_key,
                 ),
-            ).fetchone()
-            if row is not None:
-                bindings[table] = tuple(row)
+            ).fetchall()
+            if len(rows) > 1:
+                raise AgendaAuthorityError("Agenda idempotency binding conflicts")
+            if rows:
+                bindings[table] = tuple(rows[0])
         if not bindings:
             return None
         if set(bindings) != set(expected):
@@ -700,6 +703,8 @@ class PlannedAgendaAuthority(PlannedAgendaReadPort):
         if (
             version.agenda_item_id != item.agenda_item_id
             or version.version_ordinal != 1
+            or version.source_revision_id != item.created_from_source_revision_id
+            or version.recorded_at < item.created_at
         ):
             raise AgendaAuthorityError("initial Agenda Version binding differs")
         self._begin()
@@ -880,6 +885,11 @@ class PlannedAgendaAuthority(PlannedAgendaReadPort):
             self._assert_cas(command, snapshot)
             validate_agenda_successor(snapshot.current_version, successor)
             self._validate_resolution(resolution, snapshot, revision=True)
+            if (
+                successor.recorded_at < snapshot.current_version.recorded_at
+                or resolution.observed_at < successor.recorded_at
+            ):
+                raise AgendaAuthorityError("Agenda revision chronology differs")
             if resolution.successor_version_digest != successor.digest:
                 raise AgendaAuthorityError("revision successor digest differs")
             status_matrix = {
@@ -899,6 +909,21 @@ class PlannedAgendaAuthority(PlannedAgendaReadPort):
             }
             if successor.schedule_status not in status_matrix[resolution.kind]:
                 raise AgendaAuthorityError("revision status and resolution differ")
+            if (
+                resolution.kind is AgendaResolutionKind.POSTPONED_WITH_SOURCE_EVIDENCE
+                and (
+                    successor.time_precision is not AgendaTimePrecision.UNKNOWN
+                    or any(
+                        value is not None
+                        for value in (
+                            successor.asserted_start,
+                            successor.asserted_end,
+                            successor.time_zone,
+                        )
+                    )
+                )
+            ):
+                raise AgendaAuthorityError("postponement invents a replacement date")
             if resolution.kind is AgendaResolutionKind.RESCHEDULED and (
                 successor.time_precision,
                 successor.asserted_start,

--- a/newsroom/increment7/agenda_authority.py
+++ b/newsroom/increment7/agenda_authority.py
@@ -510,7 +510,8 @@ class PlannedAgendaReadPort(_NoEffect):
     def resolutions(self, agenda_item_id: str) -> tuple[AgendaResolution, ...]:
         _uuid(agenda_item_id, "agenda_item_id")
         rows = self._connection.execute(
-            "SELECT r.resolution_bytes,r.resolution_digest,v.recorded_at "
+            "SELECT r.resolution_bytes,r.resolution_digest,r.agenda_version_id,"
+            "r.agenda_version_digest,v.recorded_at "
             "FROM planned_agenda_resolutions r JOIN planned_agenda_versions v "
             "ON v.agenda_version_id=r.agenda_version_id "
             "AND v.agenda_item_id=r.agenda_item_id "
@@ -527,7 +528,9 @@ class PlannedAgendaReadPort(_NoEffect):
                 resolution.agenda_item_id != agenda_item_id
                 or resolution.resolution_ordinal != ordinal
                 or resolution.digest != stored[1]
-                or resolution.observed_at < stored[2]
+                or resolution.agenda_version_id != stored[2]
+                or resolution.agenda_version_digest != stored[3]
+                or resolution.observed_at < stored[4]
                 or resolution.previous_resolution_digest
                 != (None if previous is None else previous.digest)
                 or (

--- a/newsroom/increment7/agenda_authority.py
+++ b/newsroom/increment7/agenda_authority.py
@@ -787,6 +787,10 @@ class PlannedAgendaAuthority(PlannedAgendaReadPort):
             raise AgendaAuthorityError("Agenda Resolution current binding differs")
         if previous is not None and previous.kind in _TERMINAL_KINDS:
             raise AgendaAuthorityError("Agenda lifecycle is terminal")
+        if resolution.observed_at < current.recorded_at or (
+            previous is not None and resolution.observed_at < previous.observed_at
+        ):
+            raise AgendaAuthorityError("Agenda Resolution chronology differs")
         admitted_paths = {
             digest_bytes(canonical_json_bytes(path.to_dict()))
             for path in current.occurrence_confirmation_paths

--- a/newsroom/increment7/agenda_authority.py
+++ b/newsroom/increment7/agenda_authority.py
@@ -511,11 +511,13 @@ def _validate_retained_lifecycle(
 ) -> None:
     by_digest = {version.digest: version for version in versions}
     revision_successors: set[str] = set()
+    active = versions[0]
     previous: AgendaResolution | None = None
     for resolution in resolutions:
         bound = by_digest.get(resolution.agenda_version_digest)
         if (
             bound is None
+            or bound.digest != active.digest
             or bound.agenda_version_id != resolution.agenda_version_id
             or resolution.observed_at < bound.recorded_at
             or (previous is not None and resolution.observed_at < previous.observed_at)
@@ -564,9 +566,12 @@ def _validate_retained_lifecycle(
             if successor.digest in revision_successors:
                 raise AgendaAuthorityError("Agenda retained revision is duplicated")
             revision_successors.add(successor.digest)
+            active = successor
         previous = resolution
     if revision_successors != {version.digest for version in versions[1:]}:
         raise AgendaAuthorityError("Agenda retained Version revision coverage differs")
+    if active.digest != versions[-1].digest:
+        raise AgendaAuthorityError("Agenda retained active Version differs")
 
 
 _AUTHORITY_TOKEN = object()

--- a/newsroom/increment7/agenda_authority.py
+++ b/newsroom/increment7/agenda_authority.py
@@ -220,6 +220,38 @@ _TERMINAL_KINDS = frozenset(
     }
 )
 
+_REVISION_STATUS_MATRIX = {
+    AgendaResolutionKind.RESCHEDULED: {
+        AgendaScheduleStatus.PROVISIONAL,
+        AgendaScheduleStatus.CONFIRMED,
+    },
+    AgendaResolutionKind.CANCELLED_WITH_SOURCE_EVIDENCE: {
+        AgendaScheduleStatus.CANCELLED
+    },
+    AgendaResolutionKind.POSTPONED_WITH_SOURCE_EVIDENCE: {
+        AgendaScheduleStatus.POSTPONED_WITHOUT_DATE
+    },
+    AgendaResolutionKind.WITHDRAWN_WITH_SOURCE_EVIDENCE: {
+        AgendaScheduleStatus.WITHDRAWN
+    },
+}
+
+
+def _schedule_assertion(version: PlannedAgendaVersion) -> tuple[object, ...]:
+    return (
+        version.time_precision,
+        version.asserted_start,
+        version.asserted_end,
+        version.time_zone,
+    )
+
+
+def _postponement_has_no_date(version: PlannedAgendaVersion) -> bool:
+    return version.time_precision is AgendaTimePrecision.UNKNOWN and all(
+        value is None
+        for value in (version.asserted_start, version.asserted_end, version.time_zone)
+    )
+
 
 _RESOLUTION_FIELDS = (
     "schema_version",
@@ -473,6 +505,70 @@ class PlannedAgendaSnapshot(_NoEffect):
             raise AgendaAuthorityError("Agenda snapshot binding differs")
 
 
+def _validate_retained_lifecycle(
+    versions: tuple[PlannedAgendaVersion, ...],
+    resolutions: tuple[AgendaResolution, ...],
+) -> None:
+    by_digest = {version.digest: version for version in versions}
+    revision_successors: set[str] = set()
+    previous: AgendaResolution | None = None
+    for resolution in resolutions:
+        bound = by_digest.get(resolution.agenda_version_digest)
+        if (
+            bound is None
+            or bound.agenda_version_id != resolution.agenda_version_id
+            or resolution.observed_at < bound.recorded_at
+            or (previous is not None and resolution.observed_at < previous.observed_at)
+        ):
+            raise AgendaAuthorityError("Agenda Resolution retained chronology differs")
+        if previous is not None and previous.kind in _TERMINAL_KINDS:
+            raise AgendaAuthorityError(
+                "Agenda retained lifecycle continues after terminal"
+            )
+        admitted_paths = {
+            digest_bytes(canonical_json_bytes(path.to_dict()))
+            for path in bound.occurrence_confirmation_paths
+        }
+        if resolution.confirmation_path_digest is not None and (
+            resolution.confirmation_path_digest not in admitted_paths
+        ):
+            raise AgendaAuthorityError("Agenda retained confirmation path differs")
+        if resolution.kind is AgendaResolutionKind.LATE_OCCURRENCE and (
+            previous is None
+            or previous.kind is not AgendaResolutionKind.MISSED_NOT_OBSERVED
+            or previous.agenda_version_id != resolution.agenda_version_id
+        ):
+            raise AgendaAuthorityError("Agenda retained late occurrence differs")
+        if resolution.kind in _REVISION_KINDS:
+            successor = by_digest.get(resolution.successor_version_digest or "")
+            if (
+                successor is None
+                or successor.version_ordinal != bound.version_ordinal + 1
+                or successor.predecessor_version_digest != bound.digest
+                or successor.recorded_at < bound.recorded_at
+                or resolution.observed_at < successor.recorded_at
+                or successor.schedule_status
+                not in _REVISION_STATUS_MATRIX[resolution.kind]
+            ):
+                raise AgendaAuthorityError("Agenda retained revision binding differs")
+            if (
+                resolution.kind is AgendaResolutionKind.RESCHEDULED
+                and _schedule_assertion(successor) == _schedule_assertion(bound)
+            ):
+                raise AgendaAuthorityError("Agenda retained reschedule differs")
+            if (
+                resolution.kind is AgendaResolutionKind.POSTPONED_WITH_SOURCE_EVIDENCE
+                and not _postponement_has_no_date(successor)
+            ):
+                raise AgendaAuthorityError("Agenda retained postponement differs")
+            if successor.digest in revision_successors:
+                raise AgendaAuthorityError("Agenda retained revision is duplicated")
+            revision_successors.add(successor.digest)
+        previous = resolution
+    if revision_successors != {version.digest for version in versions[1:]}:
+        raise AgendaAuthorityError("Agenda retained Version revision coverage differs")
+
+
 _AUTHORITY_TOKEN = object()
 
 
@@ -518,16 +614,22 @@ class PlannedAgendaReadPort(_NoEffect):
                 raise AgendaAuthorityError("Planned Agenda Version replay differs")
             if ordinal > 1:
                 validate_agenda_successor(versions[ordinal - 2], version)
+                if version.recorded_at < versions[ordinal - 2].recorded_at:
+                    raise AgendaAuthorityError(
+                        "Planned Agenda Version chronology differs"
+                    )
         return versions
 
     @_total("Agenda Resolution history failed")
     def resolutions(self, agenda_item_id: str) -> tuple[AgendaResolution, ...]:
         _uuid(agenda_item_id, "agenda_item_id")
         rows = self._connection.execute(
-            "SELECT r.resolution_bytes,r.resolution_digest,r.agenda_version_id,"
-            "r.agenda_version_digest,v.version_bytes,v.version_digest,v.recorded_at,"
-            "r.resolution_kind,r.evidence_digest,r.confirmation_path_digest,"
-            "r.baseline_evidence_digest,r.successor_version_digest,r.observed_at "
+            "SELECT r.resolution_bytes,r.resolution_digest,r.resolution_id,"
+            "r.agenda_item_id,r.agenda_version_id,r.agenda_version_digest,"
+            "r.resolution_ordinal,r.previous_resolution_digest,r.resolution_kind,"
+            "r.evidence_digest,r.confirmation_path_digest,r.baseline_evidence_digest,"
+            "r.successor_version_digest,r.observed_at,v.version_bytes,"
+            "v.version_digest,v.recorded_at "
             "FROM planned_agenda_resolutions r LEFT JOIN planned_agenda_versions v "
             "ON v.agenda_version_id=r.agenda_version_id "
             "AND v.agenda_item_id=r.agenda_item_id "
@@ -540,27 +642,31 @@ class PlannedAgendaReadPort(_NoEffect):
         )
         previous: AgendaResolution | None = None
         for ordinal, (resolution, stored) in enumerate(zip(resolutions, rows), 1):
-            if stored[4] is None:
+            if stored[14] is None:
                 raise AgendaAuthorityError("Agenda Resolution replay differs")
-            bound_version = PlannedAgendaVersion.from_canonical_bytes(bytes(stored[4]))
+            bound_version = PlannedAgendaVersion.from_canonical_bytes(bytes(stored[14]))
             if (
                 resolution.agenda_item_id != agenda_item_id
                 or resolution.resolution_ordinal != ordinal
                 or resolution.digest != stored[1]
-                or resolution.agenda_version_id != stored[2]
-                or resolution.agenda_version_digest != stored[3]
+                or resolution.resolution_id != stored[2]
+                or resolution.agenda_item_id != stored[3]
+                or resolution.agenda_version_id != stored[4]
+                or resolution.agenda_version_digest != stored[5]
+                or resolution.resolution_ordinal != stored[6]
+                or resolution.previous_resolution_digest != stored[7]
                 or bound_version.agenda_version_id != resolution.agenda_version_id
                 or bound_version.agenda_item_id != resolution.agenda_item_id
                 or bound_version.digest != resolution.agenda_version_digest
-                or bound_version.digest != stored[5]
-                or bound_version.recorded_at != stored[6]
+                or bound_version.digest != stored[15]
+                or bound_version.recorded_at != stored[16]
                 or resolution.observed_at < bound_version.recorded_at
-                or resolution.kind.value != stored[7]
-                or resolution.evidence_digest != stored[8]
-                or resolution.confirmation_path_digest != stored[9]
-                or resolution.baseline_evidence_digest != stored[10]
-                or resolution.successor_version_digest != stored[11]
-                or resolution.observed_at != stored[12]
+                or resolution.kind.value != stored[8]
+                or resolution.evidence_digest != stored[9]
+                or resolution.confirmation_path_digest != stored[10]
+                or resolution.baseline_evidence_digest != stored[11]
+                or resolution.successor_version_digest != stored[12]
+                or resolution.observed_at != stored[13]
                 or resolution.previous_resolution_digest
                 != (None if previous is None else previous.digest)
                 or (
@@ -570,6 +676,7 @@ class PlannedAgendaReadPort(_NoEffect):
             ):
                 raise AgendaAuthorityError("Agenda Resolution replay differs")
             previous = resolution
+        _validate_retained_lifecycle(self.versions(agenda_item_id), resolutions)
         return resolutions
 
     @_total("Planned Agenda load failed")
@@ -597,6 +704,11 @@ class PlannedAgendaReadPort(_NoEffect):
         versions = self.versions(agenda_item_id)
         if not versions:
             raise AgendaAuthorityError("Planned Agenda Version history is empty")
+        if (
+            versions[0].source_revision_id != item.created_from_source_revision_id
+            or versions[0].recorded_at < item.created_at
+        ):
+            raise AgendaAuthorityError("initial Agenda Version replay binding differs")
         current = versions[-1]
         if versions[0].agenda_version_id != row[4] or (
             current.agenda_version_id,
@@ -892,48 +1004,20 @@ class PlannedAgendaAuthority(PlannedAgendaReadPort):
                 raise AgendaAuthorityError("Agenda revision chronology differs")
             if resolution.successor_version_digest != successor.digest:
                 raise AgendaAuthorityError("revision successor digest differs")
-            status_matrix = {
-                AgendaResolutionKind.RESCHEDULED: {
-                    AgendaScheduleStatus.PROVISIONAL,
-                    AgendaScheduleStatus.CONFIRMED,
-                },
-                AgendaResolutionKind.CANCELLED_WITH_SOURCE_EVIDENCE: {
-                    AgendaScheduleStatus.CANCELLED
-                },
-                AgendaResolutionKind.POSTPONED_WITH_SOURCE_EVIDENCE: {
-                    AgendaScheduleStatus.POSTPONED_WITHOUT_DATE
-                },
-                AgendaResolutionKind.WITHDRAWN_WITH_SOURCE_EVIDENCE: {
-                    AgendaScheduleStatus.WITHDRAWN
-                },
-            }
-            if successor.schedule_status not in status_matrix[resolution.kind]:
+            if (
+                successor.schedule_status
+                not in _REVISION_STATUS_MATRIX[resolution.kind]
+            ):
                 raise AgendaAuthorityError("revision status and resolution differ")
             if (
                 resolution.kind is AgendaResolutionKind.POSTPONED_WITH_SOURCE_EVIDENCE
-                and (
-                    successor.time_precision is not AgendaTimePrecision.UNKNOWN
-                    or any(
-                        value is not None
-                        for value in (
-                            successor.asserted_start,
-                            successor.asserted_end,
-                            successor.time_zone,
-                        )
-                    )
-                )
+                and not _postponement_has_no_date(successor)
             ):
                 raise AgendaAuthorityError("postponement invents a replacement date")
-            if resolution.kind is AgendaResolutionKind.RESCHEDULED and (
-                successor.time_precision,
-                successor.asserted_start,
-                successor.asserted_end,
-                successor.time_zone,
-            ) == (
-                snapshot.current_version.time_precision,
-                snapshot.current_version.asserted_start,
-                snapshot.current_version.asserted_end,
-                snapshot.current_version.time_zone,
+            if (
+                resolution.kind is AgendaResolutionKind.RESCHEDULED
+                and _schedule_assertion(successor)
+                == _schedule_assertion(snapshot.current_version)
             ):
                 raise AgendaAuthorityError("reschedule leaves schedule unchanged")
             self._insert_version(successor, command)

--- a/newsroom/tests/test_increment7a2_exact_immutable_read_port.py
+++ b/newsroom/tests/test_increment7a2_exact_immutable_read_port.py
@@ -384,6 +384,19 @@ def test_explicit_miss_then_late_occurrence_is_retained_and_terminal() -> None:
         current_version=version,
         previous_resolution=missed,
     )
+    with pytest.raises(AgendaAuthorityError, match="chronology"):
+        authority.apply(
+            replace(
+                late_command,
+                command_id=_id(9_302),
+                request_id=_id(10_302),
+                idempotency_key="agenda-command-9302",
+                resolution=replace(
+                    late,
+                    observed_at="2026-08-31T12:01:00.000000Z",
+                ),
+            ).canonical_bytes
+        )
     final = authority.apply(late_command.canonical_bytes)
     assert after_miss.resolutions == (missed,)
     assert final.resolutions == (missed, late)

--- a/newsroom/tests/test_increment7a2_exact_immutable_read_port.py
+++ b/newsroom/tests/test_increment7a2_exact_immutable_read_port.py
@@ -417,6 +417,28 @@ def test_explicit_miss_then_late_occurrence_is_retained_and_terminal() -> None:
             ).canonical_bytes
         )
 
+    immutable_version = authority._connection.execute(  # noqa: SLF001
+        "SELECT sql FROM sqlite_master WHERE name='immutable_planned_agenda_versions'"
+    ).fetchone()[0]
+    authority._connection.execute(  # noqa: SLF001 - pre-fix retained-row fixture
+        "DROP TRIGGER immutable_planned_agenda_versions"
+    )
+    authority._connection.execute(  # noqa: SLF001 - pre-fix retained-row fixture
+        "UPDATE planned_agenda_versions SET recorded_at=? WHERE agenda_version_id=?",
+        ("2026-08-13T00:00:00.000000Z", version.agenda_version_id),
+    )
+    authority._connection.execute(immutable_version)  # noqa: SLF001
+    with pytest.raises(AgendaAuthorityError, match="Version replay differs"):
+        authority.read_port().versions(item.agenda_item_id)
+    authority._connection.execute(  # noqa: SLF001 - restore retained fixture
+        "DROP TRIGGER immutable_planned_agenda_versions"
+    )
+    authority._connection.execute(  # noqa: SLF001 - restore retained fixture
+        "UPDATE planned_agenda_versions SET recorded_at=? WHERE agenda_version_id=?",
+        (version.recorded_at, version.agenda_version_id),
+    )
+    authority._connection.execute(immutable_version)  # noqa: SLF001
+
     retained_invalid = replace(
         further,
         observed_at="2026-09-01T12:00:30.000000Z",

--- a/newsroom/tests/test_increment7a2_exact_immutable_read_port.py
+++ b/newsroom/tests/test_increment7a2_exact_immutable_read_port.py
@@ -419,6 +419,29 @@ def test_explicit_miss_then_late_occurrence_is_retained_and_terminal() -> None:
             ).canonical_bytes
         )
 
+    retained_invalid = replace(
+        further,
+        observed_at="2026-09-01T12:00:30.000000Z",
+    )
+    retained_command = _command(
+        AgendaCommandOperation.RESOLVE,
+        304,
+        resolution=retained_invalid,
+        current_version=version,
+        previous_resolution=late,
+    )
+    authority._insert_resolution(  # noqa: SLF001 - pre-fix retained-row fixture
+        retained_invalid,
+        retained_command,
+    )
+    authority._connection.execute(  # noqa: SLF001 - pre-fix retained-row fixture
+        "UPDATE planned_agenda_heads SET current_resolution_digest=?,"
+        "current_resolution_ordinal=? WHERE agenda_item_id=?",
+        (retained_invalid.digest, 3, item.agenda_item_id),
+    )
+    with pytest.raises(AgendaAuthorityError, match="replay differs"):
+        authority.read_port().resolutions(item.agenda_item_id)
+
 
 @pytest.mark.parametrize(
     ("kind", "status"),

--- a/newsroom/tests/test_increment7a2_exact_immutable_read_port.py
+++ b/newsroom/tests/test_increment7a2_exact_immutable_read_port.py
@@ -316,9 +316,7 @@ def test_create_replay_read_port_restart_and_no_effects(tmp_path: Path) -> None:
     item, version, command, snapshot = _create(authority)
     assert authority.apply(command.canonical_bytes) == snapshot
     with pytest.raises(AgendaAuthorityError, match="idempotency binding"):
-        authority.apply(
-            replace(command, command_id=_id(9_999)).canonical_bytes
-        )
+        authority.apply(replace(command, command_id=_id(9_999)).canonical_bytes)
     assert authority.read_port().load(item.agenda_item_id) == snapshot
     assert authority.read_port().versions(item.agenda_item_id) == (version,)
     assert authority.read_port().resolutions(item.agenda_item_id) == ()
@@ -434,10 +432,32 @@ def test_explicit_miss_then_late_occurrence_is_retained_and_terminal() -> None:
         retained_invalid,
         retained_command,
     )
+    forged_payload = replace(
+        retained_invalid,
+        agenda_version_id=_id(9_999),
+        agenda_version_digest="sha256:" + "9" * 64,
+    )
+    immutable_resolution = authority._connection.execute(  # noqa: SLF001
+        "SELECT sql FROM sqlite_master "
+        "WHERE name='immutable_planned_agenda_resolutions'"
+    ).fetchone()[0]
+    authority._connection.execute(  # noqa: SLF001 - pre-fix retained-row fixture
+        "DROP TRIGGER immutable_planned_agenda_resolutions"
+    )
+    authority._connection.execute(  # noqa: SLF001 - pre-fix retained-row fixture
+        "UPDATE planned_agenda_resolutions SET resolution_bytes=?,resolution_digest=? "
+        "WHERE resolution_id=?",
+        (
+            forged_payload.canonical_bytes,
+            forged_payload.digest,
+            retained_invalid.resolution_id,
+        ),
+    )
+    authority._connection.execute(immutable_resolution)  # noqa: SLF001
     authority._connection.execute(  # noqa: SLF001 - pre-fix retained-row fixture
         "UPDATE planned_agenda_heads SET current_resolution_digest=?,"
         "current_resolution_ordinal=? WHERE agenda_item_id=?",
-        (retained_invalid.digest, 3, item.agenda_item_id),
+        (forged_payload.digest, 3, item.agenda_item_id),
     )
     with pytest.raises(AgendaAuthorityError, match="replay differs"):
         authority.read_port().resolutions(item.agenda_item_id)

--- a/newsroom/tests/test_increment7a2_exact_immutable_read_port.py
+++ b/newsroom/tests/test_increment7a2_exact_immutable_read_port.py
@@ -317,6 +317,15 @@ def test_create_replay_read_port_restart_and_no_effects(tmp_path: Path) -> None:
     assert authority.apply(command.canonical_bytes) == snapshot
     with pytest.raises(AgendaAuthorityError, match="idempotency binding"):
         authority.apply(replace(command, command_id=_id(9_999)).canonical_bytes)
+    _, _, second_command, _ = _create(authority, 50)
+    with pytest.raises(AgendaAuthorityError, match="idempotency binding"):
+        authority.apply(
+            replace(
+                command,
+                command_id=_id(9_998),
+                idempotency_key=second_command.idempotency_key,
+            ).canonical_bytes
+        )
     assert authority.read_port().load(item.agenda_item_id) == snapshot
     assert authority.read_port().versions(item.agenda_item_id) == (version,)
     assert authority.read_port().resolutions(item.agenda_item_id) == ()
@@ -351,6 +360,23 @@ def test_create_replay_read_port_restart_and_no_effects(tmp_path: Path) -> None:
     reopened = open_planned_agenda_authority(database, applied_at=_AT)
     assert reopened.load(item.agenda_item_id).current_version == version
     reopened.close()
+
+    invalid = open_planned_agenda_authority(":memory:", applied_at=_AT)
+    invalid_item = _item(70)
+    invalid_version = _version(
+        invalid_item,
+        80,
+        source_revision_id=_id(81),
+    )
+    with pytest.raises(AgendaAuthorityError, match="initial Agenda Version binding"):
+        invalid.apply(
+            _command(
+                AgendaCommandOperation.CREATE,
+                90,
+                item=invalid_item,
+                version=invalid_version,
+            ).canonical_bytes
+        )
 
 
 def test_explicit_miss_then_late_occurrence_is_retained_and_terminal() -> None:
@@ -542,6 +568,46 @@ def test_revision_is_atomic_cas_bound_and_status_matched(kind, status) -> None:
                     315,
                     version=unchanged_schedule,
                     resolution=unchanged_resolution,
+                    current_version=prior,
+                ).canonical_bytes
+            )
+        backdated = replace(
+            successor,
+            agenda_version_id=_id(26),
+            recorded_at="2026-08-13T00:00:00.000000Z",
+        )
+        with pytest.raises(AgendaAuthorityError, match="revision chronology"):
+            authority.apply(
+                _command(
+                    AgendaCommandOperation.REVISE,
+                    316,
+                    version=backdated,
+                    resolution=replace(
+                        resolution,
+                        resolution_id=_id(216),
+                        successor_version_digest=backdated.digest,
+                    ),
+                    current_version=prior,
+                ).canonical_bytes
+            )
+    else:
+        postponed = replace(
+            successor,
+            agenda_version_id=_id(27),
+            schedule_status=AgendaScheduleStatus.POSTPONED_WITHOUT_DATE,
+        )
+        with pytest.raises(AgendaAuthorityError, match="replacement date"):
+            authority.apply(
+                _command(
+                    AgendaCommandOperation.REVISE,
+                    317,
+                    version=postponed,
+                    resolution=replace(
+                        resolution,
+                        resolution_id=_id(217),
+                        kind=AgendaResolutionKind.POSTPONED_WITH_SOURCE_EVIDENCE,
+                        successor_version_digest=postponed.digest,
+                    ),
                     current_version=prior,
                 ).canonical_bytes
             )


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-7a2-agenda-authority
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

## Summary
- reject Agenda resolutions observed before the current Version was recorded
- reject appended resolutions that would move immutable resolution chronology backwards
- retain the regression inside the existing shard-stable lifecycle proof

## Verification
- `uvx ruff@0.12.0 check newsroom/increment7/agenda_authority.py newsroom/tests/test_increment7a2_exact_immutable_read_port.py`
- `uv run pytest -q newsroom/tests/test_increment7a2_exact_immutable_read_port.py` (10 passed)

Closes #437
