### PR TITLE
Increment 7E2: add locality qualification seams

### DIFF
--- a/newsroom/increment7/locality_qualification.py
+++ b/newsroom/increment7/locality_qualification.py
@@ -232,8 +232,14 @@ _REFERENCE_FIELDS = (
     "locality_kind",
     "canonical_code",
     "display_label",
+    "canonical_alias_set_digest",
+    "parent_geography_digest",
     "boundary_definition_version",
     "boundary_digest",
+    "authoritative_boundary_source_digest",
+    "validity_interval_digest",
+    "overlap_assessment_digest",
+    "uncertainty_assessment_digest",
     "provenance_digests",
     "recorded_at",
 )
@@ -245,8 +251,14 @@ class LocalityReference(_NoEffect):
     locality_kind: LocalityKind
     canonical_code: str
     display_label: str
+    canonical_alias_set_digest: str
+    parent_geography_digest: str
     boundary_definition_version: str
     boundary_digest: str
+    authoritative_boundary_source_digest: str
+    validity_interval_digest: str
+    overlap_assessment_digest: str
+    uncertainty_assessment_digest: str
     provenance_digests: tuple[str, ...]
     recorded_at: str
     schema_version: str = LOCALITY_REFERENCE
@@ -262,8 +274,17 @@ class LocalityReference(_NoEffect):
         )
         _token(self.canonical_code, "canonical_code")
         _text(self.display_label, "display_label", 512)
+        _digest(self.canonical_alias_set_digest, "canonical_alias_set_digest")
+        _digest(self.parent_geography_digest, "parent_geography_digest")
         _token(self.boundary_definition_version, "boundary_definition_version")
         _digest(self.boundary_digest, "boundary_digest")
+        for field in (
+            "authoritative_boundary_source_digest",
+            "validity_interval_digest",
+            "overlap_assessment_digest",
+            "uncertainty_assessment_digest",
+        ):
+            _digest(getattr(self, field), field)
         object.__setattr__(
             self,
             "provenance_digests",

--- a/newsroom/increment7/locality_qualification.py
+++ b/newsroom/increment7/locality_qualification.py
@@ -168,6 +168,12 @@ def _strings(
     return result
 
 
+def _array(value: object, field: str) -> list[object]:
+    if type(value) is not list:
+        raise LocalityQualificationError(f"{field} must be an array")
+    return value
+
+
 def _pairs(pairs: list[tuple[str, object]]) -> dict[str, object]:
     result: dict[str, object] = {}
     for key, value in pairs:
@@ -275,7 +281,9 @@ class LocalityReference(_NoEffect):
     @classmethod
     def from_canonical_bytes(cls, raw: bytes) -> Self:
         value = _document(raw, LOCALITY_REFERENCE, _REFERENCE_FIELDS)
-        value["provenance_digests"] = tuple(value["provenance_digests"])  # type: ignore[arg-type]
+        value["provenance_digests"] = tuple(
+            _array(value["provenance_digests"], "provenance_digests")
+        )
         result = cls(**value)  # type: ignore[arg-type]
         if result.canonical_bytes != raw:
             raise LocalityQualificationError("Locality Reference replay differs")
@@ -357,7 +365,7 @@ class LocalityCoverageUnit(_NoEffect):
     def from_canonical_bytes(cls, raw: bytes) -> Self:
         value = _document(raw, LOCALITY_COVERAGE_UNIT, _UNIT_FIELDS)
         for field in ("source_class_scope", "explicit_exclusions", "known_gap_codes"):
-            value[field] = tuple(value[field])  # type: ignore[arg-type]
+            value[field] = tuple(_array(value[field], field))
         result = cls(**value)  # type: ignore[arg-type]
         if result.canonical_bytes != raw:
             raise LocalityQualificationError("Locality Coverage Unit replay differs")
@@ -452,7 +460,7 @@ class LocalityCoverageProposal(_NoEffect):
             "proposed_source_reference_digests",
             "unresolved_gap_codes",
         ):
-            value[field] = tuple(value[field])  # type: ignore[arg-type]
+            value[field] = tuple(_array(value[field], field))
         result = cls(**value)  # type: ignore[arg-type]
         if result.canonical_bytes != raw:
             raise LocalityQualificationError(
@@ -524,7 +532,7 @@ class LocalityCoverageDecision(_NoEffect):
     def from_canonical_bytes(cls, raw: bytes) -> Self:
         value = _document(raw, LOCALITY_COVERAGE_DECISION, _DECISION_FIELDS)
         for field in ("assessed_gap_codes", "reason_codes"):
-            value[field] = tuple(value[field])  # type: ignore[arg-type]
+            value[field] = tuple(_array(value[field], field))
         result = cls(**value)  # type: ignore[arg-type]
         if result.canonical_bytes != raw:
             raise LocalityQualificationError(
@@ -538,7 +546,9 @@ def validate_locality_coverage_chain(
     unit: LocalityCoverageUnit,
     proposal: LocalityCoverageProposal,
     decision: LocalityCoverageDecision,
-    previous: LocalityCoverageDecision | None = None,
+    previous: (
+        LocalityCoverageDecision | tuple[LocalityCoverageDecision, ...] | None
+    ) = None,
 ) -> None:
     if any(
         type(value) is not kind
@@ -569,13 +579,34 @@ def validate_locality_coverage_chain(
             raise LocalityQualificationError(
                 "initial locality decision supersedes another"
             )
-    else:
-        validate_locality_coverage_chain(reference, unit, proposal, previous)
-        if (
-            decision.supersedes_decision_digest != previous.digest
-            or decision.decided_at < previous.decided_at
-        ):
-            raise LocalityQualificationError("locality decision predecessor differs")
+        return
+    chain = previous if type(previous) is tuple else (previous,)
+    if (
+        not chain
+        or any(type(item) is not LocalityCoverageDecision for item in chain)
+        or chain[0].supersedes_decision_digest is not None
+    ):
+        raise LocalityQualificationError("locality decision predecessor differs")
+    if (
+        any(
+            item.proposal_id != proposal.proposal_id
+            or item.proposal_digest != proposal.digest
+            or item.decided_at < proposal.proposed_at
+            or set(item.assessed_gap_codes) != set(proposal.unresolved_gap_codes)
+            for item in chain
+        )
+        or len({item.decision_id for item in chain}) != len(chain)
+        or len({item.digest for item in chain}) != len(chain)
+        or any(
+            current.supersedes_decision_digest != predecessor.digest
+            or current.decided_at < predecessor.decided_at
+            for predecessor, current in zip(chain, chain[1:])
+        )
+        or decision.decision_id in {item.decision_id for item in chain}
+        or decision.supersedes_decision_digest != chain[-1].digest
+        or decision.decided_at < chain[-1].decided_at
+    ):
+        raise LocalityQualificationError("locality decision predecessor differs")
 
 
 __all__ = [

--- a/newsroom/increment7/locality_qualification.py
+++ b/newsroom/increment7/locality_qualification.py
@@ -639,7 +639,14 @@ def validate_locality_coverage_chain(
         LocalityCoverageDecision | tuple[LocalityCoverageDecision, ...] | None
     ) = None,
     *,
-    provider_qualifications: tuple[tuple[ProviderProposal, ProviderDecision], ...],
+    provider_qualifications: tuple[
+        tuple[
+            ProviderProposal,
+            ProviderDecision,
+            tuple[ProviderDecision, ...],
+        ],
+        ...,
+    ],
 ) -> None:
     if any(
         type(value) is not kind
@@ -659,19 +666,29 @@ def validate_locality_coverage_chain(
     for qualification in provider_qualifications:
         if (
             type(qualification) is not tuple
-            or len(qualification) != 2
+            or len(qualification) != 3
             or type(qualification[0]) is not ProviderProposal
             or type(qualification[1]) is not ProviderDecision
+            or type(qualification[2]) is not tuple
+            or any(type(item) is not ProviderDecision for item in qualification[2])
         ):
             raise LocalityQualificationError(
                 "locality chain requires exact Provider Decisions"
             )
         try:
-            validate_provider_decision(*qualification)
+            validate_provider_decision(
+                qualification[0],
+                qualification[1],
+                qualification[2] or None,
+            )
         except ProviderQualificationError as exc:
             raise LocalityQualificationError(
                 "locality Provider Decision basis differs"
             ) from exc
+        if qualification[1].decided_at > proposal.proposed_at:
+            raise LocalityQualificationError(
+                "locality Provider Decision chronology differs"
+            )
         provider_decision_digests.append(qualification[1].digest)
     if tuple(sorted(set(provider_decision_digests))) != tuple(
         provider_decision_digests

--- a/newsroom/increment7/locality_qualification.py
+++ b/newsroom/increment7/locality_qualification.py
@@ -68,6 +68,14 @@ class LocalityProposalPosture(StrEnum):
     RESEARCH_ONLY = "RESEARCH_ONLY"
 
 
+class LocalityQualificationFactorRole(StrEnum):
+    ACCEPTED_COVERAGE_OR_REVIEWED_GAP = "ACCEPTED_COVERAGE_OR_REVIEWED_GAP"
+    PROSPECTIVE_CONTRIBUTION = "PROSPECTIVE_CONTRIBUTION"
+    AUDIENCE_NEED = "AUDIENCE_NEED"
+    RESILIENCE = "RESILIENCE"
+    OTHER_OWNER_APPROVED = "OTHER_OWNER_APPROVED"
+
+
 class LocalityDecisionOutcome(StrEnum):
     DEFERRED = "DEFERRED"
     REJECTED = "REJECTED"
@@ -227,7 +235,9 @@ def _record_dict(record: object, fields: tuple[str, ...]) -> dict[str, object]:
         if isinstance(value, StrEnum):
             value = value.value
         elif isinstance(value, tuple):
-            value = list(value)
+            value = [
+                item.to_dict() if hasattr(item, "to_dict") else item for item in value
+            ]
         result[field] = value
     return result
 
@@ -429,14 +439,47 @@ class LocalityCoverageUnit(_NoEffect):
         return result
 
 
+_QUALIFICATION_BASIS_FIELDS = ("factor_role", "reference_digest")
+
+
+@dataclass(frozen=True, slots=True)
+class LocalityQualificationBasis(_NoEffect):
+    factor_role: LocalityQualificationFactorRole
+    reference_digest: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "factor_role",
+            _enum(
+                LocalityQualificationFactorRole,
+                self.factor_role,
+                "factor_role",
+            ),
+        )
+        _digest(self.reference_digest, "reference_digest")
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "factor_role": self.factor_role.value,
+            "reference_digest": self.reference_digest,
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> Self:
+        if type(value) is not dict or tuple(value) != _QUALIFICATION_BASIS_FIELDS:
+            raise LocalityQualificationError("qualification basis fields differ")
+        return cls(**value)  # type: ignore[arg-type]
+
+
 _PROPOSAL_FIELDS = (
     "schema_version",
     "proposal_id",
     "coverage_unit_id",
     "coverage_unit_digest",
     "posture",
-    "qualification_basis_digests",
-    "provider_decision_digests",
+    "qualification_bases",
+    "provider_proposal_digests",
     "proposed_source_reference_digests",
     "permanent_monitoring_rationale_digest",
     "expected_contribution_digest",
@@ -455,8 +498,8 @@ class LocalityCoverageProposal(_NoEffect):
     coverage_unit_id: str
     coverage_unit_digest: str
     posture: LocalityProposalPosture
-    qualification_basis_digests: tuple[str, ...]
-    provider_decision_digests: tuple[str, ...]
+    qualification_bases: tuple[LocalityQualificationBasis, ...]
+    provider_proposal_digests: tuple[str, ...]
     proposed_source_reference_digests: tuple[str, ...]
     permanent_monitoring_rationale_digest: str
     expected_contribution_digest: str
@@ -483,21 +526,35 @@ class LocalityCoverageProposal(_NoEffect):
         )
         object.__setattr__(
             self,
-            "qualification_basis_digests",
-            _strings(
-                self.qualification_basis_digests,
-                "qualification_basis_digests",
-                required=True,
-                digests=True,
-                minimum=2,
-            ),
+            "qualification_bases",
+            tuple(
+                item
+                if type(item) is LocalityQualificationBasis
+                else LocalityQualificationBasis.from_dict(item)
+                for item in self.qualification_bases
+            )
+            if type(self.qualification_bases) is tuple
+            else (),
         )
+        if (
+            len(self.qualification_bases) < 2
+            or len(self.qualification_bases) > 64
+            or tuple(
+                sorted(self.qualification_bases, key=lambda item: item.factor_role.value)
+            )
+            != self.qualification_bases
+            or len({item.factor_role for item in self.qualification_bases})
+            != len(self.qualification_bases)
+        ):
+            raise LocalityQualificationError(
+                "qualification_bases must contain independent ordered factors"
+            )
         object.__setattr__(
             self,
-            "provider_decision_digests",
+            "provider_proposal_digests",
             _strings(
-                self.provider_decision_digests,
-                "provider_decision_digests",
+                self.provider_proposal_digests,
+                "provider_proposal_digests",
                 required=True,
                 digests=True,
             ),
@@ -543,9 +600,12 @@ class LocalityCoverageProposal(_NoEffect):
     @classmethod
     def from_canonical_bytes(cls, raw: bytes) -> Self:
         value = _document(raw, LOCALITY_COVERAGE_PROPOSAL, _PROPOSAL_FIELDS)
+        value["qualification_bases"] = tuple(
+            LocalityQualificationBasis.from_dict(item)
+            for item in _array(value["qualification_bases"], "qualification_bases")
+        )
         for field in (
-            "qualification_basis_digests",
-            "provider_decision_digests",
+            "provider_proposal_digests",
             "proposed_source_reference_digests",
             "unresolved_gap_codes",
         ):
@@ -563,6 +623,7 @@ _DECISION_FIELDS = (
     "decision_id",
     "proposal_id",
     "proposal_digest",
+    "provider_decision_digests",
     "outcome",
     "assessed_gap_codes",
     "reason_codes",
@@ -577,6 +638,7 @@ class LocalityCoverageDecision(_NoEffect):
     decision_id: str
     proposal_id: str
     proposal_digest: str
+    provider_decision_digests: tuple[str, ...]
     outcome: LocalityDecisionOutcome
     assessed_gap_codes: tuple[str, ...]
     reason_codes: tuple[str, ...]
@@ -593,6 +655,16 @@ class LocalityCoverageDecision(_NoEffect):
         _uuid(self.decision_id, "decision_id")
         _uuid(self.proposal_id, "proposal_id")
         _digest(self.proposal_digest, "proposal_digest")
+        object.__setattr__(
+            self,
+            "provider_decision_digests",
+            _strings(
+                self.provider_decision_digests,
+                "provider_decision_digests",
+                required=True,
+                digests=True,
+            ),
+        )
         object.__setattr__(
             self,
             "outcome",
@@ -620,7 +692,11 @@ class LocalityCoverageDecision(_NoEffect):
     @classmethod
     def from_canonical_bytes(cls, raw: bytes) -> Self:
         value = _document(raw, LOCALITY_COVERAGE_DECISION, _DECISION_FIELDS)
-        for field in ("assessed_gap_codes", "reason_codes"):
+        for field in (
+            "provider_decision_digests",
+            "assessed_gap_codes",
+            "reason_codes",
+        ):
             value[field] = tuple(_array(value[field], field))
         result = cls(**value)  # type: ignore[arg-type]
         if result.canonical_bytes != raw:
@@ -662,6 +738,7 @@ def validate_locality_coverage_chain(
         raise LocalityQualificationError(
             "locality chain requires exact Provider Decisions"
         )
+    provider_proposal_digests: list[str] = []
     provider_decision_digests: list[str] = []
     for qualification in provider_qualifications:
         if (
@@ -685,14 +762,20 @@ def validate_locality_coverage_chain(
             raise LocalityQualificationError(
                 "locality Provider Decision basis differs"
             ) from exc
-        if qualification[1].decided_at > proposal.proposed_at:
+        if qualification[1].decided_at > decision.decided_at:
             raise LocalityQualificationError(
                 "locality Provider Decision chronology differs"
             )
+        provider_proposal_digests.append(qualification[0].digest)
         provider_decision_digests.append(qualification[1].digest)
-    if tuple(sorted(set(provider_decision_digests))) != tuple(
-        provider_decision_digests
-    ) or tuple(provider_decision_digests) != proposal.provider_decision_digests:
+    if (
+        tuple(sorted(set(provider_proposal_digests)))
+        != tuple(provider_proposal_digests)
+        or tuple(sorted(set(provider_decision_digests)))
+        != tuple(provider_decision_digests)
+        or tuple(provider_proposal_digests) != proposal.provider_proposal_digests
+        or tuple(provider_decision_digests) != decision.provider_decision_digests
+    ):
         raise LocalityQualificationError("locality Provider Decision basis differs")
     if (
         unit.locality_reference_id != reference.locality_reference_id
@@ -757,6 +840,8 @@ __all__ = [
     "LocalityDecisionOutcome",
     "LocalityKind",
     "LocalityProposalPosture",
+    "LocalityQualificationBasis",
+    "LocalityQualificationFactorRole",
     "LocalityQualificationError",
     "LocalityReference",
     "LocalityServiceBoundary",

--- a/newsroom/increment7/locality_qualification.py
+++ b/newsroom/increment7/locality_qualification.py
@@ -16,6 +16,12 @@ from newsroom.authority.canonical import (
     digest_bytes,
     validate_sha256_digest,
 )
+from newsroom.increment7.provider_qualification import (
+    ProviderDecision,
+    ProviderProposal,
+    ProviderQualificationError,
+    validate_provider_decision,
+)
 
 LOCALITY_REFERENCE = "newsroom.increment7.locality-reference.v1"
 LOCALITY_COVERAGE_UNIT = "newsroom.increment7.locality-coverage-unit.v1"
@@ -632,6 +638,8 @@ def validate_locality_coverage_chain(
     previous: (
         LocalityCoverageDecision | tuple[LocalityCoverageDecision, ...] | None
     ) = None,
+    *,
+    provider_qualifications: tuple[tuple[ProviderProposal, ProviderDecision], ...],
 ) -> None:
     if any(
         type(value) is not kind
@@ -643,6 +651,32 @@ def validate_locality_coverage_chain(
         )
     ):
         raise LocalityQualificationError("locality chain requires exact records")
+    if type(provider_qualifications) is not tuple or not provider_qualifications:
+        raise LocalityQualificationError(
+            "locality chain requires exact Provider Decisions"
+        )
+    provider_decision_digests: list[str] = []
+    for qualification in provider_qualifications:
+        if (
+            type(qualification) is not tuple
+            or len(qualification) != 2
+            or type(qualification[0]) is not ProviderProposal
+            or type(qualification[1]) is not ProviderDecision
+        ):
+            raise LocalityQualificationError(
+                "locality chain requires exact Provider Decisions"
+            )
+        try:
+            validate_provider_decision(*qualification)
+        except ProviderQualificationError as exc:
+            raise LocalityQualificationError(
+                "locality Provider Decision basis differs"
+            ) from exc
+        provider_decision_digests.append(qualification[1].digest)
+    if tuple(sorted(set(provider_decision_digests))) != tuple(
+        provider_decision_digests
+    ) or tuple(provider_decision_digests) != proposal.provider_decision_digests:
+        raise LocalityQualificationError("locality Provider Decision basis differs")
     if (
         unit.locality_reference_id != reference.locality_reference_id
         or unit.locality_reference_digest != reference.digest

--- a/newsroom/increment7/locality_qualification.py
+++ b/newsroom/increment7/locality_qualification.py
@@ -158,8 +158,14 @@ def _strings(
     *,
     required: bool = False,
     digests: bool = False,
+    minimum: int = 0,
 ) -> tuple[str, ...]:
-    if type(value) is not tuple or len(value) > 64 or (required and not value):
+    if (
+        type(value) is not tuple
+        or len(value) > 64
+        or len(value) < minimum
+        or (required and not value)
+    ):
         raise LocalityQualificationError(f"{field} must be a bounded array")
     validator = _digest if digests else _token
     result = tuple(validator(item, field) for item in value)
@@ -296,11 +302,17 @@ _UNIT_FIELDS = (
     "locality_reference_id",
     "locality_reference_digest",
     "service_boundary",
+    "obligation_scope_digest",
     "source_class_scope",
+    "population_service_event_scope_digest",
+    "language_scope_digest",
+    "source_role_scope_digest",
+    "portfolio_function_scope_digest",
     "explicit_exclusions",
     "known_gap_codes",
     "completeness_class",
     "rights_basis_digest",
+    "governing_evaluation_version_digest",
     "operational_profile_digest",
     "recorded_at",
 )
@@ -312,11 +324,17 @@ class LocalityCoverageUnit(_NoEffect):
     locality_reference_id: str
     locality_reference_digest: str
     service_boundary: LocalityServiceBoundary
+    obligation_scope_digest: str
     source_class_scope: tuple[str, ...]
+    population_service_event_scope_digest: str
+    language_scope_digest: str
+    source_role_scope_digest: str
+    portfolio_function_scope_digest: str
     explicit_exclusions: tuple[str, ...]
     known_gap_codes: tuple[str, ...]
     completeness_class: LocalityCompletenessClass
     rights_basis_digest: str
+    governing_evaluation_version_digest: str
     operational_profile_digest: str
     recorded_at: str
     schema_version: str = LOCALITY_COVERAGE_UNIT
@@ -332,6 +350,14 @@ class LocalityCoverageUnit(_NoEffect):
             "service_boundary",
             _enum(LocalityServiceBoundary, self.service_boundary, "service_boundary"),
         )
+        for field in (
+            "obligation_scope_digest",
+            "population_service_event_scope_digest",
+            "language_scope_digest",
+            "source_role_scope_digest",
+            "portfolio_function_scope_digest",
+        ):
+            _digest(getattr(self, field), field)
         for field, required in (
             ("source_class_scope", True),
             ("explicit_exclusions", False),
@@ -350,6 +376,10 @@ class LocalityCoverageUnit(_NoEffect):
             ),
         )
         _digest(self.rights_basis_digest, "rights_basis_digest")
+        _digest(
+            self.governing_evaluation_version_digest,
+            "governing_evaluation_version_digest",
+        )
         _digest(self.operational_profile_digest, "operational_profile_digest")
         _timestamp(self.recorded_at, "recorded_at")
 
@@ -378,8 +408,14 @@ _PROPOSAL_FIELDS = (
     "coverage_unit_id",
     "coverage_unit_digest",
     "posture",
+    "qualification_basis_digests",
     "provider_decision_digests",
     "proposed_source_reference_digests",
+    "permanent_monitoring_rationale_digest",
+    "expected_contribution_digest",
+    "evaluation_design_digest",
+    "alternatives_assessment_digest",
+    "non_selection_consequence_digest",
     "unresolved_gap_codes",
     "owner_identity_digest",
     "proposed_at",
@@ -392,8 +428,14 @@ class LocalityCoverageProposal(_NoEffect):
     coverage_unit_id: str
     coverage_unit_digest: str
     posture: LocalityProposalPosture
+    qualification_basis_digests: tuple[str, ...]
     provider_decision_digests: tuple[str, ...]
     proposed_source_reference_digests: tuple[str, ...]
+    permanent_monitoring_rationale_digest: str
+    expected_contribution_digest: str
+    evaluation_design_digest: str
+    alternatives_assessment_digest: str
+    non_selection_consequence_digest: str
     unresolved_gap_codes: tuple[str, ...]
     owner_identity_digest: str
     proposed_at: str
@@ -411,6 +453,17 @@ class LocalityCoverageProposal(_NoEffect):
             self,
             "posture",
             _enum(LocalityProposalPosture, self.posture, "posture"),
+        )
+        object.__setattr__(
+            self,
+            "qualification_basis_digests",
+            _strings(
+                self.qualification_basis_digests,
+                "qualification_basis_digests",
+                required=True,
+                digests=True,
+                minimum=2,
+            ),
         )
         object.__setattr__(
             self,
@@ -441,6 +494,14 @@ class LocalityCoverageProposal(_NoEffect):
                 required=True,
             ),
         )
+        for field in (
+            "permanent_monitoring_rationale_digest",
+            "expected_contribution_digest",
+            "evaluation_design_digest",
+            "alternatives_assessment_digest",
+            "non_selection_consequence_digest",
+        ):
+            _digest(getattr(self, field), field)
         _digest(self.owner_identity_digest, "owner_identity_digest")
         _timestamp(self.proposed_at, "proposed_at")
 
@@ -456,6 +517,7 @@ class LocalityCoverageProposal(_NoEffect):
     def from_canonical_bytes(cls, raw: bytes) -> Self:
         value = _document(raw, LOCALITY_COVERAGE_PROPOSAL, _PROPOSAL_FIELDS)
         for field in (
+            "qualification_basis_digests",
             "provider_decision_digests",
             "proposed_source_reference_digests",
             "unresolved_gap_codes",

--- a/newsroom/increment7/locality_qualification.py
+++ b/newsroom/increment7/locality_qualification.py
@@ -1,0 +1,599 @@
+"""Immutable, non-activating locality coverage qualification seams."""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+from typing import Self
+
+from newsroom.authority.canonical import (
+    CanonicalizationError,
+    canonical_json_bytes,
+    digest_bytes,
+    validate_sha256_digest,
+)
+
+LOCALITY_REFERENCE = "newsroom.increment7.locality-reference.v1"
+LOCALITY_COVERAGE_UNIT = "newsroom.increment7.locality-coverage-unit.v1"
+LOCALITY_COVERAGE_PROPOSAL = "newsroom.increment7.locality-coverage-proposal.v1"
+LOCALITY_COVERAGE_DECISION = "newsroom.increment7.locality-coverage-decision.v1"
+LOCALITY_COMPLETENESS = "BEST_EFFORT_EXPLICIT_GAPS_NO_COMPLETENESS_CLAIM"
+LOCALITY_ACTIVATION = "DECISION_RECORD_ONLY_NO_SELECTION_OR_ENABLEMENT"
+MAX_LOCALITY_BYTES = 1_048_576
+
+_UUID = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z"
+)
+_TOKEN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:\-]{0,255}\Z")
+_UTC = re.compile(
+    r"[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T"
+    r"(?:[01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]\.[0-9]{6}Z\Z"
+)
+
+
+class LocalityQualificationError(ValueError):
+    """A locality seam failed its exact immutable contract."""
+
+
+class LocalityKind(StrEnum):
+    ADMINISTRATIVE_AREA = "ADMINISTRATIVE_AREA"
+    EDITORIAL_REGION = "EDITORIAL_REGION"
+    SERVICE_AREA = "SERVICE_AREA"
+    OTHER_VERSIONED_BOUNDARY = "OTHER_VERSIONED_BOUNDARY"
+
+
+class LocalityServiceBoundary(StrEnum):
+    CIVIC_AND_PUBLIC_BODIES = "CIVIC_AND_PUBLIC_BODIES"
+    EMERGENCY_AND_SAFETY = "EMERGENCY_AND_SAFETY"
+    HEALTH_AND_SOCIAL_CARE = "HEALTH_AND_SOCIAL_CARE"
+    TRANSPORT_AND_INFRASTRUCTURE = "TRANSPORT_AND_INFRASTRUCTURE"
+    GENERAL_LOCAL_NEWS_RESEARCH = "GENERAL_LOCAL_NEWS_RESEARCH"
+
+
+class LocalityCompletenessClass(StrEnum):
+    BEST_EFFORT_WITH_EXPLICIT_GAPS = "BEST_EFFORT_WITH_EXPLICIT_GAPS"
+
+
+class LocalityProposalPosture(StrEnum):
+    RESEARCH_ONLY = "RESEARCH_ONLY"
+
+
+class LocalityDecisionOutcome(StrEnum):
+    DEFERRED = "DEFERRED"
+    REJECTED = "REJECTED"
+    RETAIN_RESEARCH_ONLY = "RETAIN_RESEARCH_ONLY"
+
+
+class _NoEffect:
+    authorises_external_effect = False
+    authorises_locality = False
+    authorises_source_portfolio = False
+    authorises_provider = False
+    authorises_credentials = False
+    authorises_egress = False
+    authorises_spend = False
+    authorises_schedule = False
+    authorises_search = False
+    authorises_evidence = False
+    authorises_publication = False
+    claims_completeness = False
+    creates_signal = False
+    creates_lead = False
+    creates_candidate = False
+    creates_watch = False
+    permanent_locality_selected = False
+    production_activation_authorised = False
+
+
+def _text(value: object, field: str, maximum: int = 2_048) -> str:
+    try:
+        size = len(value.encode()) if type(value) is str else 0
+    except UnicodeError as exc:
+        raise LocalityQualificationError(f"{field} must be canonical text") from exc
+    if (
+        type(value) is not str
+        or not value
+        or value != value.strip()
+        or size > maximum
+        or any(ord(character) < 32 or ord(character) == 127 for character in value)
+    ):
+        raise LocalityQualificationError(f"{field} must be canonical text")
+    return value
+
+
+def _token(value: object, field: str) -> str:
+    value = _text(value, field, 256)
+    if _TOKEN.fullmatch(value) is None:
+        raise LocalityQualificationError(f"{field} must be a canonical token")
+    return value
+
+
+def _uuid(value: object, field: str) -> str:
+    if type(value) is not str or _UUID.fullmatch(value) is None:
+        raise LocalityQualificationError(f"{field} must be a canonical UUID")
+    try:
+        if str(uuid.UUID(value)) != value:
+            raise ValueError
+    except ValueError as exc:
+        raise LocalityQualificationError(f"{field} must be a canonical UUID") from exc
+    return value
+
+
+def _digest(value: object, field: str) -> str:
+    try:
+        return validate_sha256_digest(value, field=field)
+    except (CanonicalizationError, TypeError, ValueError) as exc:
+        raise LocalityQualificationError(f"{field} must be a SHA-256 digest") from exc
+
+
+def _timestamp(value: object, field: str) -> str:
+    value = _text(value, field, 27)
+    if _UTC.fullmatch(value) is None:
+        raise LocalityQualificationError(f"{field} must be an exact UTC timestamp")
+    try:
+        datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ")
+    except ValueError as exc:
+        raise LocalityQualificationError(
+            f"{field} must be an exact UTC timestamp"
+        ) from exc
+    return value
+
+
+def _enum[T: StrEnum](kind: type[T], value: object, field: str) -> T:
+    if type(value) is not str and type(value) is not kind:
+        raise LocalityQualificationError(f"{field} differs")
+    try:
+        return kind(value)
+    except ValueError as exc:
+        raise LocalityQualificationError(f"{field} differs") from exc
+
+
+def _strings(
+    value: object,
+    field: str,
+    *,
+    required: bool = False,
+    digests: bool = False,
+) -> tuple[str, ...]:
+    if type(value) is not tuple or len(value) > 64 or (required and not value):
+        raise LocalityQualificationError(f"{field} must be a bounded array")
+    validator = _digest if digests else _token
+    result = tuple(validator(item, field) for item in value)
+    if tuple(sorted(set(result))) != result:
+        raise LocalityQualificationError(f"{field} must be unique and sorted")
+    return result
+
+
+def _pairs(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise LocalityQualificationError(f"duplicate object name: {key}")
+        result[key] = value
+    return result
+
+
+def _document(raw: bytes, schema: str, fields: tuple[str, ...]) -> dict[str, object]:
+    if type(raw) is not bytes or not raw or len(raw) > MAX_LOCALITY_BYTES:
+        raise LocalityQualificationError("locality bytes are not bounded")
+    try:
+        value = json.loads(raw.decode(), object_pairs_hook=_pairs)
+        canonical = canonical_json_bytes(value)
+    except LocalityQualificationError:
+        raise
+    except (
+        UnicodeError,
+        json.JSONDecodeError,
+        CanonicalizationError,
+        RecursionError,
+        ValueError,
+    ) as exc:
+        raise LocalityQualificationError(
+            "locality bytes are not canonical JSON"
+        ) from exc
+    if type(value) is not dict or raw != canonical:
+        raise LocalityQualificationError("locality bytes are not exact canonical JSON")
+    if tuple(value) != tuple(sorted(fields)) or value.get("schema_version") != schema:
+        raise LocalityQualificationError("locality fields or schema differ")
+    return value
+
+
+def _record_dict(record: object, fields: tuple[str, ...]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for field in fields:
+        value = getattr(record, field)
+        if isinstance(value, StrEnum):
+            value = value.value
+        elif isinstance(value, tuple):
+            value = list(value)
+        result[field] = value
+    return result
+
+
+_REFERENCE_FIELDS = (
+    "schema_version",
+    "locality_reference_id",
+    "locality_kind",
+    "canonical_code",
+    "display_label",
+    "boundary_definition_version",
+    "boundary_digest",
+    "provenance_digests",
+    "recorded_at",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class LocalityReference(_NoEffect):
+    locality_reference_id: str
+    locality_kind: LocalityKind
+    canonical_code: str
+    display_label: str
+    boundary_definition_version: str
+    boundary_digest: str
+    provenance_digests: tuple[str, ...]
+    recorded_at: str
+    schema_version: str = LOCALITY_REFERENCE
+
+    def __post_init__(self) -> None:
+        if self.schema_version != LOCALITY_REFERENCE:
+            raise LocalityQualificationError("Locality Reference schema differs")
+        _uuid(self.locality_reference_id, "locality_reference_id")
+        object.__setattr__(
+            self,
+            "locality_kind",
+            _enum(LocalityKind, self.locality_kind, "locality_kind"),
+        )
+        _token(self.canonical_code, "canonical_code")
+        _text(self.display_label, "display_label", 512)
+        _token(self.boundary_definition_version, "boundary_definition_version")
+        _digest(self.boundary_digest, "boundary_digest")
+        object.__setattr__(
+            self,
+            "provenance_digests",
+            _strings(
+                self.provenance_digests,
+                "provenance_digests",
+                required=True,
+                digests=True,
+            ),
+        )
+        _timestamp(self.recorded_at, "recorded_at")
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return canonical_json_bytes(_record_dict(self, _REFERENCE_FIELDS))
+
+    @property
+    def digest(self) -> str:
+        return digest_bytes(self.canonical_bytes)
+
+    @classmethod
+    def from_canonical_bytes(cls, raw: bytes) -> Self:
+        value = _document(raw, LOCALITY_REFERENCE, _REFERENCE_FIELDS)
+        value["provenance_digests"] = tuple(value["provenance_digests"])  # type: ignore[arg-type]
+        result = cls(**value)  # type: ignore[arg-type]
+        if result.canonical_bytes != raw:
+            raise LocalityQualificationError("Locality Reference replay differs")
+        return result
+
+
+_UNIT_FIELDS = (
+    "schema_version",
+    "coverage_unit_id",
+    "locality_reference_id",
+    "locality_reference_digest",
+    "service_boundary",
+    "source_class_scope",
+    "explicit_exclusions",
+    "known_gap_codes",
+    "completeness_class",
+    "rights_basis_digest",
+    "operational_profile_digest",
+    "recorded_at",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class LocalityCoverageUnit(_NoEffect):
+    coverage_unit_id: str
+    locality_reference_id: str
+    locality_reference_digest: str
+    service_boundary: LocalityServiceBoundary
+    source_class_scope: tuple[str, ...]
+    explicit_exclusions: tuple[str, ...]
+    known_gap_codes: tuple[str, ...]
+    completeness_class: LocalityCompletenessClass
+    rights_basis_digest: str
+    operational_profile_digest: str
+    recorded_at: str
+    schema_version: str = LOCALITY_COVERAGE_UNIT
+
+    def __post_init__(self) -> None:
+        if self.schema_version != LOCALITY_COVERAGE_UNIT:
+            raise LocalityQualificationError("Locality Coverage Unit schema differs")
+        _uuid(self.coverage_unit_id, "coverage_unit_id")
+        _uuid(self.locality_reference_id, "locality_reference_id")
+        _digest(self.locality_reference_digest, "locality_reference_digest")
+        object.__setattr__(
+            self,
+            "service_boundary",
+            _enum(LocalityServiceBoundary, self.service_boundary, "service_boundary"),
+        )
+        for field, required in (
+            ("source_class_scope", True),
+            ("explicit_exclusions", False),
+            ("known_gap_codes", True),
+        ):
+            object.__setattr__(
+                self, field, _strings(getattr(self, field), field, required=required)
+            )
+        object.__setattr__(
+            self,
+            "completeness_class",
+            _enum(
+                LocalityCompletenessClass,
+                self.completeness_class,
+                "completeness_class",
+            ),
+        )
+        _digest(self.rights_basis_digest, "rights_basis_digest")
+        _digest(self.operational_profile_digest, "operational_profile_digest")
+        _timestamp(self.recorded_at, "recorded_at")
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return canonical_json_bytes(_record_dict(self, _UNIT_FIELDS))
+
+    @property
+    def digest(self) -> str:
+        return digest_bytes(self.canonical_bytes)
+
+    @classmethod
+    def from_canonical_bytes(cls, raw: bytes) -> Self:
+        value = _document(raw, LOCALITY_COVERAGE_UNIT, _UNIT_FIELDS)
+        for field in ("source_class_scope", "explicit_exclusions", "known_gap_codes"):
+            value[field] = tuple(value[field])  # type: ignore[arg-type]
+        result = cls(**value)  # type: ignore[arg-type]
+        if result.canonical_bytes != raw:
+            raise LocalityQualificationError("Locality Coverage Unit replay differs")
+        return result
+
+
+_PROPOSAL_FIELDS = (
+    "schema_version",
+    "proposal_id",
+    "coverage_unit_id",
+    "coverage_unit_digest",
+    "posture",
+    "provider_decision_digests",
+    "proposed_source_reference_digests",
+    "unresolved_gap_codes",
+    "owner_identity_digest",
+    "proposed_at",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class LocalityCoverageProposal(_NoEffect):
+    proposal_id: str
+    coverage_unit_id: str
+    coverage_unit_digest: str
+    posture: LocalityProposalPosture
+    provider_decision_digests: tuple[str, ...]
+    proposed_source_reference_digests: tuple[str, ...]
+    unresolved_gap_codes: tuple[str, ...]
+    owner_identity_digest: str
+    proposed_at: str
+    schema_version: str = LOCALITY_COVERAGE_PROPOSAL
+
+    def __post_init__(self) -> None:
+        if self.schema_version != LOCALITY_COVERAGE_PROPOSAL:
+            raise LocalityQualificationError(
+                "Locality Coverage Proposal schema differs"
+            )
+        _uuid(self.proposal_id, "proposal_id")
+        _uuid(self.coverage_unit_id, "coverage_unit_id")
+        _digest(self.coverage_unit_digest, "coverage_unit_digest")
+        object.__setattr__(
+            self,
+            "posture",
+            _enum(LocalityProposalPosture, self.posture, "posture"),
+        )
+        object.__setattr__(
+            self,
+            "provider_decision_digests",
+            _strings(
+                self.provider_decision_digests,
+                "provider_decision_digests",
+                required=True,
+                digests=True,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "proposed_source_reference_digests",
+            _strings(
+                self.proposed_source_reference_digests,
+                "proposed_source_reference_digests",
+                required=True,
+                digests=True,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "unresolved_gap_codes",
+            _strings(
+                self.unresolved_gap_codes,
+                "unresolved_gap_codes",
+                required=True,
+            ),
+        )
+        _digest(self.owner_identity_digest, "owner_identity_digest")
+        _timestamp(self.proposed_at, "proposed_at")
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return canonical_json_bytes(_record_dict(self, _PROPOSAL_FIELDS))
+
+    @property
+    def digest(self) -> str:
+        return digest_bytes(self.canonical_bytes)
+
+    @classmethod
+    def from_canonical_bytes(cls, raw: bytes) -> Self:
+        value = _document(raw, LOCALITY_COVERAGE_PROPOSAL, _PROPOSAL_FIELDS)
+        for field in (
+            "provider_decision_digests",
+            "proposed_source_reference_digests",
+            "unresolved_gap_codes",
+        ):
+            value[field] = tuple(value[field])  # type: ignore[arg-type]
+        result = cls(**value)  # type: ignore[arg-type]
+        if result.canonical_bytes != raw:
+            raise LocalityQualificationError(
+                "Locality Coverage Proposal replay differs"
+            )
+        return result
+
+
+_DECISION_FIELDS = (
+    "schema_version",
+    "decision_id",
+    "proposal_id",
+    "proposal_digest",
+    "outcome",
+    "assessed_gap_codes",
+    "reason_codes",
+    "decider_identity_digest",
+    "supersedes_decision_digest",
+    "decided_at",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class LocalityCoverageDecision(_NoEffect):
+    decision_id: str
+    proposal_id: str
+    proposal_digest: str
+    outcome: LocalityDecisionOutcome
+    assessed_gap_codes: tuple[str, ...]
+    reason_codes: tuple[str, ...]
+    decider_identity_digest: str
+    supersedes_decision_digest: str | None
+    decided_at: str
+    schema_version: str = LOCALITY_COVERAGE_DECISION
+
+    def __post_init__(self) -> None:
+        if self.schema_version != LOCALITY_COVERAGE_DECISION:
+            raise LocalityQualificationError(
+                "Locality Coverage Decision schema differs"
+            )
+        _uuid(self.decision_id, "decision_id")
+        _uuid(self.proposal_id, "proposal_id")
+        _digest(self.proposal_digest, "proposal_digest")
+        object.__setattr__(
+            self,
+            "outcome",
+            _enum(LocalityDecisionOutcome, self.outcome, "outcome"),
+        )
+        for field in ("assessed_gap_codes", "reason_codes"):
+            object.__setattr__(
+                self,
+                field,
+                _strings(getattr(self, field), field, required=True),
+            )
+        _digest(self.decider_identity_digest, "decider_identity_digest")
+        if self.supersedes_decision_digest is not None:
+            _digest(self.supersedes_decision_digest, "supersedes_decision_digest")
+        _timestamp(self.decided_at, "decided_at")
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return canonical_json_bytes(_record_dict(self, _DECISION_FIELDS))
+
+    @property
+    def digest(self) -> str:
+        return digest_bytes(self.canonical_bytes)
+
+    @classmethod
+    def from_canonical_bytes(cls, raw: bytes) -> Self:
+        value = _document(raw, LOCALITY_COVERAGE_DECISION, _DECISION_FIELDS)
+        for field in ("assessed_gap_codes", "reason_codes"):
+            value[field] = tuple(value[field])  # type: ignore[arg-type]
+        result = cls(**value)  # type: ignore[arg-type]
+        if result.canonical_bytes != raw:
+            raise LocalityQualificationError(
+                "Locality Coverage Decision replay differs"
+            )
+        return result
+
+
+def validate_locality_coverage_chain(
+    reference: LocalityReference,
+    unit: LocalityCoverageUnit,
+    proposal: LocalityCoverageProposal,
+    decision: LocalityCoverageDecision,
+    previous: LocalityCoverageDecision | None = None,
+) -> None:
+    if any(
+        type(value) is not kind
+        for value, kind in (
+            (reference, LocalityReference),
+            (unit, LocalityCoverageUnit),
+            (proposal, LocalityCoverageProposal),
+            (decision, LocalityCoverageDecision),
+        )
+    ):
+        raise LocalityQualificationError("locality chain requires exact records")
+    if (
+        unit.locality_reference_id != reference.locality_reference_id
+        or unit.locality_reference_digest != reference.digest
+        or unit.recorded_at < reference.recorded_at
+        or proposal.coverage_unit_id != unit.coverage_unit_id
+        or proposal.coverage_unit_digest != unit.digest
+        or proposal.proposed_at < unit.recorded_at
+        or not set(unit.known_gap_codes).issubset(proposal.unresolved_gap_codes)
+        or decision.proposal_id != proposal.proposal_id
+        or decision.proposal_digest != proposal.digest
+        or decision.decided_at < proposal.proposed_at
+        or set(decision.assessed_gap_codes) != set(proposal.unresolved_gap_codes)
+    ):
+        raise LocalityQualificationError("locality coverage lineage or gaps differ")
+    if previous is None:
+        if decision.supersedes_decision_digest is not None:
+            raise LocalityQualificationError(
+                "initial locality decision supersedes another"
+            )
+    else:
+        validate_locality_coverage_chain(reference, unit, proposal, previous)
+        if (
+            decision.supersedes_decision_digest != previous.digest
+            or decision.decided_at < previous.decided_at
+        ):
+            raise LocalityQualificationError("locality decision predecessor differs")
+
+
+__all__ = [
+    "LOCALITY_ACTIVATION",
+    "LOCALITY_COMPLETENESS",
+    "LOCALITY_COVERAGE_DECISION",
+    "LOCALITY_COVERAGE_PROPOSAL",
+    "LOCALITY_COVERAGE_UNIT",
+    "LOCALITY_REFERENCE",
+    "LocalityCompletenessClass",
+    "LocalityCoverageDecision",
+    "LocalityCoverageProposal",
+    "LocalityCoverageUnit",
+    "LocalityDecisionOutcome",
+    "LocalityKind",
+    "LocalityProposalPosture",
+    "LocalityQualificationError",
+    "LocalityReference",
+    "LocalityServiceBoundary",
+    "validate_locality_coverage_chain",
+]

--- a/newsroom/tests/test_increment6d3_lineage_store.py
+++ b/newsroom/tests/test_increment6d3_lineage_store.py
@@ -1804,7 +1804,14 @@ def test_ten_core_shard_probe_selections_derive_exact_template_subsets() -> None
         ),
         CaseId.TAMPER_REJECTION: ("record-1", "record-b"),
     }
-    selected = tuple(_selected_shared_template_keys(tuple(shard)) for shard in shards)
+    d3_shards = tuple(
+        shard
+        for shard in shards
+        if any("test_increment6d3_lineage_store.py" in node_id for node_id in shard)
+    )
+    selected = tuple(
+        _selected_shared_template_keys(tuple(shard)) for shard in d3_shards
+    )
     expected = tuple(
         tuple(
             key
@@ -1817,7 +1824,8 @@ def test_ten_core_shard_probe_selections_derive_exact_template_subsets() -> None
         )
         if probe_ids
         else _SHARED_CONFORMANCE_TEMPLATE_KEYS
-        for probe_ids in probe_ids_by_shard
+        for shard, probe_ids in zip(shards, probe_ids_by_shard, strict=True)
+        if any("test_increment6d3_lineage_store.py" in node_id for node_id in shard)
     )
     assert selected == expected
 

--- a/newsroom/tests/test_increment7e2_locality_no_activation.py
+++ b/newsroom/tests/test_increment7e2_locality_no_activation.py
@@ -40,7 +40,9 @@ def _id(value: int) -> str:
     return str(uuid.UUID(int=value, version=4))
 
 
-def _provider_qualifications() -> tuple[tuple[ProviderProposal, ProviderDecision], ...]:
+def _provider_qualifications() -> tuple[
+    tuple[ProviderProposal, ProviderDecision, tuple[ProviderDecision, ...]], ...
+]:
     provider = ProviderProposal(
         _id(90),
         "fixture-provider-locality",
@@ -72,7 +74,7 @@ def _provider_qualifications() -> tuple[tuple[ProviderProposal, ProviderDecision
         ("CURRENT_POSTURE_RETAINED",),
         "2026-08-14T00:00:00.500000Z",
     )
-    return ((provider, decision),)
+    return ((provider, decision, ()),)
 
 
 def _validate(*args: object) -> None:
@@ -203,6 +205,40 @@ def test_reference_unit_and_proposal_bind_exact_boundaries_and_gaps() -> None:
             unit,
             fabricated,
             replace(decision, proposal_digest=fabricated.digest),
+        )
+
+
+def test_provider_successor_ancestry_and_locality_chronology_are_exact() -> None:
+    reference, unit, proposal, decision = _chain()
+    provider, first, _ = _provider_qualifications()[0]
+    successor = replace(
+        first,
+        decision_id=_id(92),
+        supersedes_decision_digest=first.digest,
+        decided_at="2026-08-14T00:00:01.500000Z",
+    )
+    bound_proposal = replace(
+        proposal, provider_decision_digests=(successor.digest,)
+    )
+    bound_decision = replace(decision, proposal_digest=bound_proposal.digest)
+    validate_locality_coverage_chain(
+        reference,
+        unit,
+        bound_proposal,
+        bound_decision,
+        provider_qualifications=((provider, successor, (first,)),),
+    )
+    late = replace(successor, decided_at="2026-08-14T00:00:02.500000Z")
+    late_proposal = replace(
+        proposal, provider_decision_digests=(late.digest,)
+    )
+    with pytest.raises(LocalityQualificationError, match="chronology"):
+        validate_locality_coverage_chain(
+            reference,
+            unit,
+            late_proposal,
+            replace(decision, proposal_digest=late_proposal.digest),
+            provider_qualifications=((provider, late, (first,)),),
         )
 
 

--- a/newsroom/tests/test_increment7e2_locality_no_activation.py
+++ b/newsroom/tests/test_increment7e2_locality_no_activation.py
@@ -17,6 +17,8 @@ from newsroom.increment7.locality_qualification import (
     LocalityDecisionOutcome,
     LocalityKind,
     LocalityProposalPosture,
+    LocalityQualificationBasis,
+    LocalityQualificationFactorRole,
     LocalityQualificationError,
     LocalityReference,
     LocalityServiceBoundary,
@@ -125,11 +127,17 @@ def _chain():
         coverage_unit_id=unit.coverage_unit_id,
         coverage_unit_digest=unit.digest,
         posture=LocalityProposalPosture.RESEARCH_ONLY,
-        qualification_basis_digests=(
-            "sha256:" + "7" * 64,
-            "sha256:" + "8" * 64,
+        qualification_bases=(
+            LocalityQualificationBasis(
+                LocalityQualificationFactorRole.ACCEPTED_COVERAGE_OR_REVIEWED_GAP,
+                "sha256:" + "7" * 64,
+            ),
+            LocalityQualificationBasis(
+                LocalityQualificationFactorRole.PROSPECTIVE_CONTRIBUTION,
+                "sha256:" + "8" * 64,
+            ),
         ),
-        provider_decision_digests=(_provider_qualifications()[0][1].digest,),
+        provider_proposal_digests=(_provider_qualifications()[0][0].digest,),
         proposed_source_reference_digests=("sha256:" + "d" * 64,),
         permanent_monitoring_rationale_digest="sha256:" + "1" * 64,
         expected_contribution_digest="sha256:" + "2" * 64,
@@ -141,15 +149,16 @@ def _chain():
         proposed_at="2026-08-14T00:00:02.000000Z",
     )
     decision = LocalityCoverageDecision(
-        _id(4),
-        proposal.proposal_id,
-        proposal.digest,
-        LocalityDecisionOutcome.RETAIN_RESEARCH_ONLY,
-        proposal.unresolved_gap_codes,
-        ("GAPS_REMAIN_EXPLICIT",),
-        "sha256:" + "f" * 64,
-        None,
-        "2026-08-14T00:00:03.000000Z",
+        decision_id=_id(4),
+        proposal_id=proposal.proposal_id,
+        proposal_digest=proposal.digest,
+        provider_decision_digests=(_provider_qualifications()[0][1].digest,),
+        outcome=LocalityDecisionOutcome.RETAIN_RESEARCH_ONLY,
+        assessed_gap_codes=proposal.unresolved_gap_codes,
+        reason_codes=("GAPS_REMAIN_EXPLICIT",),
+        decider_identity_digest="sha256:" + "f" * 64,
+        supersedes_decision_digest=None,
+        decided_at="2026-08-14T00:00:03.000000Z",
     )
     return reference, unit, proposal, decision
 
@@ -197,14 +206,14 @@ def test_reference_unit_and_proposal_bind_exact_boundaries_and_gaps() -> None:
             replace(decision, assessed_gap_codes=("UNASSESSED_GAP",)),
         )
     fabricated = replace(
-        proposal, provider_decision_digests=("sha256:" + "9" * 64,)
+        decision, provider_decision_digests=("sha256:" + "9" * 64,)
     )
     with pytest.raises(LocalityQualificationError, match="Provider Decision basis"):
         _validate(
             reference,
             unit,
+            proposal,
             fabricated,
-            replace(decision, proposal_digest=fabricated.digest),
         )
 
 
@@ -217,27 +226,21 @@ def test_provider_successor_ancestry_and_locality_chronology_are_exact() -> None
         supersedes_decision_digest=first.digest,
         decided_at="2026-08-14T00:00:01.500000Z",
     )
-    bound_proposal = replace(
-        proposal, provider_decision_digests=(successor.digest,)
-    )
-    bound_decision = replace(decision, proposal_digest=bound_proposal.digest)
+    bound_decision = replace(decision, provider_decision_digests=(successor.digest,))
     validate_locality_coverage_chain(
         reference,
         unit,
-        bound_proposal,
+        proposal,
         bound_decision,
         provider_qualifications=((provider, successor, (first,)),),
     )
-    late = replace(successor, decided_at="2026-08-14T00:00:02.500000Z")
-    late_proposal = replace(
-        proposal, provider_decision_digests=(late.digest,)
-    )
+    late = replace(successor, decided_at="2026-08-14T00:00:03.500000Z")
     with pytest.raises(LocalityQualificationError, match="chronology"):
         validate_locality_coverage_chain(
             reference,
             unit,
-            late_proposal,
-            replace(decision, proposal_digest=late_proposal.digest),
+            proposal,
+            replace(decision, provider_decision_digests=(late.digest,)),
             provider_qualifications=((provider, late, (first,)),),
         )
 
@@ -270,10 +273,10 @@ def test_locality_reference_identity_commits_boundary_ambiguity_dimensions() -> 
 
 def test_proposal_requires_multiple_qualification_bases_and_full_assessment() -> None:
     _, _, proposal, _ = _chain()
-    with pytest.raises(LocalityQualificationError, match="bounded array"):
+    with pytest.raises(LocalityQualificationError, match="independent ordered"):
         replace(
             proposal,
-            qualification_basis_digests=(proposal.qualification_basis_digests[0],),
+            qualification_bases=(proposal.qualification_bases[0],),
         )
     for field, value in (
         ("permanent_monitoring_rationale_digest", "sha256:" + "a" * 64),

--- a/newsroom/tests/test_increment7e2_locality_no_activation.py
+++ b/newsroom/tests/test_increment7e2_locality_no_activation.py
@@ -33,14 +33,20 @@ def _id(value: int) -> str:
 
 def _chain():
     reference = LocalityReference(
-        _id(1),
-        LocalityKind.ADMINISTRATIVE_AREA,
-        "FIXTURE:AREA:001",
-        "Fixture Area",
-        "fixture-boundary-v1",
-        _D,
-        (_D,),
-        _AT,
+        locality_reference_id=_id(1),
+        locality_kind=LocalityKind.ADMINISTRATIVE_AREA,
+        canonical_code="FIXTURE:AREA:001",
+        display_label="Fixture Area",
+        canonical_alias_set_digest="sha256:" + "1" * 64,
+        parent_geography_digest="sha256:" + "2" * 64,
+        boundary_definition_version="fixture-boundary-v1",
+        boundary_digest=_D,
+        authoritative_boundary_source_digest="sha256:" + "3" * 64,
+        validity_interval_digest="sha256:" + "4" * 64,
+        overlap_assessment_digest="sha256:" + "5" * 64,
+        uncertainty_assessment_digest="sha256:" + "6" * 64,
+        provenance_digests=(_D,),
+        recorded_at=_AT,
     )
     unit = LocalityCoverageUnit(
         coverage_unit_id=_id(2),
@@ -150,6 +156,19 @@ def test_coverage_unit_identity_commits_every_qualified_scope_dimension() -> Non
         ("governing_evaluation_version_digest", "sha256:" + "f" * 64),
     ):
         assert replace(unit, **{field: value}).digest != unit.digest
+
+
+def test_locality_reference_identity_commits_boundary_ambiguity_dimensions() -> None:
+    reference, *_ = _chain()
+    for field, value in (
+        ("canonical_alias_set_digest", "sha256:" + "a" * 64),
+        ("parent_geography_digest", "sha256:" + "b" * 64),
+        ("authoritative_boundary_source_digest", "sha256:" + "c" * 64),
+        ("validity_interval_digest", "sha256:" + "d" * 64),
+        ("overlap_assessment_digest", "sha256:" + "e" * 64),
+        ("uncertainty_assessment_digest", "sha256:" + "f" * 64),
+    ):
+        assert replace(reference, **{field: value}).digest != reference.digest
 
 
 def test_proposal_requires_multiple_qualification_bases_and_full_assessment() -> None:

--- a/newsroom/tests/test_increment7e2_locality_no_activation.py
+++ b/newsroom/tests/test_increment7e2_locality_no_activation.py
@@ -139,6 +139,23 @@ def test_decisions_only_retain_defer_or_reject_and_chain_exactly() -> None:
         decided_at="2026-08-14T00:00:04.000000Z",
     )
     validate_locality_coverage_chain(reference, unit, proposal, second, first)
+    third = replace(
+        second,
+        decision_id=_id(6),
+        supersedes_decision_digest=second.digest,
+        decided_at="2026-08-14T00:00:05.000000Z",
+    )
+    validate_locality_coverage_chain(reference, unit, proposal, third, (first, second))
+    with pytest.raises(LocalityQualificationError, match="predecessor"):
+        validate_locality_coverage_chain(reference, unit, proposal, third, second)
+    with pytest.raises(LocalityQualificationError, match="predecessor"):
+        validate_locality_coverage_chain(
+            reference,
+            unit,
+            proposal,
+            replace(second, decision_id=first.decision_id),
+            first,
+        )
     with pytest.raises(LocalityQualificationError, match="predecessor"):
         validate_locality_coverage_chain(
             reference,
@@ -166,6 +183,10 @@ def test_unknown_duplicate_noncanonical_and_unbounded_arrays_fail_closed() -> No
         replace(
             unit, source_class_scope=tuple(f"SOURCE_{value:03d}" for value in range(65))
         )
+    malformed = json.loads(unit.canonical_bytes)
+    malformed["source_class_scope"] = None
+    with pytest.raises(LocalityQualificationError, match="must be an array"):
+        LocalityCoverageUnit.from_canonical_bytes(canonical_json_bytes(malformed))
 
 
 def test_locality_records_create_no_watch_editorial_or_external_effect() -> None:

--- a/newsroom/tests/test_increment7e2_locality_no_activation.py
+++ b/newsroom/tests/test_increment7e2_locality_no_activation.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import replace
+
+import pytest
+
+from newsroom.authority.canonical import canonical_json_bytes
+from newsroom.increment7.locality_qualification import (
+    LOCALITY_ACTIVATION,
+    LOCALITY_COMPLETENESS,
+    LocalityCompletenessClass,
+    LocalityCoverageDecision,
+    LocalityCoverageProposal,
+    LocalityCoverageUnit,
+    LocalityDecisionOutcome,
+    LocalityKind,
+    LocalityProposalPosture,
+    LocalityQualificationError,
+    LocalityReference,
+    LocalityServiceBoundary,
+    validate_locality_coverage_chain,
+)
+
+_AT = "2026-08-14T00:00:00.000000Z"
+_D = "sha256:" + "a" * 64
+
+
+def _id(value: int) -> str:
+    return str(uuid.UUID(int=value, version=4))
+
+
+def _chain():
+    reference = LocalityReference(
+        _id(1),
+        LocalityKind.ADMINISTRATIVE_AREA,
+        "FIXTURE:AREA:001",
+        "Fixture Area",
+        "fixture-boundary-v1",
+        _D,
+        (_D,),
+        _AT,
+    )
+    unit = LocalityCoverageUnit(
+        _id(2),
+        reference.locality_reference_id,
+        reference.digest,
+        LocalityServiceBoundary.CIVIC_AND_PUBLIC_BODIES,
+        ("PUBLIC_BODY_NOTICES", "PUBLIC_MEETINGS"),
+        ("PRIVATE_COMMUNITY_GROUPS",),
+        ("MISSING_SMALL_PUBLISHERS",),
+        LocalityCompletenessClass.BEST_EFFORT_WITH_EXPLICIT_GAPS,
+        "sha256:" + "b" * 64,
+        "sha256:" + "c" * 64,
+        "2026-08-14T00:00:01.000000Z",
+    )
+    proposal = LocalityCoverageProposal(
+        _id(3),
+        unit.coverage_unit_id,
+        unit.digest,
+        LocalityProposalPosture.RESEARCH_ONLY,
+        ("sha256:" + "9" * 64,),
+        ("sha256:" + "d" * 64,),
+        ("MISSING_SMALL_PUBLISHERS",),
+        "sha256:" + "e" * 64,
+        "2026-08-14T00:00:02.000000Z",
+    )
+    decision = LocalityCoverageDecision(
+        _id(4),
+        proposal.proposal_id,
+        proposal.digest,
+        LocalityDecisionOutcome.RETAIN_RESEARCH_ONLY,
+        proposal.unresolved_gap_codes,
+        ("GAPS_REMAIN_EXPLICIT",),
+        "sha256:" + "f" * 64,
+        None,
+        "2026-08-14T00:00:03.000000Z",
+    )
+    return reference, unit, proposal, decision
+
+
+def test_exact_locality_chain_roundtrips_without_completeness_or_activation() -> None:
+    records = _chain()
+    validate_locality_coverage_chain(*records)
+    kinds = (
+        LocalityReference,
+        LocalityCoverageUnit,
+        LocalityCoverageProposal,
+        LocalityCoverageDecision,
+    )
+    for record, kind in zip(records, kinds, strict=True):
+        assert kind.from_canonical_bytes(record.canonical_bytes) == record
+        assert record.authorises_locality is False
+        assert record.authorises_source_portfolio is False
+        assert record.claims_completeness is False
+        assert record.production_activation_authorised is False
+    assert LOCALITY_COMPLETENESS == "BEST_EFFORT_EXPLICIT_GAPS_NO_COMPLETENESS_CLAIM"
+    assert LOCALITY_ACTIVATION == "DECISION_RECORD_ONLY_NO_SELECTION_OR_ENABLEMENT"
+
+
+def test_reference_unit_and_proposal_bind_exact_boundaries_and_gaps() -> None:
+    reference, unit, proposal, decision = _chain()
+    with pytest.raises(LocalityQualificationError, match="lineage"):
+        validate_locality_coverage_chain(
+            reference,
+            replace(unit, locality_reference_digest="sha256:" + "0" * 64),
+            proposal,
+            decision,
+        )
+    with pytest.raises(LocalityQualificationError, match="lineage"):
+        validate_locality_coverage_chain(
+            reference,
+            unit,
+            replace(proposal, unresolved_gap_codes=("OTHER_GAP",)),
+            decision,
+        )
+    with pytest.raises(LocalityQualificationError, match="lineage"):
+        validate_locality_coverage_chain(
+            reference,
+            unit,
+            proposal,
+            replace(decision, assessed_gap_codes=("UNASSESSED_GAP",)),
+        )
+
+
+def test_decisions_only_retain_defer_or_reject_and_chain_exactly() -> None:
+    reference, unit, proposal, first = _chain()
+    assert {item.value for item in LocalityDecisionOutcome} == {
+        "DEFERRED",
+        "REJECTED",
+        "RETAIN_RESEARCH_ONLY",
+    }
+    second = replace(
+        first,
+        decision_id=_id(5),
+        outcome=LocalityDecisionOutcome.DEFERRED,
+        supersedes_decision_digest=first.digest,
+        decided_at="2026-08-14T00:00:04.000000Z",
+    )
+    validate_locality_coverage_chain(reference, unit, proposal, second, first)
+    with pytest.raises(LocalityQualificationError, match="predecessor"):
+        validate_locality_coverage_chain(
+            reference,
+            unit,
+            proposal,
+            replace(second, supersedes_decision_digest=_D),
+            first,
+        )
+
+
+def test_unknown_duplicate_noncanonical_and_unbounded_arrays_fail_closed() -> None:
+    reference, unit, *_ = _chain()
+    value = json.loads(reference.canonical_bytes)
+    value["selected_permanently"] = True
+    with pytest.raises(LocalityQualificationError, match="fields"):
+        LocalityReference.from_canonical_bytes(canonical_json_bytes(value))
+    duplicate = reference.canonical_bytes.replace(
+        b'"canonical_code":', b'"canonical_code":"OTHER","canonical_code":', 1
+    )
+    with pytest.raises(LocalityQualificationError, match="duplicate"):
+        LocalityReference.from_canonical_bytes(duplicate)
+    with pytest.raises(LocalityQualificationError, match="canonical JSON"):
+        LocalityReference.from_canonical_bytes(reference.canonical_bytes + b" ")
+    with pytest.raises(LocalityQualificationError, match="bounded array"):
+        replace(
+            unit, source_class_scope=tuple(f"SOURCE_{value:03d}" for value in range(65))
+        )
+
+
+def test_locality_records_create_no_watch_editorial_or_external_effect() -> None:
+    for record in _chain():
+        assert record.authorises_provider is False
+        assert record.authorises_credentials is False
+        assert record.authorises_egress is False
+        assert record.authorises_spend is False
+        assert record.authorises_search is False
+        assert record.authorises_evidence is False
+        assert record.authorises_publication is False
+        assert record.creates_watch is False
+        assert record.creates_signal is False
+        assert record.creates_lead is False
+        assert record.creates_candidate is False
+        assert record.permanent_locality_selected is False

--- a/newsroom/tests/test_increment7e2_locality_no_activation.py
+++ b/newsroom/tests/test_increment7e2_locality_no_activation.py
@@ -22,6 +22,15 @@ from newsroom.increment7.locality_qualification import (
     LocalityServiceBoundary,
     validate_locality_coverage_chain,
 )
+from newsroom.increment7.provider_qualification import (
+    ProviderDecision,
+    ProviderKind,
+    ProviderPrerequisite,
+    ProviderPrerequisiteAssessment,
+    ProviderPrerequisiteOutcome,
+    ProviderProposal,
+    ProviderQualificationStatus,
+)
 
 _AT = "2026-08-14T00:00:00.000000Z"
 _D = "sha256:" + "a" * 64
@@ -29,6 +38,48 @@ _D = "sha256:" + "a" * 64
 
 def _id(value: int) -> str:
     return str(uuid.UUID(int=value, version=4))
+
+
+def _provider_qualifications() -> tuple[tuple[ProviderProposal, ProviderDecision], ...]:
+    provider = ProviderProposal(
+        _id(90),
+        "fixture-provider-locality",
+        ProviderKind.GDELT,
+        "Fixture GDELT",
+        ProviderQualificationStatus.HELD,
+        ("PUBLIC_NEWS_SEARCH",),
+        "research-snapshot-v1",
+        (_D,),
+        "sha256:" + "b" * 64,
+        _AT,
+    )
+    assessments = tuple(
+        ProviderPrerequisiteAssessment(
+            prerequisite,
+            ProviderPrerequisiteOutcome.MISSING,
+            None,
+        )
+        for prerequisite in ProviderPrerequisite
+    )
+    decision = ProviderDecision(
+        _id(91),
+        provider.proposal_id,
+        provider.digest,
+        ProviderQualificationStatus.HELD,
+        assessments,
+        None,
+        "sha256:" + "c" * 64,
+        ("CURRENT_POSTURE_RETAINED",),
+        "2026-08-14T00:00:00.500000Z",
+    )
+    return ((provider, decision),)
+
+
+def _validate(*args: object) -> None:
+    validate_locality_coverage_chain(
+        *args,  # type: ignore[arg-type]
+        provider_qualifications=_provider_qualifications(),
+    )
 
 
 def _chain():
@@ -76,7 +127,7 @@ def _chain():
             "sha256:" + "7" * 64,
             "sha256:" + "8" * 64,
         ),
-        provider_decision_digests=("sha256:" + "9" * 64,),
+        provider_decision_digests=(_provider_qualifications()[0][1].digest,),
         proposed_source_reference_digests=("sha256:" + "d" * 64,),
         permanent_monitoring_rationale_digest="sha256:" + "1" * 64,
         expected_contribution_digest="sha256:" + "2" * 64,
@@ -103,7 +154,7 @@ def _chain():
 
 def test_exact_locality_chain_roundtrips_without_completeness_or_activation() -> None:
     records = _chain()
-    validate_locality_coverage_chain(*records)
+    _validate(*records)
     kinds = (
         LocalityReference,
         LocalityCoverageUnit,
@@ -123,25 +174,35 @@ def test_exact_locality_chain_roundtrips_without_completeness_or_activation() ->
 def test_reference_unit_and_proposal_bind_exact_boundaries_and_gaps() -> None:
     reference, unit, proposal, decision = _chain()
     with pytest.raises(LocalityQualificationError, match="lineage"):
-        validate_locality_coverage_chain(
+        _validate(
             reference,
             replace(unit, locality_reference_digest="sha256:" + "0" * 64),
             proposal,
             decision,
         )
     with pytest.raises(LocalityQualificationError, match="lineage"):
-        validate_locality_coverage_chain(
+        _validate(
             reference,
             unit,
             replace(proposal, unresolved_gap_codes=("OTHER_GAP",)),
             decision,
         )
     with pytest.raises(LocalityQualificationError, match="lineage"):
-        validate_locality_coverage_chain(
+        _validate(
             reference,
             unit,
             proposal,
             replace(decision, assessed_gap_codes=("UNASSESSED_GAP",)),
+        )
+    fabricated = replace(
+        proposal, provider_decision_digests=("sha256:" + "9" * 64,)
+    )
+    with pytest.raises(LocalityQualificationError, match="Provider Decision basis"):
+        _validate(
+            reference,
+            unit,
+            fabricated,
+            replace(decision, proposal_digest=fabricated.digest),
         )
 
 
@@ -202,18 +263,18 @@ def test_decisions_only_retain_defer_or_reject_and_chain_exactly() -> None:
         supersedes_decision_digest=first.digest,
         decided_at="2026-08-14T00:00:04.000000Z",
     )
-    validate_locality_coverage_chain(reference, unit, proposal, second, first)
+    _validate(reference, unit, proposal, second, first)
     third = replace(
         second,
         decision_id=_id(6),
         supersedes_decision_digest=second.digest,
         decided_at="2026-08-14T00:00:05.000000Z",
     )
-    validate_locality_coverage_chain(reference, unit, proposal, third, (first, second))
+    _validate(reference, unit, proposal, third, (first, second))
     with pytest.raises(LocalityQualificationError, match="predecessor"):
-        validate_locality_coverage_chain(reference, unit, proposal, third, second)
+        _validate(reference, unit, proposal, third, second)
     with pytest.raises(LocalityQualificationError, match="predecessor"):
-        validate_locality_coverage_chain(
+        _validate(
             reference,
             unit,
             proposal,
@@ -221,7 +282,7 @@ def test_decisions_only_retain_defer_or_reject_and_chain_exactly() -> None:
             first,
         )
     with pytest.raises(LocalityQualificationError, match="predecessor"):
-        validate_locality_coverage_chain(
+        _validate(
             reference,
             unit,
             proposal,

--- a/newsroom/tests/test_increment7e2_locality_no_activation.py
+++ b/newsroom/tests/test_increment7e2_locality_no_activation.py
@@ -43,28 +43,43 @@ def _chain():
         _AT,
     )
     unit = LocalityCoverageUnit(
-        _id(2),
-        reference.locality_reference_id,
-        reference.digest,
-        LocalityServiceBoundary.CIVIC_AND_PUBLIC_BODIES,
-        ("PUBLIC_BODY_NOTICES", "PUBLIC_MEETINGS"),
-        ("PRIVATE_COMMUNITY_GROUPS",),
-        ("MISSING_SMALL_PUBLISHERS",),
-        LocalityCompletenessClass.BEST_EFFORT_WITH_EXPLICIT_GAPS,
-        "sha256:" + "b" * 64,
-        "sha256:" + "c" * 64,
-        "2026-08-14T00:00:01.000000Z",
+        coverage_unit_id=_id(2),
+        locality_reference_id=reference.locality_reference_id,
+        locality_reference_digest=reference.digest,
+        service_boundary=LocalityServiceBoundary.CIVIC_AND_PUBLIC_BODIES,
+        obligation_scope_digest="sha256:" + "1" * 64,
+        source_class_scope=("PUBLIC_BODY_NOTICES", "PUBLIC_MEETINGS"),
+        population_service_event_scope_digest="sha256:" + "2" * 64,
+        language_scope_digest="sha256:" + "3" * 64,
+        source_role_scope_digest="sha256:" + "4" * 64,
+        portfolio_function_scope_digest="sha256:" + "5" * 64,
+        explicit_exclusions=("PRIVATE_COMMUNITY_GROUPS",),
+        known_gap_codes=("MISSING_SMALL_PUBLISHERS",),
+        completeness_class=LocalityCompletenessClass.BEST_EFFORT_WITH_EXPLICIT_GAPS,
+        rights_basis_digest="sha256:" + "b" * 64,
+        governing_evaluation_version_digest="sha256:" + "6" * 64,
+        operational_profile_digest="sha256:" + "c" * 64,
+        recorded_at="2026-08-14T00:00:01.000000Z",
     )
     proposal = LocalityCoverageProposal(
-        _id(3),
-        unit.coverage_unit_id,
-        unit.digest,
-        LocalityProposalPosture.RESEARCH_ONLY,
-        ("sha256:" + "9" * 64,),
-        ("sha256:" + "d" * 64,),
-        ("MISSING_SMALL_PUBLISHERS",),
-        "sha256:" + "e" * 64,
-        "2026-08-14T00:00:02.000000Z",
+        proposal_id=_id(3),
+        coverage_unit_id=unit.coverage_unit_id,
+        coverage_unit_digest=unit.digest,
+        posture=LocalityProposalPosture.RESEARCH_ONLY,
+        qualification_basis_digests=(
+            "sha256:" + "7" * 64,
+            "sha256:" + "8" * 64,
+        ),
+        provider_decision_digests=("sha256:" + "9" * 64,),
+        proposed_source_reference_digests=("sha256:" + "d" * 64,),
+        permanent_monitoring_rationale_digest="sha256:" + "1" * 64,
+        expected_contribution_digest="sha256:" + "2" * 64,
+        evaluation_design_digest="sha256:" + "3" * 64,
+        alternatives_assessment_digest="sha256:" + "4" * 64,
+        non_selection_consequence_digest="sha256:" + "5" * 64,
+        unresolved_gap_codes=("MISSING_SMALL_PUBLISHERS",),
+        owner_identity_digest="sha256:" + "e" * 64,
+        proposed_at="2026-08-14T00:00:02.000000Z",
     )
     decision = LocalityCoverageDecision(
         _id(4),
@@ -122,6 +137,36 @@ def test_reference_unit_and_proposal_bind_exact_boundaries_and_gaps() -> None:
             proposal,
             replace(decision, assessed_gap_codes=("UNASSESSED_GAP",)),
         )
+
+
+def test_coverage_unit_identity_commits_every_qualified_scope_dimension() -> None:
+    _, unit, *_ = _chain()
+    for field, value in (
+        ("obligation_scope_digest", "sha256:" + "a" * 64),
+        ("population_service_event_scope_digest", "sha256:" + "b" * 64),
+        ("language_scope_digest", "sha256:" + "c" * 64),
+        ("source_role_scope_digest", "sha256:" + "d" * 64),
+        ("portfolio_function_scope_digest", "sha256:" + "e" * 64),
+        ("governing_evaluation_version_digest", "sha256:" + "f" * 64),
+    ):
+        assert replace(unit, **{field: value}).digest != unit.digest
+
+
+def test_proposal_requires_multiple_qualification_bases_and_full_assessment() -> None:
+    _, _, proposal, _ = _chain()
+    with pytest.raises(LocalityQualificationError, match="bounded array"):
+        replace(
+            proposal,
+            qualification_basis_digests=(proposal.qualification_basis_digests[0],),
+        )
+    for field, value in (
+        ("permanent_monitoring_rationale_digest", "sha256:" + "a" * 64),
+        ("expected_contribution_digest", "sha256:" + "b" * 64),
+        ("evaluation_design_digest", "sha256:" + "c" * 64),
+        ("alternatives_assessment_digest", "sha256:" + "d" * 64),
+        ("non_selection_consequence_digest", "sha256:" + "e" * 64),
+    ):
+        assert replace(proposal, **{field: value}).digest != proposal.digest
 
 
 def test_decisions_only_retain_defer_or_reject_and_chain_exactly() -> None:


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: 7e2
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

## Summary

- add strict Locality Reference and Coverage Unit contracts
- add immutable Locality Coverage Proposal and Decision seams with explicit gaps
- bind locality decisions to accepted provider-decision digests while preserving best-effort, no-completeness and no-activation semantics
- keep locality/source portfolio selection, provider access and external effects disabled

## Evidence

- `uv run pytest -q newsroom/tests/test_increment7e1_provider_decision_seams.py newsroom/tests/test_increment7e2_locality_no_activation.py` — 10 passed

Closes #441
