### PR TITLE
Increment 7D2: add checked Local Watch lifecycle authority

### DIFF
--- a/newsroom/authority/local_watch_migrations.py
+++ b/newsroom/authority/local_watch_migrations.py
@@ -1,0 +1,264 @@
+"""Checked v29 Event-Scoped Local Watch migration and exact v28 backup gate."""
+
+# fmt: off
+# ruff: noqa: I001
+from __future__ import annotations
+import sqlite3
+from pathlib import Path
+from . import coverage_audit_migrations as predecessor
+from .canonical import digest_canonical
+
+LOCAL_WATCH_SCHEMA_VERSION = 29
+LOCAL_WATCH_MIGRATION_NAME = "event_scoped_local_watch_authority_v29"
+LOCAL_WATCH_PREDECESSOR_MIGRATION_CHECKSUM = (
+    "sha256:c923daf18aed10bb9c197bfd588d816223d978668bda56c157438d1a4b7cc487"
+)
+LOCAL_WATCH_PREDECESSOR_FINGERPRINT = (
+    "sha256:a613b28a765b36fa9110bcdc2b9bc565c6e2bc0ed8b8381d77f5fcd734c39c48"
+)
+LocalWatchBackupError = predecessor.CoverageAuditBackupError
+LocalWatchBackupReceipt = predecessor.CoverageAuditBackupReceipt
+LocalWatchMigrationRecord = predecessor.CoverageAuditMigrationRecord
+_helpers = predecessor._helpers
+
+
+def local_watch_backup_paths(database: str | Path) -> tuple[Path, Path]:
+    source = Path(database)
+    backup = source.with_name(source.name + ".pre-v29.sqlite3")
+    return backup, backup.with_name(backup.name + ".sha256")
+
+
+def _checked_backup(path: Path, logical: str) -> LocalWatchBackupReceipt:
+    digest_path = path.with_name(path.name + ".sha256")
+    digest = _helpers._file_digest(path)
+    if digest_path.read_text(encoding="ascii") != digest + "\n":
+        raise LocalWatchBackupError("backup digest differs")
+    target = sqlite3.connect(f"file:{path}?mode=ro", uri=True, isolation_level=None)
+    try:
+        if (
+            target.execute("PRAGMA user_version").fetchone()[0] != 28
+            or _helpers._schema_fingerprint(target) != LOCAL_WATCH_PREDECESSOR_FINGERPRINT
+            or _helpers._logical_database_digest(target) != logical
+        ):
+            raise LocalWatchBackupError("backup differs from source")
+    finally:
+        target.close()
+    return LocalWatchBackupReceipt(path, digest_path, digest, logical)
+
+
+def prepare_local_watch_backup(
+    connection: sqlite3.Connection, backup_path: Path
+) -> LocalWatchBackupReceipt:
+    fingerprint = _helpers._schema_fingerprint
+    logical_digest = _helpers._logical_database_digest
+    file_digest = _helpers._file_digest
+    if (
+        connection.in_transaction
+        or connection.execute("PRAGMA user_version").fetchone()[0] != 28
+        or fingerprint(connection) != LOCAL_WATCH_PREDECESSOR_FINGERPRINT
+        or not isinstance(backup_path, Path)
+        or not backup_path.is_absolute()
+    ):
+        raise LocalWatchBackupError("backup requires checked schema v28")
+    source = Path(
+        next(row[2] for row in connection.execute("PRAGMA database_list") if row[1] == "main")
+    )
+    digest_path = backup_path.with_name(backup_path.name + ".sha256")
+    logical = logical_digest(connection)
+    if (
+        not source
+        or source.resolve() == backup_path.resolve()
+        or backup_path.exists() != digest_path.exists()
+    ):
+        raise LocalWatchBackupError("backup boundary differs")
+    if not backup_path.exists():
+        backup_path.open("xb").close()
+        target = sqlite3.connect(backup_path, isolation_level=None)
+        try:
+            connection.backup(target)
+        finally:
+            target.close()
+        digest_path.write_text(file_digest(backup_path) + "\n", encoding="ascii")
+    receipt = _checked_backup(backup_path, logical)
+    connection.execute(
+        "CREATE TEMP TABLE IF NOT EXISTS local_watch_backup_gate("
+        "backup_path TEXT PRIMARY KEY,backup_digest TEXT NOT NULL,"
+        "logical_digest TEXT NOT NULL) STRICT"
+    )
+    connection.execute("DELETE FROM local_watch_backup_gate")
+    connection.execute(
+        "INSERT INTO local_watch_backup_gate VALUES(?,?,?)",
+        (str(backup_path), receipt.backup_digest, logical),
+    )
+    if connection.in_transaction:
+        connection.commit()
+    return receipt
+
+
+def require_local_watch_backup(
+    connection: sqlite3.Connection,
+    *,
+    expected_history: tuple[tuple[int, str, str], ...],
+) -> LocalWatchBackupReceipt:
+    logical_digest = _helpers._logical_database_digest
+    try:
+        row = connection.execute(
+            "SELECT backup_path,backup_digest,logical_digest "
+            "FROM temp.local_watch_backup_gate"
+        ).fetchone()
+    except sqlite3.OperationalError as exc:
+        raise LocalWatchBackupError("v28 to v29 requires prepared backup") from exc
+    if row is None or logical_digest(connection) != row[2]:
+        raise LocalWatchBackupError("v28 to v29 requires prepared backup")
+    receipt = _checked_backup(Path(row[0]), str(row[2]))
+    target = sqlite3.connect(
+        f"file:{receipt.backup_path}?mode=ro", uri=True, isolation_level=None
+    )
+    try:
+        history = target.execute(
+            "SELECT version,name,checksum FROM authority_migrations ORDER BY version"
+        ).fetchall()
+    finally:
+        target.close()
+    if receipt.backup_digest != row[1] or history != list(expected_history):
+        raise LocalWatchBackupError("prepared backup is not exact v28")
+    return receipt
+
+
+_D = "substr({0},1,7)='sha256:' AND length({0})=71 AND substr({0},8) NOT GLOB '*[^0-9a-f]*'"
+LOCAL_WATCH_MIGRATION_STATEMENTS: tuple[str, ...] = (
+    f"""CREATE TABLE event_scoped_local_watches(
+        watch_id TEXT PRIMARY KEY,
+        watch_bytes BLOB NOT NULL,
+        watch_digest TEXT NOT NULL UNIQUE CHECK({_D.format('watch_digest')}),
+        subject_kind TEXT NOT NULL,
+        subject_id TEXT NOT NULL,
+        subject_version_digest TEXT NOT NULL CHECK({_D.format('subject_version_digest')}),
+        owner_identity_digest TEXT NOT NULL CHECK({_D.format('owner_identity_digest')}),
+        created_at TEXT NOT NULL,
+        UNIQUE(subject_kind,subject_id,subject_version_digest,watch_digest),
+        CHECK(length(watch_bytes)>0)
+    ) STRICT""",
+    f"""CREATE TABLE event_scoped_local_watch_versions(
+        watch_version_id TEXT PRIMARY KEY,
+        watch_id TEXT NOT NULL REFERENCES event_scoped_local_watches(watch_id),
+        version_ordinal INTEGER NOT NULL CHECK(version_ordinal BETWEEN 1 AND 10000),
+        previous_version_digest TEXT CHECK(previous_version_digest IS NULL OR {_D.format('previous_version_digest')}),
+        version_bytes BLOB NOT NULL,
+        version_digest TEXT NOT NULL UNIQUE CHECK({_D.format('version_digest')}),
+        status TEXT NOT NULL CHECK(status IN ('PLANNED','OPEN','PAUSED','EXTENDED')),
+        starts_at TEXT NOT NULL,
+        review_at TEXT NOT NULL,
+        expires_at TEXT NOT NULL,
+        command_bytes BLOB NOT NULL,
+        command_digest TEXT NOT NULL UNIQUE CHECK({_D.format('command_digest')}),
+        command_id TEXT NOT NULL UNIQUE,
+        request_id TEXT NOT NULL UNIQUE,
+        actor_identity_digest TEXT NOT NULL CHECK({_D.format('actor_identity_digest')}),
+        idempotency_key TEXT NOT NULL UNIQUE,
+        recorded_at TEXT NOT NULL,
+        UNIQUE(watch_id,version_ordinal),
+        UNIQUE(watch_id,version_digest),
+        UNIQUE(watch_version_id,watch_id,version_digest),
+        FOREIGN KEY(watch_id,previous_version_digest)
+            REFERENCES event_scoped_local_watch_versions(watch_id,version_digest),
+        CHECK(length(version_bytes)>0 AND length(command_bytes)>0),
+        CHECK((version_ordinal=1 AND previous_version_digest IS NULL)
+           OR (version_ordinal>1 AND previous_version_digest IS NOT NULL))
+    ) STRICT""",
+    f"""CREATE TABLE event_scoped_local_watch_heads(
+        watch_id TEXT PRIMARY KEY REFERENCES event_scoped_local_watches(watch_id),
+        current_version_id TEXT NOT NULL,
+        current_version_digest TEXT NOT NULL CHECK({_D.format('current_version_digest')}),
+        current_version_ordinal INTEGER NOT NULL CHECK(current_version_ordinal BETWEEN 1 AND 10000),
+        closed INTEGER NOT NULL CHECK(closed IN (0,1)),
+        closure_digest TEXT CHECK(closure_digest IS NULL OR {_D.format('closure_digest')}),
+        updated_at TEXT NOT NULL,
+        FOREIGN KEY(current_version_id,watch_id,current_version_digest)
+            REFERENCES event_scoped_local_watch_versions(watch_version_id,watch_id,version_digest),
+        CHECK((closed=0 AND closure_digest IS NULL) OR (closed=1 AND closure_digest IS NOT NULL))
+    ) STRICT""",
+    f"""CREATE TABLE event_scoped_local_watch_closures(
+        closure_id TEXT PRIMARY KEY,
+        watch_id TEXT NOT NULL UNIQUE REFERENCES event_scoped_local_watches(watch_id),
+        watch_version_id TEXT NOT NULL,
+        watch_version_digest TEXT NOT NULL CHECK({_D.format('watch_version_digest')}),
+        closure_bytes BLOB NOT NULL,
+        closure_digest TEXT NOT NULL UNIQUE CHECK({_D.format('closure_digest')}),
+        outcome TEXT NOT NULL CHECK(outcome IN ('EXPIRED','CLOSED_BY_OWNER','EVENT_RESOLVED','CANCELLED','CONVERSION_PROPOSED','SUPERSEDED')),
+        effective_at TEXT NOT NULL,
+        locality_coverage_proposal_digest TEXT CHECK(locality_coverage_proposal_digest IS NULL OR {_D.format('locality_coverage_proposal_digest')}),
+        reentry_bytes BLOB,
+        reentry_digest TEXT UNIQUE CHECK(reentry_digest IS NULL OR {_D.format('reentry_digest')}),
+        reentry_id TEXT UNIQUE,
+        command_bytes BLOB NOT NULL,
+        command_digest TEXT NOT NULL UNIQUE CHECK({_D.format('command_digest')}),
+        command_id TEXT NOT NULL UNIQUE,
+        request_id TEXT NOT NULL UNIQUE,
+        actor_identity_digest TEXT NOT NULL CHECK({_D.format('actor_identity_digest')}),
+        idempotency_key TEXT NOT NULL UNIQUE,
+        recorded_at TEXT NOT NULL,
+        FOREIGN KEY(watch_version_id,watch_id,watch_version_digest)
+            REFERENCES event_scoped_local_watch_versions(watch_version_id,watch_id,version_digest),
+        CHECK(length(closure_bytes)>0 AND length(command_bytes)>0),
+        CHECK((reentry_bytes IS NULL AND reentry_digest IS NULL AND reentry_id IS NULL)
+           OR (reentry_bytes IS NOT NULL AND length(reentry_bytes)>0 AND reentry_digest IS NOT NULL AND reentry_id IS NOT NULL))
+    ) STRICT""",
+    "CREATE TRIGGER immutable_event_scoped_local_watches BEFORE UPDATE ON event_scoped_local_watches BEGIN SELECT RAISE(ABORT,'immutable Event-Scoped Local Watch'); END",
+    "CREATE TRIGGER retained_event_scoped_local_watches BEFORE DELETE ON event_scoped_local_watches BEGIN SELECT RAISE(ABORT,'retained Event-Scoped Local Watch'); END",
+    "CREATE TRIGGER immutable_event_scoped_local_watch_versions BEFORE UPDATE ON event_scoped_local_watch_versions BEGIN SELECT RAISE(ABORT,'immutable Local Watch Version'); END",
+    "CREATE TRIGGER retained_event_scoped_local_watch_versions BEFORE DELETE ON event_scoped_local_watch_versions BEGIN SELECT RAISE(ABORT,'retained Local Watch Version'); END",
+    "CREATE TRIGGER immutable_event_scoped_local_watch_closures BEFORE UPDATE ON event_scoped_local_watch_closures BEGIN SELECT RAISE(ABORT,'immutable Local Watch Closure'); END",
+    "CREATE TRIGGER retained_event_scoped_local_watch_closures BEFORE DELETE ON event_scoped_local_watch_closures BEGIN SELECT RAISE(ABORT,'retained Local Watch Closure'); END",
+    "CREATE TRIGGER retained_event_scoped_local_watch_heads BEFORE DELETE ON event_scoped_local_watch_heads BEGIN SELECT RAISE(ABORT,'retained Local Watch head'); END",
+    """CREATE TRIGGER local_watch_version_predecessor_guard
+       BEFORE INSERT ON event_scoped_local_watch_versions WHEN NEW.version_ordinal>1 AND NOT EXISTS(
+          SELECT 1 FROM event_scoped_local_watch_heads h
+          WHERE h.watch_id=NEW.watch_id AND h.closed=0
+            AND h.current_version_ordinal=NEW.version_ordinal-1
+            AND h.current_version_digest=NEW.previous_version_digest)
+       BEGIN SELECT RAISE(ABORT,'Local Watch Version predecessor differs'); END""",
+    """CREATE TRIGGER local_watch_closure_head_guard
+       BEFORE INSERT ON event_scoped_local_watch_closures WHEN NOT EXISTS(
+          SELECT 1 FROM event_scoped_local_watch_heads h
+          WHERE h.watch_id=NEW.watch_id AND h.closed=0
+            AND h.current_version_id=NEW.watch_version_id
+            AND h.current_version_digest=NEW.watch_version_digest)
+       BEGIN SELECT RAISE(ABORT,'Local Watch Closure head differs'); END""",
+    """CREATE TRIGGER local_watch_head_progress_guard
+       BEFORE UPDATE ON event_scoped_local_watch_heads WHEN
+          OLD.closed=1
+          OR NEW.current_version_ordinal NOT BETWEEN OLD.current_version_ordinal AND OLD.current_version_ordinal+1
+          OR (NEW.current_version_ordinal=OLD.current_version_ordinal+1 AND (
+                NEW.closed!=0 OR NEW.closure_digest IS NOT NULL
+                OR NOT EXISTS(SELECT 1 FROM event_scoped_local_watch_versions v
+                    WHERE v.watch_id=NEW.watch_id
+                      AND v.watch_version_id=NEW.current_version_id
+                      AND v.version_digest=NEW.current_version_digest
+                      AND v.version_ordinal=NEW.current_version_ordinal)))
+          OR (NEW.current_version_ordinal=OLD.current_version_ordinal AND (
+                NEW.current_version_id!=OLD.current_version_id
+                OR NEW.current_version_digest!=OLD.current_version_digest
+                OR NEW.closed!=1 OR NEW.closure_digest IS NULL
+                OR NOT EXISTS(SELECT 1 FROM event_scoped_local_watch_closures c
+                    WHERE c.watch_id=NEW.watch_id
+                      AND c.closure_digest=NEW.closure_digest)))
+       BEGIN SELECT RAISE(ABORT,'Local Watch head progression differs'); END""",
+)
+LOCAL_WATCH_MIGRATION_CHECKSUM = digest_canonical(
+    {
+        "version": LOCAL_WATCH_SCHEMA_VERSION,
+        "name": LOCAL_WATCH_MIGRATION_NAME,
+        "statements": list(LOCAL_WATCH_MIGRATION_STATEMENTS),
+    }
+)
+LOCAL_WATCH_MIGRATION = LocalWatchMigrationRecord(
+    LOCAL_WATCH_SCHEMA_VERSION,
+    LOCAL_WATCH_MIGRATION_NAME,
+    LOCAL_WATCH_MIGRATION_CHECKSUM,
+)
+__all__ = [
+    name for name in globals()
+    if name.startswith(("LOCAL_WATCH_", "LocalWatch", "local_watch_", "prepare_", "require_"))
+]
+# fmt: on

--- a/newsroom/authority/migrations.py
+++ b/newsroom/authority/migrations.py
@@ -29,6 +29,17 @@ from .coverage_audit_migrations import (
     prepare_coverage_audit_backup,
     require_coverage_audit_backup,
 )
+from .local_watch_migrations import (
+    LOCAL_WATCH_MIGRATION,
+    LOCAL_WATCH_MIGRATION_CHECKSUM,
+    LOCAL_WATCH_MIGRATION_NAME,
+    LOCAL_WATCH_MIGRATION_STATEMENTS,
+    LOCAL_WATCH_SCHEMA_VERSION,
+    LocalWatchBackupReceipt,
+    local_watch_backup_paths,
+    prepare_local_watch_backup,
+    require_local_watch_backup,
+)
 from .check_migrations import (
     CHECK_AUTHORITY_MIGRATION,
     CHECK_AUTHORITY_MIGRATION_CHECKSUM,
@@ -246,7 +257,7 @@ from .triage_work_item_migrations import (
 )
 
 BASE_SCHEMA_VERSION = 1
-SCHEMA_VERSION = COVERAGE_AUDIT_SCHEMA_VERSION
+SCHEMA_VERSION = LOCAL_WATCH_SCHEMA_VERSION
 MIGRATION_NAME = "authority_event_foundation_v1"
 
 
@@ -698,11 +709,12 @@ def prepare_pending_migration_backup(
     | PlannedAgendaBackupReceipt
     | BoundedSearchBackupReceipt
     | CoverageAuditBackupReceipt
+    | LocalWatchBackupReceipt
     | None
 ):
     """Prepare the exact retained backup required by a checked predecessor."""
     version = int(conn.execute("PRAGMA user_version").fetchone()[0])
-    if version not in {16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27}:
+    if version not in {16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28}:
         return None
     database_path = next(
         str(row[2])
@@ -746,8 +758,11 @@ def prepare_pending_migration_backup(
     if version == 26:
         backup_path, _ = bounded_search_backup_paths(database_path)
         return prepare_bounded_search_backup(conn, backup_path)
-    backup_path, _ = coverage_audit_backup_paths(database_path)
-    return prepare_coverage_audit_backup(conn, backup_path)
+    if version == 27:
+        backup_path, _ = coverage_audit_backup_paths(database_path)
+        return prepare_coverage_audit_backup(conn, backup_path)
+    backup_path, _ = local_watch_backup_paths(database_path)
+    return prepare_local_watch_backup(conn, backup_path)
 
 
 def apply_migration(
@@ -1384,6 +1399,29 @@ def apply_pending_migrations(conn: sqlite3.Connection, *, applied_at: str) -> No
                  COVERAGE_AUDIT_MIGRATION_CHECKSUM, applied_at),
             )
             current = COVERAGE_AUDIT_SCHEMA_VERSION
+        if current == COVERAGE_AUDIT_SCHEMA_VERSION:
+            if 0 < starting_version < COVERAGE_AUDIT_SCHEMA_VERSION:
+                conn.execute(f"PRAGMA user_version={COVERAGE_AUDIT_SCHEMA_VERSION}")
+                conn.execute("COMMIT")
+                database_path = next(str(row[2]) for row in conn.execute("PRAGMA database_list") if row[1] == "main")
+                if not database_path:
+                    raise sqlite3.DatabaseError("existing multihop upgrade requires a file-backed database")
+                backup_path, _ = local_watch_backup_paths(database_path)
+                prepare_local_watch_backup(conn, backup_path)
+                conn.execute("BEGIN EXCLUSIVE")
+            if starting_version != 0:
+                require_local_watch_backup(
+                    conn, expected_history=tuple((r.version, r.name, r.checksum) for r in MIGRATIONS
+                                                 if r.version <= COVERAGE_AUDIT_SCHEMA_VERSION),
+                )
+            for statement in LOCAL_WATCH_MIGRATION_STATEMENTS:
+                conn.execute(statement)
+            conn.execute(
+                "INSERT INTO authority_migrations(version,name,checksum,applied_at) VALUES(?,?,?,?)",
+                (LOCAL_WATCH_SCHEMA_VERSION, LOCAL_WATCH_MIGRATION_NAME,
+                 LOCAL_WATCH_MIGRATION_CHECKSUM, applied_at),
+            )
+            current = LOCAL_WATCH_SCHEMA_VERSION
         # fmt: on
         conn.execute(f"PRAGMA user_version={current}")
         conn.execute("COMMIT")
@@ -1422,6 +1460,7 @@ MIGRATIONS: tuple[MigrationRecord | object, ...] = (
     PLANNED_AGENDA_MIGRATION,
     BOUNDED_SEARCH_MIGRATION,
     COVERAGE_AUDIT_MIGRATION,
+    LOCAL_WATCH_MIGRATION,
 )
 
 
@@ -1568,6 +1607,11 @@ EXPECTED_MIGRATION_HISTORY: tuple[tuple[int, str, str], ...] = (
         COVERAGE_AUDIT_SCHEMA_VERSION,
         COVERAGE_AUDIT_MIGRATION_NAME,
         COVERAGE_AUDIT_MIGRATION_CHECKSUM,
+    ),
+    (
+        LOCAL_WATCH_SCHEMA_VERSION,
+        LOCAL_WATCH_MIGRATION_NAME,
+        LOCAL_WATCH_MIGRATION_CHECKSUM,
     ),
 )
 # fmt: on

--- a/newsroom/increment7/local_watch_authority.py
+++ b/newsroom/increment7/local_watch_authority.py
@@ -1,0 +1,949 @@
+"""Checked Event-Scoped Local Watch lifecycle authority for Increment 7D2.
+
+The v29 authority retains exact caller-supplied fixture/replay records.  It has
+no clock, scheduler, source adapter, provider, network, evidence, Candidate,
+publication or production activation capability.  Expiry and re-entry are
+explicit commands, never autonomous effects.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+from pathlib import Path
+from typing import Self
+
+from newsroom.authority.canonical import (
+    CanonicalizationError,
+    canonical_json_bytes,
+    digest_bytes,
+    validate_sha256_digest,
+)
+from newsroom.authority.migrations import (
+    SCHEMA_VERSION,
+    apply_pending_migrations,
+    prepare_pending_migration_backup,
+)
+from newsroom.increment6.work_items import SupplementalDiscoveryReentry
+from newsroom.increment7.local_watch import (
+    EventScopedLocalWatch,
+    LocalWatchClosure,
+    LocalWatchClosureOutcome,
+    LocalWatchVersion,
+    validate_local_watch_closure,
+    validate_local_watch_version_chain,
+)
+from newsroom.increment7.locality_qualification import LocalityCoverageProposal
+
+LOCAL_WATCH_COMMAND = "newsroom.increment7.local-watch-command.v1"
+LOCAL_WATCH_REENTRY = "newsroom.increment7.local-watch-reentry.v1"
+LOCAL_WATCH_AUTHORITY = "CHECKED_SQLITE_TRANSACTIONAL_V29"
+LOCAL_WATCH_REENTRY_AUTHORITY = "EXISTING_INCREMENT6_GOVERNED_LINEAGE_ONLY"
+MAX_LOCAL_WATCH_COMMAND_BYTES = 8_388_608
+
+_UUID = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z"
+)
+_TOKEN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:\-]{0,255}\Z")
+_UTC = re.compile(
+    r"[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T"
+    r"(?:[01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]\.[0-9]{6}Z\Z"
+)
+
+
+class LocalWatchAuthorityError(ValueError):
+    """A command, retained row or governed lineage failed closed."""
+
+
+class LocalWatchAction(StrEnum):
+    CREATE = "CREATE"
+    APPEND_VERSION = "APPEND_VERSION"
+    CLOSE = "CLOSE"
+
+
+class LocalWatchReentryKind(StrEnum):
+    EXPIRY = "EXPIRY"
+    OBSERVABLE_TRANSITION = "OBSERVABLE_TRANSITION"
+    OWNER_REVIEW = "OWNER_REVIEW"
+
+
+class _NoEffect:
+    authorises_external_effect = False
+    authorises_source_access = False
+    authorises_search = False
+    authorises_provider = False
+    authorises_locality = False
+    authorises_credentials = False
+    authorises_egress = False
+    authorises_spend = False
+    authorises_schedule = False
+    authorises_evidence = False
+    authorises_publication = False
+    creates_signal = False
+    creates_lead = False
+    creates_candidate = False
+    creates_locality_proposal = False
+    production_activation_authorised = False
+
+
+def _total(label: str):
+    def decorate(function):
+        def wrapped(*args: object, **kwargs: object):
+            try:
+                return function(*args, **kwargs)
+            except LocalWatchAuthorityError:
+                raise
+            except Exception as exc:
+                raise LocalWatchAuthorityError(label) from exc
+
+        return wrapped
+
+    return decorate
+
+
+def _text(value: object, field: str, maximum: int = 2_048) -> str:
+    try:
+        size = len(value.encode()) if type(value) is str else 0
+    except UnicodeError as exc:
+        raise LocalWatchAuthorityError(f"{field} must be canonical text") from exc
+    if (
+        type(value) is not str
+        or not value
+        or value != value.strip()
+        or size > maximum
+        or any(ord(character) < 32 or ord(character) == 127 for character in value)
+    ):
+        raise LocalWatchAuthorityError(f"{field} must be canonical text")
+    return value
+
+
+def _token(value: object, field: str) -> str:
+    value = _text(value, field, 256)
+    if _TOKEN.fullmatch(value) is None:
+        raise LocalWatchAuthorityError(f"{field} must be a canonical token")
+    return value
+
+
+def _uuid(value: object, field: str) -> str:
+    if type(value) is not str or _UUID.fullmatch(value) is None:
+        raise LocalWatchAuthorityError(f"{field} must be a canonical UUID")
+    try:
+        if str(uuid.UUID(value)) != value:
+            raise ValueError
+    except ValueError as exc:
+        raise LocalWatchAuthorityError(f"{field} must be a canonical UUID") from exc
+    return value
+
+
+def _digest(value: object, field: str) -> str:
+    try:
+        return validate_sha256_digest(value, field=field)
+    except (CanonicalizationError, TypeError, ValueError) as exc:
+        raise LocalWatchAuthorityError(f"{field} must be a SHA-256 digest") from exc
+
+
+def _timestamp(value: object, field: str) -> str:
+    value = _text(value, field, 27)
+    if _UTC.fullmatch(value) is None:
+        raise LocalWatchAuthorityError(f"{field} must be an exact UTC timestamp")
+    try:
+        datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise LocalWatchAuthorityError(
+            f"{field} must be an exact UTC timestamp"
+        ) from exc
+    return value
+
+
+def _enum[T: StrEnum](kind: type[T], value: object, field: str) -> T:
+    if type(value) is not str and type(value) is not kind:
+        raise LocalWatchAuthorityError(f"{field} differs")
+    try:
+        return kind(value)
+    except ValueError as exc:
+        raise LocalWatchAuthorityError(f"{field} differs") from exc
+
+
+def _pairs(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise LocalWatchAuthorityError(f"duplicate object name: {key}")
+        result[key] = value
+    return result
+
+
+def _document(raw: bytes, schema: str, fields: tuple[str, ...]) -> dict[str, object]:
+    if type(raw) is not bytes or not raw or len(raw) > MAX_LOCAL_WATCH_COMMAND_BYTES:
+        raise LocalWatchAuthorityError("Local Watch authority bytes are not bounded")
+    try:
+        value = json.loads(raw.decode(), object_pairs_hook=_pairs)
+        canonical = canonical_json_bytes(value)
+    except LocalWatchAuthorityError:
+        raise
+    except (
+        UnicodeError,
+        json.JSONDecodeError,
+        CanonicalizationError,
+        RecursionError,
+        ValueError,
+    ) as exc:
+        raise LocalWatchAuthorityError(
+            "Local Watch authority document is not canonical JSON"
+        ) from exc
+    if type(value) is not dict or raw != canonical:
+        raise LocalWatchAuthorityError(
+            "Local Watch authority document is not exact canonical JSON"
+        )
+    if tuple(value) != tuple(sorted(fields)) or value.get("schema_version") != schema:
+        raise LocalWatchAuthorityError("Local Watch authority fields or schema differ")
+    return value
+
+
+def _embedded(record: object) -> dict[str, object]:
+    return json.loads(record.canonical_bytes)
+
+
+def _supplemental_bytes(reentry: SupplementalDiscoveryReentry) -> bytes:
+    if type(reentry) is not SupplementalDiscoveryReentry:
+        raise LocalWatchAuthorityError("supplemental discovery re-entry differs")
+    return canonical_json_bytes(reentry.canonical_value())
+
+
+_REENTRY_FIELDS = (
+    "schema_version",
+    "reentry_id",
+    "watch_id",
+    "watch_version_id",
+    "watch_version_digest",
+    "closure_digest",
+    "reentry_kind",
+    "supplemental_reentry",
+    "supplemental_reentry_digest",
+    "actor_identity_digest",
+    "recorded_at",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class LocalWatchReentry(_NoEffect):
+    reentry_id: str
+    watch_id: str
+    watch_version_id: str
+    watch_version_digest: str
+    closure_digest: str
+    reentry_kind: LocalWatchReentryKind
+    supplemental_reentry: SupplementalDiscoveryReentry
+    supplemental_reentry_digest: str
+    actor_identity_digest: str
+    recorded_at: str
+
+    @property
+    def schema_version(self) -> str:
+        return LOCAL_WATCH_REENTRY
+
+    def __post_init__(self) -> None:
+        for field in ("reentry_id", "watch_id", "watch_version_id"):
+            _uuid(getattr(self, field), field)
+        for field in (
+            "watch_version_digest",
+            "closure_digest",
+            "supplemental_reentry_digest",
+            "actor_identity_digest",
+        ):
+            _digest(getattr(self, field), field)
+        object.__setattr__(
+            self,
+            "reentry_kind",
+            _enum(LocalWatchReentryKind, self.reentry_kind, "reentry_kind"),
+        )
+        expected = digest_bytes(_supplemental_bytes(self.supplemental_reentry))
+        if self.supplemental_reentry_digest != expected:
+            raise LocalWatchAuthorityError(
+                "supplemental discovery re-entry digest differs"
+            )
+        _timestamp(self.recorded_at, "recorded_at")
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return canonical_json_bytes(
+            {
+                "actor_identity_digest": self.actor_identity_digest,
+                "closure_digest": self.closure_digest,
+                "recorded_at": self.recorded_at,
+                "reentry_id": self.reentry_id,
+                "reentry_kind": self.reentry_kind.value,
+                "schema_version": self.schema_version,
+                "supplemental_reentry": self.supplemental_reentry.canonical_value(),
+                "supplemental_reentry_digest": self.supplemental_reentry_digest,
+                "watch_id": self.watch_id,
+                "watch_version_digest": self.watch_version_digest,
+                "watch_version_id": self.watch_version_id,
+            }
+        )
+
+    @property
+    def digest(self) -> str:
+        return digest_bytes(self.canonical_bytes)
+
+    @classmethod
+    def from_canonical_bytes(cls, raw: bytes) -> Self:
+        value = _document(raw, LOCAL_WATCH_REENTRY, _REENTRY_FIELDS)
+        if type(value["supplemental_reentry"]) is not dict:
+            raise LocalWatchAuthorityError("supplemental discovery re-entry differs")
+        try:
+            value["supplemental_reentry"] = SupplementalDiscoveryReentry.from_value(
+                value["supplemental_reentry"]
+            )
+        except Exception as exc:
+            raise LocalWatchAuthorityError(
+                "supplemental discovery re-entry differs"
+            ) from exc
+        value.pop("schema_version")
+        result = cls(**value)  # type: ignore[arg-type]
+        if result.canonical_bytes != raw:
+            raise LocalWatchAuthorityError("Local Watch Re-entry replay differs")
+        return result
+
+
+_COMMAND_FIELDS = (
+    "schema_version",
+    "command_id",
+    "action",
+    "watch",
+    "version",
+    "closure",
+    "reentry",
+    "expected_head_version_digest",
+    "request_id",
+    "actor_identity_digest",
+    "idempotency_key",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class LocalWatchCommand(_NoEffect):
+    command_id: str
+    action: LocalWatchAction
+    watch: EventScopedLocalWatch
+    version: LocalWatchVersion
+    closure: LocalWatchClosure | None
+    reentry: LocalWatchReentry | None
+    expected_head_version_digest: str | None
+    request_id: str
+    actor_identity_digest: str
+    idempotency_key: str
+
+    @property
+    def schema_version(self) -> str:
+        return LOCAL_WATCH_COMMAND
+
+    def __post_init__(self) -> None:
+        _uuid(self.command_id, "command_id")
+        _uuid(self.request_id, "request_id")
+        object.__setattr__(
+            self, "action", _enum(LocalWatchAction, self.action, "action")
+        )
+        if (
+            type(self.watch) is not EventScopedLocalWatch
+            or type(self.version) is not LocalWatchVersion
+        ):
+            raise LocalWatchAuthorityError("Local Watch command records differ")
+        _digest(self.actor_identity_digest, "actor_identity_digest")
+        _token(self.idempotency_key, "idempotency_key")
+        if self.expected_head_version_digest is not None:
+            _digest(
+                self.expected_head_version_digest,
+                "expected_head_version_digest",
+            )
+        if (
+            self.version.watch_id != self.watch.watch_id
+            or self.version.watch_digest != self.watch.canonical_digest
+            or self.version.actor_identity_digest != self.actor_identity_digest
+        ):
+            raise LocalWatchAuthorityError("Local Watch command binding differs")
+        if self.action is LocalWatchAction.CREATE:
+            if (
+                self.version.version_ordinal != 1
+                or self.version.previous_version_digest is not None
+                or self.expected_head_version_digest is not None
+                or self.closure is not None
+                or self.reentry is not None
+            ):
+                raise LocalWatchAuthorityError("Local Watch CREATE shape differs")
+            validate_local_watch_version_chain(self.watch, (self.version,))
+        elif self.action is LocalWatchAction.APPEND_VERSION:
+            if (
+                self.version.version_ordinal <= 1
+                or self.version.previous_version_digest
+                != self.expected_head_version_digest
+                or self.closure is not None
+                or self.reentry is not None
+            ):
+                raise LocalWatchAuthorityError(
+                    "Local Watch APPEND_VERSION shape differs"
+                )
+        else:
+            if (
+                self.expected_head_version_digest != self.version.canonical_digest
+                or type(self.closure) is not LocalWatchClosure
+                or (
+                    self.reentry is not None
+                    and type(self.reentry) is not LocalWatchReentry
+                )
+            ):
+                raise LocalWatchAuthorityError("Local Watch CLOSE shape differs")
+            validate_local_watch_closure(self.watch, self.version, self.closure)
+            if (
+                self.closure.actor_identity_digest != self.actor_identity_digest
+                or self.closure.recorded_at < self.version.recorded_at
+            ):
+                raise LocalWatchAuthorityError(
+                    "Local Watch closure actor or chronology differs"
+                )
+            if self.reentry is not None and (
+                self.reentry.watch_id != self.watch.watch_id
+                or self.reentry.watch_version_id != self.version.watch_version_id
+                or self.reentry.watch_version_digest != self.version.canonical_digest
+                or self.reentry.closure_digest != self.closure.canonical_digest
+                or self.reentry.actor_identity_digest != self.actor_identity_digest
+                or self.reentry.recorded_at < self.closure.recorded_at
+            ):
+                raise LocalWatchAuthorityError("Local Watch Re-entry binding differs")
+            if (
+                self.closure.outcome is LocalWatchClosureOutcome.CONVERSION_PROPOSED
+                and self.reentry is not None
+            ):
+                raise LocalWatchAuthorityError(
+                    "conversion proposal cannot be a supplemental re-entry"
+                )
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return canonical_json_bytes(
+            {
+                "action": self.action.value,
+                "actor_identity_digest": self.actor_identity_digest,
+                "closure": None if self.closure is None else _embedded(self.closure),
+                "command_id": self.command_id,
+                "expected_head_version_digest": self.expected_head_version_digest,
+                "idempotency_key": self.idempotency_key,
+                "reentry": None if self.reentry is None else _embedded(self.reentry),
+                "request_id": self.request_id,
+                "schema_version": self.schema_version,
+                "version": _embedded(self.version),
+                "watch": _embedded(self.watch),
+            }
+        )
+
+    @property
+    def digest(self) -> str:
+        return digest_bytes(self.canonical_bytes)
+
+    @classmethod
+    def from_canonical_bytes(cls, raw: bytes) -> Self:
+        value = _document(raw, LOCAL_WATCH_COMMAND, _COMMAND_FIELDS)
+        for field, kind in (
+            ("watch", EventScopedLocalWatch),
+            ("version", LocalWatchVersion),
+        ):
+            if type(value[field]) is not dict:
+                raise LocalWatchAuthorityError(f"{field} differs")
+            value[field] = kind.from_bytes(canonical_json_bytes(value[field]))
+        for field, kind in (
+            ("closure", LocalWatchClosure),
+            ("reentry", LocalWatchReentry),
+        ):
+            if value[field] is not None:
+                if type(value[field]) is not dict:
+                    raise LocalWatchAuthorityError(f"{field} differs")
+                parser = (
+                    kind.from_bytes
+                    if kind is LocalWatchClosure
+                    else kind.from_canonical_bytes
+                )
+                value[field] = parser(canonical_json_bytes(value[field]))
+        value.pop("schema_version")
+        result = cls(**value)  # type: ignore[arg-type]
+        if result.canonical_bytes != raw:
+            raise LocalWatchAuthorityError("Local Watch Command replay differs")
+        return result
+
+
+@dataclass(frozen=True, slots=True)
+class LocalWatchSnapshot(_NoEffect):
+    watch: EventScopedLocalWatch
+    versions: tuple[LocalWatchVersion, ...]
+    closure: LocalWatchClosure | None
+    reentry: LocalWatchReentry | None
+
+    @property
+    def current_version(self) -> LocalWatchVersion:
+        return self.versions[-1]
+
+    @property
+    def closed(self) -> bool:
+        return self.closure is not None
+
+
+def validate_local_watch_command(
+    command: LocalWatchCommand,
+    *,
+    existing_versions: tuple[LocalWatchVersion, ...] = (),
+    conversion_proposal: LocalityCoverageProposal | None = None,
+) -> None:
+    if type(command) is not LocalWatchCommand or type(existing_versions) is not tuple:
+        raise LocalWatchAuthorityError("Local Watch validation input differs")
+    if command.action is LocalWatchAction.CREATE:
+        if existing_versions:
+            raise LocalWatchAuthorityError("Local Watch CREATE already exists")
+        validate_local_watch_version_chain(command.watch, (command.version,))
+    elif command.action is LocalWatchAction.APPEND_VERSION:
+        validate_local_watch_version_chain(
+            command.watch, (*existing_versions, command.version)
+        )
+        if (
+            not existing_versions
+            or command.expected_head_version_digest
+            != existing_versions[-1].canonical_digest
+        ):
+            raise LocalWatchAuthorityError("Local Watch version CAS differs")
+    else:
+        if (
+            not existing_versions
+            or command.version != existing_versions[-1]
+            or command.expected_head_version_digest
+            != existing_versions[-1].canonical_digest
+        ):
+            raise LocalWatchAuthorityError("Local Watch closure CAS differs")
+        validate_local_watch_closure(
+            command.watch,
+            command.version,
+            command.closure,  # type: ignore[arg-type]
+        )
+    closure = command.closure
+    if (
+        closure is not None
+        and closure.outcome is LocalWatchClosureOutcome.CONVERSION_PROPOSED
+    ):
+        if (
+            type(conversion_proposal) is not LocalityCoverageProposal
+            or conversion_proposal.digest != closure.locality_coverage_proposal_digest
+        ):
+            raise LocalWatchAuthorityError(
+                "conversion requires the exact separate Locality Coverage Proposal"
+            )
+    elif conversion_proposal is not None:
+        raise LocalWatchAuthorityError("unexpected Locality Coverage Proposal")
+
+
+_TOKEN_PORT = object()
+
+
+class LocalWatchReadPort(_NoEffect):
+    __slots__ = ("_connection",)
+
+    def __init__(self, token: object, connection: sqlite3.Connection) -> None:
+        if token is not _TOKEN_PORT:
+            raise LocalWatchAuthorityError(
+                "Local Watch read port construction is private"
+            )
+        object.__setattr__(self, "_connection", connection)
+
+    def __setattr__(self, name: str, value: object) -> None:
+        raise AttributeError("LocalWatchReadPort is immutable")
+
+    def _snapshot(self, function, *args):
+        owns = not self._connection.in_transaction
+        if owns:
+            self._connection.execute("BEGIN")
+        try:
+            result = function(*args)
+        except BaseException:
+            if owns and self._connection.in_transaction:
+                self._connection.execute("ROLLBACK")
+            raise
+        if owns:
+            self._connection.execute("COMMIT")
+        return result
+
+    def _load(self, watch_id: str) -> LocalWatchSnapshot:
+        row = self._connection.execute(
+            "SELECT watch_bytes,watch_digest,subject_kind,subject_id,subject_version_digest,"
+            "owner_identity_digest,created_at FROM event_scoped_local_watches WHERE watch_id=?",
+            (watch_id,),
+        ).fetchone()
+        if row is None:
+            raise LocalWatchAuthorityError("Event-Scoped Local Watch is absent")
+        watch = EventScopedLocalWatch.from_bytes(bytes(row[0]))
+        version_rows = self._connection.execute(
+            "SELECT watch_version_id,version_ordinal,previous_version_digest,version_bytes,"
+            "version_digest,status,starts_at,review_at,expires_at,command_bytes,command_digest,"
+            "command_id,request_id,actor_identity_digest,idempotency_key,recorded_at "
+            "FROM event_scoped_local_watch_versions WHERE watch_id=? ORDER BY version_ordinal",
+            (watch_id,),
+        ).fetchall()
+        versions: list[LocalWatchVersion] = []
+        for item in version_rows:
+            version = LocalWatchVersion.from_bytes(bytes(item[3]))
+            command = LocalWatchCommand.from_canonical_bytes(bytes(item[9]))
+            if (
+                version.watch_version_id != item[0]
+                or version.version_ordinal != item[1]
+                or version.previous_version_digest != item[2]
+                or version.canonical_digest != item[4]
+                or version.status.value != item[5]
+                or version.starts_at != item[6]
+                or version.review_at != item[7]
+                or version.expires_at != item[8]
+                or command.digest != item[10]
+                or command.command_id != item[11]
+                or command.request_id != item[12]
+                or command.actor_identity_digest != item[13]
+                or command.idempotency_key != item[14]
+                or version.recorded_at != item[15]
+                or command.watch != watch
+                or command.version != version
+            ):
+                raise LocalWatchAuthorityError(
+                    "Local Watch Version retained representation differs"
+                )
+            versions.append(version)
+        chain = validate_local_watch_version_chain(watch, tuple(versions))
+        head = self._connection.execute(
+            "SELECT current_version_id,current_version_digest,current_version_ordinal,"
+            "closed,closure_digest,updated_at FROM event_scoped_local_watch_heads WHERE watch_id=?",
+            (watch_id,),
+        ).fetchone()
+        if head is None or (
+            watch.canonical_digest != row[1]
+            or watch.subject_kind.value != row[2]
+            or watch.subject_id != row[3]
+            or watch.subject_version_digest != row[4]
+            or watch.owner_identity_digest != row[5]
+            or watch.created_at != row[6]
+            or head[0] != chain[-1].watch_version_id
+            or head[1] != chain[-1].canonical_digest
+            or head[2] != chain[-1].version_ordinal
+        ):
+            raise LocalWatchAuthorityError(
+                "Local Watch retained representation differs"
+            )
+        closure_row = self._connection.execute(
+            "SELECT closure_bytes,closure_digest,watch_version_id,watch_version_digest,"
+            "outcome,effective_at,locality_coverage_proposal_digest,reentry_bytes,"
+            "reentry_digest,reentry_id,command_bytes,command_digest,command_id,request_id,"
+            "actor_identity_digest,idempotency_key,recorded_at "
+            "FROM event_scoped_local_watch_closures WHERE watch_id=?",
+            (watch_id,),
+        ).fetchone()
+        closure = None
+        reentry = None
+        if closure_row is not None:
+            closure = LocalWatchClosure.from_bytes(bytes(closure_row[0]))
+            command = LocalWatchCommand.from_canonical_bytes(bytes(closure_row[10]))
+            reentry = (
+                None
+                if closure_row[7] is None
+                else LocalWatchReentry.from_canonical_bytes(bytes(closure_row[7]))
+            )
+            validate_local_watch_closure(watch, chain[-1], closure)
+            if (
+                closure.canonical_digest != closure_row[1]
+                or closure.watch_version_id != closure_row[2]
+                or closure.watch_version_digest != closure_row[3]
+                or closure.outcome.value != closure_row[4]
+                or closure.effective_at != closure_row[5]
+                or closure.locality_coverage_proposal_digest != closure_row[6]
+                or (None if reentry is None else reentry.digest) != closure_row[8]
+                or (None if reentry is None else reentry.reentry_id) != closure_row[9]
+                or command.digest != closure_row[11]
+                or command.command_id != closure_row[12]
+                or command.request_id != closure_row[13]
+                or command.actor_identity_digest != closure_row[14]
+                or command.idempotency_key != closure_row[15]
+                or closure.recorded_at != closure_row[16]
+                or command.watch != watch
+                or command.version != chain[-1]
+                or command.closure != closure
+                or command.reentry != reentry
+            ):
+                raise LocalWatchAuthorityError(
+                    "Local Watch Closure retained representation differs"
+                )
+        if (
+            bool(head[3]) is not (closure is not None)
+            or head[4] != (None if closure is None else closure.canonical_digest)
+            or head[5]
+            != (chain[-1].recorded_at if closure is None else closure.recorded_at)
+        ):
+            raise LocalWatchAuthorityError("Local Watch head differs")
+        return LocalWatchSnapshot(watch, chain, closure, reentry)
+
+    @_total("Local Watch replay failed")
+    def load(self, watch_id: str) -> LocalWatchSnapshot:
+        _uuid(watch_id, "watch_id")
+        return self._snapshot(self._load, watch_id)
+
+    @_total("Local Watch command replay failed")
+    def command(self, command_id: str) -> LocalWatchCommand:
+        _uuid(command_id, "command_id")
+
+        def read() -> LocalWatchCommand:
+            rows = self._connection.execute(
+                "SELECT command_bytes FROM event_scoped_local_watch_versions WHERE command_id=? "
+                "UNION ALL SELECT command_bytes FROM event_scoped_local_watch_closures WHERE command_id=?",
+                (command_id, command_id),
+            ).fetchall()
+            if len(rows) != 1:
+                raise LocalWatchAuthorityError(
+                    "Local Watch Command is absent or ambiguous"
+                )
+            command = LocalWatchCommand.from_canonical_bytes(bytes(rows[0][0]))
+            self._load(command.watch.watch_id)
+            return command
+
+        return self._snapshot(read)
+
+
+class LocalWatchAuthority(LocalWatchReadPort):
+    """Transactional v29 writer with exact replay, CAS and terminal closure."""
+
+    __slots__ = ()
+
+    def _matching_replay(self, command: LocalWatchCommand) -> bytes | None:
+        rows = self._connection.execute(
+            "SELECT command_bytes FROM event_scoped_local_watch_versions "
+            "WHERE command_id=? OR request_id=? OR idempotency_key=? "
+            "UNION ALL SELECT command_bytes FROM event_scoped_local_watch_closures "
+            "WHERE command_id=? OR request_id=? OR idempotency_key=?",
+            (
+                command.command_id,
+                command.request_id,
+                command.idempotency_key,
+                command.command_id,
+                command.request_id,
+                command.idempotency_key,
+            ),
+        ).fetchall()
+        if not rows:
+            return None
+        if len(rows) != 1 or bytes(rows[0][0]) != command.canonical_bytes:
+            raise LocalWatchAuthorityError("Local Watch Command identity collision")
+        return bytes(rows[0][0])
+
+    def _insert_version(self, command: LocalWatchCommand) -> None:
+        version = command.version
+        self._connection.execute(
+            "INSERT INTO event_scoped_local_watch_versions VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+            (
+                version.watch_version_id,
+                version.watch_id,
+                version.version_ordinal,
+                version.previous_version_digest,
+                version.canonical_bytes,
+                version.canonical_digest,
+                version.status.value,
+                version.starts_at,
+                version.review_at,
+                version.expires_at,
+                command.canonical_bytes,
+                command.digest,
+                command.command_id,
+                command.request_id,
+                command.actor_identity_digest,
+                command.idempotency_key,
+                version.recorded_at,
+            ),
+        )
+
+    @_total("Local Watch command failed")
+    def record(
+        self,
+        raw: bytes,
+        *,
+        conversion_proposal: LocalityCoverageProposal | None = None,
+    ) -> LocalWatchSnapshot:
+        command = LocalWatchCommand.from_canonical_bytes(raw)
+        self._connection.execute("BEGIN IMMEDIATE")
+        try:
+            replay = self._matching_replay(command)
+            if replay is not None:
+                snapshot = self._load(command.watch.watch_id)
+                existing = (
+                    ()
+                    if command.action is LocalWatchAction.CREATE
+                    else snapshot.versions[:-1]
+                    if command.action is LocalWatchAction.APPEND_VERSION
+                    else snapshot.versions
+                )
+                validate_local_watch_command(
+                    command,
+                    existing_versions=existing,
+                    conversion_proposal=conversion_proposal,
+                )
+                self._connection.execute("COMMIT")
+                return snapshot
+            if command.action is LocalWatchAction.CREATE:
+                validate_local_watch_command(
+                    command, conversion_proposal=conversion_proposal
+                )
+                self._connection.execute(
+                    "INSERT INTO event_scoped_local_watches VALUES(?,?,?,?,?,?,?,?)",
+                    (
+                        command.watch.watch_id,
+                        command.watch.canonical_bytes,
+                        command.watch.canonical_digest,
+                        command.watch.subject_kind.value,
+                        command.watch.subject_id,
+                        command.watch.subject_version_digest,
+                        command.watch.owner_identity_digest,
+                        command.watch.created_at,
+                    ),
+                )
+                self._insert_version(command)
+                self._connection.execute(
+                    "INSERT INTO event_scoped_local_watch_heads VALUES(?,?,?,?,?,?,?)",
+                    (
+                        command.watch.watch_id,
+                        command.version.watch_version_id,
+                        command.version.canonical_digest,
+                        1,
+                        0,
+                        None,
+                        command.version.recorded_at,
+                    ),
+                )
+            else:
+                snapshot = self._load(command.watch.watch_id)
+                if snapshot.closed:
+                    raise LocalWatchAuthorityError("Local Watch lifecycle is terminal")
+                if command.watch != snapshot.watch:
+                    raise LocalWatchAuthorityError(
+                        "Local Watch immutable identity differs"
+                    )
+                validate_local_watch_command(
+                    command,
+                    existing_versions=snapshot.versions,
+                    conversion_proposal=conversion_proposal,
+                )
+                if command.action is LocalWatchAction.APPEND_VERSION:
+                    self._insert_version(command)
+                    self._connection.execute(
+                        "UPDATE event_scoped_local_watch_heads SET current_version_id=?,"
+                        "current_version_digest=?,current_version_ordinal=?,updated_at=? "
+                        "WHERE watch_id=?",
+                        (
+                            command.version.watch_version_id,
+                            command.version.canonical_digest,
+                            command.version.version_ordinal,
+                            command.version.recorded_at,
+                            command.watch.watch_id,
+                        ),
+                    )
+                else:
+                    assert command.closure is not None
+                    self._connection.execute(
+                        "INSERT INTO event_scoped_local_watch_closures VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                        (
+                            command.closure.closure_id,
+                            command.watch.watch_id,
+                            command.version.watch_version_id,
+                            command.version.canonical_digest,
+                            command.closure.canonical_bytes,
+                            command.closure.canonical_digest,
+                            command.closure.outcome.value,
+                            command.closure.effective_at,
+                            command.closure.locality_coverage_proposal_digest,
+                            None
+                            if command.reentry is None
+                            else command.reentry.canonical_bytes,
+                            None if command.reentry is None else command.reentry.digest,
+                            None
+                            if command.reentry is None
+                            else command.reentry.reentry_id,
+                            command.canonical_bytes,
+                            command.digest,
+                            command.command_id,
+                            command.request_id,
+                            command.actor_identity_digest,
+                            command.idempotency_key,
+                            command.closure.recorded_at,
+                        ),
+                    )
+                    self._connection.execute(
+                        "UPDATE event_scoped_local_watch_heads SET closed=1,"
+                        "closure_digest=?,updated_at=? WHERE watch_id=?",
+                        (
+                            command.closure.canonical_digest,
+                            command.closure.recorded_at,
+                            command.watch.watch_id,
+                        ),
+                    )
+            retained = self._load(command.watch.watch_id)
+            self._connection.execute("COMMIT")
+            return retained
+        except BaseException:
+            if self._connection.in_transaction:
+                self._connection.execute("ROLLBACK")
+            raise
+
+    def read_port(self) -> LocalWatchReadPort:
+        return LocalWatchReadPort(_TOKEN_PORT, self._connection)
+
+    def close(self) -> None:
+        self._connection.close()
+
+
+@_total("Local Watch authority open failed")
+def open_local_watch_authority(
+    path: str | Path,
+    *,
+    applied_at: str,
+    timeout_seconds: float = 5.0,
+) -> LocalWatchAuthority:
+    _timestamp(applied_at, "applied_at")
+    database = Path(path)
+    existed = database.exists() and database.stat().st_size > 0
+    connection = sqlite3.connect(
+        database,
+        isolation_level=None,
+        timeout=timeout_seconds,
+        check_same_thread=False,
+    )
+    try:
+        connection.execute("PRAGMA foreign_keys=ON")
+        connection.execute("PRAGMA busy_timeout=5000")
+        connection.execute("PRAGMA journal_mode=WAL")
+        if existed:
+            prepare_pending_migration_backup(connection)
+        apply_pending_migrations(connection, applied_at=applied_at)
+        if connection.execute("PRAGMA user_version").fetchone()[0] != SCHEMA_VERSION:
+            raise LocalWatchAuthorityError("checked v29 schema differs")
+        return LocalWatchAuthority(_TOKEN_PORT, connection)
+    except BaseException:
+        connection.close()
+        raise
+
+
+__all__ = [
+    "LOCAL_WATCH_AUTHORITY",
+    "LOCAL_WATCH_COMMAND",
+    "LOCAL_WATCH_REENTRY",
+    "LOCAL_WATCH_REENTRY_AUTHORITY",
+    "LocalWatchAction",
+    "LocalWatchAuthority",
+    "LocalWatchAuthorityError",
+    "LocalWatchCommand",
+    "LocalWatchReadPort",
+    "LocalWatchReentry",
+    "LocalWatchReentryKind",
+    "LocalWatchSnapshot",
+    "open_local_watch_authority",
+    "validate_local_watch_command",
+]

--- a/newsroom/tests/authority_migration_compatibility.py
+++ b/newsroom/tests/authority_migration_compatibility.py
@@ -188,6 +188,11 @@ PINNED_MIGRATION_HISTORY: tuple[HistoryRow, ...] = (
         "coverage_audit_authority_v28",
         "sha256:c923daf18aed10bb9c197bfd588d816223d978668bda56c157438d1a4b7cc487",
     ),
+    (
+        29,
+        "event_scoped_local_watch_authority_v29",
+        "sha256:ca57c62c9bfadc2ea0a09a3bf762f95854e413aa71d324a296b4c867c90dec7b",
+    ),
 )
 
 

--- a/newsroom/tests/graphiti_adapter_4d_migration_helpers.py
+++ b/newsroom/tests/graphiti_adapter_4d_migration_helpers.py
@@ -34,6 +34,72 @@ from newsroom.authority.triage_work_item_migrations import (
 )
 
 
+def drop_empty_v29_local_watch_schema(connection: sqlite3.Connection) -> None:
+    """Remove the exact empty v29 Local Watch suffix atomically."""
+    savepoint = "checked_local_watch_downgrade"
+    connection.execute(f"SAVEPOINT {savepoint}")
+    try:
+        _drop_empty_v29_local_watch_schema(connection)
+    except Exception:
+        connection.execute(f"ROLLBACK TO SAVEPOINT {savepoint}")
+        connection.execute(f"RELEASE SAVEPOINT {savepoint}")
+        raise
+    connection.execute(f"RELEASE SAVEPOINT {savepoint}")
+
+
+def _drop_empty_v29_local_watch_schema(connection: sqlite3.Connection) -> None:
+    if int(connection.execute("PRAGMA user_version").fetchone()[0]) == 29:
+        from newsroom.authority.local_watch_migrations import (
+            LOCAL_WATCH_MIGRATION_CHECKSUM,
+            LOCAL_WATCH_MIGRATION_NAME,
+            LOCAL_WATCH_MIGRATION_STATEMENTS,
+        )
+
+        def normalise_local_watch_sql(value: str) -> str:
+            return " ".join(value.split()).replace(" IF NOT EXISTS", "")
+
+        local_watch_tables = (
+            "event_scoped_local_watches",
+            "event_scoped_local_watch_versions",
+            "event_scoped_local_watch_heads",
+            "event_scoped_local_watch_closures",
+        )
+        placeholders = ",".join("?" for _ in local_watch_tables)
+        objects = connection.execute(
+            f"SELECT type,name,sql FROM sqlite_master WHERE tbl_name IN ({placeholders}) "
+            "AND type IN ('table','trigger','index') AND sql IS NOT NULL",
+            local_watch_tables,
+        ).fetchall()
+        if connection.execute(
+            "SELECT name,checksum FROM authority_migrations WHERE version=29"
+        ).fetchone() != (
+            LOCAL_WATCH_MIGRATION_NAME,
+            LOCAL_WATCH_MIGRATION_CHECKSUM,
+        ) or {normalise_local_watch_sql(str(row[2])) for row in objects} != {
+            normalise_local_watch_sql(statement)
+            for statement in LOCAL_WATCH_MIGRATION_STATEMENTS
+        }:
+            raise sqlite3.DatabaseError(
+                "downgrade requires exact empty v29 Local Watch schema"
+            )
+        for table in local_watch_tables:
+            if connection.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone() != (0,):
+                raise sqlite3.DatabaseError("v29 Local Watch tables must be empty")
+        guard = connection.execute(
+            "SELECT sql FROM sqlite_master WHERE type='trigger' "
+            "AND name='immutable_authority_migrations_delete'"
+        ).fetchone()[0]
+        connection.execute("DROP TRIGGER immutable_authority_migrations_delete")
+        for object_type, name, _ in objects:
+            if object_type == "trigger":
+                connection.execute(f'DROP TRIGGER "{name}"')
+        for table in reversed(local_watch_tables):
+            connection.execute(f'DROP TABLE "{table}"')
+        connection.execute("DELETE FROM authority_migrations WHERE version=29")
+        connection.execute(guard)
+        connection.execute("PRAGMA user_version=28")
+
+
 def drop_empty_v28_coverage_schema(connection: sqlite3.Connection) -> None:
     """Remove the exact empty v28 Coverage Audit suffix atomically."""
     savepoint = "checked_coverage_audit_downgrade"
@@ -48,6 +114,7 @@ def drop_empty_v28_coverage_schema(connection: sqlite3.Connection) -> None:
 
 
 def _drop_empty_v28_coverage_schema(connection: sqlite3.Connection) -> None:
+    _drop_empty_v29_local_watch_schema(connection)
     if int(connection.execute("PRAGMA user_version").fetchone()[0]) == 28:
         from newsroom.authority.coverage_audit_migrations import (
             COVERAGE_AUDIT_MIGRATION_CHECKSUM,

--- a/newsroom/tests/test_authority_migration_compatibility.py
+++ b/newsroom/tests/test_authority_migration_compatibility.py
@@ -48,6 +48,7 @@ _EXPECTED_NAMES = {
     26: "planned_agenda_authority_v26",
     27: "bounded_search_authority_v27",
     28: "coverage_audit_authority_v28",
+    29: "event_scoped_local_watch_authority_v29",
 }
 _EXPECTED_CHECKSUMS = {
     13: "sha256:c3e5ae627dda1c04bebc50952786413d977bd399e67b7f5b87452794f08f49ab",
@@ -66,6 +67,7 @@ _EXPECTED_CHECKSUMS = {
     26: "sha256:55e6e8878140714dc6fc6c8149357e1f15e4683fcb7ee0b31b168a737bfd3d4c",
     27: "sha256:ee5679aba6ceb3e95ba925febbbb7853369f93d055563ac85402d380377672b0",
     28: "sha256:c923daf18aed10bb9c197bfd588d816223d978668bda56c157438d1a4b7cc487",
+    29: "sha256:ca57c62c9bfadc2ea0a09a3bf762f95854e413aa71d324a296b4c867c90dec7b",
 }
 
 _EXPECTED_MATRIX = """version | migration | objects | history fingerprint | schema fingerprint | object fingerprint
@@ -86,6 +88,7 @@ v25 | evaluation_feedback_authority_v25 | 1253 | sha256:bea793377d065d3073e6dfa8
 v26 | planned_agenda_authority_v26 | 1285 | sha256:d2cb21a981674513b4495ca19012e49b93c8dc30cbe61165b5462c391f989004 | sha256:9c4d5b94b10b34d3b9ef2f140dbfbcc85b2c01fb6d8660879403a21fef701374 | sha256:0724fb8b7796f7581123d17658613baf488090dfcc7d5320f9dd804364d5a542
 v27 | bounded_search_authority_v27 | 1347 | sha256:f4afb25765da01175b272333daaaef80b21416d9258a5ec4e09ffba59f878936 | sha256:d7fc1557bd02588969efdd53c749a2f125ab5bab146395c4cf8f7d51b1e32719 | sha256:ebd8c2d5739a09103f526fa682dadf66efa7646304b25f266265b91b70e55cbd
 v28 | coverage_audit_authority_v28 | 1381 | sha256:81792dba56950b37325ccdffe06b64f322379218a10264e949d57e7e0dec58d6 | sha256:a613b28a765b36fa9110bcdc2b9bc565c6e2bc0ed8b8381d77f5fcd734c39c48 | sha256:a8330e1d8ae8c9e181f0e2d1ebbde88a1386e934e93eaac3c3d292722c7fff35
+v29 | event_scoped_local_watch_authority_v29 | 1417 | sha256:02e531a9279e316e7f131beabfef5b2f5d02f6b825b7312f4c6296028ffee4ff | sha256:68194825ecc7c429b283204dbc1332a43481e04ca2681fcbf75886a984ea6f55 | sha256:75fc30052c67d91d4a439a3baadc6c3410f65d470d535906a0624d051a0f32cd
 """
 
 

--- a/newsroom/tests/test_increment6d3_lineage_store.py
+++ b/newsroom/tests/test_increment6d3_lineage_store.py
@@ -402,6 +402,7 @@ def test_v22_to_v23_preserves_retained_relationship_before_lineage_use(
     from newsroom.authority.evaluation_feedback_migrations import (
         evaluation_feedback_backup_paths,
     )
+    from newsroom.authority.local_watch_migrations import local_watch_backup_paths
     from newsroom.authority.planned_agenda_migrations import (
         planned_agenda_backup_paths,
     )
@@ -414,9 +415,11 @@ def test_v22_to_v23_preserves_retained_relationship_before_lineage_use(
         path.unlink(missing_ok=True)
     for path in coverage_audit_backup_paths(seed[1]):
         path.unlink(missing_ok=True)
+    for path in local_watch_backup_paths(seed[1]):
+        path.unlink(missing_ok=True)
     assert prepare_pending_migration_backup(connection) is not None
     apply_pending_migrations(connection, applied_at="2042-01-03T00:00:00.000000Z")
-    assert connection.execute("PRAGMA user_version").fetchone() == (28,)
+    assert connection.execute("PRAGMA user_version").fetchone() == (29,)
     assert (
         connection.execute(
             "SELECT * FROM event_hypothesis_relationship_decisions ORDER BY decision_id"
@@ -1442,10 +1445,10 @@ class _LineageAdapter:
                 apply_pending_migrations(
                     connection, applied_at="2042-01-03T00:00:00.000000Z"
                 )
-                assert connection.execute("PRAGMA user_version").fetchone() == (28,)
+                assert connection.execute("PRAGMA user_version").fetchone() == (29,)
                 assert connection.execute(
                     "SELECT MAX(version) FROM authority_migrations"
-                ).fetchone() == (28,)
+                ).fetchone() == (29,)
             finally:
                 connection.close()
         return _ConformanceHandle(location)

--- a/newsroom/tests/test_increment6e2_candidate_authority.py
+++ b/newsroom/tests/test_increment6e2_candidate_authority.py
@@ -83,7 +83,9 @@ def test_v24_allocates_only_exact_candidate_tables(tmp_path: Path) -> None:
     migrations.apply_pending_migrations(
         connection, applied_at="2042-01-01T00:00:00.000000Z"
     )
-    assert connection.execute("PRAGMA user_version").fetchone() == (migrations.SCHEMA_VERSION,)
+    assert connection.execute("PRAGMA user_version").fetchone() == (
+        migrations.SCHEMA_VERSION,
+    )
     assert connection.execute(
         "SELECT name FROM authority_migrations WHERE version=24"
     ).fetchone() == (STORY_CANDIDATE_MIGRATION_NAME,)
@@ -156,7 +158,7 @@ def test_v24_downgrade_preflight_is_non_mutating(tmp_path: Path, failure: str) -
             ("sha256:" + "f" * 64,),
         )
     else:
-        connection.execute("PRAGMA user_version=29")
+        connection.execute("PRAGMA user_version=30")
     damaged = (
         connection.execute("PRAGMA user_version").fetchone(),
         tuple(connection.iterdump()),

--- a/newsroom/tests/test_increment7_head_migration_ownership.py
+++ b/newsroom/tests/test_increment7_head_migration_ownership.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 import sqlite3
+from pathlib import Path
 
 import pytest
 
@@ -222,10 +222,10 @@ def test_reserved_additive_schema_suffix_is_checked(
     monkeypatch.setattr(
         authority_migrations,
         "EXPECTED_MIGRATION_HISTORY",
-        authority_migrations.EXPECTED_MIGRATION_HISTORY[:-2]
+        authority_migrations.EXPECTED_MIGRATION_HISTORY[:-3]
         + (
             (27, "wrong_v27", checksum),
-            authority_migrations.EXPECTED_MIGRATION_HISTORY[-1],
+            *authority_migrations.EXPECTED_MIGRATION_HISTORY[-2:],
         ),
     )
     assert any(

--- a/newsroom/tests/test_increment7a2_exact_immutable_read_port.py
+++ b/newsroom/tests/test_increment7a2_exact_immutable_read_port.py
@@ -269,14 +269,14 @@ def test_v26_fresh_create_history_fingerprint_and_integrity() -> None:
     connection = sqlite3.connect(":memory:", isolation_level=None)
     connection.execute("PRAGMA foreign_keys=ON")
     apply_pending_migrations(connection, applied_at=_AT)
-    assert SCHEMA_VERSION == 28
+    assert SCHEMA_VERSION == 29
     assert PLANNED_AGENDA_SCHEMA_VERSION == 26
     assert EXPECTED_MIGRATION_HISTORY[25] == (
         26,
         PLANNED_AGENDA_MIGRATION_NAME,
         PLANNED_AGENDA_MIGRATION_CHECKSUM,
     )
-    assert connection.execute("PRAGMA user_version").fetchone() == (28,)
+    assert connection.execute("PRAGMA user_version").fetchone() == (29,)
     assert schema_fingerprint(connection) == EXPECTED_SCHEMA_FINGERPRINT
     assert connection.execute("PRAGMA foreign_key_check").fetchall() == []
     assert connection.execute("PRAGMA quick_check").fetchone() == ("ok",)
@@ -314,7 +314,7 @@ def test_v25_upgrade_requires_and_retains_exact_backup(tmp_path: Path) -> None:
     authority.close()
     checked = sqlite3.connect(older_database)
     try:
-        assert checked.execute("PRAGMA user_version").fetchone() == (28,)
+        assert checked.execute("PRAGMA user_version").fetchone() == (29,)
     finally:
         checked.close()
 
@@ -478,27 +478,23 @@ def test_explicit_miss_then_late_occurrence_is_retained_and_terminal() -> None:
             ).canonical_bytes
         )
 
-    immutable_version = authority._connection.execute(  # noqa: SLF001
+    immutable_version = authority._connection.execute(
         "SELECT sql FROM sqlite_master WHERE name='immutable_planned_agenda_versions'"
     ).fetchone()[0]
-    authority._connection.execute(  # noqa: SLF001 - pre-fix retained-row fixture
-        "DROP TRIGGER immutable_planned_agenda_versions"
-    )
-    authority._connection.execute(  # noqa: SLF001 - pre-fix retained-row fixture
+    authority._connection.execute("DROP TRIGGER immutable_planned_agenda_versions")
+    authority._connection.execute(
         "UPDATE planned_agenda_versions SET recorded_at=? WHERE agenda_version_id=?",
         ("2026-08-13T00:00:00.000000Z", version.agenda_version_id),
     )
-    authority._connection.execute(immutable_version)  # noqa: SLF001
+    authority._connection.execute(immutable_version)
     with pytest.raises(AgendaAuthorityError, match="Version replay differs"):
         authority.read_port().versions(item.agenda_item_id)
-    authority._connection.execute(  # noqa: SLF001 - restore retained fixture
-        "DROP TRIGGER immutable_planned_agenda_versions"
-    )
-    authority._connection.execute(  # noqa: SLF001 - restore retained fixture
+    authority._connection.execute("DROP TRIGGER immutable_planned_agenda_versions")
+    authority._connection.execute(
         "UPDATE planned_agenda_versions SET recorded_at=? WHERE agenda_version_id=?",
         (version.recorded_at, version.agenda_version_id),
     )
-    authority._connection.execute(immutable_version)  # noqa: SLF001
+    authority._connection.execute(immutable_version)
 
     retained_invalid = replace(
         further,
@@ -511,7 +507,7 @@ def test_explicit_miss_then_late_occurrence_is_retained_and_terminal() -> None:
         current_version=version,
         previous_resolution=late,
     )
-    authority._insert_resolution(  # noqa: SLF001 - pre-fix retained-row fixture
+    authority._insert_resolution(
         retained_invalid,
         retained_command,
     )
@@ -520,14 +516,12 @@ def test_explicit_miss_then_late_occurrence_is_retained_and_terminal() -> None:
         agenda_version_id=_id(9_999),
         agenda_version_digest="sha256:" + "9" * 64,
     )
-    immutable_resolution = authority._connection.execute(  # noqa: SLF001
+    immutable_resolution = authority._connection.execute(
         "SELECT sql FROM sqlite_master "
         "WHERE name='immutable_planned_agenda_resolutions'"
     ).fetchone()[0]
-    authority._connection.execute(  # noqa: SLF001 - pre-fix retained-row fixture
-        "DROP TRIGGER immutable_planned_agenda_resolutions"
-    )
-    authority._connection.execute(  # noqa: SLF001 - pre-fix retained-row fixture
+    authority._connection.execute("DROP TRIGGER immutable_planned_agenda_resolutions")
+    authority._connection.execute(
         "UPDATE planned_agenda_resolutions SET resolution_bytes=?,resolution_digest=? "
         "WHERE resolution_id=?",
         (
@@ -536,8 +530,8 @@ def test_explicit_miss_then_late_occurrence_is_retained_and_terminal() -> None:
             retained_invalid.resolution_id,
         ),
     )
-    authority._connection.execute(immutable_resolution)  # noqa: SLF001
-    authority._connection.execute(  # noqa: SLF001 - pre-fix retained-row fixture
+    authority._connection.execute(immutable_resolution)
+    authority._connection.execute(
         "UPDATE planned_agenda_heads SET current_resolution_digest=?,"
         "current_resolution_ordinal=? WHERE agenda_item_id=?",
         (forged_payload.digest, 3, item.agenda_item_id),
@@ -746,13 +740,13 @@ def test_retained_rows_reject_direct_mutation_and_delete(tmp_path: Path) -> None
     authority = open_planned_agenda_authority(database, applied_at=_AT)
     item, _, _, _ = _create(authority)
     with pytest.raises(sqlite3.DatabaseError):
-        authority._connection.execute(  # noqa: SLF001 - adversarial fixture proof
+        authority._connection.execute(
             "UPDATE planned_agenda_items SET stable_subject_key='tampered' "
             "WHERE agenda_item_id=?",
             (item.agenda_item_id,),
         )
     with pytest.raises(sqlite3.DatabaseError):
-        authority._connection.execute(  # noqa: SLF001 - adversarial fixture proof
+        authority._connection.execute(
             "DELETE FROM planned_agenda_versions WHERE agenda_item_id=?",
             (item.agenda_item_id,),
         )

--- a/newsroom/tests/test_increment7b2_budget_privacy_authority.py
+++ b/newsroom/tests/test_increment7b2_budget_privacy_authority.py
@@ -233,9 +233,9 @@ def test_v27_fresh_history_fingerprint_integrity_and_reserved_tables() -> None:
     connection = sqlite3.connect(":memory:", isolation_level=None)
     connection.execute("PRAGMA foreign_keys=ON")
     apply_pending_migrations(connection, applied_at=_AT)
-    assert SCHEMA_VERSION == 28
+    assert SCHEMA_VERSION == 29
     assert BOUNDED_SEARCH_SCHEMA_VERSION == 27
-    assert EXPECTED_MIGRATION_HISTORY[-2] == (
+    assert EXPECTED_MIGRATION_HISTORY[-3] == (
         27,
         BOUNDED_SEARCH_MIGRATION_NAME,
         BOUNDED_SEARCH_MIGRATION_CHECKSUM,
@@ -285,7 +285,7 @@ def test_v26_upgrade_requires_exact_backup_and_rolls_back_atomically(
     assert schema_fingerprint(connection) == BOUNDED_SEARCH_PREDECESSOR_FINGERPRINT
     monkeypatch.setattr(migrations, "BOUNDED_SEARCH_MIGRATION_STATEMENTS", statements)
     apply_pending_migrations(connection, applied_at=_AT)
-    assert connection.execute("PRAGMA user_version").fetchone() == (28,)
+    assert connection.execute("PRAGMA user_version").fetchone() == (29,)
     restored = sqlite3.connect(f"file:{backup}?mode=ro", uri=True)
     try:
         assert restored.execute("PRAGMA user_version").fetchone() == (26,)
@@ -595,9 +595,7 @@ def test_attempt_concurrency_reconciles_outcome_interval_before_cas(
         limits=replace(_request(purpose).limits, max_concurrent_attempts=1),
     )
     first = _attempt(request)
-    outcome = replace(
-        _outcome(first), completed_at="2026-08-14T00:00:05.000000Z"
-    )
+    outcome = replace(_outcome(first), completed_at="2026-08-14T00:00:05.000000Z")
     authority.record_purpose(purpose.canonical_bytes)
     authority.record_request(request.canonical_bytes)
     authority.record_attempt(first.canonical_bytes)
@@ -677,8 +675,7 @@ def test_result_admission_reconciles_retained_rank_columns(tmp_path: Path) -> No
     try:
         attacker.execute("DROP TRIGGER immutable_search_result_references")
         attacker.execute(
-            "UPDATE search_result_references SET rank=2 "
-            "WHERE result_reference_id=?",
+            "UPDATE search_result_references SET rank=2 WHERE result_reference_id=?",
             (first.result_reference_id,),
         )
         second = _result(attempt, outcome, 88)
@@ -754,9 +751,7 @@ def test_root_identity_inventories_block_deleted_purpose_and_request_replacement
     tmp_path: Path,
 ) -> None:
     purpose_database = tmp_path / "purpose-inventory.sqlite3"
-    purpose_authority = open_bounded_search_authority(
-        purpose_database, applied_at=_AT
-    )
+    purpose_authority = open_bounded_search_authority(purpose_database, applied_at=_AT)
     purpose = _purpose()
     purpose_authority.record_purpose(purpose.canonical_bytes)
     attacker = sqlite3.connect(purpose_database, isolation_level=None)
@@ -773,9 +768,7 @@ def test_root_identity_inventories_block_deleted_purpose_and_request_replacement
         purpose_authority.close()
 
     request_database = tmp_path / "request-inventory.sqlite3"
-    request_authority = open_bounded_search_authority(
-        request_database, applied_at=_AT
-    )
+    request_authority = open_bounded_search_authority(request_database, applied_at=_AT)
     purpose = _purpose()
     request = _request(purpose)
     request_authority.record_purpose(purpose.canonical_bytes)

--- a/newsroom/tests/test_increment7c2_coverage_audit_authority.py
+++ b/newsroom/tests/test_increment7c2_coverage_audit_authority.py
@@ -55,6 +55,9 @@ from newsroom.increment7.coverage_authority import (
     validate_coverage_command,
 )
 from newsroom.increment7.search import SearchReviewAction, SearchReviewDecision
+from newsroom.tests.graphiti_adapter_4d_migration_helpers import (
+    drop_empty_v29_local_watch_schema,
+)
 from newsroom.tests.test_increment7b1_gross_request_privacy import (
     _attempt,
     _outcome,
@@ -332,9 +335,10 @@ def test_v28_fresh_create_history_fingerprint_and_reserved_tables() -> None:
             "SELECT name FROM sqlite_master WHERE type='table'"
         )
     }
-    assert SCHEMA_VERSION == COVERAGE_AUDIT_SCHEMA_VERSION == 28
-    assert EXPECTED_MIGRATION_HISTORY[-1][1] == COVERAGE_AUDIT_MIGRATION_NAME
-    assert connection.execute("PRAGMA user_version").fetchone()[0] == 28
+    assert SCHEMA_VERSION == 29
+    assert COVERAGE_AUDIT_SCHEMA_VERSION == 28
+    assert EXPECTED_MIGRATION_HISTORY[-2][1] == COVERAGE_AUDIT_MIGRATION_NAME
+    assert connection.execute("PRAGMA user_version").fetchone()[0] == 29
     assert schema_fingerprint(connection) == EXPECTED_SCHEMA_FINGERPRINT
     assert {
         "coverage_audits",
@@ -352,6 +356,7 @@ def _create_v27(path) -> sqlite3.Connection:
     apply_pending_migrations(connection, applied_at=_APPLIED)
     connection.execute("PRAGMA foreign_keys=OFF")
     connection.execute("BEGIN EXCLUSIVE")
+    drop_empty_v29_local_watch_schema(connection)
     immutable = connection.execute(
         "SELECT sql FROM sqlite_master "
         "WHERE name='immutable_authority_migrations_delete'"
@@ -405,7 +410,7 @@ def test_v27_upgrade_requires_exact_backup_and_preserves_restore_point(
     )
     monkeypatch.setattr(migrations, "COVERAGE_AUDIT_MIGRATION_STATEMENTS", statements)
     apply_pending_migrations(connection, applied_at=_APPLIED)
-    assert connection.execute("PRAGMA user_version").fetchone()[0] == 28
+    assert connection.execute("PRAGMA user_version").fetchone()[0] == 29
 
     restored = sqlite3.connect(backup, isolation_level=None)
     try:

--- a/newsroom/tests/test_increment7d2_local_watch_authority.py
+++ b/newsroom/tests/test_increment7d2_local_watch_authority.py
@@ -1,0 +1,466 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+import uuid
+from dataclasses import replace
+
+import pytest
+
+from newsroom.authority.canonical import canonical_json_bytes, digest_bytes
+from newsroom.authority.local_watch_migrations import (
+    LOCAL_WATCH_MIGRATION_NAME,
+    LOCAL_WATCH_SCHEMA_VERSION,
+    LocalWatchBackupError,
+    local_watch_backup_paths,
+    prepare_local_watch_backup,
+)
+from newsroom.authority.migrations import (
+    EXPECTED_MIGRATION_HISTORY,
+    EXPECTED_SCHEMA_FINGERPRINT,
+    SCHEMA_VERSION,
+    apply_pending_migrations,
+    schema_fingerprint,
+)
+from newsroom.increment7.local_watch import (
+    LocalWatchClosureOutcome,
+    LocalWatchVersionStatus,
+)
+from newsroom.increment7.local_watch_authority import (
+    LOCAL_WATCH_AUTHORITY,
+    LOCAL_WATCH_COMMAND,
+    LOCAL_WATCH_REENTRY,
+    LOCAL_WATCH_REENTRY_AUTHORITY,
+    LocalWatchAction,
+    LocalWatchAuthorityError,
+    LocalWatchCommand,
+    LocalWatchReadPort,
+    LocalWatchReentry,
+    LocalWatchReentryKind,
+    open_local_watch_authority,
+)
+from newsroom.tests.test_increment6f2_feedback import _supplemental_reentry
+from newsroom.tests.test_increment7d1_local_watch_contracts import (
+    D,
+    _closure,
+    _version,
+    _watch,
+)
+from newsroom.tests.test_increment7e2_locality_no_activation import (
+    _chain as _locality_chain,
+)
+
+_APPLIED = "2042-01-01T00:00:00.000000Z"
+_ACTOR = D("b")
+
+
+def _id(value: int) -> str:
+    return str(uuid.UUID(int=value, version=4))
+
+
+def _create_command(value: int = 100) -> LocalWatchCommand:
+    watch = _watch()
+    version = _version(watch)
+    return LocalWatchCommand(
+        command_id=_id(value),
+        action=LocalWatchAction.CREATE,
+        watch=watch,
+        version=version,
+        closure=None,
+        reentry=None,
+        expected_head_version_digest=None,
+        request_id=_id(value + 1),
+        actor_identity_digest=_ACTOR,
+        idempotency_key=f"local-watch:create:{value}",
+    )
+
+
+def _append_command(
+    create: LocalWatchCommand | None = None,
+    value: int = 200,
+) -> LocalWatchCommand:
+    create = create or _create_command()
+    first = create.version
+    version = replace(
+        first,
+        watch_version_id=_id(value + 2),
+        version_ordinal=2,
+        previous_version_digest=first.canonical_digest,
+        status=LocalWatchVersionStatus.EXTENDED,
+        review_at="2042-01-03T00:00:00.000000Z",
+        expires_at="2042-01-04T00:00:00.000000Z",
+        change_reason="Owner-approved bounded extension.",
+        recorded_at="2042-01-01T00:02:00.000000Z",
+    )
+    return LocalWatchCommand(
+        command_id=_id(value),
+        action=LocalWatchAction.APPEND_VERSION,
+        watch=create.watch,
+        version=version,
+        closure=None,
+        reentry=None,
+        expected_head_version_digest=first.canonical_digest,
+        request_id=_id(value + 1),
+        actor_identity_digest=_ACTOR,
+        idempotency_key=f"local-watch:append:{value}",
+    )
+
+
+def _close_command(
+    append: LocalWatchCommand | None = None,
+    *,
+    value: int = 300,
+    with_reentry: bool = True,
+    conversion: bool = False,
+) -> LocalWatchCommand:
+    append = append or _append_command()
+    closure = _closure(
+        append.version,
+        closure_id=_id(value + 2),
+        outcome=(
+            LocalWatchClosureOutcome.CONVERSION_PROPOSED
+            if conversion
+            else LocalWatchClosureOutcome.EXPIRED
+        ),
+        effective_at=(
+            "2042-01-03T12:00:00.000000Z" if conversion else append.version.expires_at
+        ),
+        locality_coverage_proposal_digest=(
+            _locality_chain()[2].digest if conversion else None
+        ),
+        recorded_at="2042-01-04T00:01:00.000000Z",
+    )
+    reentry = None
+    if with_reentry:
+        supplemental = _supplemental_reentry()
+        reentry = LocalWatchReentry(
+            reentry_id=_id(value + 3),
+            watch_id=append.watch.watch_id,
+            watch_version_id=append.version.watch_version_id,
+            watch_version_digest=append.version.canonical_digest,
+            closure_digest=closure.canonical_digest,
+            reentry_kind=LocalWatchReentryKind.EXPIRY,
+            supplemental_reentry=supplemental,
+            supplemental_reentry_digest=digest_bytes(
+                canonical_json_bytes(supplemental.canonical_value())
+            ),
+            actor_identity_digest=_ACTOR,
+            recorded_at="2042-01-04T00:02:00.000000Z",
+        )
+    return LocalWatchCommand(
+        command_id=_id(value),
+        action=LocalWatchAction.CLOSE,
+        watch=append.watch,
+        version=append.version,
+        closure=closure,
+        reentry=reentry,
+        expected_head_version_digest=append.version.canonical_digest,
+        request_id=_id(value + 1),
+        actor_identity_digest=_ACTOR,
+        idempotency_key=f"local-watch:close:{value}",
+    )
+
+
+def test_command_and_reentry_are_strict_exact_governed_contracts() -> None:
+    command = _close_command()
+    assert LocalWatchCommand.from_canonical_bytes(command.canonical_bytes) == command
+    assert (
+        LocalWatchReentry.from_canonical_bytes(
+            command.reentry.canonical_bytes  # type: ignore[union-attr]
+        )
+        == command.reentry
+    )
+    pretty = json.dumps(json.loads(command.canonical_bytes), indent=2).encode()
+    with pytest.raises(LocalWatchAuthorityError, match="exact canonical JSON"):
+        LocalWatchCommand.from_canonical_bytes(pretty)
+    duplicate = command.canonical_bytes.replace(
+        b'"command_id":',
+        b'"command_id":"' + _id(999).encode() + b'","command_id":',
+        1,
+    )
+    with pytest.raises(LocalWatchAuthorityError, match="duplicate object name"):
+        LocalWatchCommand.from_canonical_bytes(duplicate)
+    unknown = json.loads(command.canonical_bytes)
+    unknown["activate_locality"] = False
+    with pytest.raises(LocalWatchAuthorityError, match="fields or schema"):
+        LocalWatchCommand.from_canonical_bytes(canonical_json_bytes(unknown))
+    with pytest.raises(LocalWatchAuthorityError, match="digest differs"):
+        replace(
+            command.reentry,
+            supplemental_reentry_digest=D("0"),
+        )
+
+
+def test_v29_fresh_create_has_exact_history_schema_and_allocated_tables() -> None:
+    connection = sqlite3.connect(":memory:", isolation_level=None)
+    connection.execute("PRAGMA foreign_keys=ON")
+    apply_pending_migrations(connection, applied_at=_APPLIED)
+    tables = {
+        row[0]
+        for row in connection.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        )
+    }
+    assert SCHEMA_VERSION == LOCAL_WATCH_SCHEMA_VERSION == 29
+    assert EXPECTED_MIGRATION_HISTORY[-1][1] == LOCAL_WATCH_MIGRATION_NAME
+    assert connection.execute("PRAGMA user_version").fetchone()[0] == 29
+    assert schema_fingerprint(connection) == EXPECTED_SCHEMA_FINGERPRINT
+    assert {
+        "event_scoped_local_watches",
+        "event_scoped_local_watch_versions",
+        "event_scoped_local_watch_heads",
+        "event_scoped_local_watch_closures",
+    } <= tables
+    assert connection.execute("PRAGMA foreign_key_check").fetchall() == []
+    assert connection.execute("PRAGMA quick_check").fetchone()[0] == "ok"
+
+
+def _create_v28(path) -> sqlite3.Connection:
+    connection = sqlite3.connect(path, isolation_level=None)
+    connection.execute("PRAGMA foreign_keys=ON")
+    apply_pending_migrations(connection, applied_at=_APPLIED)
+    connection.execute("PRAGMA foreign_keys=OFF")
+    connection.execute("BEGIN EXCLUSIVE")
+    immutable = connection.execute(
+        "SELECT sql FROM sqlite_master "
+        "WHERE name='immutable_authority_migrations_delete'"
+    ).fetchone()[0]
+    connection.execute("DROP TRIGGER immutable_authority_migrations_delete")
+    for table in (
+        "event_scoped_local_watch_closures",
+        "event_scoped_local_watch_heads",
+        "event_scoped_local_watch_versions",
+        "event_scoped_local_watches",
+    ):
+        for (name,) in connection.execute(
+            "SELECT name FROM sqlite_master WHERE type='trigger' AND tbl_name=?",
+            (table,),
+        ).fetchall():
+            connection.execute(f'DROP TRIGGER "{name}"')
+        connection.execute(f"DROP TABLE {table}")
+    connection.execute("DELETE FROM authority_migrations WHERE version=29")
+    connection.execute(immutable)
+    connection.execute("PRAGMA user_version=28")
+    connection.execute("COMMIT")
+    connection.execute("PRAGMA foreign_keys=ON")
+    return connection
+
+
+def test_v28_upgrade_requires_backup_rolls_back_and_preserves_restore_point(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database = tmp_path / "authority.sqlite3"
+    connection = _create_v28(database)
+    with pytest.raises(LocalWatchBackupError, match="requires prepared backup"):
+        apply_pending_migrations(connection, applied_at=_APPLIED)
+    backup, digest_path = local_watch_backup_paths(database)
+    receipt = prepare_local_watch_backup(connection, backup)
+    assert receipt.backup_path == backup
+    assert digest_path.is_file()
+    from newsroom.authority import migrations
+
+    statements = migrations.LOCAL_WATCH_MIGRATION_STATEMENTS
+    monkeypatch.setattr(
+        migrations,
+        "LOCAL_WATCH_MIGRATION_STATEMENTS",
+        (statements[0], "CREATE TABLE deliberate_failure("),
+    )
+    with pytest.raises(sqlite3.OperationalError):
+        apply_pending_migrations(connection, applied_at=_APPLIED)
+    assert connection.execute("PRAGMA user_version").fetchone()[0] == 28
+    assert schema_fingerprint(connection) == (
+        "sha256:a613b28a765b36fa9110bcdc2b9bc565c6e2bc0ed8b8381d77f5fcd734c39c48"
+    )
+    monkeypatch.setattr(migrations, "LOCAL_WATCH_MIGRATION_STATEMENTS", statements)
+    apply_pending_migrations(connection, applied_at=_APPLIED)
+    assert connection.execute("PRAGMA user_version").fetchone()[0] == 29
+    restored = sqlite3.connect(backup, isolation_level=None)
+    try:
+        assert restored.execute("PRAGMA user_version").fetchone()[0] == 28
+        assert restored.execute("PRAGMA quick_check").fetchone()[0] == "ok"
+    finally:
+        restored.close()
+
+
+def test_checked_lifecycle_replays_restarts_expires_and_governed_reenters(
+    tmp_path,
+) -> None:
+    path = tmp_path / "watch.sqlite3"
+    create = _create_command()
+    append = _append_command(create)
+    close = _close_command(append)
+    authority = open_local_watch_authority(path, applied_at=_APPLIED)
+    first = authority.record(create.canonical_bytes)
+    assert first.current_version == create.version
+    assert first.closed is False
+    assert authority.record(create.canonical_bytes) == first
+    second = authority.record(append.canonical_bytes)
+    assert second.versions == (create.version, append.version)
+    assert second.closed is False
+    final = authority.record(close.canonical_bytes)
+    assert final.closure == close.closure
+    assert final.reentry == close.reentry
+    assert final.closed is True
+    assert authority.record(close.canonical_bytes) == final
+    port = authority.read_port()
+    assert type(port) is LocalWatchReadPort
+    assert port.command(create.command_id) == create
+    assert port.command(append.command_id) == append
+    assert port.command(close.command_id) == close
+    authority.close()
+    reopened = open_local_watch_authority(path, applied_at=_APPLIED)
+    assert reopened.load(create.watch.watch_id) == final
+    reopened.close()
+
+
+def test_expiry_has_no_clock_effect_and_cas_terminal_boundaries_fail_closed(
+    tmp_path,
+) -> None:
+    path = tmp_path / "watch.sqlite3"
+    create = _create_command()
+    append = _append_command(create)
+    authority = open_local_watch_authority(path, applied_at=_APPLIED)
+    assert authority.record(create.canonical_bytes).closed is False
+    # The declared 2042 expiry is data; opening/loading does not close or re-enter.
+    assert authority.load(create.watch.watch_id).closed is False
+    authority.record(append.canonical_bytes)
+    stale = replace(
+        append,
+        command_id=_id(500),
+        request_id=_id(501),
+        idempotency_key="local-watch:stale",
+        version=replace(append.version, watch_version_id=_id(502)),
+    )
+    with pytest.raises(LocalWatchAuthorityError, match="command failed"):
+        authority.record(stale.canonical_bytes)
+    close = _close_command(append)
+    authority.record(close.canonical_bytes)
+    third_version = replace(
+        append.version,
+        watch_version_id=_id(503),
+        version_ordinal=3,
+        previous_version_digest=append.version.canonical_digest,
+        recorded_at="2042-01-01T00:03:00.000000Z",
+    )
+    third = replace(
+        append,
+        command_id=_id(504),
+        request_id=_id(505),
+        idempotency_key="local-watch:after-close",
+        version=third_version,
+        expected_head_version_digest=append.version.canonical_digest,
+    )
+    with pytest.raises(LocalWatchAuthorityError, match="terminal"):
+        authority.record(third.canonical_bytes)
+    authority.close()
+
+
+def test_conversion_closure_requires_exact_separate_proposal_and_no_reentry(
+    tmp_path,
+) -> None:
+    path = tmp_path / "watch.sqlite3"
+    create = _create_command()
+    append = _append_command(create)
+    conversion = _close_command(
+        append,
+        value=600,
+        with_reentry=False,
+        conversion=True,
+    )
+    proposal = _locality_chain()[2]
+    authority = open_local_watch_authority(path, applied_at=_APPLIED)
+    authority.record(create.canonical_bytes)
+    authority.record(append.canonical_bytes)
+    with pytest.raises(LocalWatchAuthorityError, match="exact separate"):
+        authority.record(conversion.canonical_bytes)
+    final = authority.record(
+        conversion.canonical_bytes,
+        conversion_proposal=proposal,
+    )
+    assert final.closure == conversion.closure
+    assert final.reentry is None
+    with pytest.raises(LocalWatchAuthorityError, match="supplemental re-entry"):
+        replace(
+            conversion,
+            reentry=replace(
+                _close_command(append).reentry,
+                closure_digest=conversion.closure.canonical_digest,
+            ),
+        )
+    authority.close()
+
+
+def test_restart_detects_retained_tamper_with_restored_trigger(tmp_path) -> None:
+    path = tmp_path / "watch.sqlite3"
+    command = _create_command()
+    authority = open_local_watch_authority(path, applied_at=_APPLIED)
+    authority.record(command.canonical_bytes)
+    authority.close()
+    attacker = sqlite3.connect(path, isolation_level=None)
+    trigger = attacker.execute(
+        "SELECT sql FROM sqlite_master "
+        "WHERE name='immutable_event_scoped_local_watch_versions'"
+    ).fetchone()[0]
+    attacker.execute("DROP TRIGGER immutable_event_scoped_local_watch_versions")
+    attacker.execute(
+        "UPDATE event_scoped_local_watch_versions SET status='PAUSED' WHERE watch_id=?",
+        (command.watch.watch_id,),
+    )
+    attacker.execute(trigger)
+    attacker.close()
+    reopened = open_local_watch_authority(path, applied_at=_APPLIED)
+    with pytest.raises(LocalWatchAuthorityError, match="retained representation"):
+        reopened.load(command.watch.watch_id)
+    reopened.close()
+
+
+def test_competing_identical_creates_converge_to_one_retained_watch(tmp_path) -> None:
+    path = tmp_path / "watch.sqlite3"
+    command = _create_command()
+    authorities = [
+        open_local_watch_authority(path, applied_at=_APPLIED) for _ in range(2)
+    ]
+    barrier = threading.Barrier(2)
+    results: list[str] = []
+
+    def writer(authority) -> None:
+        barrier.wait()
+        results.append(
+            authority.record(command.canonical_bytes).current_version.canonical_digest
+        )
+        authority.close()
+
+    threads = [threading.Thread(target=writer, args=(item,)) for item in authorities]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=20)
+    assert results == [command.version.canonical_digest] * 2
+    connection = sqlite3.connect(path)
+    assert (
+        connection.execute(
+            "SELECT COUNT(*) FROM event_scoped_local_watches"
+        ).fetchone()[0]
+        == 1
+    )
+    assert connection.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+    connection.close()
+
+
+def test_allocated_schemas_authority_and_non_effects_are_exact() -> None:
+    assert LOCAL_WATCH_COMMAND == "newsroom.increment7.local-watch-command.v1"
+    assert LOCAL_WATCH_REENTRY == "newsroom.increment7.local-watch-reentry.v1"
+    assert LOCAL_WATCH_AUTHORITY == "CHECKED_SQLITE_TRANSACTIONAL_V29"
+    assert LOCAL_WATCH_REENTRY_AUTHORITY.endswith("GOVERNED_LINEAGE_ONLY")
+    command = _close_command()
+    for value in (command, command.reentry):
+        assert value.authorises_external_effect is False
+        assert value.authorises_source_access is False
+        assert value.authorises_egress is False
+        assert value.authorises_spend is False
+        assert value.authorises_evidence is False
+        assert value.authorises_publication is False
+        assert value.creates_candidate is False
+        assert value.production_activation_authorised is False


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: 7d2
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

## Summary
- add checked SQLite v29 Event-Scoped Local Watch persistence with immutable identity/version/closure records and CAS head progression
- retain explicit expiry/closure and bounded conversion proposal references without clock-triggered or locality-selection effects
- bind optional re-entry to the exact closure and the existing Increment 6 `SupplementalDiscoveryReentry` governed lineage
- extend exact predecessor backup, rollback, migration compatibility and retained-prefix fixtures through v29

## Evidence
- `9 passed` — focused 7D2 authority, migration, replay, concurrency, tamper and re-entry suite
- `110 passed` — complete Increment 7 test set
- `64 passed` — migration compatibility matrix
- `138 passed` — affected authority/migration compatibility set
- `270 passed` — extended Increment 7, D3, future-version and migration set (one initial stale pre-v29 backup fixture repaired; targeted rerun passed)
- exact source-integrity check passed on `origin/main..346e924`

## Non-effects
Fixture/replay authority only. Expiry has no autonomous clock effect; re-entry must already be exact Increment 6 governed lineage; conversion records only a separate proposal. No source access, recurring schedule, locality selection, provider, credential, egress, spend, evidence acquisition, Candidate, publication or production effect.

Closes #445
