### PR TITLE
Increment 7C2: add checked Coverage Audit authority

### DIFF
--- a/newsroom/authority/coverage_audit_migrations.py
+++ b/newsroom/authority/coverage_audit_migrations.py
@@ -1,0 +1,223 @@
+"""Checked v28 Coverage Audit authority migration and exact v27 backup gate."""
+
+# fmt: off
+# ruff: noqa: I001
+from __future__ import annotations
+import sqlite3
+from pathlib import Path
+from . import bounded_search_migrations as predecessor
+from .canonical import digest_canonical
+
+COVERAGE_AUDIT_SCHEMA_VERSION = 28
+COVERAGE_AUDIT_MIGRATION_NAME = "coverage_audit_authority_v28"
+COVERAGE_AUDIT_PREDECESSOR_MIGRATION_CHECKSUM = (
+    "sha256:ee5679aba6ceb3e95ba925febbbb7853369f93d055563ac85402d380377672b0"
+)
+COVERAGE_AUDIT_PREDECESSOR_FINGERPRINT = (
+    "sha256:d7fc1557bd02588969efdd53c749a2f125ab5bab146395c4cf8f7d51b1e32719"
+)
+CoverageAuditBackupError = predecessor.BoundedSearchBackupError
+CoverageAuditBackupReceipt = predecessor.BoundedSearchBackupReceipt
+CoverageAuditMigrationRecord = predecessor.BoundedSearchMigrationRecord
+_helpers = predecessor._helpers
+
+
+def coverage_audit_backup_paths(database: str | Path) -> tuple[Path, Path]:
+    source = Path(database)
+    backup = source.with_name(source.name + ".pre-v28.sqlite3")
+    return backup, backup.with_name(backup.name + ".sha256")
+
+
+def _checked_backup(path: Path, logical: str) -> CoverageAuditBackupReceipt:
+    digest_path = path.with_name(path.name + ".sha256")
+    digest = _helpers._file_digest(path)
+    if digest_path.read_text(encoding="ascii") != digest + "\n":
+        raise CoverageAuditBackupError("backup digest differs")
+    target = sqlite3.connect(f"file:{path}?mode=ro", uri=True, isolation_level=None)
+    try:
+        if (
+            target.execute("PRAGMA user_version").fetchone()[0] != 27
+            or _helpers._schema_fingerprint(target) != COVERAGE_AUDIT_PREDECESSOR_FINGERPRINT
+            or _helpers._logical_database_digest(target) != logical
+        ):
+            raise CoverageAuditBackupError("backup differs from source")
+    finally:
+        target.close()
+    return CoverageAuditBackupReceipt(path, digest_path, digest, logical)
+
+
+def prepare_coverage_audit_backup(
+    connection: sqlite3.Connection, backup_path: Path
+) -> CoverageAuditBackupReceipt:
+    fingerprint = _helpers._schema_fingerprint
+    logical_digest = _helpers._logical_database_digest
+    file_digest = _helpers._file_digest
+    if (
+        connection.in_transaction
+        or connection.execute("PRAGMA user_version").fetchone()[0] != 27
+        or fingerprint(connection) != COVERAGE_AUDIT_PREDECESSOR_FINGERPRINT
+        or not isinstance(backup_path, Path)
+        or not backup_path.is_absolute()
+    ):
+        raise CoverageAuditBackupError("backup requires checked schema v27")
+    source = Path(
+        next(row[2] for row in connection.execute("PRAGMA database_list") if row[1] == "main")
+    )
+    digest_path = backup_path.with_name(backup_path.name + ".sha256")
+    logical = logical_digest(connection)
+    if (
+        not source
+        or source.resolve() == backup_path.resolve()
+        or backup_path.exists() != digest_path.exists()
+    ):
+        raise CoverageAuditBackupError("backup boundary differs")
+    if not backup_path.exists():
+        backup_path.open("xb").close()
+        target = sqlite3.connect(backup_path, isolation_level=None)
+        try:
+            connection.backup(target)
+        finally:
+            target.close()
+        digest_path.write_text(file_digest(backup_path) + "\n", encoding="ascii")
+    receipt = _checked_backup(backup_path, logical)
+    connection.execute(
+        "CREATE TEMP TABLE IF NOT EXISTS coverage_audit_backup_gate("
+        "backup_path TEXT PRIMARY KEY,backup_digest TEXT NOT NULL,"
+        "logical_digest TEXT NOT NULL) STRICT"
+    )
+    connection.execute("DELETE FROM coverage_audit_backup_gate")
+    connection.execute(
+        "INSERT INTO coverage_audit_backup_gate VALUES(?,?,?)",
+        (str(backup_path), receipt.backup_digest, logical),
+    )
+    if connection.in_transaction:
+        connection.commit()
+    return receipt
+
+
+def require_coverage_audit_backup(
+    connection: sqlite3.Connection,
+    *,
+    expected_history: tuple[tuple[int, str, str], ...],
+) -> CoverageAuditBackupReceipt:
+    logical_digest = _helpers._logical_database_digest
+    try:
+        row = connection.execute(
+            "SELECT backup_path,backup_digest,logical_digest "
+            "FROM temp.coverage_audit_backup_gate"
+        ).fetchone()
+    except sqlite3.OperationalError as exc:
+        raise CoverageAuditBackupError("v27 to v28 requires prepared backup") from exc
+    if row is None or logical_digest(connection) != row[2]:
+        raise CoverageAuditBackupError("v27 to v28 requires prepared backup")
+    receipt = _checked_backup(Path(row[0]), str(row[2]))
+    target = sqlite3.connect(
+        f"file:{receipt.backup_path}?mode=ro", uri=True, isolation_level=None
+    )
+    try:
+        history = target.execute(
+            "SELECT version,name,checksum FROM authority_migrations ORDER BY version"
+        ).fetchall()
+    finally:
+        target.close()
+    if receipt.backup_digest != row[1] or history != list(expected_history):
+        raise CoverageAuditBackupError("prepared backup is not exact v27")
+    return receipt
+
+
+_D = "substr({0},1,7)='sha256:' AND length({0})=71 AND substr({0},8) NOT GLOB '*[^0-9a-f]*'"
+COVERAGE_AUDIT_MIGRATION_STATEMENTS: tuple[str, ...] = (
+    f"""CREATE TABLE coverage_audits(
+        audit_id TEXT PRIMARY KEY,
+        comparator_bytes BLOB NOT NULL,
+        comparator_digest TEXT NOT NULL UNIQUE CHECK({_D.format('comparator_digest')}),
+        assessment_bytes BLOB NOT NULL,
+        assessment_digest TEXT NOT NULL UNIQUE CHECK({_D.format('assessment_digest')}),
+        audit_bytes BLOB NOT NULL,
+        audit_digest TEXT NOT NULL UNIQUE CHECK({_D.format('audit_digest')}),
+        assessment_state TEXT NOT NULL CHECK(assessment_state IN ('COMPLETE_BEST_EFFORT','PARTIAL_LIMITED','DEFERRED')),
+        completed_at TEXT NOT NULL,
+        actor_identity_digest TEXT NOT NULL CHECK({_D.format('actor_identity_digest')}),
+        UNIQUE(audit_id,audit_digest),
+        CHECK(length(comparator_bytes)>0 AND length(assessment_bytes)>0 AND length(audit_bytes)>0)
+    ) STRICT""",
+    f"""CREATE TABLE coverage_audit_observations(
+        audit_id TEXT NOT NULL REFERENCES coverage_audits(audit_id),
+        observation_ordinal INTEGER NOT NULL CHECK(observation_ordinal BETWEEN 1 AND 256),
+        kind TEXT NOT NULL CHECK(kind IN ('SEARCH_RESULT_REFERENCE','EDITORIAL_RECORD','SOURCE_CHECK','EXPECTATION_NOT_OBSERVED')),
+        reference_digest TEXT NOT NULL CHECK({_D.format('reference_digest')}),
+        observed_at TEXT NOT NULL,
+        PRIMARY KEY(audit_id,observation_ordinal),
+        UNIQUE(audit_id,kind,reference_digest)
+    ) STRICT""",
+    f"""CREATE TABLE coverage_gaps(
+        gap_id TEXT PRIMARY KEY,
+        gap_bytes BLOB NOT NULL,
+        gap_digest TEXT NOT NULL UNIQUE CHECK({_D.format('gap_digest')}),
+        audit_id TEXT NOT NULL UNIQUE REFERENCES coverage_audits(audit_id),
+        gap_state TEXT NOT NULL CHECK(gap_state IN ('PROPOSED','DEFERRED_ASSESSMENT')),
+        proposed_at TEXT NOT NULL,
+        UNIQUE(gap_id,gap_digest),
+        CHECK(length(gap_bytes)>0)
+    ) STRICT""",
+    f"""CREATE TABLE coverage_gap_decisions(
+        decision_id TEXT PRIMARY KEY,
+        decision_bytes BLOB NOT NULL,
+        decision_digest TEXT NOT NULL UNIQUE CHECK({_D.format('decision_digest')}),
+        gap_id TEXT NOT NULL REFERENCES coverage_gaps(gap_id),
+        decision_ordinal INTEGER NOT NULL CHECK(decision_ordinal BETWEEN 1 AND 1000000),
+        previous_decision_digest TEXT CHECK(previous_decision_digest IS NULL OR {_D.format('previous_decision_digest')}),
+        command_bytes BLOB NOT NULL,
+        command_digest TEXT NOT NULL UNIQUE CHECK({_D.format('command_digest')}),
+        command_id TEXT NOT NULL UNIQUE,
+        request_id TEXT NOT NULL UNIQUE,
+        actor_identity_digest TEXT NOT NULL CHECK({_D.format('actor_identity_digest')}),
+        idempotency_key TEXT NOT NULL UNIQUE,
+        disposition TEXT NOT NULL CHECK(disposition IN ('CONFIRMED_BEST_EFFORT_GAP','NOT_CONFIRMED','DEFERRED_INSUFFICIENT_BASIS')),
+        decided_at TEXT NOT NULL,
+        locality_decision_digest TEXT NOT NULL CHECK({_D.format('locality_decision_digest')}),
+        UNIQUE(gap_id,decision_ordinal),
+        UNIQUE(gap_id,decision_digest),
+        FOREIGN KEY(gap_id,previous_decision_digest) REFERENCES coverage_gap_decisions(gap_id,decision_digest),
+        CHECK((decision_ordinal=1 AND previous_decision_digest IS NULL) OR (decision_ordinal>1 AND previous_decision_digest IS NOT NULL)),
+        CHECK(length(decision_bytes)>0 AND length(command_bytes)>0)
+    ) STRICT""",
+    """CREATE TRIGGER insert_once_coverage_audits BEFORE INSERT ON coverage_audits
+       WHEN EXISTS(SELECT 1 FROM coverage_audits WHERE audit_id=NEW.audit_id OR comparator_digest=NEW.comparator_digest OR assessment_digest=NEW.assessment_digest OR audit_digest=NEW.audit_digest)
+       BEGIN SELECT RAISE(ABORT,'Coverage Audit identity already retained'); END""",
+    """CREATE TRIGGER insert_once_coverage_gaps BEFORE INSERT ON coverage_gaps
+       WHEN EXISTS(SELECT 1 FROM coverage_gaps WHERE gap_id=NEW.gap_id OR gap_digest=NEW.gap_digest OR audit_id=NEW.audit_id)
+       BEGIN SELECT RAISE(ABORT,'Coverage Gap identity already retained'); END""",
+    """CREATE TRIGGER insert_once_coverage_gap_decisions BEFORE INSERT ON coverage_gap_decisions
+       WHEN EXISTS(SELECT 1 FROM coverage_gap_decisions WHERE decision_id=NEW.decision_id OR decision_digest=NEW.decision_digest OR command_id=NEW.command_id OR command_digest=NEW.command_digest OR request_id=NEW.request_id OR idempotency_key=NEW.idempotency_key OR (gap_id=NEW.gap_id AND decision_ordinal=NEW.decision_ordinal))
+       BEGIN SELECT RAISE(ABORT,'Coverage Gap Decision identity already retained'); END""",
+    *tuple(
+        f"CREATE TRIGGER immutable_{table} BEFORE UPDATE ON {table} BEGIN SELECT RAISE(ABORT,'immutable Coverage record'); END"
+        for table in (
+            "coverage_audits", "coverage_audit_observations", "coverage_gaps", "coverage_gap_decisions",
+        )
+    ),
+    *tuple(
+        f"CREATE TRIGGER retained_{table} BEFORE DELETE ON {table} BEGIN SELECT RAISE(ABORT,'retained Coverage record'); END"
+        for table in (
+            "coverage_audits", "coverage_audit_observations", "coverage_gaps", "coverage_gap_decisions",
+        )
+    ),
+)
+COVERAGE_AUDIT_MIGRATION_CHECKSUM = digest_canonical(
+    {
+        "version": COVERAGE_AUDIT_SCHEMA_VERSION,
+        "name": COVERAGE_AUDIT_MIGRATION_NAME,
+        "statements": list(COVERAGE_AUDIT_MIGRATION_STATEMENTS),
+    }
+)
+COVERAGE_AUDIT_MIGRATION = CoverageAuditMigrationRecord(
+    COVERAGE_AUDIT_SCHEMA_VERSION,
+    COVERAGE_AUDIT_MIGRATION_NAME,
+    COVERAGE_AUDIT_MIGRATION_CHECKSUM,
+)
+__all__ = [
+    name for name in globals()
+    if name.startswith(("COVERAGE_", "Coverage", "coverage_", "prepare_", "require_"))
+]
+# fmt: on

--- a/newsroom/authority/migrations.py
+++ b/newsroom/authority/migrations.py
@@ -18,6 +18,17 @@ from .bounded_search_migrations import (
     prepare_bounded_search_backup,
     require_bounded_search_backup,
 )
+from .coverage_audit_migrations import (
+    COVERAGE_AUDIT_MIGRATION,
+    COVERAGE_AUDIT_MIGRATION_CHECKSUM,
+    COVERAGE_AUDIT_MIGRATION_NAME,
+    COVERAGE_AUDIT_MIGRATION_STATEMENTS,
+    COVERAGE_AUDIT_SCHEMA_VERSION,
+    CoverageAuditBackupReceipt,
+    coverage_audit_backup_paths,
+    prepare_coverage_audit_backup,
+    require_coverage_audit_backup,
+)
 from .check_migrations import (
     CHECK_AUTHORITY_MIGRATION,
     CHECK_AUTHORITY_MIGRATION_CHECKSUM,
@@ -235,7 +246,7 @@ from .triage_work_item_migrations import (
 )
 
 BASE_SCHEMA_VERSION = 1
-SCHEMA_VERSION = BOUNDED_SEARCH_SCHEMA_VERSION
+SCHEMA_VERSION = COVERAGE_AUDIT_SCHEMA_VERSION
 MIGRATION_NAME = "authority_event_foundation_v1"
 
 
@@ -686,11 +697,12 @@ def prepare_pending_migration_backup(
     | EvaluationFeedbackBackupReceipt
     | PlannedAgendaBackupReceipt
     | BoundedSearchBackupReceipt
+    | CoverageAuditBackupReceipt
     | None
 ):
     """Prepare the exact retained backup required by a checked predecessor."""
     version = int(conn.execute("PRAGMA user_version").fetchone()[0])
-    if version not in {16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}:
+    if version not in {16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27}:
         return None
     database_path = next(
         str(row[2])
@@ -731,8 +743,11 @@ def prepare_pending_migration_backup(
     if version == 25:
         backup_path, _ = planned_agenda_backup_paths(database_path)
         return prepare_planned_agenda_backup(conn, backup_path)
-    backup_path, _ = bounded_search_backup_paths(database_path)
-    return prepare_bounded_search_backup(conn, backup_path)
+    if version == 26:
+        backup_path, _ = bounded_search_backup_paths(database_path)
+        return prepare_bounded_search_backup(conn, backup_path)
+    backup_path, _ = coverage_audit_backup_paths(database_path)
+    return prepare_coverage_audit_backup(conn, backup_path)
 
 
 def apply_migration(
@@ -1346,6 +1361,29 @@ def apply_pending_migrations(conn: sqlite3.Connection, *, applied_at: str) -> No
                  BOUNDED_SEARCH_MIGRATION_CHECKSUM, applied_at),
             )
             current = BOUNDED_SEARCH_SCHEMA_VERSION
+        if current == BOUNDED_SEARCH_SCHEMA_VERSION:
+            if 0 < starting_version < BOUNDED_SEARCH_SCHEMA_VERSION:
+                conn.execute(f"PRAGMA user_version={BOUNDED_SEARCH_SCHEMA_VERSION}")
+                conn.execute("COMMIT")
+                database_path = next(str(row[2]) for row in conn.execute("PRAGMA database_list") if row[1] == "main")
+                if not database_path:
+                    raise sqlite3.DatabaseError("existing multihop upgrade requires a file-backed database")
+                backup_path, _ = coverage_audit_backup_paths(database_path)
+                prepare_coverage_audit_backup(conn, backup_path)
+                conn.execute("BEGIN EXCLUSIVE")
+            if starting_version != 0:
+                require_coverage_audit_backup(
+                    conn, expected_history=tuple((r.version, r.name, r.checksum) for r in MIGRATIONS
+                                                 if r.version <= BOUNDED_SEARCH_SCHEMA_VERSION),
+                )
+            for statement in COVERAGE_AUDIT_MIGRATION_STATEMENTS:
+                conn.execute(statement)
+            conn.execute(
+                "INSERT INTO authority_migrations(version,name,checksum,applied_at) VALUES(?,?,?,?)",
+                (COVERAGE_AUDIT_SCHEMA_VERSION, COVERAGE_AUDIT_MIGRATION_NAME,
+                 COVERAGE_AUDIT_MIGRATION_CHECKSUM, applied_at),
+            )
+            current = COVERAGE_AUDIT_SCHEMA_VERSION
         # fmt: on
         conn.execute(f"PRAGMA user_version={current}")
         conn.execute("COMMIT")
@@ -1383,6 +1421,7 @@ MIGRATIONS: tuple[MigrationRecord | object, ...] = (
     EVALUATION_FEEDBACK_MIGRATION,
     PLANNED_AGENDA_MIGRATION,
     BOUNDED_SEARCH_MIGRATION,
+    COVERAGE_AUDIT_MIGRATION,
 )
 
 
@@ -1524,6 +1563,11 @@ EXPECTED_MIGRATION_HISTORY: tuple[tuple[int, str, str], ...] = (
         BOUNDED_SEARCH_SCHEMA_VERSION,
         BOUNDED_SEARCH_MIGRATION_NAME,
         BOUNDED_SEARCH_MIGRATION_CHECKSUM,
+    ),
+    (
+        COVERAGE_AUDIT_SCHEMA_VERSION,
+        COVERAGE_AUDIT_MIGRATION_NAME,
+        COVERAGE_AUDIT_MIGRATION_CHECKSUM,
     ),
 )
 # fmt: on

--- a/newsroom/increment7/coverage_authority.py
+++ b/newsroom/increment7/coverage_authority.py
@@ -1,0 +1,1114 @@
+"""Checked Coverage Audit and Gap persistence with deterministic assessment.
+
+The authority retains caller-supplied fixture/replay records only. It has no
+clock, provider, credential, network, scheduler, evidence acquisition,
+publication or production activation capability. Comparators and Gap decisions
+remain best-effort review assertions rather than ground truth.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+from pathlib import Path
+from typing import Self
+
+from newsroom.authority.canonical import (
+    CanonicalizationError,
+    canonical_json_bytes,
+    digest_bytes,
+    validate_sha256_digest,
+)
+from newsroom.authority.migrations import (
+    SCHEMA_VERSION,
+    apply_pending_migrations,
+    prepare_pending_migration_backup,
+)
+from newsroom.increment7.coverage import (
+    CoverageAssessmentState,
+    CoverageAudit,
+    CoverageComparator,
+    CoverageGap,
+    CoverageGapDecision,
+    CoverageObservationKind,
+    validate_coverage_chain,
+)
+from newsroom.increment7.locality_qualification import (
+    LocalityCoverageDecision,
+    LocalityCoverageProposal,
+    LocalityCoverageUnit,
+    LocalityReference,
+    validate_locality_coverage_chain,
+)
+from newsroom.increment7.provider_qualification import (
+    ProviderDecision,
+    ProviderProposal,
+)
+from newsroom.increment7.search import (
+    SearchAttempt,
+    SearchOutcome,
+    SearchPurpose,
+    SearchRequest,
+    SearchResultReference,
+    SearchReviewDecision,
+    validate_search_attempt,
+    validate_search_outcome,
+    validate_search_request,
+    validate_search_result,
+    validate_search_review,
+)
+
+COVERAGE_COMMAND = "newsroom.increment7.coverage-command.v1"
+COVERAGE_ASSESSMENT = "newsroom.increment7.coverage-assessment.v1"
+COVERAGE_AUDIT_AUTHORITY = "CHECKED_SQLITE_TRANSACTIONAL_V28"
+COVERAGE_ASSESSMENT_AUTHORITY = "DETERMINISTIC_DEPENDENCY_TIMELINESS_HEALTH"
+MAX_COVERAGE_COMMAND_BYTES = 8_388_608
+
+_UUID = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z"
+)
+_TOKEN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:\-]{0,255}\Z")
+_UTC = re.compile(
+    r"[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T"
+    r"(?:[01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]\.[0-9]{6}Z\Z"
+)
+
+
+class CoverageAuthorityError(ValueError):
+    """An assessment, command, retained row or identity binding failed closed."""
+
+
+class DependencyState(StrEnum):
+    AVAILABLE = "AVAILABLE"
+    DEGRADED = "DEGRADED"
+    UNAVAILABLE = "UNAVAILABLE"
+    UNKNOWN = "UNKNOWN"
+
+
+class TimelinessState(StrEnum):
+    ON_TIME = "ON_TIME"
+    LATE = "LATE"
+    UNKNOWN = "UNKNOWN"
+
+
+class HealthState(StrEnum):
+    HEALTHY = "HEALTHY"
+    DEGRADED = "DEGRADED"
+    UNAVAILABLE = "UNAVAILABLE"
+    UNKNOWN = "UNKNOWN"
+
+
+class _NoEffect:
+    authorises_external_effect = False
+    authorises_search = False
+    authorises_provider = False
+    authorises_locality = False
+    authorises_credentials = False
+    authorises_egress = False
+    authorises_spend = False
+    authorises_schedule = False
+    authorises_evidence = False
+    authorises_publication = False
+    creates_signal = False
+    creates_lead = False
+    creates_candidate = False
+    creates_watch = False
+    comparator_is_ground_truth = False
+    gap_is_automatic_truth = False
+    production_activation_authorised = False
+
+
+def _total(label: str):
+    def decorate(function):
+        def wrapped(*args: object, **kwargs: object):
+            try:
+                return function(*args, **kwargs)
+            except CoverageAuthorityError:
+                raise
+            except Exception as exc:
+                raise CoverageAuthorityError(label) from exc
+
+        return wrapped
+
+    return decorate
+
+
+def _text(value: object, field: str, maximum: int = 2_048) -> str:
+    try:
+        size = len(value.encode()) if type(value) is str else 0
+    except UnicodeError as exc:
+        raise CoverageAuthorityError(f"{field} must be canonical text") from exc
+    if (
+        type(value) is not str
+        or not value
+        or value != value.strip()
+        or size > maximum
+        or any(ord(character) < 32 or ord(character) == 127 for character in value)
+    ):
+        raise CoverageAuthorityError(f"{field} must be canonical text")
+    return value
+
+
+def _token(value: object, field: str) -> str:
+    value = _text(value, field, 256)
+    if _TOKEN.fullmatch(value) is None:
+        raise CoverageAuthorityError(f"{field} must be a canonical token")
+    return value
+
+
+def _uuid(value: object, field: str) -> str:
+    if type(value) is not str or _UUID.fullmatch(value) is None:
+        raise CoverageAuthorityError(f"{field} must be a canonical UUID")
+    try:
+        if str(uuid.UUID(value)) != value:
+            raise ValueError
+    except ValueError as exc:
+        raise CoverageAuthorityError(f"{field} must be a canonical UUID") from exc
+    return value
+
+
+def _digest(value: object, field: str) -> str:
+    try:
+        return validate_sha256_digest(value, field=field)
+    except (CanonicalizationError, TypeError, ValueError) as exc:
+        raise CoverageAuthorityError(f"{field} must be a SHA-256 digest") from exc
+
+
+def _timestamp(value: object, field: str) -> str:
+    value = _text(value, field, 27)
+    if _UTC.fullmatch(value) is None:
+        raise CoverageAuthorityError(f"{field} must be an exact UTC timestamp")
+    try:
+        datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise CoverageAuthorityError(f"{field} must be an exact UTC timestamp") from exc
+    return value
+
+
+def _enum[T: StrEnum](kind: type[T], value: object, field: str) -> T:
+    if type(value) is not str and type(value) is not kind:
+        raise CoverageAuthorityError(f"{field} differs")
+    try:
+        return kind(value)
+    except ValueError as exc:
+        raise CoverageAuthorityError(f"{field} differs") from exc
+
+
+def _strings(
+    value: object, field: str, *, required: bool = False, digests: bool = False
+) -> tuple[str, ...]:
+    if type(value) is not tuple or len(value) > 256 or (required and not value):
+        raise CoverageAuthorityError(f"{field} must be a bounded array")
+    validator = _digest if digests else _token
+    result = tuple(validator(item, field) for item in value)
+    if result != tuple(sorted(set(result))):
+        raise CoverageAuthorityError(f"{field} must be unique and sorted")
+    return result
+
+
+def _pairs(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise CoverageAuthorityError(f"duplicate object name: {key}")
+        result[key] = value
+    return result
+
+
+def _document(raw: bytes, schema: str, fields: tuple[str, ...]) -> dict[str, object]:
+    if type(raw) is not bytes or not raw or len(raw) > MAX_COVERAGE_COMMAND_BYTES:
+        raise CoverageAuthorityError("Coverage document bytes are not bounded")
+    try:
+        value = json.loads(raw.decode(), object_pairs_hook=_pairs)
+        canonical = canonical_json_bytes(value)
+    except CoverageAuthorityError:
+        raise
+    except (
+        UnicodeError,
+        json.JSONDecodeError,
+        CanonicalizationError,
+        RecursionError,
+        ValueError,
+    ) as exc:
+        raise CoverageAuthorityError("Coverage document is not canonical JSON") from exc
+    if type(value) is not dict or raw != canonical:
+        raise CoverageAuthorityError("Coverage document is not exact canonical JSON")
+    if tuple(value) != tuple(sorted(fields)) or value.get("schema_version") != schema:
+        raise CoverageAuthorityError("Coverage document fields or schema differ")
+    return value
+
+
+def _embedded(record: object) -> dict[str, object]:
+    return json.loads(record.canonical_bytes)
+
+
+def _embedded_record(value: object, field: str, kind):
+    if type(value) is not dict:
+        raise CoverageAuthorityError(f"{field} differs")
+    return kind.from_canonical_bytes(canonical_json_bytes(value))
+
+
+_FACTOR_FIELDS = ("evidence_digest", "factor_key", "state")
+
+
+@dataclass(frozen=True, slots=True)
+class AssessmentFactor(_NoEffect):
+    factor_key: str
+    state: DependencyState | TimelinessState | HealthState
+    evidence_digest: str
+
+    def __post_init__(self) -> None:
+        _token(self.factor_key, "factor_key")
+        if type(self.state) not in (DependencyState, TimelinessState, HealthState):
+            raise CoverageAuthorityError("assessment factor state differs")
+        _digest(self.evidence_digest, "evidence_digest")
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "evidence_digest": self.evidence_digest,
+            "factor_key": self.factor_key,
+            "state": self.state.value,
+        }
+
+    @classmethod
+    def from_dict(cls, value: object, state_kind):
+        if type(value) is not dict or tuple(value) != _FACTOR_FIELDS:
+            raise CoverageAuthorityError("assessment factor fields differ")
+        return cls(
+            factor_key=value["factor_key"],
+            state=_enum(state_kind, value["state"], "state"),
+            evidence_digest=value["evidence_digest"],
+        )
+
+
+_ASSESSMENT_FIELDS = (
+    "schema_version",
+    "assessment_id",
+    "dependency_factors",
+    "timeliness_factors",
+    "health_factors",
+    "declared_limitation_codes",
+    "derived_state",
+    "derived_limitation_codes",
+    "assessed_at",
+)
+
+
+def _factor_limitations(
+    prefix: str, factors: tuple[AssessmentFactor, ...], healthy: StrEnum
+) -> set[str]:
+    return {
+        f"{prefix}.{factor.factor_key}.{factor.state.value.lower()}"
+        for factor in factors
+        if factor.state is not healthy
+    }
+
+
+def deterministic_assessment(
+    dependency_factors: tuple[AssessmentFactor, ...],
+    timeliness_factors: tuple[AssessmentFactor, ...],
+    health_factors: tuple[AssessmentFactor, ...],
+    declared_limitation_codes: tuple[str, ...],
+) -> tuple[CoverageAssessmentState, tuple[str, ...]]:
+    groups = (
+        (dependency_factors, DependencyState),
+        (timeliness_factors, TimelinessState),
+        (health_factors, HealthState),
+    )
+    for factors, kind in groups:
+        if type(factors) is not tuple or not factors or len(factors) > 64:
+            raise CoverageAuthorityError("assessment factors must be bounded")
+        if any(
+            type(item) is not AssessmentFactor or type(item.state) is not kind
+            for item in factors
+        ):
+            raise CoverageAuthorityError("assessment factor vocabulary differs")
+        if tuple(item.factor_key for item in factors) != tuple(
+            sorted({item.factor_key for item in factors})
+        ):
+            raise CoverageAuthorityError("assessment factors must be unique and sorted")
+    declared = _strings(
+        declared_limitation_codes,
+        "declared_limitation_codes",
+        required=True,
+    )
+    deferred = (
+        any(
+            item.state in (DependencyState.UNAVAILABLE, DependencyState.UNKNOWN)
+            for item in dependency_factors
+        )
+        or any(item.state is TimelinessState.UNKNOWN for item in timeliness_factors)
+        or any(
+            item.state in (HealthState.UNAVAILABLE, HealthState.UNKNOWN)
+            for item in health_factors
+        )
+    )
+    partial = (
+        any(item.state is DependencyState.DEGRADED for item in dependency_factors)
+        or any(item.state is TimelinessState.LATE for item in timeliness_factors)
+        or any(item.state is HealthState.DEGRADED for item in health_factors)
+    )
+    state = (
+        CoverageAssessmentState.DEFERRED
+        if deferred
+        else CoverageAssessmentState.PARTIAL_LIMITED
+        if partial
+        else CoverageAssessmentState.COMPLETE_BEST_EFFORT
+    )
+    limitations = set(declared)
+    limitations.update(
+        _factor_limitations("dependency", dependency_factors, DependencyState.AVAILABLE)
+    )
+    limitations.update(
+        _factor_limitations("timeliness", timeliness_factors, TimelinessState.ON_TIME)
+    )
+    limitations.update(
+        _factor_limitations("health", health_factors, HealthState.HEALTHY)
+    )
+    return state, tuple(sorted(limitations))
+
+
+@dataclass(frozen=True, slots=True)
+class CoverageAssessment(_NoEffect):
+    assessment_id: str
+    dependency_factors: tuple[AssessmentFactor, ...]
+    timeliness_factors: tuple[AssessmentFactor, ...]
+    health_factors: tuple[AssessmentFactor, ...]
+    declared_limitation_codes: tuple[str, ...]
+    derived_state: CoverageAssessmentState
+    derived_limitation_codes: tuple[str, ...]
+    assessed_at: str
+    schema_version: str = COVERAGE_ASSESSMENT
+
+    def __post_init__(self) -> None:
+        if self.schema_version != COVERAGE_ASSESSMENT:
+            raise CoverageAuthorityError("Coverage Assessment schema differs")
+        _uuid(self.assessment_id, "assessment_id")
+        object.__setattr__(
+            self,
+            "derived_state",
+            _enum(CoverageAssessmentState, self.derived_state, "derived_state"),
+        )
+        expected_state, expected_codes = deterministic_assessment(
+            self.dependency_factors,
+            self.timeliness_factors,
+            self.health_factors,
+            self.declared_limitation_codes,
+        )
+        object.__setattr__(
+            self,
+            "declared_limitation_codes",
+            _strings(
+                self.declared_limitation_codes,
+                "declared_limitation_codes",
+                required=True,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "derived_limitation_codes",
+            _strings(
+                self.derived_limitation_codes,
+                "derived_limitation_codes",
+                required=True,
+            ),
+        )
+        if (
+            self.derived_state is not expected_state
+            or self.derived_limitation_codes != expected_codes
+        ):
+            raise CoverageAuthorityError("Coverage Assessment derivation differs")
+        _timestamp(self.assessed_at, "assessed_at")
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return canonical_json_bytes(
+            {
+                "assessed_at": self.assessed_at,
+                "assessment_id": self.assessment_id,
+                "declared_limitation_codes": list(self.declared_limitation_codes),
+                "dependency_factors": [
+                    item.to_dict() for item in self.dependency_factors
+                ],
+                "derived_limitation_codes": list(self.derived_limitation_codes),
+                "derived_state": self.derived_state.value,
+                "health_factors": [item.to_dict() for item in self.health_factors],
+                "schema_version": self.schema_version,
+                "timeliness_factors": [
+                    item.to_dict() for item in self.timeliness_factors
+                ],
+            }
+        )
+
+    @property
+    def digest(self) -> str:
+        return digest_bytes(self.canonical_bytes)
+
+    @classmethod
+    def from_canonical_bytes(cls, raw: bytes) -> Self:
+        value = _document(raw, COVERAGE_ASSESSMENT, _ASSESSMENT_FIELDS)
+        for field, kind in (
+            ("dependency_factors", DependencyState),
+            ("timeliness_factors", TimelinessState),
+            ("health_factors", HealthState),
+        ):
+            items = value[field]
+            if type(items) is not list:
+                raise CoverageAuthorityError("assessment factors must be arrays")
+            value[field] = tuple(
+                AssessmentFactor.from_dict(item, kind) for item in items
+            )
+        for field in ("declared_limitation_codes", "derived_limitation_codes"):
+            if type(value[field]) is not list:
+                raise CoverageAuthorityError("assessment limitations must be arrays")
+            value[field] = tuple(value[field])
+        result = cls(**value)  # type: ignore[arg-type]
+        if result.canonical_bytes != raw:
+            raise CoverageAuthorityError("Coverage Assessment replay differs")
+        return result
+
+
+_COMMAND_FIELDS = (
+    "schema_version",
+    "command_id",
+    "comparator",
+    "assessment",
+    "audit",
+    "gap",
+    "decision",
+    "search_request_digests",
+    "search_result_digests",
+    "search_review_decision_digests",
+    "provider_decision_digests",
+    "locality_reference_digest",
+    "locality_coverage_unit_digest",
+    "locality_decision_digest",
+    "expected_previous_decision_digest",
+    "request_id",
+    "actor_identity_digest",
+    "idempotency_key",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CoverageCommand(_NoEffect):
+    command_id: str
+    comparator: CoverageComparator
+    assessment: CoverageAssessment
+    audit: CoverageAudit
+    gap: CoverageGap
+    decision: CoverageGapDecision
+    search_request_digests: tuple[str, ...]
+    search_result_digests: tuple[str, ...]
+    search_review_decision_digests: tuple[str, ...]
+    provider_decision_digests: tuple[str, ...]
+    locality_reference_digest: str
+    locality_coverage_unit_digest: str
+    locality_decision_digest: str
+    expected_previous_decision_digest: str | None
+    request_id: str
+    actor_identity_digest: str
+    idempotency_key: str
+    schema_version: str = COVERAGE_COMMAND
+
+    def __post_init__(self) -> None:
+        if self.schema_version != COVERAGE_COMMAND:
+            raise CoverageAuthorityError("Coverage Command schema differs")
+        for field in ("command_id", "request_id"):
+            _uuid(getattr(self, field), field)
+        for field, kind in (
+            ("comparator", CoverageComparator),
+            ("assessment", CoverageAssessment),
+            ("audit", CoverageAudit),
+            ("gap", CoverageGap),
+            ("decision", CoverageGapDecision),
+        ):
+            if type(getattr(self, field)) is not kind:
+                raise CoverageAuthorityError(f"Coverage Command {field} differs")
+        for field in (
+            "search_request_digests",
+            "search_result_digests",
+            "search_review_decision_digests",
+            "provider_decision_digests",
+        ):
+            object.__setattr__(
+                self,
+                field,
+                _strings(getattr(self, field), field, required=True, digests=True),
+            )
+        for field in (
+            "locality_reference_digest",
+            "locality_coverage_unit_digest",
+            "locality_decision_digest",
+            "actor_identity_digest",
+        ):
+            _digest(getattr(self, field), field)
+        if self.expected_previous_decision_digest is not None:
+            _digest(
+                self.expected_previous_decision_digest,
+                "expected_previous_decision_digest",
+            )
+        _token(self.idempotency_key, "idempotency_key")
+        if (
+            self.audit.assessment_state is not self.assessment.derived_state
+            or self.audit.limitation_codes != self.assessment.derived_limitation_codes
+            or self.audit.completed_at != self.assessment.assessed_at
+            or self.comparator.search_request_digests != self.search_request_digests
+            or self.locality_coverage_unit_digest
+            not in self.comparator.coverage_unit_digests
+            or self.decision.supersedes_decision_digest
+            != self.expected_previous_decision_digest
+        ):
+            raise CoverageAuthorityError(
+                "Coverage Command assessment or lineage differs"
+            )
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return canonical_json_bytes(
+            {
+                "actor_identity_digest": self.actor_identity_digest,
+                "assessment": _embedded(self.assessment),
+                "audit": _embedded(self.audit),
+                "command_id": self.command_id,
+                "comparator": _embedded(self.comparator),
+                "decision": _embedded(self.decision),
+                "expected_previous_decision_digest": self.expected_previous_decision_digest,
+                "gap": _embedded(self.gap),
+                "idempotency_key": self.idempotency_key,
+                "locality_coverage_unit_digest": self.locality_coverage_unit_digest,
+                "locality_decision_digest": self.locality_decision_digest,
+                "locality_reference_digest": self.locality_reference_digest,
+                "provider_decision_digests": list(self.provider_decision_digests),
+                "request_id": self.request_id,
+                "schema_version": self.schema_version,
+                "search_request_digests": list(self.search_request_digests),
+                "search_result_digests": list(self.search_result_digests),
+                "search_review_decision_digests": list(
+                    self.search_review_decision_digests
+                ),
+            }
+        )
+
+    @property
+    def digest(self) -> str:
+        return digest_bytes(self.canonical_bytes)
+
+    @classmethod
+    def from_canonical_bytes(cls, raw: bytes) -> Self:
+        value = _document(raw, COVERAGE_COMMAND, _COMMAND_FIELDS)
+        for field, kind in (
+            ("comparator", CoverageComparator),
+            ("assessment", CoverageAssessment),
+            ("audit", CoverageAudit),
+            ("gap", CoverageGap),
+            ("decision", CoverageGapDecision),
+        ):
+            value[field] = _embedded_record(value[field], field, kind)
+        for field in (
+            "search_request_digests",
+            "search_result_digests",
+            "search_review_decision_digests",
+            "provider_decision_digests",
+        ):
+            if type(value[field]) is not list:
+                raise CoverageAuthorityError(f"{field} must be an array")
+            value[field] = tuple(value[field])
+        result = cls(**value)  # type: ignore[arg-type]
+        if result.canonical_bytes != raw:
+            raise CoverageAuthorityError("Coverage Command replay differs")
+        return result
+
+
+type SearchEvidenceChain = tuple[
+    SearchPurpose,
+    SearchRequest,
+    SearchAttempt,
+    SearchOutcome,
+    tuple[SearchResultReference, ...],
+    SearchReviewDecision,
+]
+type ProviderQualification = tuple[
+    ProviderProposal, ProviderDecision, tuple[ProviderDecision, ...]
+]
+type LocalityQualification = tuple[
+    LocalityReference,
+    LocalityCoverageUnit,
+    LocalityCoverageProposal,
+    LocalityCoverageDecision,
+]
+
+
+def validate_coverage_command(
+    command: CoverageCommand,
+    *,
+    search_evidence: tuple[SearchEvidenceChain, ...],
+    provider_qualifications: tuple[ProviderQualification, ...],
+    locality_qualification: LocalityQualification,
+    previous_decision: CoverageGapDecision | None = None,
+) -> None:
+    if type(command) is not CoverageCommand:
+        raise CoverageAuthorityError("Coverage validation requires an exact command")
+    if type(search_evidence) is not tuple or not search_evidence:
+        raise CoverageAuthorityError("Coverage Search evidence differs")
+    requests: list[SearchRequest] = []
+    results: list[SearchResultReference] = []
+    reviews: list[SearchReviewDecision] = []
+    for chain in search_evidence:
+        if type(chain) is not tuple or len(chain) != 6:
+            raise CoverageAuthorityError("Coverage Search evidence differs")
+        purpose, request, attempt, outcome, chain_results, review = chain
+        if (
+            type(purpose) is not SearchPurpose
+            or type(request) is not SearchRequest
+            or type(attempt) is not SearchAttempt
+            or type(outcome) is not SearchOutcome
+            or type(chain_results) is not tuple
+            or not chain_results
+            or any(type(item) is not SearchResultReference for item in chain_results)
+            or type(review) is not SearchReviewDecision
+        ):
+            raise CoverageAuthorityError("Coverage Search evidence differs")
+        validate_search_request(purpose, request)
+        validate_search_attempt(request, attempt)
+        validate_search_outcome(attempt, outcome, request)
+        for result in chain_results:
+            validate_search_result(outcome, result, attempt)
+        validate_search_review(chain_results, review, request)
+        requests.append(request)
+        results.extend(chain_results)
+        reviews.append(review)
+    digest_groups = (
+        (
+            tuple(sorted({item.digest for item in requests})),
+            command.search_request_digests,
+        ),
+        (
+            tuple(sorted({item.digest for item in results})),
+            command.search_result_digests,
+        ),
+        (
+            tuple(sorted({item.digest for item in reviews})),
+            command.search_review_decision_digests,
+        ),
+    )
+    if any(actual != expected for actual, expected in digest_groups):
+        raise CoverageAuthorityError("Coverage Search identity set differs")
+    observed_search = tuple(
+        sorted(
+            item.reference_digest
+            for item in command.audit.observations
+            if item.kind is CoverageObservationKind.SEARCH_RESULT_REFERENCE
+        )
+    )
+    if observed_search != command.search_result_digests:
+        raise CoverageAuthorityError("Coverage Search observations differ")
+    if type(locality_qualification) is not tuple or len(locality_qualification) != 4:
+        raise CoverageAuthorityError("Coverage locality qualification differs")
+    reference, unit, proposal, locality_decision = locality_qualification
+    try:
+        validate_locality_coverage_chain(
+            reference,
+            unit,
+            proposal,
+            locality_decision,
+            provider_qualifications=provider_qualifications,
+        )
+        validate_coverage_chain(
+            command.comparator,
+            command.audit,
+            command.gap,
+            command.decision,
+            previous_decision,
+        )
+    except Exception as exc:
+        raise CoverageAuthorityError(f"Coverage accepted chain differs: {exc}") from exc
+    if (
+        tuple(sorted(item[1].digest for item in provider_qualifications))
+        != command.provider_decision_digests
+        or reference.digest != command.locality_reference_digest
+        or unit.digest != command.locality_coverage_unit_digest
+        or locality_decision.digest != command.locality_decision_digest
+        or command.expected_previous_decision_digest
+        != (None if previous_decision is None else previous_decision.digest)
+    ):
+        raise CoverageAuthorityError("Coverage qualification identity set differs")
+
+
+_TOKEN_PORT = object()
+
+
+class CoverageAuditReadPort(_NoEffect):
+    __slots__ = ("_connection",)
+
+    def __init__(self, token: object, connection: sqlite3.Connection) -> None:
+        if token is not _TOKEN_PORT:
+            raise CoverageAuthorityError("Coverage read port construction is private")
+        object.__setattr__(self, "_connection", connection)
+
+    def __setattr__(self, name: str, value: object) -> None:
+        raise AttributeError("CoverageAuditReadPort is immutable")
+
+    def _snapshot(self, function, *args):
+        owns = not self._connection.in_transaction
+        if owns:
+            self._connection.execute("BEGIN")
+        try:
+            result = function(*args)
+        except BaseException:
+            if owns and self._connection.in_transaction:
+                self._connection.execute("ROLLBACK")
+            raise
+        if owns:
+            self._connection.execute("COMMIT")
+        return result
+
+    def _audit(
+        self, audit_id: str
+    ) -> tuple[CoverageComparator, CoverageAssessment, CoverageAudit]:
+        row = self._connection.execute(
+            "SELECT comparator_bytes,comparator_digest,assessment_bytes,assessment_digest,"
+            "audit_bytes,audit_digest,assessment_state,completed_at FROM coverage_audits WHERE audit_id=?",
+            (audit_id,),
+        ).fetchone()
+        if row is None:
+            raise CoverageAuthorityError("Coverage Audit is absent")
+        comparator = CoverageComparator.from_canonical_bytes(bytes(row[0]))
+        assessment = CoverageAssessment.from_canonical_bytes(bytes(row[2]))
+        audit = CoverageAudit.from_canonical_bytes(bytes(row[4]))
+        observations = self._connection.execute(
+            "SELECT observation_ordinal,kind,reference_digest,observed_at FROM coverage_audit_observations WHERE audit_id=? ORDER BY observation_ordinal",
+            (audit_id,),
+        ).fetchall()
+        expected = [
+            (ordinal, item.kind.value, item.reference_digest, item.observed_at)
+            for ordinal, item in enumerate(audit.observations, 1)
+        ]
+        if (
+            comparator.digest != row[1]
+            or assessment.digest != row[3]
+            or audit.digest != row[5]
+            or audit.assessment_state.value != row[6]
+            or audit.completed_at != row[7]
+            or observations != expected
+            or audit.comparator_id != comparator.comparator_id
+            or audit.comparator_digest != comparator.digest
+            or audit.assessment_state is not assessment.derived_state
+            or audit.limitation_codes != assessment.derived_limitation_codes
+        ):
+            raise CoverageAuthorityError(
+                "Coverage Audit retained representation differs"
+            )
+        return comparator, assessment, audit
+
+    @_total("Coverage Audit replay failed")
+    def audit(self, audit_id: str) -> CoverageAudit:
+        return self._snapshot(lambda: self._audit(audit_id)[2])
+
+    @_total("Coverage Assessment replay failed")
+    def assessment(self, audit_id: str) -> CoverageAssessment:
+        return self._snapshot(lambda: self._audit(audit_id)[1])
+
+    def _gap(self, gap_id: str) -> CoverageGap:
+        row = self._connection.execute(
+            "SELECT gap_bytes,gap_digest,audit_id,gap_state,proposed_at FROM coverage_gaps WHERE gap_id=?",
+            (gap_id,),
+        ).fetchone()
+        if row is None:
+            raise CoverageAuthorityError("Coverage Gap is absent")
+        gap = CoverageGap.from_canonical_bytes(bytes(row[0]))
+        audit = self._audit(str(row[2]))[2]
+        if (
+            gap.digest != row[1]
+            or gap.audit_id != row[2]
+            or gap.gap_state.value != row[3]
+            or gap.proposed_at != row[4]
+            or gap.audit_digest != audit.digest
+        ):
+            raise CoverageAuthorityError("Coverage Gap retained representation differs")
+        return gap
+
+    @_total("Coverage Gap replay failed")
+    def gap(self, gap_id: str) -> CoverageGap:
+        return self._snapshot(lambda: self._gap(gap_id))
+
+    def _decision(
+        self, decision_id: str
+    ) -> tuple[CoverageGapDecision, CoverageCommand]:
+        row = self._connection.execute(
+            "SELECT decision_bytes,decision_digest,gap_id,decision_ordinal,previous_decision_digest,"
+            "command_bytes,command_digest,command_id,request_id,actor_identity_digest,idempotency_key,decided_at "
+            "FROM coverage_gap_decisions WHERE decision_id=?",
+            (decision_id,),
+        ).fetchone()
+        if row is None:
+            raise CoverageAuthorityError("Coverage Gap Decision is absent")
+        decision = CoverageGapDecision.from_canonical_bytes(bytes(row[0]))
+        command = CoverageCommand.from_canonical_bytes(bytes(row[5]))
+        gap = self._gap(str(row[2]))
+        predecessor = None
+        if row[4] is not None:
+            prior_row = self._connection.execute(
+                "SELECT decision_bytes FROM coverage_gap_decisions WHERE decision_digest=?",
+                (row[4],),
+            ).fetchone()
+            if prior_row is None:
+                raise CoverageAuthorityError("Coverage Decision predecessor is absent")
+            predecessor = CoverageGapDecision.from_canonical_bytes(bytes(prior_row[0]))
+        validate_coverage_chain(
+            command.comparator, command.audit, gap, decision, predecessor
+        )
+        if (
+            decision.digest != row[1]
+            or decision.gap_id != row[2]
+            or decision.supersedes_decision_digest != row[4]
+            or command.digest != row[6]
+            or command.command_id != row[7]
+            or command.request_id != row[8]
+            or command.actor_identity_digest != row[9]
+            or command.idempotency_key != row[10]
+            or decision.decided_at != row[11]
+            or command.decision != decision
+            or command.gap != gap
+            or command.expected_previous_decision_digest != row[4]
+            or int(row[3])
+            != (
+                1
+                + self._connection.execute(
+                    "SELECT COUNT(*) FROM coverage_gap_decisions WHERE gap_id=? AND decision_ordinal<?",
+                    (row[2], row[3]),
+                ).fetchone()[0]
+            )
+        ):
+            raise CoverageAuthorityError(
+                "Coverage Decision retained representation differs"
+            )
+        return decision, command
+
+    @_total("Coverage Gap Decision replay failed")
+    def decision(self, decision_id: str) -> CoverageGapDecision:
+        return self._snapshot(lambda: self._decision(decision_id)[0])
+
+    @_total("Coverage Command replay failed")
+    def command(self, command_id: str) -> CoverageCommand:
+        def read() -> CoverageCommand:
+            row = self._connection.execute(
+                "SELECT decision_id FROM coverage_gap_decisions WHERE command_id=?",
+                (command_id,),
+            ).fetchone()
+            if row is None:
+                raise CoverageAuthorityError("Coverage Command is absent")
+            return self._decision(str(row[0]))[1]
+
+        return self._snapshot(read)
+
+
+class CoverageAuditAuthority(CoverageAuditReadPort):
+    """Transactional v28 writer with exact replay and immutable Gap decisions."""
+
+    __slots__ = ()
+
+    def __init__(self, token: object, connection: sqlite3.Connection) -> None:
+        super().__init__(token, connection)
+
+    def _previous(self, gap_id: str) -> CoverageGapDecision | None:
+        row = self._connection.execute(
+            "SELECT decision_bytes FROM coverage_gap_decisions WHERE gap_id=? ORDER BY decision_ordinal DESC LIMIT 1",
+            (gap_id,),
+        ).fetchone()
+        return (
+            None
+            if row is None
+            else CoverageGapDecision.from_canonical_bytes(bytes(row[0]))
+        )
+
+    @_total("Coverage command failed")
+    def record(
+        self,
+        raw: bytes,
+        *,
+        search_evidence: tuple[SearchEvidenceChain, ...],
+        provider_qualifications: tuple[ProviderQualification, ...],
+        locality_qualification: LocalityQualification,
+    ) -> CoverageGapDecision:
+        command = CoverageCommand.from_canonical_bytes(raw)
+        self._connection.execute("BEGIN IMMEDIATE")
+        try:
+            replay = self._connection.execute(
+                "SELECT command_bytes,decision_id FROM coverage_gap_decisions "
+                "WHERE command_id=? OR request_id=? OR idempotency_key=?",
+                (command.command_id, command.request_id, command.idempotency_key),
+            ).fetchall()
+            if replay:
+                if len(replay) != 1 or bytes(replay[0][0]) != raw:
+                    raise CoverageAuthorityError("Coverage command identity collision")
+                decision = self._decision(str(replay[0][1]))[0]
+                self._connection.execute("COMMIT")
+                return decision
+            previous = self._previous(command.gap.gap_id)
+            validate_coverage_command(
+                command,
+                search_evidence=search_evidence,
+                provider_qualifications=provider_qualifications,
+                locality_qualification=locality_qualification,
+                previous_decision=previous,
+            )
+            existing_audit = self._connection.execute(
+                "SELECT audit_bytes,assessment_bytes,comparator_bytes FROM coverage_audits WHERE audit_id=?",
+                (command.audit.audit_id,),
+            ).fetchone()
+            existing_gap = self._connection.execute(
+                "SELECT gap_bytes FROM coverage_gaps WHERE gap_id=?",
+                (command.gap.gap_id,),
+            ).fetchone()
+            if (existing_audit is None) != (existing_gap is None):
+                raise CoverageAuthorityError("Coverage retained chain is incomplete")
+            if existing_audit is None:
+                if previous is not None:
+                    raise CoverageAuthorityError(
+                        "Coverage Decision predecessor differs"
+                    )
+                self._connection.execute(
+                    "INSERT INTO coverage_audits VALUES(?,?,?,?,?,?,?,?,?,?)",
+                    (
+                        command.audit.audit_id,
+                        command.comparator.canonical_bytes,
+                        command.comparator.digest,
+                        command.assessment.canonical_bytes,
+                        command.assessment.digest,
+                        command.audit.canonical_bytes,
+                        command.audit.digest,
+                        command.audit.assessment_state.value,
+                        command.audit.completed_at,
+                        command.actor_identity_digest,
+                    ),
+                )
+                self._connection.executemany(
+                    "INSERT INTO coverage_audit_observations VALUES(?,?,?,?,?)",
+                    [
+                        (
+                            command.audit.audit_id,
+                            ordinal,
+                            item.kind.value,
+                            item.reference_digest,
+                            item.observed_at,
+                        )
+                        for ordinal, item in enumerate(command.audit.observations, 1)
+                    ],
+                )
+                self._connection.execute(
+                    "INSERT INTO coverage_gaps VALUES(?,?,?,?,?,?)",
+                    (
+                        command.gap.gap_id,
+                        command.gap.canonical_bytes,
+                        command.gap.digest,
+                        command.gap.audit_id,
+                        command.gap.gap_state.value,
+                        command.gap.proposed_at,
+                    ),
+                )
+            elif (
+                bytes(existing_audit[0]) != command.audit.canonical_bytes
+                or bytes(existing_audit[1]) != command.assessment.canonical_bytes
+                or bytes(existing_audit[2]) != command.comparator.canonical_bytes
+                or bytes(existing_gap[0]) != command.gap.canonical_bytes
+            ):
+                raise CoverageAuthorityError("Coverage immutable chain differs")
+            ordinal = (
+                1
+                if previous is None
+                else self._connection.execute(
+                    "SELECT MAX(decision_ordinal)+1 FROM coverage_gap_decisions WHERE gap_id=?",
+                    (command.gap.gap_id,),
+                ).fetchone()[0]
+            )
+            self._connection.execute(
+                "INSERT INTO coverage_gap_decisions VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                (
+                    command.decision.decision_id,
+                    command.decision.canonical_bytes,
+                    command.decision.digest,
+                    command.gap.gap_id,
+                    ordinal,
+                    command.expected_previous_decision_digest,
+                    raw,
+                    command.digest,
+                    command.command_id,
+                    command.request_id,
+                    command.actor_identity_digest,
+                    command.idempotency_key,
+                    command.decision.disposition.value,
+                    command.decision.decided_at,
+                    command.locality_decision_digest,
+                ),
+            )
+            retained = self._decision(command.decision.decision_id)[0]
+            self._connection.execute("COMMIT")
+            return retained
+        except BaseException:
+            if self._connection.in_transaction:
+                self._connection.execute("ROLLBACK")
+            raise
+
+    def read_port(self) -> CoverageAuditReadPort:
+        return CoverageAuditReadPort(_TOKEN_PORT, self._connection)
+
+    def close(self) -> None:
+        self._connection.close()
+
+
+def open_coverage_audit_authority(
+    path: str | Path,
+    *,
+    applied_at: str,
+    timeout_seconds: float = 5.0,
+) -> CoverageAuditAuthority:
+    database = Path(path)
+    existed = database.exists() and database.stat().st_size > 0
+    connection = sqlite3.connect(
+        database,
+        isolation_level=None,
+        timeout=timeout_seconds,
+        check_same_thread=False,
+    )
+    try:
+        connection.execute("PRAGMA foreign_keys=ON")
+        connection.execute("PRAGMA busy_timeout=5000")
+        connection.execute("PRAGMA journal_mode=WAL")
+        if existed:
+            prepare_pending_migration_backup(connection)
+        apply_pending_migrations(connection, applied_at=applied_at)
+        if connection.execute("PRAGMA user_version").fetchone()[0] != SCHEMA_VERSION:
+            raise CoverageAuthorityError("checked v28 schema differs")
+        return CoverageAuditAuthority(_TOKEN_PORT, connection)
+    except BaseException:
+        connection.close()
+        raise
+
+
+__all__ = [
+    "COVERAGE_ASSESSMENT",
+    "COVERAGE_ASSESSMENT_AUTHORITY",
+    "COVERAGE_AUDIT_AUTHORITY",
+    "COVERAGE_COMMAND",
+    "AssessmentFactor",
+    "CoverageAssessment",
+    "CoverageAuditAuthority",
+    "CoverageAuditReadPort",
+    "CoverageAuthorityError",
+    "CoverageCommand",
+    "DependencyState",
+    "HealthState",
+    "LocalityQualification",
+    "ProviderQualification",
+    "SearchEvidenceChain",
+    "TimelinessState",
+    "deterministic_assessment",
+    "open_coverage_audit_authority",
+    "validate_coverage_command",
+]

--- a/newsroom/increment7/coverage_authority.py
+++ b/newsroom/increment7/coverage_authority.py
@@ -940,13 +940,35 @@ class CoverageAuditAuthority(CoverageAuditReadPort):
         self._connection.execute("BEGIN IMMEDIATE")
         try:
             replay = self._connection.execute(
-                "SELECT command_bytes,decision_id FROM coverage_gap_decisions "
+                "SELECT command_bytes,decision_id,previous_decision_digest "
+                "FROM coverage_gap_decisions "
                 "WHERE command_id=? OR request_id=? OR idempotency_key=?",
                 (command.command_id, command.request_id, command.idempotency_key),
             ).fetchall()
             if replay:
                 if len(replay) != 1 or bytes(replay[0][0]) != raw:
                     raise CoverageAuthorityError("Coverage command identity collision")
+                predecessor = None
+                if replay[0][2] is not None:
+                    prior = self._connection.execute(
+                        "SELECT decision_bytes FROM coverage_gap_decisions "
+                        "WHERE decision_digest=?",
+                        (replay[0][2],),
+                    ).fetchone()
+                    if prior is None:
+                        raise CoverageAuthorityError(
+                            "Coverage Decision predecessor is absent"
+                        )
+                    predecessor = CoverageGapDecision.from_canonical_bytes(
+                        bytes(prior[0])
+                    )
+                validate_coverage_command(
+                    command,
+                    search_evidence=search_evidence,
+                    provider_qualifications=provider_qualifications,
+                    locality_qualification=locality_qualification,
+                    previous_decision=predecessor,
+                )
                 decision = self._decision(str(replay[0][1]))[0]
                 self._connection.execute("COMMIT")
                 return decision

--- a/newsroom/tests/authority_migration_compatibility.py
+++ b/newsroom/tests/authority_migration_compatibility.py
@@ -183,6 +183,11 @@ PINNED_MIGRATION_HISTORY: tuple[HistoryRow, ...] = (
         "bounded_search_authority_v27",
         "sha256:ee5679aba6ceb3e95ba925febbbb7853369f93d055563ac85402d380377672b0",
     ),
+    (
+        28,
+        "coverage_audit_authority_v28",
+        "sha256:c923daf18aed10bb9c197bfd588d816223d978668bda56c157438d1a4b7cc487",
+    ),
 )
 
 

--- a/newsroom/tests/graphiti_adapter_4d_migration_helpers.py
+++ b/newsroom/tests/graphiti_adapter_4d_migration_helpers.py
@@ -34,6 +34,72 @@ from newsroom.authority.triage_work_item_migrations import (
 )
 
 
+def drop_empty_v28_coverage_schema(connection: sqlite3.Connection) -> None:
+    """Remove the exact empty v28 Coverage Audit suffix atomically."""
+    savepoint = "checked_coverage_audit_downgrade"
+    connection.execute(f"SAVEPOINT {savepoint}")
+    try:
+        _drop_empty_v28_coverage_schema(connection)
+    except Exception:
+        connection.execute(f"ROLLBACK TO SAVEPOINT {savepoint}")
+        connection.execute(f"RELEASE SAVEPOINT {savepoint}")
+        raise
+    connection.execute(f"RELEASE SAVEPOINT {savepoint}")
+
+
+def _drop_empty_v28_coverage_schema(connection: sqlite3.Connection) -> None:
+    if int(connection.execute("PRAGMA user_version").fetchone()[0]) == 28:
+        from newsroom.authority.coverage_audit_migrations import (
+            COVERAGE_AUDIT_MIGRATION_CHECKSUM,
+            COVERAGE_AUDIT_MIGRATION_NAME,
+            COVERAGE_AUDIT_MIGRATION_STATEMENTS,
+        )
+
+        def normalise_coverage_sql(value: str) -> str:
+            return " ".join(value.split()).replace(" IF NOT EXISTS", "")
+
+        coverage_tables = (
+            "coverage_audits",
+            "coverage_audit_observations",
+            "coverage_gaps",
+            "coverage_gap_decisions",
+        )
+        placeholders = ",".join("?" for _ in coverage_tables)
+        objects = connection.execute(
+            f"SELECT type,name,sql FROM sqlite_master WHERE tbl_name IN ({placeholders}) "
+            "AND type IN ('table','trigger','index') AND sql IS NOT NULL",
+            coverage_tables,
+        ).fetchall()
+        if connection.execute(
+            "SELECT name,checksum FROM authority_migrations WHERE version=28"
+        ).fetchone() != (
+            COVERAGE_AUDIT_MIGRATION_NAME,
+            COVERAGE_AUDIT_MIGRATION_CHECKSUM,
+        ) or {normalise_coverage_sql(str(row[2])) for row in objects} != {
+            normalise_coverage_sql(statement)
+            for statement in COVERAGE_AUDIT_MIGRATION_STATEMENTS
+        }:
+            raise sqlite3.DatabaseError(
+                "downgrade requires exact empty v28 Coverage Audit schema"
+            )
+        for table in coverage_tables:
+            if connection.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone() != (0,):
+                raise sqlite3.DatabaseError("v28 Coverage Audit tables must be empty")
+        guard = connection.execute(
+            "SELECT sql FROM sqlite_master WHERE type='trigger' "
+            "AND name='immutable_authority_migrations_delete'"
+        ).fetchone()[0]
+        connection.execute("DROP TRIGGER immutable_authority_migrations_delete")
+        for object_type, name, _ in objects:
+            if object_type == "trigger":
+                connection.execute(f'DROP TRIGGER "{name}"')
+        for table in reversed(coverage_tables):
+            connection.execute(f'DROP TABLE "{table}"')
+        connection.execute("DELETE FROM authority_migrations WHERE version=28")
+        connection.execute(guard)
+        connection.execute("PRAGMA user_version=27")
+
+
 def drop_empty_v23_lineage_schema(connection: sqlite3.Connection) -> None:
     """Remove exact empty v24/v23 schemas as one rollback-safe operation."""
     savepoint = "checked_candidate_lineage_downgrade"
@@ -49,6 +115,7 @@ def drop_empty_v23_lineage_schema(connection: sqlite3.Connection) -> None:
 
 def _drop_empty_v23_lineage_schema(connection: sqlite3.Connection) -> None:
     """Remove an exact, empty v23 lineage schema atomically."""
+    _drop_empty_v28_coverage_schema(connection)
     if int(connection.execute("PRAGMA user_version").fetchone()[0]) == 27:
         from newsroom.authority.bounded_search_migrations import (
             BOUNDED_SEARCH_MIGRATION_CHECKSUM,

--- a/newsroom/tests/test_authority_migration_compatibility.py
+++ b/newsroom/tests/test_authority_migration_compatibility.py
@@ -47,6 +47,7 @@ _EXPECTED_NAMES = {
     25: "evaluation_feedback_authority_v25",
     26: "planned_agenda_authority_v26",
     27: "bounded_search_authority_v27",
+    28: "coverage_audit_authority_v28",
 }
 _EXPECTED_CHECKSUMS = {
     13: "sha256:c3e5ae627dda1c04bebc50952786413d977bd399e67b7f5b87452794f08f49ab",
@@ -64,6 +65,7 @@ _EXPECTED_CHECKSUMS = {
     25: "sha256:59fe3bd40a2e22e874b4e5b02448501deffc23597e11b442e35b18e39ead0496",
     26: "sha256:55e6e8878140714dc6fc6c8149357e1f15e4683fcb7ee0b31b168a737bfd3d4c",
     27: "sha256:ee5679aba6ceb3e95ba925febbbb7853369f93d055563ac85402d380377672b0",
+    28: "sha256:c923daf18aed10bb9c197bfd588d816223d978668bda56c157438d1a4b7cc487",
 }
 
 _EXPECTED_MATRIX = """version | migration | objects | history fingerprint | schema fingerprint | object fingerprint
@@ -83,6 +85,7 @@ v24 | story_candidate_authority_v24 | 1221 | sha256:87fbc9d10bfea4239e9105cf8518
 v25 | evaluation_feedback_authority_v25 | 1253 | sha256:bea793377d065d3073e6dfa8d40139fedfd377d5e24d9812d12cdb1ad52e9a0f | sha256:353900bf5804f0b770489982541f3cff4fd30ea36fc75d19b9c63315d1b6ec06 | sha256:002a7c3cb59690568a8779e05c46a751ef57f91ee9070dc9095b0bfb953cf3f8
 v26 | planned_agenda_authority_v26 | 1285 | sha256:d2cb21a981674513b4495ca19012e49b93c8dc30cbe61165b5462c391f989004 | sha256:9c4d5b94b10b34d3b9ef2f140dbfbcc85b2c01fb6d8660879403a21fef701374 | sha256:0724fb8b7796f7581123d17658613baf488090dfcc7d5320f9dd804364d5a542
 v27 | bounded_search_authority_v27 | 1347 | sha256:f4afb25765da01175b272333daaaef80b21416d9258a5ec4e09ffba59f878936 | sha256:d7fc1557bd02588969efdd53c749a2f125ab5bab146395c4cf8f7d51b1e32719 | sha256:ebd8c2d5739a09103f526fa682dadf66efa7646304b25f266265b91b70e55cbd
+v28 | coverage_audit_authority_v28 | 1381 | sha256:81792dba56950b37325ccdffe06b64f322379218a10264e949d57e7e0dec58d6 | sha256:a613b28a765b36fa9110bcdc2b9bc565c6e2bc0ed8b8381d77f5fcd734c39c48 | sha256:a8330e1d8ae8c9e181f0e2d1ebbde88a1386e934e93eaac3c3d292722c7fff35
 """
 
 

--- a/newsroom/tests/test_increment6d3_lineage_store.py
+++ b/newsroom/tests/test_increment6d3_lineage_store.py
@@ -396,6 +396,9 @@ def test_v22_to_v23_preserves_retained_relationship_before_lineage_use(
     from newsroom.authority.bounded_search_migrations import (
         bounded_search_backup_paths,
     )
+    from newsroom.authority.coverage_audit_migrations import (
+        coverage_audit_backup_paths,
+    )
     from newsroom.authority.evaluation_feedback_migrations import (
         evaluation_feedback_backup_paths,
     )
@@ -408,6 +411,8 @@ def test_v22_to_v23_preserves_retained_relationship_before_lineage_use(
     for path in planned_agenda_backup_paths(seed[1]):
         path.unlink(missing_ok=True)
     for path in bounded_search_backup_paths(seed[1]):
+        path.unlink(missing_ok=True)
+    for path in coverage_audit_backup_paths(seed[1]):
         path.unlink(missing_ok=True)
     assert prepare_pending_migration_backup(connection) is not None
     apply_pending_migrations(connection, applied_at="2042-01-03T00:00:00.000000Z")

--- a/newsroom/tests/test_increment6d3_lineage_store.py
+++ b/newsroom/tests/test_increment6d3_lineage_store.py
@@ -411,7 +411,7 @@ def test_v22_to_v23_preserves_retained_relationship_before_lineage_use(
         path.unlink(missing_ok=True)
     assert prepare_pending_migration_backup(connection) is not None
     apply_pending_migrations(connection, applied_at="2042-01-03T00:00:00.000000Z")
-    assert connection.execute("PRAGMA user_version").fetchone() == (27,)
+    assert connection.execute("PRAGMA user_version").fetchone() == (28,)
     assert (
         connection.execute(
             "SELECT * FROM event_hypothesis_relationship_decisions ORDER BY decision_id"
@@ -1437,10 +1437,10 @@ class _LineageAdapter:
                 apply_pending_migrations(
                     connection, applied_at="2042-01-03T00:00:00.000000Z"
                 )
-                assert connection.execute("PRAGMA user_version").fetchone() == (27,)
+                assert connection.execute("PRAGMA user_version").fetchone() == (28,)
                 assert connection.execute(
                     "SELECT MAX(version) FROM authority_migrations"
-                ).fetchone() == (27,)
+                ).fetchone() == (28,)
             finally:
                 connection.close()
         return _ConformanceHandle(location)

--- a/newsroom/tests/test_increment6e2_candidate_authority.py
+++ b/newsroom/tests/test_increment6e2_candidate_authority.py
@@ -156,7 +156,7 @@ def test_v24_downgrade_preflight_is_non_mutating(tmp_path: Path, failure: str) -
             ("sha256:" + "f" * 64,),
         )
     else:
-        connection.execute("PRAGMA user_version=28")
+        connection.execute("PRAGMA user_version=29")
     damaged = (
         connection.execute("PRAGMA user_version").fetchone(),
         tuple(connection.iterdump()),

--- a/newsroom/tests/test_increment6f2_feedback_system.py
+++ b/newsroom/tests/test_increment6f2_feedback_system.py
@@ -391,7 +391,7 @@ def test_disposition_is_generic_ledger_anchored_and_replay_precedes_ports(
     assert disposition.obligation_id == accepted.obligation.obligation_id
 
 
-def test_disposition_restart_chain_is_terminal_and_tamper_evident(
+def test_disposition_restart_chain_is_terminal(
     _generic_disposition_state,
 ) -> None:
     location, args, feedback, obligation, accepted, disposition = (
@@ -467,6 +467,22 @@ def test_disposition_restart_chain_is_terminal_and_tamper_evident(
             expected_current_disposition_digest=fulfilled.canonical_digest,
             expected_current_ordinal=3,
         )
+    reopened.close()
+
+
+def test_disposition_tamper_is_evident(
+    _generic_disposition_state,
+) -> None:
+    location, args, feedback, _, _, disposition = _generic_disposition_state
+    reopened = open_evaluation_feedback_authority_system(
+        location.seed[1],
+        retrieval_authority=args["retrieval_authority"],
+        authenticator=args["authenticator"],
+        authorizer=args["authorizer"],
+        command_registry=args["command_registry"],
+        payload_schemas=args["payload_schemas"],
+        clock=args["clock"],
+    )
     connection = reopened._EvaluationFeedbackAuthority__authority._connection
     trigger = connection.execute(
         "SELECT sql FROM sqlite_master WHERE name='immutable_evaluation_feedback'"
@@ -474,7 +490,7 @@ def test_disposition_restart_chain_is_terminal_and_tamper_evident(
     event = connection.execute(
         "SELECT authority_event_id,recorded_at FROM "
         "evaluation_reconciliation_dispositions WHERE disposition_id=?",
-        (fulfilled.disposition_id,),
+        (disposition.disposition_id,),
     ).fetchone()
     connection.execute("DROP TRIGGER immutable_evaluation_feedback")
     connection.execute(

--- a/newsroom/tests/test_increment6f2_feedback_system.py
+++ b/newsroom/tests/test_increment6f2_feedback_system.py
@@ -292,9 +292,9 @@ def test_accept_replay_snapshot_and_direct_tamper_fail_closed(tmp_path: Path) ->
     authority.close()
 
 
-def test_disposition_is_generic_ledger_anchored_and_replay_precedes_ports(
-    tmp_path: Path,
-) -> None:
+@pytest.fixture(scope="module")
+def _generic_disposition_state(tmp_path_factory: pytest.TempPathFactory):
+    tmp_path = tmp_path_factory.mktemp("feedback-disposition")
     location, args, feedback, obligation = _seed(tmp_path)
     authority = open_evaluation_feedback_authority_system(
         location.seed[1],
@@ -381,6 +381,22 @@ def test_disposition_is_generic_ledger_anchored_and_replay_precedes_ports(
         == 2
     )
     authority.close()
+    return location, args, feedback, obligation, accepted, disposition
+
+
+def test_disposition_is_generic_ledger_anchored_and_replay_precedes_ports(
+    _generic_disposition_state,
+) -> None:
+    _, _, _, _, accepted, disposition = _generic_disposition_state
+    assert disposition.obligation_id == accepted.obligation.obligation_id
+
+
+def test_disposition_restart_chain_is_terminal_and_tamper_evident(
+    _generic_disposition_state,
+) -> None:
+    location, args, feedback, obligation, accepted, disposition = (
+        _generic_disposition_state
+    )
     reopened = open_evaluation_feedback_authority_system(
         location.seed[1],
         retrieval_authority=args["retrieval_authority"],

--- a/newsroom/tests/test_increment7_head_migration_ownership.py
+++ b/newsroom/tests/test_increment7_head_migration_ownership.py
@@ -222,8 +222,11 @@ def test_reserved_additive_schema_suffix_is_checked(
     monkeypatch.setattr(
         authority_migrations,
         "EXPECTED_MIGRATION_HISTORY",
-        authority_migrations.EXPECTED_MIGRATION_HISTORY[:-1]
-        + ((27, "wrong_v27", checksum),),
+        authority_migrations.EXPECTED_MIGRATION_HISTORY[:-2]
+        + (
+            (27, "wrong_v27", checksum),
+            authority_migrations.EXPECTED_MIGRATION_HISTORY[-1],
+        ),
     )
     assert any(
         "reserved v27 name differs" in finding

--- a/newsroom/tests/test_increment7a2_exact_immutable_read_port.py
+++ b/newsroom/tests/test_increment7a2_exact_immutable_read_port.py
@@ -44,6 +44,9 @@ from newsroom.increment7.agenda_authority import (
     PlannedAgendaCommand,
     open_planned_agenda_authority,
 )
+from newsroom.tests.graphiti_adapter_4d_migration_helpers import (
+    drop_empty_v28_coverage_schema,
+)
 
 _AT = "2026-08-14T00:00:00.000000Z"
 _ACTOR = "sha256:" + "a" * 64
@@ -209,6 +212,7 @@ def _downgrade_empty_v26_to_v25(connection: sqlite3.Connection) -> None:
 
 
 def _downgrade_empty_v27_to_v26(connection: sqlite3.Connection) -> None:
+    drop_empty_v28_coverage_schema(connection)
     connection.execute("PRAGMA foreign_keys=OFF")
     immutable = connection.execute(
         "SELECT sql FROM sqlite_master WHERE name='immutable_authority_migrations_delete'"
@@ -265,14 +269,14 @@ def test_v26_fresh_create_history_fingerprint_and_integrity() -> None:
     connection = sqlite3.connect(":memory:", isolation_level=None)
     connection.execute("PRAGMA foreign_keys=ON")
     apply_pending_migrations(connection, applied_at=_AT)
-    assert SCHEMA_VERSION == 27
+    assert SCHEMA_VERSION == 28
     assert PLANNED_AGENDA_SCHEMA_VERSION == 26
     assert EXPECTED_MIGRATION_HISTORY[25] == (
         26,
         PLANNED_AGENDA_MIGRATION_NAME,
         PLANNED_AGENDA_MIGRATION_CHECKSUM,
     )
-    assert connection.execute("PRAGMA user_version").fetchone() == (27,)
+    assert connection.execute("PRAGMA user_version").fetchone() == (28,)
     assert schema_fingerprint(connection) == EXPECTED_SCHEMA_FINGERPRINT
     assert connection.execute("PRAGMA foreign_key_check").fetchall() == []
     assert connection.execute("PRAGMA quick_check").fetchone() == ("ok",)
@@ -310,7 +314,7 @@ def test_v25_upgrade_requires_and_retains_exact_backup(tmp_path: Path) -> None:
     authority.close()
     checked = sqlite3.connect(older_database)
     try:
-        assert checked.execute("PRAGMA user_version").fetchone() == (27,)
+        assert checked.execute("PRAGMA user_version").fetchone() == (28,)
     finally:
         checked.close()
 

--- a/newsroom/tests/test_increment7b2_budget_privacy_authority.py
+++ b/newsroom/tests/test_increment7b2_budget_privacy_authority.py
@@ -48,6 +48,9 @@ from newsroom.increment7.search_authority import (
     SearchAuthorityError,
     open_bounded_search_authority,
 )
+from newsroom.tests.graphiti_adapter_4d_migration_helpers import (
+    drop_empty_v28_coverage_schema,
+)
 
 _AT = "2026-08-14T00:00:00.000000Z"
 _D = "sha256:" + "a" * 64
@@ -183,6 +186,7 @@ def _decision(result: SearchResultReference) -> SearchReviewDecision:
 
 
 def _downgrade_empty_v27_to_v26(connection: sqlite3.Connection) -> None:
+    drop_empty_v28_coverage_schema(connection)
     connection.execute("PRAGMA foreign_keys=OFF")
     immutable = connection.execute(
         "SELECT sql FROM sqlite_master WHERE name='immutable_authority_migrations_delete'"
@@ -229,8 +233,9 @@ def test_v27_fresh_history_fingerprint_integrity_and_reserved_tables() -> None:
     connection = sqlite3.connect(":memory:", isolation_level=None)
     connection.execute("PRAGMA foreign_keys=ON")
     apply_pending_migrations(connection, applied_at=_AT)
-    assert SCHEMA_VERSION == BOUNDED_SEARCH_SCHEMA_VERSION == 27
-    assert EXPECTED_MIGRATION_HISTORY[-1] == (
+    assert SCHEMA_VERSION == 28
+    assert BOUNDED_SEARCH_SCHEMA_VERSION == 27
+    assert EXPECTED_MIGRATION_HISTORY[-2] == (
         27,
         BOUNDED_SEARCH_MIGRATION_NAME,
         BOUNDED_SEARCH_MIGRATION_CHECKSUM,
@@ -280,7 +285,7 @@ def test_v26_upgrade_requires_exact_backup_and_rolls_back_atomically(
     assert schema_fingerprint(connection) == BOUNDED_SEARCH_PREDECESSOR_FINGERPRINT
     monkeypatch.setattr(migrations, "BOUNDED_SEARCH_MIGRATION_STATEMENTS", statements)
     apply_pending_migrations(connection, applied_at=_AT)
-    assert connection.execute("PRAGMA user_version").fetchone() == (27,)
+    assert connection.execute("PRAGMA user_version").fetchone() == (28,)
     restored = sqlite3.connect(f"file:{backup}?mode=ro", uri=True)
     try:
         assert restored.execute("PRAGMA user_version").fetchone() == (26,)

--- a/newsroom/tests/test_increment7c2_coverage_audit_authority.py
+++ b/newsroom/tests/test_increment7c2_coverage_audit_authority.py
@@ -1,0 +1,566 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+import uuid
+from dataclasses import replace
+
+import pytest
+
+from newsroom.authority.canonical import canonical_json_bytes
+from newsroom.authority.coverage_audit_migrations import (
+    COVERAGE_AUDIT_MIGRATION_NAME,
+    COVERAGE_AUDIT_SCHEMA_VERSION,
+    CoverageAuditBackupError,
+    coverage_audit_backup_paths,
+    prepare_coverage_audit_backup,
+)
+from newsroom.authority.migrations import (
+    EXPECTED_MIGRATION_HISTORY,
+    EXPECTED_SCHEMA_FINGERPRINT,
+    SCHEMA_VERSION,
+    apply_pending_migrations,
+    schema_fingerprint,
+)
+from newsroom.increment7.coverage import (
+    CoverageAssessmentState,
+    CoverageAudit,
+    CoverageAuditMode,
+    CoverageBasisKind,
+    CoverageComparator,
+    CoverageGap,
+    CoverageGapDecision,
+    CoverageGapDisposition,
+    CoverageGapScope,
+    CoverageGapState,
+    CoverageObservation,
+    CoverageObservationKind,
+)
+from newsroom.increment7.coverage_authority import (
+    COVERAGE_ASSESSMENT,
+    COVERAGE_ASSESSMENT_AUTHORITY,
+    COVERAGE_AUDIT_AUTHORITY,
+    COVERAGE_COMMAND,
+    AssessmentFactor,
+    CoverageAssessment,
+    CoverageAuditReadPort,
+    CoverageAuthorityError,
+    CoverageCommand,
+    DependencyState,
+    HealthState,
+    TimelinessState,
+    deterministic_assessment,
+    open_coverage_audit_authority,
+    validate_coverage_command,
+)
+from newsroom.increment7.search import SearchReviewAction, SearchReviewDecision
+from newsroom.tests.test_increment7b1_gross_request_privacy import (
+    _attempt,
+    _outcome,
+    _purpose,
+    _request,
+    _result,
+)
+from newsroom.tests.test_increment7e2_locality_no_activation import (
+    _chain as _locality_chain,
+)
+from newsroom.tests.test_increment7e2_locality_no_activation import (
+    _provider_qualifications,
+)
+
+_AT = "2026-08-14T00:00:00.000000Z"
+_D = "sha256:" + "a" * 64
+_APPLIED = "2026-08-14T09:00:00.000000Z"
+
+
+def _id(value: int) -> str:
+    return str(uuid.UUID(int=value, version=4))
+
+
+def _search_chain():
+    purpose = _purpose()
+    request = _request(purpose)
+    attempt = _attempt(request)
+    outcome = _outcome(attempt)
+    result = _result(attempt, outcome)
+    review = SearchReviewDecision(
+        _id(106),
+        (result.result_reference_id,),
+        (result.digest,),
+        SearchReviewAction.SUPPORT_COVERAGE_GAP_REVIEW,
+        "sha256:" + "2" * 64,
+        "sha256:" + "3" * 64,
+        ("PROSPECTIVE_COMPARATOR_HIT",),
+        "2026-08-14T00:00:03.000000Z",
+    )
+    return purpose, request, attempt, outcome, (result,), review
+
+
+def _assessment(
+    *,
+    dependency: DependencyState = DependencyState.AVAILABLE,
+    timeliness: TimelinessState = TimelinessState.ON_TIME,
+    health: HealthState = HealthState.HEALTHY,
+) -> CoverageAssessment:
+    dependencies = (AssessmentFactor("search", dependency, "sha256:" + "4" * 64),)
+    timings = (AssessmentFactor("window", timeliness, "sha256:" + "5" * 64),)
+    healths = (AssessmentFactor("source_pack", health, "sha256:" + "6" * 64),)
+    state, limitations = deterministic_assessment(
+        dependencies,
+        timings,
+        healths,
+        ("best_effort_not_ground_truth",),
+    )
+    return CoverageAssessment(
+        _id(110),
+        dependencies,
+        timings,
+        healths,
+        ("best_effort_not_ground_truth",),
+        state,
+        limitations,
+        "2026-08-14T04:00:00.000000Z",
+    )
+
+
+def _command(
+    *,
+    assessment: CoverageAssessment | None = None,
+    decision: CoverageGapDecision | None = None,
+    previous: CoverageGapDecision | None = None,
+    command_value: int = 120,
+) -> tuple[CoverageCommand, tuple, tuple, tuple]:
+    search = _search_chain()
+    request = search[1]
+    result = search[4][0]
+    review = search[5]
+    providers = _provider_qualifications()
+    locality = _locality_chain()
+    unit = locality[1]
+    locality_decision = locality[3]
+    assessment = assessment or _assessment()
+    comparator = CoverageComparator(
+        _id(111),
+        CoverageAuditMode.PROSPECTIVE_PRE_REGISTERED,
+        CoverageBasisKind.PLANNED_AGENDA,
+        "fixture.policy.decision",
+        (_D,),
+        (unit.digest,),
+        unit.source_class_scope,
+        (request.digest,),
+        "2026-08-14T01:00:00.000000Z",
+        "2026-08-14T02:00:00.000000Z",
+        None,
+        ("sha256:" + "7" * 64,),
+        _AT,
+    )
+    observations = (
+        CoverageObservation(
+            CoverageObservationKind.SEARCH_RESULT_REFERENCE,
+            result.digest,
+            result.recorded_at,
+        ),
+        CoverageObservation(
+            CoverageObservationKind.EXPECTATION_NOT_OBSERVED,
+            _D,
+            "2026-08-14T03:00:00.000000Z",
+        ),
+    )
+    audit = CoverageAudit(
+        _id(112),
+        comparator.comparator_id,
+        comparator.digest,
+        comparator.audit_mode,
+        observations,
+        assessment.derived_state,
+        assessment.derived_limitation_codes,
+        "sha256:" + "8" * 64,
+        assessment.assessed_at,
+    )
+    gap = CoverageGap(
+        _id(113),
+        audit.audit_id,
+        audit.digest,
+        CoverageGapScope.ISOLATED
+        if assessment.derived_state is not CoverageAssessmentState.DEFERRED
+        else CoverageGapScope.UNDETERMINED,
+        CoverageGapState.PROPOSED
+        if assessment.derived_state is not CoverageAssessmentState.DEFERRED
+        else CoverageGapState.DEFERRED_ASSESSMENT,
+        (unit.digest,),
+        (_D,),
+        (),
+        audit.limitation_codes,
+        "2026-08-14T05:00:00.000000Z",
+    )
+    if decision is None:
+        decision = CoverageGapDecision(
+            _id(114),
+            gap.gap_id,
+            gap.digest,
+            CoverageGapDisposition.CONFIRMED_BEST_EFFORT_GAP
+            if assessment.derived_state is not CoverageAssessmentState.DEFERRED
+            else CoverageGapDisposition.DEFERRED_INSUFFICIENT_BASIS,
+            (result.digest,),
+            gap.limitation_codes,
+            "sha256:" + "9" * 64,
+            ("reviewed_best_effort_gap",),
+            None if previous is None else previous.digest,
+            "2026-08-14T06:00:00.000000Z"
+            if previous is None
+            else "2026-08-14T07:00:00.000000Z",
+        )
+    command = CoverageCommand(
+        _id(command_value),
+        comparator,
+        assessment,
+        audit,
+        gap,
+        decision,
+        (request.digest,),
+        (result.digest,),
+        (review.digest,),
+        (providers[0][1].digest,),
+        locality[0].digest,
+        unit.digest,
+        locality_decision.digest,
+        None if previous is None else previous.digest,
+        _id(command_value + 1),
+        "sha256:" + "b" * 64,
+        f"coverage-command-{command_value}",
+    )
+    return command, (search,), providers, locality
+
+
+def test_deterministic_assessment_derives_state_and_exact_limitations() -> None:
+    complete = _assessment()
+    partial = _assessment(timeliness=TimelinessState.LATE)
+    deferred = _assessment(health=HealthState.UNKNOWN)
+
+    assert complete.derived_state is CoverageAssessmentState.COMPLETE_BEST_EFFORT
+    assert partial.derived_state is CoverageAssessmentState.PARTIAL_LIMITED
+    assert "timeliness.window.late" in partial.derived_limitation_codes
+    assert deferred.derived_state is CoverageAssessmentState.DEFERRED
+    assert "health.source_pack.unknown" in deferred.derived_limitation_codes
+    for assessment in (complete, partial, deferred):
+        assert (
+            CoverageAssessment.from_canonical_bytes(assessment.canonical_bytes)
+            == assessment
+        )
+        assert assessment.authorises_evidence is False
+        assert assessment.creates_watch is False
+        assert assessment.production_activation_authorised is False
+
+    with pytest.raises(CoverageAuthorityError, match="derivation differs"):
+        replace(complete, derived_state=CoverageAssessmentState.DEFERRED)
+    with pytest.raises(CoverageAuthorityError, match="unique and sorted"):
+        replace(
+            complete,
+            dependency_factors=(
+                complete.dependency_factors[0],
+                complete.dependency_factors[0],
+            ),
+        )
+
+
+def test_command_binds_exact_search_provider_locality_and_coverage_chains() -> None:
+    command, searches, providers, locality = _command()
+    validate_coverage_command(
+        command,
+        search_evidence=searches,
+        provider_qualifications=providers,
+        locality_qualification=locality,
+    )
+    assert CoverageCommand.from_canonical_bytes(command.canonical_bytes) == command
+    assert command.search_request_digests == command.comparator.search_request_digests
+    assert (
+        command.locality_coverage_unit_digest
+        in command.comparator.coverage_unit_digests
+    )
+    assert command.authorises_search is False
+    assert command.authorises_provider is False
+    assert command.authorises_locality is False
+
+    with pytest.raises(CoverageAuthorityError, match="Search identity set"):
+        validate_coverage_command(
+            replace(command, search_review_decision_digests=("sha256:" + "0" * 64,)),
+            search_evidence=searches,
+            provider_qualifications=providers,
+            locality_qualification=locality,
+        )
+    with pytest.raises(CoverageAuthorityError, match="qualification identity"):
+        validate_coverage_command(
+            replace(command, locality_decision_digest="sha256:" + "0" * 64),
+            search_evidence=searches,
+            provider_qualifications=providers,
+            locality_qualification=locality,
+        )
+
+
+def test_command_parser_rejects_noncanonical_duplicate_unknown_and_oversized() -> None:
+    command = _command()[0]
+    pretty = json.dumps(json.loads(command.canonical_bytes), indent=2).encode()
+    with pytest.raises(CoverageAuthorityError, match="exact canonical JSON"):
+        CoverageCommand.from_canonical_bytes(pretty)
+    duplicate = command.canonical_bytes.replace(
+        b'"command_id":',
+        b'"command_id":"' + _id(999).encode() + b'","command_id":',
+        1,
+    )
+    with pytest.raises(CoverageAuthorityError, match="duplicate object name"):
+        CoverageCommand.from_canonical_bytes(duplicate)
+    unknown = json.loads(command.canonical_bytes)
+    unknown["activate_provider"] = False
+    with pytest.raises(CoverageAuthorityError, match="fields or schema"):
+        CoverageCommand.from_canonical_bytes(canonical_json_bytes(unknown))
+    oversized = command.canonical_bytes.replace(
+        b'"idempotency_key":"coverage-command-120"',
+        b'"idempotency_key":"' + b"x" * 9_000_000 + b'"',
+    )
+    with pytest.raises(CoverageAuthorityError, match="not bounded"):
+        CoverageCommand.from_canonical_bytes(oversized)
+
+
+def test_v28_fresh_create_history_fingerprint_and_reserved_tables() -> None:
+    connection = sqlite3.connect(":memory:", isolation_level=None)
+    connection.execute("PRAGMA foreign_keys=ON")
+    apply_pending_migrations(connection, applied_at=_APPLIED)
+    tables = {
+        row[0]
+        for row in connection.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        )
+    }
+    assert SCHEMA_VERSION == COVERAGE_AUDIT_SCHEMA_VERSION == 28
+    assert EXPECTED_MIGRATION_HISTORY[-1][1] == COVERAGE_AUDIT_MIGRATION_NAME
+    assert connection.execute("PRAGMA user_version").fetchone()[0] == 28
+    assert schema_fingerprint(connection) == EXPECTED_SCHEMA_FINGERPRINT
+    assert {
+        "coverage_audits",
+        "coverage_audit_observations",
+        "coverage_gaps",
+        "coverage_gap_decisions",
+    } <= tables
+    assert connection.execute("PRAGMA foreign_key_check").fetchall() == []
+    assert connection.execute("PRAGMA quick_check").fetchone()[0] == "ok"
+
+
+def _create_v27(path) -> sqlite3.Connection:
+    connection = sqlite3.connect(path, isolation_level=None)
+    connection.execute("PRAGMA foreign_keys=ON")
+    apply_pending_migrations(connection, applied_at=_APPLIED)
+    connection.execute("PRAGMA foreign_keys=OFF")
+    connection.execute("BEGIN EXCLUSIVE")
+    immutable = connection.execute(
+        "SELECT sql FROM sqlite_master "
+        "WHERE name='immutable_authority_migrations_delete'"
+    ).fetchone()[0]
+    connection.execute("DROP TRIGGER immutable_authority_migrations_delete")
+    for table in (
+        "coverage_gap_decisions",
+        "coverage_audit_observations",
+        "coverage_gaps",
+        "coverage_audits",
+    ):
+        for (name,) in connection.execute(
+            "SELECT name FROM sqlite_master WHERE type='trigger' AND tbl_name=?",
+            (table,),
+        ).fetchall():
+            connection.execute(f'DROP TRIGGER "{name}"')
+        connection.execute(f"DROP TABLE {table}")
+    connection.execute("DELETE FROM authority_migrations WHERE version=28")
+    connection.execute(immutable)
+    connection.execute("PRAGMA user_version=27")
+    connection.execute("COMMIT")
+    connection.execute("PRAGMA foreign_keys=ON")
+    return connection
+
+
+def test_v27_upgrade_requires_exact_backup_and_preserves_restore_point(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database = tmp_path / "authority.sqlite3"
+    connection = _create_v27(database)
+    with pytest.raises(CoverageAuditBackupError, match="requires prepared backup"):
+        apply_pending_migrations(connection, applied_at=_APPLIED)
+    backup, digest_path = coverage_audit_backup_paths(database)
+    receipt = prepare_coverage_audit_backup(connection, backup)
+    assert receipt.backup_path == backup
+    assert digest_path.is_file()
+    from newsroom.authority import migrations
+
+    statements = migrations.COVERAGE_AUDIT_MIGRATION_STATEMENTS
+    monkeypatch.setattr(
+        migrations,
+        "COVERAGE_AUDIT_MIGRATION_STATEMENTS",
+        (statements[0], "CREATE TABLE deliberate_failure("),
+    )
+    with pytest.raises(sqlite3.OperationalError):
+        apply_pending_migrations(connection, applied_at=_APPLIED)
+    assert connection.execute("PRAGMA user_version").fetchone()[0] == 27
+    assert schema_fingerprint(connection) == (
+        "sha256:d7fc1557bd02588969efdd53c749a2f125ab5bab146395c4cf8f7d51b1e32719"
+    )
+    monkeypatch.setattr(migrations, "COVERAGE_AUDIT_MIGRATION_STATEMENTS", statements)
+    apply_pending_migrations(connection, applied_at=_APPLIED)
+    assert connection.execute("PRAGMA user_version").fetchone()[0] == 28
+
+    restored = sqlite3.connect(backup, isolation_level=None)
+    try:
+        assert restored.execute("PRAGMA user_version").fetchone()[0] == 27
+        assert restored.execute("PRAGMA quick_check").fetchone()[0] == "ok"
+    finally:
+        restored.close()
+
+
+def test_authority_persists_exact_replay_restart_and_rejects_tamper(tmp_path) -> None:
+    path = tmp_path / "coverage.sqlite3"
+    command, searches, providers, locality = _command()
+    authority = open_coverage_audit_authority(path, applied_at=_APPLIED)
+    decision = authority.record(
+        command.canonical_bytes,
+        search_evidence=searches,
+        provider_qualifications=providers,
+        locality_qualification=locality,
+    )
+    assert decision == command.decision
+    assert (
+        authority.record(
+            command.canonical_bytes,
+            search_evidence=searches,
+            provider_qualifications=providers,
+            locality_qualification=locality,
+        )
+        == decision
+    )
+    port = authority.read_port()
+    assert type(port) is CoverageAuditReadPort
+    assert port.audit(command.audit.audit_id) == command.audit
+    assert port.assessment(command.audit.audit_id) == command.assessment
+    assert port.gap(command.gap.gap_id) == command.gap
+    assert port.decision(decision.decision_id) == decision
+    assert port.command(command.command_id) == command
+    authority.close()
+
+    reopened = open_coverage_audit_authority(path, applied_at=_APPLIED)
+    assert reopened.read_port().command(command.command_id) == command
+    reopened.close()
+
+    attacker = sqlite3.connect(path, isolation_level=None)
+    attacker.execute("DROP TRIGGER immutable_coverage_audits")
+    attacker.execute(
+        "UPDATE coverage_audits SET assessment_state='DEFERRED' WHERE audit_id=?",
+        (command.audit.audit_id,),
+    )
+    attacker.close()
+    reopened = open_coverage_audit_authority(path, applied_at=_APPLIED)
+    with pytest.raises(CoverageAuthorityError, match="retained representation"):
+        reopened.read_port().audit(command.audit.audit_id)
+    reopened.close()
+
+
+def test_successor_decision_is_cas_bound_and_preserves_initial_bytes(tmp_path) -> None:
+    path = tmp_path / "coverage.sqlite3"
+    first_command, searches, providers, locality = _command()
+    authority = open_coverage_audit_authority(path, applied_at=_APPLIED)
+    first = authority.record(
+        first_command.canonical_bytes,
+        search_evidence=searches,
+        provider_qualifications=providers,
+        locality_qualification=locality,
+    )
+    successor_decision = replace(
+        first,
+        decision_id=_id(115),
+        supersedes_decision_digest=first.digest,
+        decided_at="2026-08-14T07:00:00.000000Z",
+    )
+    successor, searches, providers, locality = _command(
+        decision=successor_decision,
+        previous=first,
+        command_value=130,
+    )
+    assert (
+        authority.record(
+            successor.canonical_bytes,
+            search_evidence=searches,
+            provider_qualifications=providers,
+            locality_qualification=locality,
+        )
+        == successor_decision
+    )
+    assert authority.read_port().decision(first.decision_id) == first
+    stale = replace(
+        successor,
+        command_id=_id(140),
+        request_id=_id(141),
+        idempotency_key="coverage-command-stale",
+        expected_previous_decision_digest=None,
+        decision=replace(
+            successor.decision, decision_id=_id(142), supersedes_decision_digest=None
+        ),
+    )
+    with pytest.raises(CoverageAuthorityError, match="predecessor"):
+        authority.record(
+            stale.canonical_bytes,
+            search_evidence=searches,
+            provider_qualifications=providers,
+            locality_qualification=locality,
+        )
+    authority.close()
+
+
+def test_competing_identical_writers_have_one_retained_decision(tmp_path) -> None:
+    path = tmp_path / "coverage.sqlite3"
+    command, searches, providers, locality = _command()
+    barrier = threading.Barrier(2)
+    outcomes: list[str] = []
+    authorities = [
+        open_coverage_audit_authority(path, applied_at=_APPLIED) for _ in range(2)
+    ]
+
+    def writer(authority) -> None:
+        barrier.wait()
+        result = authority.record(
+            command.canonical_bytes,
+            search_evidence=searches,
+            provider_qualifications=providers,
+            locality_qualification=locality,
+        )
+        outcomes.append(result.digest)
+        authority.close()
+
+    threads = [
+        threading.Thread(target=writer, args=(authority,)) for authority in authorities
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=20)
+    assert outcomes == [command.decision.digest, command.decision.digest]
+    connection = sqlite3.connect(path)
+    assert (
+        connection.execute("SELECT COUNT(*) FROM coverage_gap_decisions").fetchone()[0]
+        == 1
+    )
+    assert connection.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+    connection.close()
+
+
+def test_allocated_schemas_authority_and_non_effects_are_exact() -> None:
+    assert COVERAGE_COMMAND == "newsroom.increment7.coverage-command.v1"
+    assert COVERAGE_ASSESSMENT == "newsroom.increment7.coverage-assessment.v1"
+    assert COVERAGE_AUDIT_AUTHORITY == "CHECKED_SQLITE_TRANSACTIONAL_V28"
+    assert COVERAGE_ASSESSMENT_AUTHORITY == "DETERMINISTIC_DEPENDENCY_TIMELINESS_HEALTH"
+    command = _command()[0]
+    for value in (command, command.assessment):
+        assert value.authorises_external_effect is False
+        assert value.authorises_credentials is False
+        assert value.authorises_egress is False
+        assert value.authorises_spend is False
+        assert value.authorises_publication is False
+        assert value.creates_candidate is False
+        assert value.creates_watch is False
+        assert value.production_activation_authorised is False

--- a/newsroom/tests/test_increment7c2_coverage_audit_authority.py
+++ b/newsroom/tests/test_increment7c2_coverage_audit_authority.py
@@ -435,6 +435,13 @@ def test_authority_persists_exact_replay_restart_and_rejects_tamper(tmp_path) ->
         )
         == decision
     )
+    with pytest.raises(CoverageAuthorityError, match="Search evidence"):
+        authority.record(
+            command.canonical_bytes,
+            search_evidence=(),
+            provider_qualifications=providers,
+            locality_qualification=locality,
+        )
     port = authority.read_port()
     assert type(port) is CoverageAuditReadPort
     assert port.audit(command.audit.audit_id) == command.audit


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: 7c2
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

## Summary
- add deterministic dependency, timeliness, health and limitation assessment contracts
- bind Coverage Audit/Gap commands to exact accepted Search, provider and locality identities
- add checked SQLite v28 persistence with immutable replay, CAS decision succession and retained-row validation
- extend migration compatibility, exact predecessor backup, rollback and topology fixtures

## Evidence
- `9 passed` — focused 7C2 authority suite
- `163 passed` — migration/Increment 7 compatibility set
- `202 passed` — authority, migration and D3 conformance set
- local SDLC source-check passed on `origin/main..73d2bde`

## Non-effects
Fixture/replay only. No search/provider/locality activation, credential, egress, spend, scheduling, evidence acquisition, publication, Candidate or Watch creation, or production effect.

Closes #443
