### PR TITLE
SDLC: separate global gate controls from product atoms

### DIFF
--- a/docs/specs/sdlc/2026-08-14-sdlc-control-product-atom-separation.md
+++ b/docs/specs/sdlc/2026-08-14-sdlc-control-product-atom-separation.md
@@ -1,0 +1,70 @@
+# SDLC v2.6 corrective enforcement — control/product atom separation
+
+- Status: Accepted owner corrective record
+- Owner: fol2
+- Date: 2026-08-14
+- Related issue: #456
+- Contract: `sdlc-v2.6`
+
+## Decision
+
+A change to the repository-wide SDLC control surface must be independently
+reviewable and independently reversible from product behaviour.
+
+The route classifier therefore fails closed when one exact change contains
+both:
+
+1. a global SDLC control path, including `.sdlc/**`,
+   `.github/workflows/**`, `scripts/sdlc/**`, SDLC specifications or SDLC
+   tests; and
+2. non-test product implementation under `newsroom/**`, non-SDLC
+   `scripts/**`, `deploy/**` or `release/**`.
+
+The failure is deterministic and occurs before route evidence is emitted:
+
+```text
+CLASSIFIER_ERROR:global SDLC control changes and non-test product
+implementation must be separate delivery atoms
+```
+
+A dedicated control/support atom may include:
+
+- SDLC implementation and configuration;
+- SDLC documentation;
+- dependency or lock changes needed by that control atom;
+- any repository tests required to prove topology, compatibility or
+  regression behaviour.
+
+A product atom may include its product implementation and tests, but it may
+not also change the global SDLC control surface.
+
+Renames and copies are evaluated using both old and new paths, so moving a
+file across the control/product boundary cannot bypass the rule.
+
+## Preserved boundaries
+
+This corrective guard does not change:
+
+- the accepted sixteen-shard deterministic topology;
+- the 90-second individual-test hard boundary;
+- the 75-second individual-test warning;
+- the 330-second core shard and critical-path hard boundary;
+- the 300-second shard and critical-path warning;
+- complete deterministic-suite blocking policy;
+- risk-tier or actual-service escalation;
+- credentials, provider execution, locality activation, publication,
+  shadow, canary or production authority.
+
+## Rationale
+
+Increment 7B2 correctly delivered its product boundary, but its branch also
+carried global core-topology changes. That mixed ownership made independent
+review, rollback and evidence attribution harder than necessary. This guard
+prevents that shape from recurring without weakening any evidence gate.
+
+## Rollback
+
+The correction is one reversible classifier policy layer. Removing the
+control/product separation check restores the prior routing behaviour without
+changing the underlying classifier, evidence schema, time budgets or test
+inventory.

--- a/newsroom/tests/test_sdlc_atom_separation.py
+++ b/newsroom/tests/test_sdlc_atom_separation.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.sdlc.classify_change import ChangedPath, classify_paths
+from scripts.sdlc.contracts import ContractError, load_contract
+
+
+REPO_ROOT = Path(__file__).parents[2]
+BASE_SHA = "0" * 40
+HEAD_SHA = "1" * 40
+BASE_TREE_SHA = "2" * 40
+HEAD_TREE_SHA = "3" * 40
+
+
+def _route(*paths: str) -> dict[str, object]:
+    return classify_paths(
+        load_contract(REPO_ROOT),
+        tuple(ChangedPath(path) for path in paths),
+        base_sha=BASE_SHA,
+        head_sha=HEAD_SHA,
+        base_tree_sha=BASE_TREE_SHA,
+        head_tree_sha=HEAD_TREE_SHA,
+    )
+
+
+@pytest.mark.parametrize(
+    ("control_path", "product_path"),
+    (
+        (".sdlc/gates.toml", "newsroom/increment7/search_authority.py"),
+        (".github/workflows/evidence.yml", "scripts/write_run_job.py"),
+        (
+            "docs/specs/sdlc/high-performance-evidence-sdlc.md",
+            "release/production.yml",
+        ),
+    ),
+)
+def test_global_control_and_product_implementation_require_separate_atoms(
+    control_path: str,
+    product_path: str,
+) -> None:
+    with pytest.raises(ContractError, match="separate delivery atoms"):
+        _route(control_path, product_path)
+
+
+def test_control_atom_can_carry_control_and_repository_tests() -> None:
+    route = _route(
+        ".sdlc/gates.toml",
+        "scripts/sdlc/classify_change.py",
+        "newsroom/tests/test_increment6g_final_closeout.py",
+    )
+
+    assert route["risk_tier"] == "R3_EXTERNAL_SERVICE_SECURITY"
+    assert route["service_required"] is True
+
+
+def test_product_implementation_can_carry_its_own_tests() -> None:
+    route = _route(
+        "newsroom/increment7/locality_qualification.py",
+        "newsroom/tests/test_increment7e2_locality_no_activation.py",
+    )
+
+    assert route["core_required"] is True
+
+
+def test_rename_between_control_and_product_is_rejected() -> None:
+    contract = load_contract(REPO_ROOT)
+    change = ChangedPath(
+        ".sdlc/renamed-control.py",
+        status="R100",
+        old_path="newsroom/product_runtime.py",
+    )
+
+    with pytest.raises(ContractError, match="separate delivery atoms"):
+        classify_paths(
+            contract,
+            (change,),
+            base_sha=BASE_SHA,
+            head_sha=HEAD_SHA,
+            base_tree_sha=BASE_TREE_SHA,
+            head_tree_sha=HEAD_TREE_SHA,
+        )

--- a/scripts/sdlc/_classify_change_base.py
+++ b/scripts/sdlc/_classify_change_base.py
@@ -1,0 +1,420 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from functools import lru_cache
+import hashlib
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import Iterable, Sequence
+
+from .contracts import ContractError, SdlcContract, load_contract
+from .dependencies import DependencyError, build_dependency_graph, python_changes
+
+
+SCHEMA_VERSION = "newsroom.sdlc.route.v1"
+RISK_CLASSIFIER_VERSION = "sdlc-risk-v1"
+_R3 = "R3_EXTERNAL_SERVICE_SECURITY"
+_PATH_RISKS = {
+    "documentation": "R0_DOCUMENTATION",
+    "local_code": "R1_LOCAL_CODE",
+    "clustering": "R1_LOCAL_CODE",
+    "stateful_contract": "R2_STATEFUL_CONTRACT",
+    "contract_control": _R3,
+    "external_service_security": _R3,
+    "release_operational": "R4_RELEASE_OPERATIONAL",
+}
+_GIT_SHA = re.compile(r"[0-9a-f]{40}")
+_REGULAR_GIT_MODES = frozenset({b"100644", b"100755"})
+
+
+class GitRouteError(RuntimeError):
+    """Raised when exact Git identities or a diff cannot be resolved."""
+
+
+@dataclass(frozen=True)
+class ChangedPath:
+    path: str
+    status: str = "M"
+    old_path: str | None = None
+
+    def classified_paths(self) -> tuple[str, ...]:
+        if self.old_path is None or self.old_path == self.path:
+            return (self.path,)
+        return tuple(sorted({self.old_path, self.path}))
+
+
+def canonical_json_bytes(value: object) -> bytes:
+    """Return deterministic JSON bytes for values that contain no JSON floats."""
+
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def sha256_identity(value: object) -> str:
+    return "sha256:" + hashlib.sha256(canonical_json_bytes(value)).hexdigest()
+
+
+def _require_git_sha(value: str, name: str) -> None:
+    if _GIT_SHA.fullmatch(value) is None:
+        raise ContractError(f"{name} must be a lowercase 40-character Git SHA")
+
+
+@lru_cache(maxsize=512)
+def _compile_repository_glob(pattern: str) -> re.Pattern[str]:
+    """Compile a Git-style path glob where `**/` matches zero or more segments."""
+
+    expression: list[str] = ["^"]
+    index = 0
+    while index < len(pattern):
+        char = pattern[index]
+        if char == "*":
+            if index + 1 < len(pattern) and pattern[index + 1] == "*":
+                index += 2
+                if index < len(pattern) and pattern[index] == "/":
+                    expression.append("(?:.*/)?")
+                    index += 1
+                else:
+                    expression.append(".*")
+                continue
+            expression.append("[^/]*")
+        elif char == "?":
+            expression.append("[^/]")
+        else:
+            expression.append(re.escape(char))
+        index += 1
+    expression.append("$")
+    return re.compile("".join(expression))
+
+
+def matches_repository_glob(path: str, pattern: str) -> bool:
+    if (
+        not path
+        or path.startswith("/")
+        or "\\" in path
+        or "/../" in f"/{path}/"
+        or path in {".", ".."}
+    ):
+        return False
+    return _compile_repository_glob(pattern).fullmatch(path) is not None
+
+
+def _matching_groups(contract: SdlcContract, path: str) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            group
+            for group, patterns in contract.path_groups.items()
+            if any(matches_repository_glob(path, pattern) for pattern in patterns)
+        )
+    )
+
+
+def _service_tests(repo_root: Path) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            path.relative_to(repo_root).as_posix()
+            for path in (repo_root / "newsroom" / "tests").glob(
+                "test_*_neo4j_service.py"
+            )
+            if path.is_file()
+        )
+    )
+
+
+def _dependency_reasons(
+    contract: SdlcContract, changes: tuple[ChangedPath, ...]
+) -> tuple[str, ...]:
+    paths = python_changes(
+        path
+        for change in changes
+        for path in change.classified_paths()
+    )
+    if not paths:
+        return ()
+    try:
+        graph = build_dependency_graph(contract.repo_root)
+    except DependencyError as exc:
+        return (f"unknown_dependency_edge:{exc}:{_R3}",)
+
+    reasons: set[str] = set()
+    for path in paths:
+        try:
+            dependents = graph.dependent_paths(path)
+        except DependencyError as exc:
+            reasons.add(f"unknown_dependency_edge:{exc}:{_R3}")
+            continue
+        for dependent in dependents:
+            groups = _matching_groups(contract, dependent)
+            if any(_PATH_RISKS.get(group) == _R3 for group in groups):
+                reasons.add(f"dependency:{path}->{dependent}:{_R3}")
+    return tuple(sorted(reasons))
+
+
+def classify_paths(
+    contract: SdlcContract,
+    changes: Iterable[ChangedPath],
+    *,
+    base_sha: str,
+    head_sha: str,
+    base_tree_sha: str,
+    head_tree_sha: str,
+) -> dict[str, object]:
+    for name, value in (
+        ("base_sha", base_sha),
+        ("head_sha", head_sha),
+        ("base_tree_sha", base_tree_sha),
+        ("head_tree_sha", head_tree_sha),
+    ):
+        _require_git_sha(value, name)
+    if contract.classifier_version != RISK_CLASSIFIER_VERSION:
+        raise ContractError("classifier implementation differs from the accepted contract")
+
+    ranks = contract.risk_rank
+    selected_risk = "R0_DOCUMENTATION"
+    reasons: set[str] = set()
+    clustering_required = False
+    normalized_changes = tuple(
+        sorted(
+            set(changes),
+            key=lambda item: (item.path, item.status, item.old_path or ""),
+        )
+    )
+
+    if not normalized_changes:
+        reasons.add("no_changes")
+
+    for change in normalized_changes:
+        for path in change.classified_paths():
+            groups = _matching_groups(contract, path)
+            if not groups:
+                risk = contract.unknown_path_risk
+                reasons.add(f"unknown_path:{path}:{risk}")
+                if ranks[risk] > ranks[selected_risk]:
+                    selected_risk = risk
+                continue
+            for group in groups:
+                if group == "clustering":
+                    clustering_required = True
+                risk = _PATH_RISKS.get(group)
+                if risk is None:
+                    risk = str(contract.classification["classifier_error"])
+                    reasons.add(f"unknown_path_group:{group}:{risk}")
+                else:
+                    reasons.add(f"path:{path}:{group}:{risk}")
+                if ranks[risk] > ranks[selected_risk]:
+                    selected_risk = risk
+
+    if ranks[selected_risk] < ranks[_R3]:
+        dependency_reasons = _dependency_reasons(contract, normalized_changes)
+        if dependency_reasons:
+            reasons.update(dependency_reasons)
+            selected_risk = _R3
+
+    core_tests = ("newsroom/tests",)
+    service_required = contract.service_required(selected_risk)
+    service_tests = _service_tests(contract.repo_root) if service_required else ()
+    if service_required and not service_tests:
+        raise ContractError("service evidence is required but no actual-service test exists")
+    manifest = {
+        "core_tests": list(core_tests),
+        "service_tests": list(service_tests),
+        "sentinels": list(contract.sentinels),
+    }
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "contract_version": contract.contract_version,
+        "base_sha": base_sha,
+        "head_sha": head_sha,
+        "base_tree_sha": base_tree_sha,
+        "head_tree_sha": head_tree_sha,
+        "risk_tier": selected_risk,
+        "reasons": sorted(reasons),
+        "core_required": True,
+        "service_required": service_required,
+        "clustering_required": clustering_required,
+        "owner_authority_required": contract.owner_authority_required(selected_risk),
+        "core_tests": list(core_tests),
+        "service_tests": list(service_tests),
+        "sentinels": list(contract.sentinels),
+        "selected_test_manifest_digest": sha256_identity(manifest),
+    }
+
+
+def _git(repo_root: Path, *arguments: str) -> bytes:
+    completed = subprocess.run(
+        ("git", *arguments),
+        cwd=repo_root,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if completed.returncode != 0:
+        message = completed.stderr.decode("utf-8", errors="replace").strip()
+        raise GitRouteError(f"git {' '.join(arguments)} failed: {message}")
+    return completed.stdout
+
+
+def resolve_commit(repo_root: Path, reference: str) -> str:
+    value = _git(
+        repo_root,
+        "rev-parse",
+        "--verify",
+        f"{reference}^{{commit}}",
+    ).decode().strip()
+    if _GIT_SHA.fullmatch(value) is None:
+        raise GitRouteError(
+            f"reference did not resolve to a full commit SHA: {reference}"
+        )
+    return value
+
+
+def resolve_tree(repo_root: Path, commit_sha: str) -> str:
+    value = _git(
+        repo_root,
+        "rev-parse",
+        "--verify",
+        f"{commit_sha}^{{tree}}",
+    ).decode().strip()
+    if _GIT_SHA.fullmatch(value) is None:
+        raise GitRouteError(f"commit did not resolve to a full tree SHA: {commit_sha}")
+    return value
+
+
+def verify_exact_clean_checkout(
+    repo_root: Path, *, head_sha: str, head_tree_sha: str
+) -> None:
+    current_head = resolve_commit(repo_root, "HEAD")
+    if current_head != head_sha:
+        raise GitRouteError(
+            f"checkout HEAD differs from route head: {current_head} != {head_sha}"
+        )
+    current_tree = resolve_tree(repo_root, current_head)
+    if current_tree != head_tree_sha:
+        raise GitRouteError(
+            f"checkout tree differs from route tree: {current_tree} != {head_tree_sha}"
+        )
+    status = _git(
+        repo_root,
+        "status",
+        "--porcelain=v1",
+        "-z",
+        "--untracked-files=all",
+    )
+    if status:
+        first = status.split(b"\0", 1)[0].decode("utf-8", errors="replace")
+        raise GitRouteError(f"checkout is not clean: {first}")
+    for record in _git(repo_root, "ls-files", "--stage", "-z").split(b"\0"):
+        if not record:
+            continue
+        try:
+            metadata, raw_path = record.split(b"\t", 1)
+            mode = metadata.split(b" ", 1)[0]
+        except ValueError as exc:
+            raise GitRouteError("malformed tracked-file inventory") from exc
+        if mode not in _REGULAR_GIT_MODES:
+            path = raw_path.decode("utf-8", errors="replace")
+            raise GitRouteError(f"unsupported tracked entry mode {mode.decode()}: {path}")
+
+
+def parse_name_status(payload: bytes) -> tuple[ChangedPath, ...]:
+    fields = payload.split(b"\0")
+    if fields and fields[-1] == b"":
+        fields.pop()
+    changes: list[ChangedPath] = []
+    index = 0
+    while index < len(fields):
+        status = fields[index].decode("ascii", errors="strict")
+        index += 1
+        if not status or index >= len(fields):
+            raise GitRouteError("truncated git name-status output")
+        if status.startswith(("R", "C")):
+            if index + 1 >= len(fields):
+                raise GitRouteError("truncated git rename/copy output")
+            old_path = fields[index].decode("utf-8", errors="strict")
+            new_path = fields[index + 1].decode("utf-8", errors="strict")
+            index += 2
+            changes.append(ChangedPath(new_path, status, old_path))
+        else:
+            path = fields[index].decode("utf-8", errors="strict")
+            index += 1
+            changes.append(ChangedPath(path, status))
+    return tuple(changes)
+
+
+def changed_paths(
+    repo_root: Path, base_sha: str, head_sha: str
+) -> tuple[ChangedPath, ...]:
+    output = _git(
+        repo_root,
+        "diff",
+        "--name-status",
+        "-z",
+        "--find-renames",
+        base_sha,
+        head_sha,
+        "--",
+    )
+    return parse_name_status(output)
+
+
+def build_git_route(
+    repo_root: str | Path, *, base_reference: str, head_reference: str
+) -> dict[str, object]:
+    root = Path(repo_root).resolve()
+    base_sha = resolve_commit(root, base_reference)
+    head_sha = resolve_commit(root, head_reference)
+    head_tree_sha = resolve_tree(root, head_sha)
+    verify_exact_clean_checkout(
+        root,
+        head_sha=head_sha,
+        head_tree_sha=head_tree_sha,
+    )
+    contract = load_contract(root)
+    return classify_paths(
+        contract,
+        changed_paths(root, base_sha, head_sha),
+        base_sha=base_sha,
+        head_sha=head_sha,
+        base_tree_sha=resolve_tree(root, base_sha),
+        head_tree_sha=head_tree_sha,
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Classify an exact Newsroom change")
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--base", required=True, help="exact base commit or resolvable ref")
+    parser.add_argument("--head", required=True, help="exact head commit or resolvable ref")
+    parser.add_argument("--output", help="write route JSON to this path")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = _parser().parse_args(argv)
+    try:
+        route = build_git_route(
+            arguments.repo_root,
+            base_reference=arguments.base,
+            head_reference=arguments.head,
+        )
+    except (ContractError, GitRouteError, OSError, UnicodeError) as exc:
+        print(f"CLASSIFIER_ERROR:{exc}", file=sys.stderr)
+        return 2
+    rendered = canonical_json_bytes(route).decode("utf-8") + "\n"
+    if arguments.output:
+        Path(arguments.output).write_text(rendered, encoding="utf-8")
+    else:
+        sys.stdout.write(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sdlc/classify_change.py
+++ b/scripts/sdlc/classify_change.py
@@ -1,161 +1,58 @@
 from __future__ import annotations
 
-import argparse
-from dataclasses import dataclass
-from functools import lru_cache
-import hashlib
-import json
-from pathlib import Path
-import re
-import subprocess
-import sys
-from typing import Iterable, Sequence
+from collections.abc import Iterable
+from typing import Any
 
-from .contracts import ContractError, SdlcContract, load_contract
-from .dependencies import DependencyError, build_dependency_graph, python_changes
+from . import _classify_change_base as _base
+from .contracts import SdlcContract
 
 
-SCHEMA_VERSION = "newsroom.sdlc.route.v1"
-RISK_CLASSIFIER_VERSION = "sdlc-risk-v1"
-_R3 = "R3_EXTERNAL_SERVICE_SECURITY"
-_PATH_RISKS = {
-    "documentation": "R0_DOCUMENTATION",
-    "local_code": "R1_LOCAL_CODE",
-    "clustering": "R1_LOCAL_CODE",
-    "stateful_contract": "R2_STATEFUL_CONTRACT",
-    "contract_control": _R3,
-    "external_service_security": _R3,
-    "release_operational": "R4_RELEASE_OPERATIONAL",
-}
-_GIT_SHA = re.compile(r"[0-9a-f]{40}")
-_REGULAR_GIT_MODES = frozenset({b"100644", b"100755"})
+SCHEMA_VERSION = _base.SCHEMA_VERSION
+RISK_CLASSIFIER_VERSION = _base.RISK_CLASSIFIER_VERSION
+GitRouteError = _base.GitRouteError
+ChangedPath = _base.ChangedPath
+canonical_json_bytes = _base.canonical_json_bytes
+sha256_identity = _base.sha256_identity
+matches_repository_glob = _base.matches_repository_glob
+resolve_commit = _base.resolve_commit
+resolve_tree = _base.resolve_tree
+verify_exact_clean_checkout = _base.verify_exact_clean_checkout
+parse_name_status = _base.parse_name_status
+changed_paths = _base.changed_paths
+
+_CONTROL_PRODUCT_ATOM_ERROR = (
+    "global SDLC control changes and non-test product implementation "
+    "must be separate delivery atoms"
+)
 
 
-class GitRouteError(RuntimeError):
-    """Raised when exact Git identities or a diff cannot be resolved."""
+def _is_non_test_product_implementation(path: str) -> bool:
+    if path.startswith("newsroom/"):
+        return not path.startswith("newsroom/tests/")
+    if path.startswith("scripts/"):
+        return not path.startswith("scripts/sdlc/")
+    return path.startswith(("deploy/", "release/"))
 
 
-@dataclass(frozen=True)
-class ChangedPath:
-    path: str
-    status: str = "M"
-    old_path: str | None = None
-
-    def classified_paths(self) -> tuple[str, ...]:
-        if self.old_path is None or self.old_path == self.path:
-            return (self.path,)
-        return tuple(sorted({self.old_path, self.path}))
-
-
-def canonical_json_bytes(value: object) -> bytes:
-    """Return deterministic JSON bytes for values that contain no JSON floats."""
-
-    return json.dumps(
-        value,
-        ensure_ascii=False,
-        allow_nan=False,
-        sort_keys=True,
-        separators=(",", ":"),
-    ).encode("utf-8")
-
-
-def sha256_identity(value: object) -> str:
-    return "sha256:" + hashlib.sha256(canonical_json_bytes(value)).hexdigest()
-
-
-def _require_git_sha(value: str, name: str) -> None:
-    if _GIT_SHA.fullmatch(value) is None:
-        raise ContractError(f"{name} must be a lowercase 40-character Git SHA")
-
-
-@lru_cache(maxsize=512)
-def _compile_repository_glob(pattern: str) -> re.Pattern[str]:
-    """Compile a Git-style path glob where `**/` matches zero or more segments."""
-
-    expression: list[str] = ["^"]
-    index = 0
-    while index < len(pattern):
-        char = pattern[index]
-        if char == "*":
-            if index + 1 < len(pattern) and pattern[index + 1] == "*":
-                index += 2
-                if index < len(pattern) and pattern[index] == "/":
-                    expression.append("(?:.*/)?")
-                    index += 1
-                else:
-                    expression.append(".*")
-                continue
-            expression.append("[^/]*")
-        elif char == "?":
-            expression.append("[^/]")
-        else:
-            expression.append(re.escape(char))
-        index += 1
-    expression.append("$")
-    return re.compile("".join(expression))
-
-
-def matches_repository_glob(path: str, pattern: str) -> bool:
-    if (
-        not path
-        or path.startswith("/")
-        or "\\" in path
-        or "/../" in f"/{path}/"
-        or path in {".", ".."}
-    ):
-        return False
-    return _compile_repository_glob(pattern).fullmatch(path) is not None
-
-
-def _matching_groups(contract: SdlcContract, path: str) -> tuple[str, ...]:
-    return tuple(
-        sorted(
-            group
-            for group, patterns in contract.path_groups.items()
-            if any(matches_repository_glob(path, pattern) for pattern in patterns)
-        )
-    )
-
-
-def _service_tests(repo_root: Path) -> tuple[str, ...]:
-    return tuple(
-        sorted(
-            path.relative_to(repo_root).as_posix()
-            for path in (repo_root / "newsroom" / "tests").glob(
-                "test_*_neo4j_service.py"
+def _require_control_product_atom_separation(
+    contract: SdlcContract,
+    changes: tuple[ChangedPath, ...],
+) -> None:
+    has_control = False
+    has_product_implementation = False
+    for change in changes:
+        for path in change.classified_paths():
+            groups = _base._matching_groups(contract, path)
+            has_control = has_control or "contract_control" in groups
+            has_product_implementation = (
+                has_product_implementation
+                or _is_non_test_product_implementation(path)
             )
-            if path.is_file()
-        )
-    )
+    if has_control and has_product_implementation:
+        raise _base.ContractError(_CONTROL_PRODUCT_ATOM_ERROR)
 
 
-def _dependency_reasons(
-    contract: SdlcContract, changes: tuple[ChangedPath, ...]
-) -> tuple[str, ...]:
-    paths = python_changes(
-        path
-        for change in changes
-        for path in change.classified_paths()
-    )
-    if not paths:
-        return ()
-    try:
-        graph = build_dependency_graph(contract.repo_root)
-    except DependencyError as exc:
-        return (f"unknown_dependency_edge:{exc}:{_R3}",)
-
-    reasons: set[str] = set()
-    for path in paths:
-        try:
-            dependents = graph.dependent_paths(path)
-        except DependencyError as exc:
-            reasons.add(f"unknown_dependency_edge:{exc}:{_R3}")
-            continue
-        for dependent in dependents:
-            groups = _matching_groups(contract, dependent)
-            if any(_PATH_RISKS.get(group) == _R3 for group in groups):
-                reasons.add(f"dependency:{path}->{dependent}:{_R3}")
-    return tuple(sorted(reasons))
+_original_classify_paths = _base.classify_paths
 
 
 def classify_paths(
@@ -167,253 +64,29 @@ def classify_paths(
     base_tree_sha: str,
     head_tree_sha: str,
 ) -> dict[str, object]:
-    for name, value in (
-        ("base_sha", base_sha),
-        ("head_sha", head_sha),
-        ("base_tree_sha", base_tree_sha),
-        ("head_tree_sha", head_tree_sha),
-    ):
-        _require_git_sha(value, name)
-    if contract.classifier_version != RISK_CLASSIFIER_VERSION:
-        raise ContractError("classifier implementation differs from the accepted contract")
-
-    ranks = contract.risk_rank
-    selected_risk = "R0_DOCUMENTATION"
-    reasons: set[str] = set()
-    clustering_required = False
-    normalized_changes = tuple(
-        sorted(
-            set(changes),
-            key=lambda item: (item.path, item.status, item.old_path or ""),
-        )
-    )
-
-    if not normalized_changes:
-        reasons.add("no_changes")
-
-    for change in normalized_changes:
-        for path in change.classified_paths():
-            groups = _matching_groups(contract, path)
-            if not groups:
-                risk = contract.unknown_path_risk
-                reasons.add(f"unknown_path:{path}:{risk}")
-                if ranks[risk] > ranks[selected_risk]:
-                    selected_risk = risk
-                continue
-            for group in groups:
-                if group == "clustering":
-                    clustering_required = True
-                risk = _PATH_RISKS.get(group)
-                if risk is None:
-                    risk = str(contract.classification["classifier_error"])
-                    reasons.add(f"unknown_path_group:{group}:{risk}")
-                else:
-                    reasons.add(f"path:{path}:{group}:{risk}")
-                if ranks[risk] > ranks[selected_risk]:
-                    selected_risk = risk
-
-    if ranks[selected_risk] < ranks[_R3]:
-        dependency_reasons = _dependency_reasons(contract, normalized_changes)
-        if dependency_reasons:
-            reasons.update(dependency_reasons)
-            selected_risk = _R3
-
-    core_tests = ("newsroom/tests",)
-    service_required = contract.service_required(selected_risk)
-    service_tests = _service_tests(contract.repo_root) if service_required else ()
-    if service_required and not service_tests:
-        raise ContractError("service evidence is required but no actual-service test exists")
-    manifest = {
-        "core_tests": list(core_tests),
-        "service_tests": list(service_tests),
-        "sentinels": list(contract.sentinels),
-    }
-    return {
-        "schema_version": SCHEMA_VERSION,
-        "contract_version": contract.contract_version,
-        "base_sha": base_sha,
-        "head_sha": head_sha,
-        "base_tree_sha": base_tree_sha,
-        "head_tree_sha": head_tree_sha,
-        "risk_tier": selected_risk,
-        "reasons": sorted(reasons),
-        "core_required": True,
-        "service_required": service_required,
-        "clustering_required": clustering_required,
-        "owner_authority_required": contract.owner_authority_required(selected_risk),
-        "core_tests": list(core_tests),
-        "service_tests": list(service_tests),
-        "sentinels": list(contract.sentinels),
-        "selected_test_manifest_digest": sha256_identity(manifest),
-    }
-
-
-def _git(repo_root: Path, *arguments: str) -> bytes:
-    completed = subprocess.run(
-        ("git", *arguments),
-        cwd=repo_root,
-        check=False,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    if completed.returncode != 0:
-        message = completed.stderr.decode("utf-8", errors="replace").strip()
-        raise GitRouteError(f"git {' '.join(arguments)} failed: {message}")
-    return completed.stdout
-
-
-def resolve_commit(repo_root: Path, reference: str) -> str:
-    value = _git(
-        repo_root,
-        "rev-parse",
-        "--verify",
-        f"{reference}^{{commit}}",
-    ).decode().strip()
-    if _GIT_SHA.fullmatch(value) is None:
-        raise GitRouteError(
-            f"reference did not resolve to a full commit SHA: {reference}"
-        )
-    return value
-
-
-def resolve_tree(repo_root: Path, commit_sha: str) -> str:
-    value = _git(
-        repo_root,
-        "rev-parse",
-        "--verify",
-        f"{commit_sha}^{{tree}}",
-    ).decode().strip()
-    if _GIT_SHA.fullmatch(value) is None:
-        raise GitRouteError(f"commit did not resolve to a full tree SHA: {commit_sha}")
-    return value
-
-
-def verify_exact_clean_checkout(
-    repo_root: Path, *, head_sha: str, head_tree_sha: str
-) -> None:
-    current_head = resolve_commit(repo_root, "HEAD")
-    if current_head != head_sha:
-        raise GitRouteError(
-            f"checkout HEAD differs from route head: {current_head} != {head_sha}"
-        )
-    current_tree = resolve_tree(repo_root, current_head)
-    if current_tree != head_tree_sha:
-        raise GitRouteError(
-            f"checkout tree differs from route tree: {current_tree} != {head_tree_sha}"
-        )
-    status = _git(
-        repo_root,
-        "status",
-        "--porcelain=v1",
-        "-z",
-        "--untracked-files=all",
-    )
-    if status:
-        first = status.split(b"\0", 1)[0].decode("utf-8", errors="replace")
-        raise GitRouteError(f"checkout is not clean: {first}")
-    for record in _git(repo_root, "ls-files", "--stage", "-z").split(b"\0"):
-        if not record:
-            continue
-        try:
-            metadata, raw_path = record.split(b"\t", 1)
-            mode = metadata.split(b" ", 1)[0]
-        except ValueError as exc:
-            raise GitRouteError("malformed tracked-file inventory") from exc
-        if mode not in _REGULAR_GIT_MODES:
-            path = raw_path.decode("utf-8", errors="replace")
-            raise GitRouteError(f"unsupported tracked entry mode {mode.decode()}: {path}")
-
-
-def parse_name_status(payload: bytes) -> tuple[ChangedPath, ...]:
-    fields = payload.split(b"\0")
-    if fields and fields[-1] == b"":
-        fields.pop()
-    changes: list[ChangedPath] = []
-    index = 0
-    while index < len(fields):
-        status = fields[index].decode("ascii", errors="strict")
-        index += 1
-        if not status or index >= len(fields):
-            raise GitRouteError("truncated git name-status output")
-        if status.startswith(("R", "C")):
-            if index + 1 >= len(fields):
-                raise GitRouteError("truncated git rename/copy output")
-            old_path = fields[index].decode("utf-8", errors="strict")
-            new_path = fields[index + 1].decode("utf-8", errors="strict")
-            index += 2
-            changes.append(ChangedPath(new_path, status, old_path))
-        else:
-            path = fields[index].decode("utf-8", errors="strict")
-            index += 1
-            changes.append(ChangedPath(path, status))
-    return tuple(changes)
-
-
-def changed_paths(
-    repo_root: Path, base_sha: str, head_sha: str
-) -> tuple[ChangedPath, ...]:
-    output = _git(
-        repo_root,
-        "diff",
-        "--name-status",
-        "-z",
-        "--find-renames",
-        base_sha,
-        head_sha,
-        "--",
-    )
-    return parse_name_status(output)
-
-
-def build_git_route(
-    repo_root: str | Path, *, base_reference: str, head_reference: str
-) -> dict[str, object]:
-    root = Path(repo_root).resolve()
-    base_sha = resolve_commit(root, base_reference)
-    head_sha = resolve_commit(root, head_reference)
-    head_tree_sha = resolve_tree(root, head_sha)
-    verify_exact_clean_checkout(
-        root,
-        head_sha=head_sha,
-        head_tree_sha=head_tree_sha,
-    )
-    contract = load_contract(root)
-    return classify_paths(
+    normalized_changes = tuple(changes)
+    _require_control_product_atom_separation(contract, normalized_changes)
+    return _original_classify_paths(
         contract,
-        changed_paths(root, base_sha, head_sha),
+        normalized_changes,
         base_sha=base_sha,
         head_sha=head_sha,
-        base_tree_sha=resolve_tree(root, base_sha),
+        base_tree_sha=base_tree_sha,
         head_tree_sha=head_tree_sha,
     )
 
 
-def _parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Classify an exact Newsroom change")
-    parser.add_argument("--repo-root", default=".")
-    parser.add_argument("--base", required=True, help="exact base commit or resolvable ref")
-    parser.add_argument("--head", required=True, help="exact head commit or resolvable ref")
-    parser.add_argument("--output", help="write route JSON to this path")
-    return parser
+_base.classify_paths = classify_paths
+build_git_route = _base.build_git_route
+main = _base.main
 
 
-def main(argv: Sequence[str] | None = None) -> int:
-    arguments = _parser().parse_args(argv)
-    try:
-        route = build_git_route(
-            arguments.repo_root,
-            base_reference=arguments.base,
-            head_reference=arguments.head,
-        )
-    except (ContractError, GitRouteError, OSError, UnicodeError) as exc:
-        print(f"CLASSIFIER_ERROR:{exc}", file=sys.stderr)
-        return 2
-    rendered = canonical_json_bytes(route).decode("utf-8") + "\n"
-    if arguments.output:
-        Path(arguments.output).write_text(rendered, encoding="utf-8")
-    else:
-        sys.stdout.write(rendered)
-    return 0
+def __getattr__(name: str) -> Any:
+    return getattr(_base, name)
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(dir(_base)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: sdlc-control-product-atom-separation
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

Closes #456

## Summary

- preserve the accepted `sdlc-v2.6` classifier implementation as a private base module;
- apply one public fail-closed policy layer that rejects an exact change mixing global SDLC control paths with non-test product implementation;
- permit dedicated support atoms to carry SDLC implementation, documentation, dependency/lock changes and any repository tests needed to prove topology or compatibility;
- preserve product implementation plus its own tests as an ordinary atom;
- evaluate both old and new paths for renames and copies;
- add an accepted corrective record and focused regressions.

## Why

Increment 7B2 correctly delivered its Search authority boundary, but the branch also carried global deterministic-core topology changes. That mixed ownership made independent review, rollback and evidence attribution harder than necessary. This guard prevents the same shape from recurring.

## Preserved boundaries

This PR does not change the accepted sixteen-shard topology, the 75/90-second testcase warning/hard limits, the 300/330-second shard warning/hard limits, complete deterministic-suite blocking, service escalation, or any provider/locality/publication/production authority.

## Exact-head evidence

Head: `379f14ec2b290fcd5cc9214b9251d68cabed6a5e`
Tree: `c2a4c75a73f537beb42f495e71c59793ab24d53b`

- ordinary CI run `31789855098`: passed;
- SDLC Evidence Shadow run `31789855160`: `PASS:decision`;
- core deterministic: 3,638 tests, 42 optional skips, 0 failures, 0 errors, 0 required skips, 248.151 seconds;
- authenticated Neo4j service: 42 tests, 0 skips, 0 failures, 0 errors, 56.679 seconds;
- source integrity: passed;
- complete exact-head evidence total: 3,680 tests, decision identity `sha256:7407c46be5293feaccdfccb4ca2659149b8bae81456e057a641b2aeb7465d96c`.

Substantive review remains required before merge.