### PR TITLE
Increment 7E1: add provider qualification seams

### DIFF
--- a/newsroom/increment7/provider_qualification.py
+++ b/newsroom/increment7/provider_qualification.py
@@ -487,7 +487,7 @@ class ProviderDecision(_NoEffect):
 def validate_provider_decision(
     proposal: ProviderProposal,
     decision: ProviderDecision,
-    previous: ProviderDecision | None = None,
+    previous: ProviderDecision | tuple[ProviderDecision, ...] | None = None,
 ) -> None:
     _validate_provider_decision_binding(proposal, decision)
     if previous is None:
@@ -495,15 +495,26 @@ def validate_provider_decision(
             raise ProviderQualificationError(
                 "initial Provider Decision supersedes another"
             )
-    else:
-        _validate_provider_decision_binding(proposal, previous)
-        if (
-            decision.decision_id == previous.decision_id
-            or decision.proposal_id != previous.proposal_id
-            or decision.supersedes_decision_digest != previous.digest
-            or decision.decided_at < previous.decided_at
-        ):
-            raise ProviderQualificationError("Provider Decision predecessor differs")
+        return
+    chain = previous if type(previous) is tuple else (previous,)
+    if not chain or any(type(item) is not ProviderDecision for item in chain):
+        raise ProviderQualificationError("Provider Decision predecessor differs")
+    for item in chain:
+        _validate_provider_decision_binding(proposal, item)
+    if (
+        len({item.decision_id for item in chain}) != len(chain)
+        or len({item.digest for item in chain}) != len(chain)
+        or any(
+            current.supersedes_decision_digest != predecessor.digest
+            or current.decided_at < predecessor.decided_at
+            for predecessor, current in zip(chain, chain[1:])
+        )
+        or decision.decision_id in {item.decision_id for item in chain}
+        or decision.proposal_id != chain[-1].proposal_id
+        or decision.supersedes_decision_digest != chain[-1].digest
+        or decision.decided_at < chain[-1].decided_at
+    ):
+        raise ProviderQualificationError("Provider Decision predecessor differs")
 
 
 def _validate_provider_decision_binding(

--- a/newsroom/increment7/provider_qualification.py
+++ b/newsroom/increment7/provider_qualification.py
@@ -1,0 +1,528 @@
+"""Immutable provider qualification decision seams for Increment 7E1.
+
+These contracts record research posture only. They expose no provider client,
+credential, query, network, spending, schedule, retry or activation capability.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+from typing import Self
+
+from newsroom.authority.canonical import (
+    CanonicalizationError,
+    canonical_json_bytes,
+    digest_bytes,
+    validate_sha256_digest,
+)
+
+PROVIDER_PROPOSAL = "newsroom.increment7.provider-proposal.v1"
+PROVIDER_DECISION = "newsroom.increment7.provider-decision.v1"
+PROVIDER_QUALIFICATION_AUTHORITY = "DECISION_RECORD_ONLY_NO_ACTIVATION"
+PROVIDER_CURRENT_POSTURE = {
+    "GDELT": "HELD",
+    "BRAVE_SEARCH": "RIGHTS_REVIEW_REQUIRED",
+    "SEARXNG": "RESEARCH",
+    "UNOFFICIAL_WRAPPER": "RESEARCH",
+}
+MAX_PROVIDER_QUALIFICATION_BYTES = 1_048_576
+
+_UUID = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z"
+)
+_TOKEN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:\-]{0,255}\Z")
+_UTC = re.compile(
+    r"[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T"
+    r"(?:[01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]\.[0-9]{6}Z\Z"
+)
+
+
+class ProviderQualificationError(ValueError):
+    """Untrusted provider qualification values failed the exact v1 contract."""
+
+
+class ProviderKind(StrEnum):
+    GDELT = "GDELT"
+    BRAVE_SEARCH = "BRAVE_SEARCH"
+    SEARXNG = "SEARXNG"
+    UNOFFICIAL_WRAPPER = "UNOFFICIAL_WRAPPER"
+    OTHER = "OTHER"
+
+
+class ProviderQualificationStatus(StrEnum):
+    RESEARCH = "RESEARCH"
+    RIGHTS_REVIEW_REQUIRED = "RIGHTS_REVIEW_REQUIRED"
+    HELD = "HELD"
+    REJECTED = "REJECTED"
+    QUALIFIED_FOR_SEPARATE_ADMISSION_REVIEW = "QUALIFIED_FOR_SEPARATE_ADMISSION_REVIEW"
+
+
+class ProviderPrerequisite(StrEnum):
+    AMPLIFICATION_LIMITS = "AMPLIFICATION_LIMITS"
+    EVALUATION_PLAN = "EVALUATION_PLAN"
+    GROSS_BUDGET = "GROSS_BUDGET"
+    OPERATIONAL_PROFILE = "OPERATIONAL_PROFILE"
+    OWNER_AUTHORITY = "OWNER_AUTHORITY"
+    PROVIDER_SOURCE_VERSION = "PROVIDER_SOURCE_VERSION"
+    QUERY_DATA_HANDLING = "QUERY_DATA_HANDLING"
+    RIGHTS_BASIS = "RIGHTS_BASIS"
+
+
+class ProviderPrerequisiteOutcome(StrEnum):
+    SATISFIED = "SATISFIED"
+    MISSING = "MISSING"
+    FAILED = "FAILED"
+    NOT_APPLICABLE = "NOT_APPLICABLE"
+
+
+class _NoEffect:
+    authorises_external_effect = False
+    authorises_provider = False
+    authorises_credentials = False
+    authorises_query_execution = False
+    authorises_egress = False
+    authorises_spend = False
+    authorises_schedule = False
+    authorises_retry = False
+    authorises_fallback = False
+    authorises_model_submission = False
+    authorises_evidence = False
+    authorises_publication = False
+    authorises_locality = False
+    creates_signal = False
+    creates_lead = False
+    creates_candidate = False
+    production_activation_authorised = False
+
+
+def _text(value: object, field: str, maximum: int = 2_048) -> str:
+    try:
+        size = len(value.encode()) if type(value) is str else 0
+    except UnicodeError as exc:
+        raise ProviderQualificationError(f"{field} must be canonical text") from exc
+    if (
+        type(value) is not str
+        or not value
+        or value != value.strip()
+        or size > maximum
+        or any(ord(character) < 32 or ord(character) == 127 for character in value)
+    ):
+        raise ProviderQualificationError(f"{field} must be canonical text")
+    return value
+
+
+def _token(value: object, field: str) -> str:
+    value = _text(value, field, 256)
+    if _TOKEN.fullmatch(value) is None:
+        raise ProviderQualificationError(f"{field} must be a canonical token")
+    return value
+
+
+def _uuid(value: object, field: str) -> str:
+    if type(value) is not str or _UUID.fullmatch(value) is None:
+        raise ProviderQualificationError(f"{field} must be a canonical UUID")
+    try:
+        if str(uuid.UUID(value)) != value:
+            raise ValueError
+    except ValueError as exc:
+        raise ProviderQualificationError(f"{field} must be a canonical UUID") from exc
+    return value
+
+
+def _digest(value: object, field: str) -> str:
+    try:
+        return validate_sha256_digest(value, field=field)
+    except (CanonicalizationError, TypeError, ValueError) as exc:
+        raise ProviderQualificationError(f"{field} must be a SHA-256 digest") from exc
+
+
+def _timestamp(value: object, field: str) -> str:
+    value = _text(value, field, 27)
+    if _UTC.fullmatch(value) is None:
+        raise ProviderQualificationError(f"{field} must be an exact UTC timestamp")
+    try:
+        datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ")
+    except ValueError as exc:
+        raise ProviderQualificationError(
+            f"{field} must be an exact UTC timestamp"
+        ) from exc
+    return value
+
+
+def _enum[T: StrEnum](kind: type[T], value: object, field: str) -> T:
+    if type(value) is not str and type(value) is not kind:
+        raise ProviderQualificationError(f"{field} differs")
+    try:
+        return kind(value)
+    except ValueError as exc:
+        raise ProviderQualificationError(f"{field} differs") from exc
+
+
+def _strings(
+    value: object, field: str, *, required: bool = False, digests: bool = False
+) -> tuple[str, ...]:
+    if type(value) is not tuple or len(value) > 64 or (required and not value):
+        raise ProviderQualificationError(f"{field} must be a bounded array")
+    validator = _digest if digests else _token
+    result = tuple(validator(item, field) for item in value)
+    if tuple(sorted(set(result))) != result:
+        raise ProviderQualificationError(f"{field} must be unique and sorted")
+    return result
+
+
+def _pairs(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ProviderQualificationError(f"duplicate object name: {key}")
+        result[key] = value
+    return result
+
+
+def _document(raw: bytes, schema: str, fields: tuple[str, ...]) -> dict[str, object]:
+    if type(raw) is not bytes or not raw or len(raw) > MAX_PROVIDER_QUALIFICATION_BYTES:
+        raise ProviderQualificationError("provider qualification bytes are not bounded")
+    try:
+        value = json.loads(raw.decode(), object_pairs_hook=_pairs)
+        canonical = canonical_json_bytes(value)
+    except ProviderQualificationError:
+        raise
+    except (
+        UnicodeError,
+        json.JSONDecodeError,
+        CanonicalizationError,
+        RecursionError,
+        ValueError,
+    ) as exc:
+        raise ProviderQualificationError(
+            "provider qualification bytes are not canonical JSON"
+        ) from exc
+    if type(value) is not dict or raw != canonical:
+        raise ProviderQualificationError(
+            "provider qualification bytes are not exact canonical JSON"
+        )
+    if tuple(value) != tuple(sorted(fields)) or value.get("schema_version") != schema:
+        raise ProviderQualificationError(
+            "provider qualification fields or schema differ"
+        )
+    return value
+
+
+_ASSESSMENT_FIELDS = ("outcome", "prerequisite", "reference_digest")
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderPrerequisiteAssessment(_NoEffect):
+    prerequisite: ProviderPrerequisite
+    outcome: ProviderPrerequisiteOutcome
+    reference_digest: str | None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "prerequisite",
+            _enum(ProviderPrerequisite, self.prerequisite, "prerequisite"),
+        )
+        object.__setattr__(
+            self,
+            "outcome",
+            _enum(ProviderPrerequisiteOutcome, self.outcome, "outcome"),
+        )
+        if self.outcome is ProviderPrerequisiteOutcome.SATISFIED:
+            if self.reference_digest is None:
+                raise ProviderQualificationError(
+                    "satisfied prerequisite lacks an exact reference"
+                )
+            _digest(self.reference_digest, "reference_digest")
+        elif self.reference_digest is not None:
+            raise ProviderQualificationError(
+                "unsatisfied prerequisite carries an authority reference"
+            )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "outcome": self.outcome.value,
+            "prerequisite": self.prerequisite.value,
+            "reference_digest": self.reference_digest,
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> Self:
+        if type(value) is not dict or tuple(value) != _ASSESSMENT_FIELDS:
+            raise ProviderQualificationError("prerequisite assessment fields differ")
+        return cls(**value)  # type: ignore[arg-type]
+
+
+_PROPOSAL_FIELDS = (
+    "schema_version",
+    "proposal_id",
+    "provider_id",
+    "provider_kind",
+    "provider_display_name",
+    "proposed_posture",
+    "capability_scope",
+    "provider_source_version",
+    "research_reference_digests",
+    "proposer_identity_digest",
+    "proposed_at",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderProposal(_NoEffect):
+    proposal_id: str
+    provider_id: str
+    provider_kind: ProviderKind
+    provider_display_name: str
+    proposed_posture: ProviderQualificationStatus
+    capability_scope: tuple[str, ...]
+    provider_source_version: str
+    research_reference_digests: tuple[str, ...]
+    proposer_identity_digest: str
+    proposed_at: str
+    schema_version: str = PROVIDER_PROPOSAL
+
+    def __post_init__(self) -> None:
+        if self.schema_version != PROVIDER_PROPOSAL:
+            raise ProviderQualificationError("Provider Proposal schema differs")
+        _uuid(self.proposal_id, "proposal_id")
+        _token(self.provider_id, "provider_id")
+        object.__setattr__(
+            self,
+            "provider_kind",
+            _enum(ProviderKind, self.provider_kind, "provider_kind"),
+        )
+        _text(self.provider_display_name, "provider_display_name", 512)
+        object.__setattr__(
+            self,
+            "proposed_posture",
+            _enum(
+                ProviderQualificationStatus,
+                self.proposed_posture,
+                "proposed_posture",
+            ),
+        )
+        expected = ProviderQualificationStatus(
+            PROVIDER_CURRENT_POSTURE.get(self.provider_kind.value, "RESEARCH")
+        )
+        if self.proposed_posture is not expected:
+            raise ProviderQualificationError(
+                "Provider current posture must be preserved"
+            )
+        object.__setattr__(
+            self,
+            "capability_scope",
+            _strings(self.capability_scope, "capability_scope", required=True),
+        )
+        _token(self.provider_source_version, "provider_source_version")
+        object.__setattr__(
+            self,
+            "research_reference_digests",
+            _strings(
+                self.research_reference_digests,
+                "research_reference_digests",
+                required=True,
+                digests=True,
+            ),
+        )
+        _digest(self.proposer_identity_digest, "proposer_identity_digest")
+        _timestamp(self.proposed_at, "proposed_at")
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return canonical_json_bytes(
+            {
+                field: (
+                    getattr(self, field).value
+                    if isinstance(getattr(self, field), StrEnum)
+                    else list(getattr(self, field))
+                    if isinstance(getattr(self, field), tuple)
+                    else getattr(self, field)
+                )
+                for field in _PROPOSAL_FIELDS
+            }
+        )
+
+    @property
+    def digest(self) -> str:
+        return digest_bytes(self.canonical_bytes)
+
+    @classmethod
+    def from_canonical_bytes(cls, raw: bytes) -> Self:
+        value = _document(raw, PROVIDER_PROPOSAL, _PROPOSAL_FIELDS)
+        for field in ("capability_scope", "research_reference_digests"):
+            value[field] = tuple(value[field])  # type: ignore[arg-type]
+        result = cls(**value)  # type: ignore[arg-type]
+        if result.canonical_bytes != raw:
+            raise ProviderQualificationError("Provider Proposal replay differs")
+        return result
+
+
+_DECISION_FIELDS = (
+    "schema_version",
+    "decision_id",
+    "proposal_id",
+    "proposal_digest",
+    "status",
+    "prerequisite_assessments",
+    "supersedes_decision_digest",
+    "decider_identity_digest",
+    "reason_codes",
+    "decided_at",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderDecision(_NoEffect):
+    decision_id: str
+    proposal_id: str
+    proposal_digest: str
+    status: ProviderQualificationStatus
+    prerequisite_assessments: tuple[ProviderPrerequisiteAssessment, ...]
+    supersedes_decision_digest: str | None
+    decider_identity_digest: str
+    reason_codes: tuple[str, ...]
+    decided_at: str
+    schema_version: str = PROVIDER_DECISION
+
+    def __post_init__(self) -> None:
+        if self.schema_version != PROVIDER_DECISION:
+            raise ProviderQualificationError("Provider Decision schema differs")
+        _uuid(self.decision_id, "decision_id")
+        _uuid(self.proposal_id, "proposal_id")
+        _digest(self.proposal_digest, "proposal_digest")
+        object.__setattr__(
+            self, "status", _enum(ProviderQualificationStatus, self.status, "status")
+        )
+        if type(self.prerequisite_assessments) is not tuple:
+            raise ProviderQualificationError("prerequisite assessments differ")
+        assessments = tuple(
+            item
+            if type(item) is ProviderPrerequisiteAssessment
+            else ProviderPrerequisiteAssessment.from_dict(item)
+            for item in self.prerequisite_assessments
+        )
+        if tuple(item.prerequisite for item in assessments) != tuple(
+            ProviderPrerequisite
+        ):
+            raise ProviderQualificationError(
+                "all prerequisite assessments must be exact and ordered"
+            )
+        object.__setattr__(self, "prerequisite_assessments", assessments)
+        if self.supersedes_decision_digest is not None:
+            _digest(self.supersedes_decision_digest, "supersedes_decision_digest")
+        _digest(self.decider_identity_digest, "decider_identity_digest")
+        object.__setattr__(
+            self,
+            "reason_codes",
+            _strings(self.reason_codes, "reason_codes", required=True),
+        )
+        _timestamp(self.decided_at, "decided_at")
+        all_satisfied = all(
+            item.outcome is ProviderPrerequisiteOutcome.SATISFIED
+            for item in assessments
+        )
+        qualified = (
+            self.status
+            is ProviderQualificationStatus.QUALIFIED_FOR_SEPARATE_ADMISSION_REVIEW
+        )
+        if qualified != all_satisfied:
+            raise ProviderQualificationError(
+                "qualification status and prerequisites differ"
+            )
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return canonical_json_bytes(
+            {
+                "decided_at": self.decided_at,
+                "decider_identity_digest": self.decider_identity_digest,
+                "decision_id": self.decision_id,
+                "prerequisite_assessments": [
+                    item.to_dict() for item in self.prerequisite_assessments
+                ],
+                "proposal_digest": self.proposal_digest,
+                "proposal_id": self.proposal_id,
+                "reason_codes": list(self.reason_codes),
+                "schema_version": self.schema_version,
+                "status": self.status.value,
+                "supersedes_decision_digest": self.supersedes_decision_digest,
+            }
+        )
+
+    @property
+    def digest(self) -> str:
+        return digest_bytes(self.canonical_bytes)
+
+    @classmethod
+    def from_canonical_bytes(cls, raw: bytes) -> Self:
+        value = _document(raw, PROVIDER_DECISION, _DECISION_FIELDS)
+        value["prerequisite_assessments"] = tuple(
+            ProviderPrerequisiteAssessment.from_dict(item)
+            for item in value["prerequisite_assessments"]  # type: ignore[union-attr]
+        )
+        value["reason_codes"] = tuple(value["reason_codes"])  # type: ignore[arg-type]
+        result = cls(**value)  # type: ignore[arg-type]
+        if result.canonical_bytes != raw:
+            raise ProviderQualificationError("Provider Decision replay differs")
+        return result
+
+
+def validate_provider_decision(
+    proposal: ProviderProposal,
+    decision: ProviderDecision,
+    previous: ProviderDecision | None = None,
+) -> None:
+    if type(proposal) is not ProviderProposal or type(decision) is not ProviderDecision:
+        raise ProviderQualificationError(
+            "Provider decision binding requires exact records"
+        )
+    expected_current = ProviderQualificationStatus(
+        PROVIDER_CURRENT_POSTURE.get(proposal.provider_kind.value, "RESEARCH")
+    )
+    allowed = {expected_current, ProviderQualificationStatus.REJECTED}
+    if (
+        decision.proposal_id != proposal.proposal_id
+        or decision.proposal_digest != proposal.digest
+        or decision.decided_at < proposal.proposed_at
+        or decision.status not in allowed
+    ):
+        raise ProviderQualificationError(
+            "Provider Decision exceeds Proposal or current posture"
+        )
+    if previous is None:
+        if decision.supersedes_decision_digest is not None:
+            raise ProviderQualificationError(
+                "initial Provider Decision supersedes another"
+            )
+    else:
+        validate_provider_decision(proposal, previous)
+        if (
+            decision.proposal_id != previous.proposal_id
+            or decision.supersedes_decision_digest != previous.digest
+            or decision.decided_at < previous.decided_at
+        ):
+            raise ProviderQualificationError("Provider Decision predecessor differs")
+
+
+__all__ = [
+    "MAX_PROVIDER_QUALIFICATION_BYTES",
+    "PROVIDER_CURRENT_POSTURE",
+    "PROVIDER_DECISION",
+    "PROVIDER_PROPOSAL",
+    "PROVIDER_QUALIFICATION_AUTHORITY",
+    "ProviderDecision",
+    "ProviderKind",
+    "ProviderPrerequisite",
+    "ProviderPrerequisiteAssessment",
+    "ProviderPrerequisiteOutcome",
+    "ProviderProposal",
+    "ProviderQualificationError",
+    "ProviderQualificationStatus",
+    "validate_provider_decision",
+]

--- a/newsroom/increment7/provider_qualification.py
+++ b/newsroom/increment7/provider_qualification.py
@@ -502,7 +502,8 @@ def validate_provider_decision(
     for item in chain:
         _validate_provider_decision_binding(proposal, item)
     if (
-        len({item.decision_id for item in chain}) != len(chain)
+        chain[0].supersedes_decision_digest is not None
+        or len({item.decision_id for item in chain}) != len(chain)
         or len({item.digest for item in chain}) != len(chain)
         or any(
             current.supersedes_decision_digest != predecessor.digest

--- a/newsroom/increment7/provider_qualification.py
+++ b/newsroom/increment7/provider_qualification.py
@@ -12,6 +12,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
+from types import MappingProxyType
 from typing import Self
 
 from newsroom.authority.canonical import (
@@ -24,12 +25,14 @@ from newsroom.authority.canonical import (
 PROVIDER_PROPOSAL = "newsroom.increment7.provider-proposal.v1"
 PROVIDER_DECISION = "newsroom.increment7.provider-decision.v1"
 PROVIDER_QUALIFICATION_AUTHORITY = "DECISION_RECORD_ONLY_NO_ACTIVATION"
-PROVIDER_CURRENT_POSTURE = {
-    "GDELT": "HELD",
-    "BRAVE_SEARCH": "RIGHTS_REVIEW_REQUIRED",
-    "SEARXNG": "RESEARCH",
-    "UNOFFICIAL_WRAPPER": "RESEARCH",
-}
+PROVIDER_CURRENT_POSTURE = MappingProxyType(
+    {
+        "GDELT": "HELD",
+        "BRAVE_SEARCH": "RIGHTS_REVIEW_REQUIRED",
+        "SEARXNG": "RESEARCH",
+        "UNOFFICIAL_WRAPPER": "RESEARCH",
+    }
+)
 MAX_PROVIDER_QUALIFICATION_BYTES = 1_048_576
 
 _UUID = re.compile(
@@ -182,6 +185,12 @@ def _pairs(pairs: list[tuple[str, object]]) -> dict[str, object]:
             raise ProviderQualificationError(f"duplicate object name: {key}")
         result[key] = value
     return result
+
+
+def _array(value: object, field: str) -> tuple[object, ...]:
+    if type(value) is not list:
+        raise ProviderQualificationError(f"{field} must be an array")
+    return tuple(value)
 
 
 def _document(raw: bytes, schema: str, fields: tuple[str, ...]) -> dict[str, object]:
@@ -356,7 +365,7 @@ class ProviderProposal(_NoEffect):
     def from_canonical_bytes(cls, raw: bytes) -> Self:
         value = _document(raw, PROVIDER_PROPOSAL, _PROPOSAL_FIELDS)
         for field in ("capability_scope", "research_reference_digests"):
-            value[field] = tuple(value[field])  # type: ignore[arg-type]
+            value[field] = _array(value[field], field)
         result = cls(**value)  # type: ignore[arg-type]
         if result.canonical_bytes != raw:
             raise ProviderQualificationError("Provider Proposal replay differs")
@@ -431,7 +440,7 @@ class ProviderDecision(_NoEffect):
             self.status
             is ProviderQualificationStatus.QUALIFIED_FOR_SEPARATE_ADMISSION_REVIEW
         )
-        if qualified != all_satisfied:
+        if qualified and not all_satisfied:
             raise ProviderQualificationError(
                 "qualification status and prerequisites differ"
             )
@@ -464,9 +473,11 @@ class ProviderDecision(_NoEffect):
         value = _document(raw, PROVIDER_DECISION, _DECISION_FIELDS)
         value["prerequisite_assessments"] = tuple(
             ProviderPrerequisiteAssessment.from_dict(item)
-            for item in value["prerequisite_assessments"]  # type: ignore[union-attr]
+            for item in _array(
+                value["prerequisite_assessments"], "prerequisite_assessments"
+            )
         )
-        value["reason_codes"] = tuple(value["reason_codes"])  # type: ignore[arg-type]
+        value["reason_codes"] = _array(value["reason_codes"], "reason_codes")
         result = cls(**value)  # type: ignore[arg-type]
         if result.canonical_bytes != raw:
             raise ProviderQualificationError("Provider Decision replay differs")

--- a/newsroom/increment7/provider_qualification.py
+++ b/newsroom/increment7/provider_qualification.py
@@ -478,6 +478,27 @@ def validate_provider_decision(
     decision: ProviderDecision,
     previous: ProviderDecision | None = None,
 ) -> None:
+    _validate_provider_decision_binding(proposal, decision)
+    if previous is None:
+        if decision.supersedes_decision_digest is not None:
+            raise ProviderQualificationError(
+                "initial Provider Decision supersedes another"
+            )
+    else:
+        _validate_provider_decision_binding(proposal, previous)
+        if (
+            decision.decision_id == previous.decision_id
+            or decision.proposal_id != previous.proposal_id
+            or decision.supersedes_decision_digest != previous.digest
+            or decision.decided_at < previous.decided_at
+        ):
+            raise ProviderQualificationError("Provider Decision predecessor differs")
+
+
+def _validate_provider_decision_binding(
+    proposal: ProviderProposal,
+    decision: ProviderDecision,
+) -> None:
     if type(proposal) is not ProviderProposal or type(decision) is not ProviderDecision:
         raise ProviderQualificationError(
             "Provider decision binding requires exact records"
@@ -495,19 +516,6 @@ def validate_provider_decision(
         raise ProviderQualificationError(
             "Provider Decision exceeds Proposal or current posture"
         )
-    if previous is None:
-        if decision.supersedes_decision_digest is not None:
-            raise ProviderQualificationError(
-                "initial Provider Decision supersedes another"
-            )
-    else:
-        validate_provider_decision(proposal, previous)
-        if (
-            decision.proposal_id != previous.proposal_id
-            or decision.supersedes_decision_digest != previous.digest
-            or decision.decided_at < previous.decided_at
-        ):
-            raise ProviderQualificationError("Provider Decision predecessor differs")
 
 
 __all__ = [

--- a/newsroom/tests/test_increment7e1_provider_decision_seams.py
+++ b/newsroom/tests/test_increment7e1_provider_decision_seams.py
@@ -171,7 +171,13 @@ def test_decision_binds_exact_proposal_predecessor_and_chronology() -> None:
         supersedes_decision_digest=second.digest,
         decided_at="2026-08-14T00:00:03.000000Z",
     )
-    validate_provider_decision(proposal, third, second)
+    validate_provider_decision(proposal, third, (first, second))
+    with pytest.raises(ProviderQualificationError, match="predecessor"):
+        validate_provider_decision(
+            proposal,
+            replace(third, decision_id=first.decision_id),
+            (first, second),
+        )
     with pytest.raises(ProviderQualificationError, match="Proposal"):
         validate_provider_decision(
             proposal,

--- a/newsroom/tests/test_increment7e1_provider_decision_seams.py
+++ b/newsroom/tests/test_increment7e1_provider_decision_seams.py
@@ -173,6 +173,8 @@ def test_decision_binds_exact_proposal_predecessor_and_chronology() -> None:
     )
     validate_provider_decision(proposal, third, (first, second))
     with pytest.raises(ProviderQualificationError, match="predecessor"):
+        validate_provider_decision(proposal, third, second)
+    with pytest.raises(ProviderQualificationError, match="predecessor"):
         validate_provider_decision(
             proposal,
             replace(third, decision_id=first.decision_id),

--- a/newsroom/tests/test_increment7e1_provider_decision_seams.py
+++ b/newsroom/tests/test_increment7e1_provider_decision_seams.py
@@ -157,6 +157,13 @@ def test_decision_binds_exact_proposal_predecessor_and_chronology() -> None:
         decided_at="2026-08-14T00:00:02.000000Z",
     )
     validate_provider_decision(proposal, second, first)
+    third = replace(
+        second,
+        decision_id=_id(22),
+        supersedes_decision_digest=second.digest,
+        decided_at="2026-08-14T00:00:03.000000Z",
+    )
+    validate_provider_decision(proposal, third, second)
     with pytest.raises(ProviderQualificationError, match="Proposal"):
         validate_provider_decision(
             proposal,
@@ -166,6 +173,12 @@ def test_decision_binds_exact_proposal_predecessor_and_chronology() -> None:
         validate_provider_decision(
             proposal,
             replace(second, supersedes_decision_digest=_D),
+            first,
+        )
+    with pytest.raises(ProviderQualificationError, match="predecessor"):
+        validate_provider_decision(
+            proposal,
+            replace(second, decision_id=first.decision_id),
             first,
         )
 

--- a/newsroom/tests/test_increment7e1_provider_decision_seams.py
+++ b/newsroom/tests/test_increment7e1_provider_decision_seams.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import replace
+
+import pytest
+
+from newsroom.authority.canonical import canonical_json_bytes
+from newsroom.increment7.provider_qualification import (
+    PROVIDER_CURRENT_POSTURE,
+    PROVIDER_QUALIFICATION_AUTHORITY,
+    ProviderDecision,
+    ProviderKind,
+    ProviderPrerequisite,
+    ProviderPrerequisiteAssessment,
+    ProviderPrerequisiteOutcome,
+    ProviderProposal,
+    ProviderQualificationError,
+    ProviderQualificationStatus,
+    validate_provider_decision,
+)
+
+_AT = "2026-08-14T00:00:00.000000Z"
+_D = "sha256:" + "a" * 64
+
+
+def _id(value: int) -> str:
+    return str(uuid.UUID(int=value, version=4))
+
+
+def _posture(kind: ProviderKind) -> ProviderQualificationStatus:
+    return ProviderQualificationStatus(PROVIDER_CURRENT_POSTURE[kind.value])
+
+
+def _proposal(kind: ProviderKind, value: int = 1) -> ProviderProposal:
+    return ProviderProposal(
+        _id(value),
+        f"fixture-provider-{value}",
+        kind,
+        f"Fixture {kind.value}",
+        _posture(kind),
+        ("PUBLIC_NEWS_SEARCH",),
+        "research-snapshot-v1",
+        (_D,),
+        "sha256:" + "b" * 64,
+        _AT,
+    )
+
+
+def _assessments(
+    missing: ProviderPrerequisite = ProviderPrerequisite.RIGHTS_BASIS,
+) -> tuple[ProviderPrerequisiteAssessment, ...]:
+    return tuple(
+        ProviderPrerequisiteAssessment(
+            prerequisite,
+            (
+                ProviderPrerequisiteOutcome.MISSING
+                if prerequisite is missing
+                else ProviderPrerequisiteOutcome.SATISFIED
+            ),
+            None if prerequisite is missing else "sha256:" + "c" * 64,
+        )
+        for prerequisite in ProviderPrerequisite
+    )
+
+
+def _decision(proposal: ProviderProposal, value: int = 20) -> ProviderDecision:
+    return ProviderDecision(
+        _id(value),
+        proposal.proposal_id,
+        proposal.digest,
+        proposal.proposed_posture,
+        _assessments(),
+        None,
+        "sha256:" + "d" * 64,
+        ("CURRENT_POSTURE_RETAINED",),
+        "2026-08-14T00:00:01.000000Z",
+    )
+
+
+def test_current_provider_postures_roundtrip_without_activation() -> None:
+    for kind, expected in (
+        (ProviderKind.GDELT, ProviderQualificationStatus.HELD),
+        (
+            ProviderKind.BRAVE_SEARCH,
+            ProviderQualificationStatus.RIGHTS_REVIEW_REQUIRED,
+        ),
+        (ProviderKind.SEARXNG, ProviderQualificationStatus.RESEARCH),
+        (ProviderKind.UNOFFICIAL_WRAPPER, ProviderQualificationStatus.RESEARCH),
+    ):
+        proposal = _proposal(kind, list(ProviderKind).index(kind) + 1)
+        decision = _decision(proposal, list(ProviderKind).index(kind) + 20)
+        validate_provider_decision(proposal, decision)
+        assert proposal.proposed_posture is expected
+        assert (
+            ProviderProposal.from_canonical_bytes(proposal.canonical_bytes) == proposal
+        )
+        assert (
+            ProviderDecision.from_canonical_bytes(decision.canonical_bytes) == decision
+        )
+        for record in (proposal, decision):
+            assert record.authorises_provider is False
+            assert record.authorises_credentials is False
+            assert record.authorises_egress is False
+            assert record.authorises_spend is False
+            assert record.production_activation_authorised is False
+    assert PROVIDER_QUALIFICATION_AUTHORITY == "DECISION_RECORD_ONLY_NO_ACTIVATION"
+
+
+def test_prerequisites_are_complete_referenced_and_never_self_qualifying() -> None:
+    proposal = _proposal(ProviderKind.BRAVE_SEARCH)
+    with pytest.raises(ProviderQualificationError, match="current posture"):
+        replace(
+            proposal,
+            proposed_posture=ProviderQualificationStatus.QUALIFIED_FOR_SEPARATE_ADMISSION_REVIEW,
+        )
+    with pytest.raises(ProviderQualificationError, match="exact reference"):
+        ProviderPrerequisiteAssessment(
+            ProviderPrerequisite.RIGHTS_BASIS,
+            ProviderPrerequisiteOutcome.SATISFIED,
+            None,
+        )
+    with pytest.raises(ProviderQualificationError, match="assessments"):
+        replace(_decision(proposal), prerequisite_assessments=_assessments()[:-1])
+    all_satisfied = tuple(
+        ProviderPrerequisiteAssessment(
+            prerequisite,
+            ProviderPrerequisiteOutcome.SATISFIED,
+            "sha256:" + "e" * 64,
+        )
+        for prerequisite in ProviderPrerequisite
+    )
+    qualified = ProviderDecision(
+        _id(99),
+        proposal.proposal_id,
+        proposal.digest,
+        ProviderQualificationStatus.QUALIFIED_FOR_SEPARATE_ADMISSION_REVIEW,
+        all_satisfied,
+        None,
+        "sha256:" + "f" * 64,
+        ("PREREQUISITES_RECORDED",),
+        "2026-08-14T00:00:01.000000Z",
+    )
+    with pytest.raises(ProviderQualificationError, match="current posture"):
+        validate_provider_decision(proposal, qualified)
+
+
+def test_decision_binds_exact_proposal_predecessor_and_chronology() -> None:
+    proposal = _proposal(ProviderKind.GDELT)
+    first = _decision(proposal)
+    validate_provider_decision(proposal, first)
+    second = replace(
+        first,
+        decision_id=_id(21),
+        supersedes_decision_digest=first.digest,
+        decided_at="2026-08-14T00:00:02.000000Z",
+    )
+    validate_provider_decision(proposal, second, first)
+    with pytest.raises(ProviderQualificationError, match="Proposal"):
+        validate_provider_decision(
+            proposal,
+            replace(first, proposal_digest="sha256:" + "0" * 64),
+        )
+    with pytest.raises(ProviderQualificationError, match="predecessor"):
+        validate_provider_decision(
+            proposal,
+            replace(second, supersedes_decision_digest=_D),
+            first,
+        )
+
+
+def test_unknown_duplicate_and_noncanonical_bytes_fail_closed() -> None:
+    proposal = _proposal(ProviderKind.SEARXNG)
+    value = json.loads(proposal.canonical_bytes)
+    value["credential"] = "TOKEN"
+    with pytest.raises(ProviderQualificationError, match="fields"):
+        ProviderProposal.from_canonical_bytes(canonical_json_bytes(value))
+    duplicate = proposal.canonical_bytes.replace(
+        b'"provider_id":', b'"provider_id":"other","provider_id":', 1
+    )
+    with pytest.raises(ProviderQualificationError, match="duplicate"):
+        ProviderProposal.from_canonical_bytes(duplicate)
+    with pytest.raises(ProviderQualificationError, match="canonical JSON"):
+        ProviderProposal.from_canonical_bytes(proposal.canonical_bytes + b" ")
+
+
+def test_rejection_is_a_record_not_provider_or_editorial_authority() -> None:
+    proposal = _proposal(ProviderKind.UNOFFICIAL_WRAPPER)
+    rejected = replace(
+        _decision(proposal),
+        status=ProviderQualificationStatus.REJECTED,
+        reason_codes=("UNOFFICIAL_ACCESS_PATH",),
+    )
+    validate_provider_decision(proposal, rejected)
+    assert rejected.authorises_query_execution is False
+    assert rejected.authorises_evidence is False
+    assert rejected.authorises_publication is False
+    assert rejected.creates_signal is False
+    assert rejected.creates_lead is False
+    assert rejected.creates_candidate is False

--- a/newsroom/tests/test_increment7e1_provider_decision_seams.py
+++ b/newsroom/tests/test_increment7e1_provider_decision_seams.py
@@ -144,6 +144,14 @@ def test_prerequisites_are_complete_referenced_and_never_self_qualifying() -> No
     )
     with pytest.raises(ProviderQualificationError, match="current posture"):
         validate_provider_decision(proposal, qualified)
+    retained = replace(
+        qualified,
+        status=proposal.proposed_posture,
+        reason_codes=("SATISFIED_BUT_NOT_ADMITTED",),
+    )
+    validate_provider_decision(proposal, retained)
+    with pytest.raises(TypeError):
+        PROVIDER_CURRENT_POSTURE[ProviderKind.BRAVE_SEARCH.value] = "RESEARCH"  # type: ignore[index]
 
 
 def test_decision_binds_exact_proposal_predecessor_and_chronology() -> None:
@@ -196,6 +204,10 @@ def test_unknown_duplicate_and_noncanonical_bytes_fail_closed() -> None:
         ProviderProposal.from_canonical_bytes(duplicate)
     with pytest.raises(ProviderQualificationError, match="canonical JSON"):
         ProviderProposal.from_canonical_bytes(proposal.canonical_bytes + b" ")
+    malformed = json.loads(proposal.canonical_bytes)
+    malformed["capability_scope"] = None
+    with pytest.raises(ProviderQualificationError, match="must be an array"):
+        ProviderProposal.from_canonical_bytes(canonical_json_bytes(malformed))
 
 
 def test_rejection_is_a_record_not_provider_or_editorial_authority() -> None:


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-7e1-provider-qualification
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

Closes #440

## Summary
- add strict immutable Provider Proposal, prerequisite assessment and Decision contracts
- preserve GDELT Held, Brave Rights Review Required, and SearXNG/unofficial-wrapper Research postures
- require exact ordered prerequisite assessments, proposal lineage, supersession and chronology
- keep every decision non-authoritative for credentials, queries, egress, spend, scheduling, evidence, locality, publication or activation

## Evidence
- focused deterministic tests: 5 passed
- ruff: passed

Tier L exact-head SDLC and zero unresolved material review findings remain required before merge.