### PR TITLE
Correct Increment 8A evaluation authority

### DIFF
--- a/docs/plans/2026-08-14-015-increment-8a-corrective-evaluation-authority.md
+++ b/docs/plans/2026-08-14-015-increment-8a-corrective-evaluation-authority.md
@@ -1,9 +1,9 @@
 # Increment 8A corrective evaluation authority
 
-Issue: #463  
-Parent: #148  
-Dependency: corrected 8R contract #462  
-Accepted base: `main@f90604e27ad6a7a522bee452755c0c79662b6054`  
+Issue: #463
+Parent: #148
+Dependency: corrected 8R contract #462
+Accepted base: `main@f90604e27ad6a7a522bee452755c0c79662b6054`
 Accepted tree: `742772a16110aa508fc2ccf76d3a47a541a74e43`
 
 ## Change contract

--- a/docs/plans/2026-08-14-015-increment-8a-corrective-evaluation-authority.md
+++ b/docs/plans/2026-08-14-015-increment-8a-corrective-evaluation-authority.md
@@ -1,0 +1,50 @@
+# Increment 8A corrective evaluation authority
+
+Issue: #463  
+Parent: #148  
+Dependency: corrected 8R contract #462  
+Accepted base: `main@f90604e27ad6a7a522bee452755c0c79662b6054`  
+Accepted tree: `742772a16110aa508fc2ccf76d3a47a541a74e43`
+
+## Change contract
+
+The v30 tables remain additive and unchanged. This correction strengthens the
+canonical records and their authority checks without collecting evaluation
+results or granting qualification, shadow, provider, network, spend,
+publication or production authority.
+
+The protected invariants are:
+
+1. an Evaluation Plan retains the exact authorised-human identity and role
+   manifest, including at least two primary reviewers and one adjudicator;
+2. Plan approval precedes Epoch freeze/open, which precedes Run start, Case
+   cutoff, labels, adjudication and the release decision;
+3. every qualification Case retains the frozen membership facts and the exact
+   required-slice and Case-stratum memberships deterministically derived from
+   the corrected 8R manifest;
+4. each Run contains distinct input-manifest identities, so repeated copies of
+   one event cannot satisfy the 120-Case exposure;
+5. the authority accepts only transaction-free SQLite connections whose
+   foreign-key enforcement is already active, and owns every write
+   transaction without committing caller work;
+6. each reviewable Case has at most one label per role, every identity is
+   authorised for that human role, and every disagreement requires retained
+   adjudication by an independent authorised adjudicator;
+7. mandatory blocker, Urgent and zero-tolerance second reviews do not count
+   towards the separate 20 per cent ordinary-Case sample;
+8. a PASS candidate requires all nine exact slices, all three exposure strata,
+   non-vacuous reviewed evidence and the frozen distinct-reviewer minimum;
+9. the release decision embeds a canonical Metric Report, derives its gate
+   values from that retained report, and binds the complete Case, label and
+   adjudication evidence-manifest digest;
+10. recording any release decision seals its Run against later Cases, labels
+    and adjudications.
+
+## Observable finish
+
+- Direct regressions cover all eleven retained P1 bypasses from PR #470.
+- The complete valid fixture exposure reaches the corrective readiness
+  blockade; it does not persist PASS while later atoms remain incomplete.
+- The full Increment 8 focused suite passes.
+- One canonical PR closes #463 only. #464-#468, #428, Increment 9 and all live
+  effects remain outside this change.

--- a/newsroom/increment8/evaluation.py
+++ b/newsroom/increment8/evaluation.py
@@ -281,140 +281,33 @@ def _verified_metric_report(
 ) -> tuple[Mapping[str, object], str, Mapping[str, str]]:
     if not isinstance(raw, bytes):
         raise EvaluationAuthorityError("Metric Report must be canonical bytes")
-    try:
-        document = json.loads(raw.decode("utf-8", errors="strict"))
-    except (UnicodeError, json.JSONDecodeError) as exc:
-        raise EvaluationAuthorityError("Metric Report is not canonical JSON") from exc
-    if canonical_json_bytes(document) != raw or not isinstance(document, dict):
-        raise EvaluationAuthorityError("Metric Report is not canonical JSON")
-    if (
-        set(document) != {"schema_version", "payload"}
-        or document["schema_version"] != "newsroom.increment8.metric-report.v1"
-    ):
-        raise EvaluationAuthorityError("Metric Report envelope differs")
-    payload = document["payload"]
-    required = {
-        "run_id",
-        "run_digest",
-        "readiness_digest",
-        "case_count",
-        "minimum_case_count",
-        "coverage_scope",
-        "rates",
-        "performance",
-        "required_slices",
-        "zero_tolerance_digest",
-        "source_contribution_digests",
-        "ablation_digests",
-        "metric_code_digest",
-        "environment_digest",
-        "sampling_manifest_digest",
-        "label_manifest_digest",
-        "deviation_digests",
-        "metric_status",
-        "performance_status",
-        "slice_status",
-        "zero_tolerance_status",
-        "overall_status",
-        "ablation_is_decision_bearing",
-        "production_activation_authorised",
-        "live_shadow_execution_authorised",
-    }
-    if not isinstance(payload, dict) or set(payload) != required:
-        raise EvaluationAuthorityError("Metric Report fields differ")
-    if payload["run_id"] != run.run_id or payload["run_digest"] != run.digest:
-        raise EvaluationAuthorityError("Metric Report Run binding differs")
-    allowed_statuses = {"PASS", "FAIL", "NOT_EVALUATED"}
-    summary: dict[str, str] = {}
-    for field in (
-        "metric_status",
-        "performance_status",
-        "slice_status",
-        "zero_tolerance_status",
-        "overall_status",
-    ):
-        value = payload[field]
-        if value not in allowed_statuses:
-            raise EvaluationAuthorityError("Metric Report status differs")
-        summary[field] = str(value)
-    minimum_cases = int(
-        INCREMENT_8_READINESS.evaluation_plan["qualification_exposure"][  # type: ignore[index]
-            "minimum_completed_cases"
-        ]
+    from newsroom.increment8.metrics import (
+        MetricReportError,
+        verify_metric_report_canonical_bytes,
     )
-    case_count = payload["case_count"]
-    if (
-        isinstance(case_count, bool)
-        or not isinstance(case_count, int)
-        or case_count < 0
-        or payload["minimum_case_count"] != minimum_cases
-        or payload["readiness_digest"] != INCREMENT_8_READINESS_DIGEST
-        or payload["coverage_scope"]
-        != "REVIEWED_PROSPECTIVE_UNIVERSE_ONLY_NOT_ABSOLUTE_RECALL"
-    ):
-        raise EvaluationAuthorityError("Metric Report frozen boundary differs")
-    for field in (
-        "zero_tolerance_digest",
-        "metric_code_digest",
-        "environment_digest",
-        "sampling_manifest_digest",
-        "label_manifest_digest",
-    ):
-        _digest(payload[field], f"Metric Report {field}")
-    for field in (
-        "rates",
-        "performance",
-        "required_slices",
-        "source_contribution_digests",
-        "ablation_digests",
-        "deviation_digests",
-    ):
-        values = payload[field]
-        if not isinstance(values, list):
-            raise EvaluationAuthorityError("Metric Report inventory differs")
-        checked = tuple(_digest(item, f"Metric Report {field}") for item in values)
-        if len(checked) != len(set(checked)) or (
-            field == "deviation_digests" and checked != tuple(sorted(checked))
-        ):
-            raise EvaluationAuthorityError("Metric Report inventory differs")
-    if not all(
-        payload[field]
-        for field in (
-            "rates",
-            "performance",
-            "required_slices",
-            "source_contribution_digests",
-            "ablation_digests",
-        )
-    ):
-        raise EvaluationAuthorityError("Metric Report inventory is incomplete")
-    if payload["zero_tolerance_status"] == "FAIL":
-        derived_overall = "FAIL"
-    elif case_count < minimum_cases or payload["slice_status"] == "NOT_EVALUATED":
-        derived_overall = "NOT_EVALUATED"
-    elif all(
-        payload[field] == "PASS"
-        for field in (
-            "metric_status",
-            "performance_status",
-            "slice_status",
-            "zero_tolerance_status",
-        )
-    ):
-        derived_overall = "PASS"
-    else:
-        derived_overall = "FAIL"
-    if payload["overall_status"] != derived_overall:
+
+    try:
+        report = verify_metric_report_canonical_bytes(raw)
+    except MetricReportError as exc:
         raise EvaluationAuthorityError(
-            "Metric Report status is internally inconsistent"
-        )
-    if (
-        payload["ablation_is_decision_bearing"] is not False
-        or payload["production_activation_authorised"] is not False
-        or payload["live_shadow_execution_authorised"] is not False
-    ):
-        raise EvaluationAuthorityError("Metric Report authority boundary differs")
-    return MappingProxyType(document), digest_bytes(raw), MappingProxyType(summary)
+            "Metric Report failed canonical reconstruction"
+        ) from exc
+    if report.run_id != run.run_id or report.payload["run_digest"] != run.digest:
+        raise EvaluationAuthorityError("Metric Report Run binding differs")
+    document = json.loads(raw.decode("utf-8", errors="strict"))
+    summary = MappingProxyType(
+        {
+            name: str(report.payload[name])
+            for name in (
+                "metric_status",
+                "performance_status",
+                "slice_status",
+                "zero_tolerance_status",
+                "overall_status",
+            )
+        }
+    )
+    return MappingProxyType(document), report.digest, summary
 
 
 def _thaw(value: object) -> object:
@@ -808,6 +701,13 @@ def build_release_decision(
 ) -> ReleaseEvidenceDecision:
     if not isinstance(run, EvaluationRun) or not isinstance(verdict, ReleaseVerdict):
         raise EvaluationAuthorityError("decision requires typed run and verdict")
+    if (
+        verdict is ReleaseVerdict.PASS
+        and run.payload["run_kind"] != RunKind.QUALIFICATION.value
+    ):
+        raise EvaluationAuthorityError(
+            "PASS differs from the pre-registered release rule"
+        )
     if not isinstance(early_stopped, bool):
         raise EvaluationAuthorityError("early_stopped must be boolean")
     report, report_digest, report_summary = _verified_metric_report(
@@ -1174,6 +1074,8 @@ class EvaluationAuthority:
         if (
             tuple(case.payload["required_slices"]) != slices  # type: ignore[arg-type]
             or tuple(case.payload["case_strata"]) != strata  # type: ignore[arg-type]
+            or case.payload["urgent"]
+            is not (facts["case_metadata"]["urgency"] == "URGENT")  # type: ignore[index]
         ):
             raise EvaluationAuthorityError("Case membership differs from frozen rules")
 
@@ -1527,6 +1429,8 @@ class EvaluationAuthority:
                 or case.payload["input_manifest_digest"] != input_manifest_digest
                 or tuple(case.payload["required_slices"]) != expected_slices  # type: ignore[arg-type]
                 or tuple(case.payload["case_strata"]) != expected_strata  # type: ignore[arg-type]
+                or case.payload["urgent"]
+                is not (facts["case_metadata"]["urgency"] == "URGENT")  # type: ignore[index]
             ):
                 raise EvaluationAuthorityError("retained Case identity differs")
             if input_manifest_digest in input_manifests:

--- a/newsroom/increment8/evaluation.py
+++ b/newsroom/increment8/evaluation.py
@@ -296,14 +296,31 @@ def _verified_metric_report(
     required = {
         "run_id",
         "run_digest",
+        "readiness_digest",
+        "case_count",
+        "minimum_case_count",
+        "coverage_scope",
+        "rates",
+        "performance",
+        "required_slices",
+        "zero_tolerance_digest",
+        "source_contribution_digests",
+        "ablation_digests",
+        "metric_code_digest",
+        "environment_digest",
+        "sampling_manifest_digest",
+        "label_manifest_digest",
+        "deviation_digests",
         "metric_status",
+        "performance_status",
         "slice_status",
         "zero_tolerance_status",
         "overall_status",
+        "ablation_is_decision_bearing",
         "production_activation_authorised",
         "live_shadow_execution_authorised",
     }
-    if not isinstance(payload, dict) or not required <= set(payload):
+    if not isinstance(payload, dict) or set(payload) != required:
         raise EvaluationAuthorityError("Metric Report fields differ")
     if payload["run_id"] != run.run_id or payload["run_digest"] != run.digest:
         raise EvaluationAuthorityError("Metric Report Run binding differs")
@@ -311,6 +328,7 @@ def _verified_metric_report(
     summary: dict[str, str] = {}
     for field in (
         "metric_status",
+        "performance_status",
         "slice_status",
         "zero_tolerance_status",
         "overall_status",
@@ -319,13 +337,80 @@ def _verified_metric_report(
         if value not in allowed_statuses:
             raise EvaluationAuthorityError("Metric Report status differs")
         summary[field] = str(value)
-    if payload["overall_status"] == "PASS" and any(
-        payload[field] != "PASS"
-        for field in ("metric_status", "slice_status", "zero_tolerance_status")
-    ):
-        raise EvaluationAuthorityError("Metric Report PASS is internally inconsistent")
+    minimum_cases = int(
+        INCREMENT_8_READINESS.evaluation_plan["qualification_exposure"][  # type: ignore[index]
+            "minimum_completed_cases"
+        ]
+    )
+    case_count = payload["case_count"]
     if (
-        payload["production_activation_authorised"] is not False
+        isinstance(case_count, bool)
+        or not isinstance(case_count, int)
+        or case_count < 0
+        or payload["minimum_case_count"] != minimum_cases
+        or payload["readiness_digest"] != INCREMENT_8_READINESS_DIGEST
+        or payload["coverage_scope"]
+        != "REVIEWED_PROSPECTIVE_UNIVERSE_ONLY_NOT_ABSOLUTE_RECALL"
+    ):
+        raise EvaluationAuthorityError("Metric Report frozen boundary differs")
+    for field in (
+        "zero_tolerance_digest",
+        "metric_code_digest",
+        "environment_digest",
+        "sampling_manifest_digest",
+        "label_manifest_digest",
+    ):
+        _digest(payload[field], f"Metric Report {field}")
+    for field in (
+        "rates",
+        "performance",
+        "required_slices",
+        "source_contribution_digests",
+        "ablation_digests",
+        "deviation_digests",
+    ):
+        values = payload[field]
+        if not isinstance(values, list):
+            raise EvaluationAuthorityError("Metric Report inventory differs")
+        checked = tuple(_digest(item, f"Metric Report {field}") for item in values)
+        if len(checked) != len(set(checked)) or (
+            field == "deviation_digests" and checked != tuple(sorted(checked))
+        ):
+            raise EvaluationAuthorityError("Metric Report inventory differs")
+    if not all(
+        payload[field]
+        for field in (
+            "rates",
+            "performance",
+            "required_slices",
+            "source_contribution_digests",
+            "ablation_digests",
+        )
+    ):
+        raise EvaluationAuthorityError("Metric Report inventory is incomplete")
+    if payload["zero_tolerance_status"] == "FAIL":
+        derived_overall = "FAIL"
+    elif case_count < minimum_cases or payload["slice_status"] == "NOT_EVALUATED":
+        derived_overall = "NOT_EVALUATED"
+    elif all(
+        payload[field] == "PASS"
+        for field in (
+            "metric_status",
+            "performance_status",
+            "slice_status",
+            "zero_tolerance_status",
+        )
+    ):
+        derived_overall = "PASS"
+    else:
+        derived_overall = "FAIL"
+    if payload["overall_status"] != derived_overall:
+        raise EvaluationAuthorityError(
+            "Metric Report status is internally inconsistent"
+        )
+    if (
+        payload["ablation_is_decision_bearing"] is not False
+        or payload["production_activation_authorised"] is not False
         or payload["live_shadow_execution_authorised"] is not False
     ):
         raise EvaluationAuthorityError("Metric Report authority boundary differs")
@@ -1316,6 +1401,17 @@ class EvaluationAuthority:
         )
         if report_digest != decision.payload["report_digest"]:
             raise EvaluationAuthorityError("decision Metric Report digest differs")
+        if (
+            decision.payload["metrics_passed"]
+            is not (report_summary["metric_status"] == "PASS")
+            or decision.payload["required_slices_passed"]
+            is not (report_summary["slice_status"] == "PASS")
+            or decision.payload["zero_tolerance_failure_count"]
+            != (0 if report_summary["zero_tolerance_status"] == "PASS" else 1)
+        ):
+            raise EvaluationAuthorityError(
+                "decision gates differ from the retained Metric Report"
+            )
         current_manifest = self.evidence_manifest_digest(retained_run.run_id)
         if current_manifest != decision.payload["evidence_manifest_digest"]:
             raise EvaluationAuthorityError("decision evidence manifest differs")

--- a/newsroom/increment8/evaluation.py
+++ b/newsroom/increment8/evaluation.py
@@ -599,6 +599,8 @@ def build_case(
         if not isinstance(value, bool):
             raise EvaluationAuthorityError(f"{name} must be boolean")
     facts = _membership_facts(membership_facts)
+    if urgent is not (facts["case_metadata"]["urgency"] == "URGENT"):  # type: ignore[index]
+        raise EvaluationAuthorityError("urgent flag differs from frozen Case facts")
     slices, strata = _memberships(facts)
     _not_after(run.payload["started_at"], cutoff_at, boundary="Run to Case cutoff")
     payload = {

--- a/newsroom/increment8/evaluation.py
+++ b/newsroom/increment8/evaluation.py
@@ -278,7 +278,7 @@ def _memberships(
 
 def _verified_metric_report(
     raw: bytes, run: EvaluationRun
-) -> tuple[Mapping[str, object], str, Mapping[str, str]]:
+) -> tuple[Mapping[str, object], str, Mapping[str, object]]:
     if not isinstance(raw, bytes):
         raise EvaluationAuthorityError("Metric Report must be canonical bytes")
     from newsroom.increment8.metrics import (
@@ -295,18 +295,27 @@ def _verified_metric_report(
     if report.run_id != run.run_id or report.payload["run_digest"] != run.digest:
         raise EvaluationAuthorityError("Metric Report Run binding differs")
     document = json.loads(raw.decode("utf-8", errors="strict"))
-    summary = MappingProxyType(
-        {
-            name: str(report.payload[name])
-            for name in (
-                "metric_status",
-                "performance_status",
-                "slice_status",
-                "zero_tolerance_status",
-                "overall_status",
-            )
-        }
-    )
+    zero_document = report.payload["zero_tolerance_evidence"]
+    if not isinstance(zero_document, Mapping):
+        raise EvaluationAuthorityError("Metric Report zero-tolerance evidence differs")
+    zero_payload = zero_document.get("payload")
+    if not isinstance(zero_payload, Mapping) or not isinstance(
+        zero_payload.get("counts"), Mapping
+    ):
+        raise EvaluationAuthorityError("Metric Report zero-tolerance evidence differs")
+    zero_failure_count = sum(zero_payload["counts"].values())  # type: ignore[arg-type]
+    summary_values: dict[str, object] = {
+        name: str(report.payload[name])
+        for name in (
+            "metric_status",
+            "performance_status",
+            "slice_status",
+            "zero_tolerance_status",
+            "overall_status",
+        )
+    }
+    summary_values["zero_tolerance_failure_count"] = zero_failure_count
+    summary = MappingProxyType(summary_values)
     return MappingProxyType(document), report.digest, summary
 
 
@@ -735,9 +744,7 @@ def build_release_decision(
         "decided_at": _timestamp(decided_at, "decided_at"),
         "metrics_passed": report_summary["metric_status"] == "PASS",
         "required_slices_passed": report_summary["slice_status"] == "PASS",
-        "zero_tolerance_failure_count": 0
-        if report_summary["zero_tolerance_status"] == "PASS"
-        else 1,
+        "zero_tolerance_failure_count": report_summary["zero_tolerance_failure_count"],
         "early_stopped": early_stopped,
         "production_activation_authorised": False,
     }
@@ -1309,7 +1316,7 @@ class EvaluationAuthority:
             or decision.payload["required_slices_passed"]
             is not (report_summary["slice_status"] == "PASS")
             or decision.payload["zero_tolerance_failure_count"]
-            != (0 if report_summary["zero_tolerance_status"] == "PASS" else 1)
+            != report_summary["zero_tolerance_failure_count"]
         ):
             raise EvaluationAuthorityError(
                 "decision gates differ from the retained Metric Report"
@@ -1417,6 +1424,7 @@ class EvaluationAuthority:
         required_secondary: set[str] = set()
         reviewable: set[str] = set()
         input_manifests: set[str] = set()
+        case_memberships: dict[str, tuple[str, tuple[str, ...], tuple[str, ...]]] = {}
         for case_id, raw, case_digest, rights_status, input_manifest_digest in rows:
             case = EvaluationCase.from_canonical_bytes(bytes(raw))
             facts = _membership_facts(case.payload["membership_facts"])  # type: ignore[arg-type]
@@ -1438,6 +1446,11 @@ class EvaluationAuthority:
                     "qualification exposure repeats an event manifest"
                 )
             input_manifests.add(str(input_manifest_digest))
+            case_memberships[str(case_id)] = (
+                str(case_digest),
+                expected_slices,
+                expected_strata,
+            )
             for slice_name in expected_slices:
                 slice_cases[slice_name].add(str(case_digest))
             for stratum_name in expected_strata:
@@ -1491,6 +1504,36 @@ class EvaluationAuthority:
             target[str(case_id)] = label
         if set(primary) != reviewable:
             raise EvaluationAuthorityError("primary review exposure is incomplete")
+        if len(primary) < minimum:
+            raise EvaluationAuthorityError(
+                "reviewed qualification exposure is insufficient"
+            )
+        reviewed_slice_cases: dict[str, set[str]] = {
+            name: set() for name in slice_manifest
+        }
+        reviewed_stratum_cases: dict[str, set[str]] = {
+            name: set() for name in stratum_manifest
+        }
+        for case_id in primary:
+            case_digest, slices, strata = case_memberships[case_id]
+            for name in slices:
+                reviewed_slice_cases[name].add(case_digest)
+            for name in strata:
+                reviewed_stratum_cases[name].add(case_digest)
+        if any(
+            len(reviewed_slice_cases[name]) < minimum_cases
+            for name, minimum_cases in slice_manifest.items()
+        ):
+            raise EvaluationAuthorityError(
+                "reviewed required-slice exposure is insufficient"
+            )
+        if any(
+            len(reviewed_stratum_cases[name]) < minimum_cases
+            for name, minimum_cases in stratum_manifest.items()
+        ):
+            raise EvaluationAuthorityError(
+                "reviewed Case-stratum exposure is insufficient"
+            )
 
         second_percent = int(
             INCREMENT_8_READINESS.evaluation_plan[

--- a/newsroom/increment8/evaluation.py
+++ b/newsroom/increment8/evaluation.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
@@ -47,6 +47,13 @@ class RightsStatus(StrEnum):
 class ReviewRole(StrEnum):
     PRIMARY = "PRIMARY"
     SECONDARY = "SECONDARY"
+
+
+class HumanAuthorityRole(StrEnum):
+    PRIMARY = "PRIMARY"
+    SECONDARY = "SECONDARY"
+    ADJUDICATOR = "ADJUDICATOR"
+    RELEASE_OWNER = "RELEASE_OWNER"
 
 
 class ReleaseVerdict(StrEnum):
@@ -92,6 +99,237 @@ def _strings(value: Sequence[str], field: str) -> tuple[str, ...]:
     if tuple(sorted(set(result))) != result:
         raise EvaluationAuthorityError(f"{field} must be sorted and unique")
     return result
+
+
+def _parse_timestamp(value: object, field: str) -> datetime:
+    return datetime.fromisoformat(_timestamp(value, field).removesuffix("Z") + "+00:00")
+
+
+def _not_after(earlier: object, later: object, *, boundary: str) -> None:
+    if _parse_timestamp(earlier, boundary) > _parse_timestamp(later, boundary):
+        raise EvaluationAuthorityError(f"{boundary} chronology differs")
+
+
+def _human_authority_manifest(
+    *,
+    primary_reviewers: Sequence[str],
+    secondary_reviewers: Sequence[str],
+    adjudicators: Sequence[str],
+    release_owners: Sequence[str],
+) -> list[dict[str, object]]:
+    by_identity: dict[str, set[str]] = {}
+    inventories = (
+        (HumanAuthorityRole.PRIMARY, primary_reviewers),
+        (HumanAuthorityRole.SECONDARY, secondary_reviewers),
+        (HumanAuthorityRole.ADJUDICATOR, adjudicators),
+        (HumanAuthorityRole.RELEASE_OWNER, release_owners),
+    )
+    for role, identities in inventories:
+        checked = _strings(identities, f"authorised_{role.value.lower()}_digests")
+        for identity in checked:
+            by_identity.setdefault(_digest(identity, "human identity"), set()).add(
+                role.value
+            )
+    minimum_primary = int(
+        INCREMENT_8_READINESS.evaluation_plan["minimum_authorised_primary_reviewers"]
+    )
+    minimum_adjudicators = int(
+        INCREMENT_8_READINESS.evaluation_plan["minimum_authorised_adjudicators"]
+    )
+    if len(set(primary_reviewers)) < minimum_primary:
+        raise EvaluationAuthorityError("authorised primary reviewer minimum differs")
+    if len(set(adjudicators)) < minimum_adjudicators:
+        raise EvaluationAuthorityError("authorised adjudicator minimum differs")
+    return [
+        {
+            "identity_digest": identity,
+            "human": True,
+            "roles": sorted(roles),
+        }
+        for identity, roles in sorted(by_identity.items())
+    ]
+
+
+def _authorised_identities(
+    plan: EvaluationPlan, role: HumanAuthorityRole
+) -> frozenset[str]:
+    manifest = plan.payload.get("authorised_human_manifest")
+    if not isinstance(manifest, list) or not manifest:
+        raise EvaluationAuthorityError("authorised human manifest differs")
+    result: set[str] = set()
+    previous = ""
+    for entry in manifest:
+        if not isinstance(entry, dict) or set(entry) != {
+            "identity_digest",
+            "human",
+            "roles",
+        }:
+            raise EvaluationAuthorityError("authorised human manifest differs")
+        identity = _digest(entry["identity_digest"], "human identity")
+        if identity <= previous or entry["human"] is not True:
+            raise EvaluationAuthorityError("authorised human manifest differs")
+        previous = identity
+        roles = _strings(entry["roles"], "human roles")  # type: ignore[arg-type]
+        if any(
+            item not in {candidate.value for candidate in HumanAuthorityRole}
+            for item in roles
+        ):
+            raise EvaluationAuthorityError("authorised human role differs")
+        if role.value in roles:
+            result.add(identity)
+    return frozenset(result)
+
+
+def _membership_facts(value: Mapping[str, object]) -> dict[str, object]:
+    if not isinstance(value, Mapping) or set(value) != {
+        "case_metadata",
+        "source_evidence",
+        "fixture",
+        "expected",
+    }:
+        raise EvaluationAuthorityError("membership_facts fields differ")
+    case_metadata = value["case_metadata"]
+    source_evidence = value["source_evidence"]
+    fixture = value["fixture"]
+    expected = value["expected"]
+    if not all(
+        isinstance(item, Mapping)
+        for item in (case_metadata, source_evidence, fixture, expected)
+    ):
+        raise EvaluationAuthorityError("membership_facts values must be objects")
+    if set(case_metadata) != {"geography", "language", "urgency"}:
+        raise EvaluationAuthorityError("case_metadata fields differ")
+    if set(source_evidence) != {"distinct_domain_count"}:
+        raise EvaluationAuthorityError("source_evidence fields differ")
+    if set(fixture) != {"injected_failure_count"}:
+        raise EvaluationAuthorityError("fixture fields differ")
+    if set(expected) != {"candidate_outcome", "transition_outcome"}:
+        raise EvaluationAuthorityError("expected fields differ")
+    domains = source_evidence["distinct_domain_count"]
+    failures = fixture["injected_failure_count"]
+    if any(
+        isinstance(item, bool) or not isinstance(item, int) or item < 0
+        for item in (domains, failures)
+    ):
+        raise EvaluationAuthorityError(
+            "membership counts must be non-negative integers"
+        )
+    return {
+        "case_metadata": {
+            "geography": _token(case_metadata["geography"], "geography"),
+            "language": _token(case_metadata["language"], "language"),
+            "urgency": _token(case_metadata["urgency"], "urgency"),
+        },
+        "source_evidence": {"distinct_domain_count": domains},
+        "fixture": {"injected_failure_count": failures},
+        "expected": {
+            "candidate_outcome": _token(
+                expected["candidate_outcome"], "candidate_outcome"
+            ),
+            "transition_outcome": _token(
+                expected["transition_outcome"], "transition_outcome"
+            ),
+        },
+    }
+
+
+def _fact(facts: Mapping[str, object], dotted: str) -> object:
+    current: object = facts
+    for component in dotted.split("."):
+        if not isinstance(current, Mapping) or component not in current:
+            raise EvaluationAuthorityError("membership rule field is absent")
+        current = current[component]
+    return current
+
+
+def _matches(rule: Mapping[str, object], facts: Mapping[str, object]) -> bool:
+    actual = _fact(facts, str(rule["field"]))
+    if rule["operator"] == "EQ":
+        return actual == rule["value"]
+    if rule["operator"] == "GTE":
+        return (
+            isinstance(actual, int)
+            and not isinstance(actual, bool)
+            and actual >= rule["value"]
+        )  # type: ignore[operator]
+    raise EvaluationAuthorityError("membership rule operator differs")
+
+
+def _memberships(
+    facts: Mapping[str, object],
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    plan = INCREMENT_8_READINESS.evaluation_plan
+    slices = tuple(
+        sorted(
+            str(item["slice_id"])
+            for item in plan["required_slice_manifest"]  # type: ignore[union-attr]
+            if _matches(item["membership_rule"], facts)  # type: ignore[index]
+        )
+    )
+    strata = tuple(
+        sorted(
+            str(item["stratum_id"])
+            for item in plan["case_strata_manifest"]  # type: ignore[union-attr]
+            if _matches(item["membership_rule"], facts)  # type: ignore[index]
+        )
+    )
+    return slices, strata
+
+
+def _verified_metric_report(
+    raw: bytes, run: EvaluationRun
+) -> tuple[Mapping[str, object], str, Mapping[str, str]]:
+    if not isinstance(raw, bytes):
+        raise EvaluationAuthorityError("Metric Report must be canonical bytes")
+    try:
+        document = json.loads(raw.decode("utf-8", errors="strict"))
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        raise EvaluationAuthorityError("Metric Report is not canonical JSON") from exc
+    if canonical_json_bytes(document) != raw or not isinstance(document, dict):
+        raise EvaluationAuthorityError("Metric Report is not canonical JSON")
+    if (
+        set(document) != {"schema_version", "payload"}
+        or document["schema_version"] != "newsroom.increment8.metric-report.v1"
+    ):
+        raise EvaluationAuthorityError("Metric Report envelope differs")
+    payload = document["payload"]
+    required = {
+        "run_id",
+        "run_digest",
+        "metric_status",
+        "slice_status",
+        "zero_tolerance_status",
+        "overall_status",
+        "production_activation_authorised",
+        "live_shadow_execution_authorised",
+    }
+    if not isinstance(payload, dict) or not required <= set(payload):
+        raise EvaluationAuthorityError("Metric Report fields differ")
+    if payload["run_id"] != run.run_id or payload["run_digest"] != run.digest:
+        raise EvaluationAuthorityError("Metric Report Run binding differs")
+    allowed_statuses = {"PASS", "FAIL", "NOT_EVALUATED"}
+    summary: dict[str, str] = {}
+    for field in (
+        "metric_status",
+        "slice_status",
+        "zero_tolerance_status",
+        "overall_status",
+    ):
+        value = payload[field]
+        if value not in allowed_statuses:
+            raise EvaluationAuthorityError("Metric Report status differs")
+        summary[field] = str(value)
+    if payload["overall_status"] == "PASS" and any(
+        payload[field] != "PASS"
+        for field in ("metric_status", "slice_status", "zero_tolerance_status")
+    ):
+        raise EvaluationAuthorityError("Metric Report PASS is internally inconsistent")
+    if (
+        payload["production_activation_authorised"] is not False
+        or payload["live_shadow_execution_authorised"] is not False
+    ):
+        raise EvaluationAuthorityError("Metric Report authority boundary differs")
+    return MappingProxyType(document), digest_bytes(raw), MappingProxyType(summary)
 
 
 def _thaw(value: object) -> object:
@@ -245,8 +483,21 @@ class ReleaseEvidenceDecision(_Record):
 
 
 def build_evaluation_plan(
-    *, approved_by_digest: str, approved_at: str, component_manifest_digest: str
+    *,
+    approved_by_digest: str,
+    approved_at: str,
+    component_manifest_digest: str,
+    authorised_primary_reviewer_digests: Sequence[str],
+    authorised_secondary_reviewer_digests: Sequence[str],
+    authorised_adjudicator_digests: Sequence[str],
+    authorised_release_owner_digests: Sequence[str],
 ) -> EvaluationPlan:
+    human_manifest = _human_authority_manifest(
+        primary_reviewers=authorised_primary_reviewer_digests,
+        secondary_reviewers=authorised_secondary_reviewer_digests,
+        adjudicators=authorised_adjudicator_digests,
+        release_owners=authorised_release_owner_digests,
+    )
     payload = {
         "readiness_digest": INCREMENT_8_READINESS_DIGEST,
         "plan_definition": _thaw(INCREMENT_8_READINESS.evaluation_plan),
@@ -255,6 +506,7 @@ def build_evaluation_plan(
         ),
         "approved_by_digest": _digest(approved_by_digest, "approved_by_digest"),
         "approved_at": _timestamp(approved_at, "approved_at"),
+        "authorised_human_manifest": human_manifest,
         "qualification_allowed": True,
         "calibration_may_qualify_selected_values": False,
         "production_activation_authorised": False,
@@ -273,6 +525,11 @@ def freeze_epoch(
 ) -> EvaluationEpoch:
     if not isinstance(plan, EvaluationPlan):
         raise EvaluationAuthorityError("epoch requires a typed plan")
+    reparsed = EvaluationPlan.from_canonical_bytes(plan.canonical_bytes)
+    if reparsed != plan:
+        raise EvaluationAuthorityError("epoch Plan differs")
+    _not_after(plan.payload["approved_at"], cutoff_at, boundary="Plan to Epoch cutoff")
+    _not_after(cutoff_at, opened_at, boundary="Epoch cutoff to open")
     payload = {
         "plan_id": plan.plan_id,
         "plan_digest": plan.digest,
@@ -297,6 +554,10 @@ def open_run(
 ) -> EvaluationRun:
     if not isinstance(epoch, EvaluationEpoch) or not isinstance(kind, RunKind):
         raise EvaluationAuthorityError("run requires typed epoch and kind")
+    reparsed = EvaluationEpoch.from_canonical_bytes(epoch.canonical_bytes)
+    if reparsed != epoch:
+        raise EvaluationAuthorityError("run Epoch differs")
+    _not_after(epoch.payload["opened_at"], started_at, boundary="Epoch to Run")
     payload = {
         "epoch_id": epoch.epoch_id,
         "epoch_digest": epoch.digest,
@@ -313,7 +574,7 @@ def build_case(
     run: EvaluationRun,
     input_manifest_digest: str,
     cutoff_at: str,
-    required_slices: Sequence[str],
+    membership_facts: Mapping[str, object],
     rights_status: RightsStatus,
     prospective: bool,
     launch_blocker: bool = False,
@@ -337,13 +598,18 @@ def build_case(
     ):
         if not isinstance(value, bool):
             raise EvaluationAuthorityError(f"{name} must be boolean")
+    facts = _membership_facts(membership_facts)
+    slices, strata = _memberships(facts)
+    _not_after(run.payload["started_at"], cutoff_at, boundary="Run to Case cutoff")
     payload = {
         "run_id": run.run_id,
         "input_manifest_digest": _digest(
             input_manifest_digest, "input_manifest_digest"
         ),
         "cutoff_at": _timestamp(cutoff_at, "cutoff_at"),
-        "required_slices": list(_strings(required_slices, "required_slices")),
+        "membership_facts": facts,
+        "required_slices": list(slices),
+        "case_strata": list(strata),
         "rights_status": rights_status.value,
         "prospective": prospective,
         "launch_blocker": launch_blocker,
@@ -368,6 +634,7 @@ def build_review_label(
         raise EvaluationAuthorityError("an unreviewable Case cannot be labelled")
     if not isinstance(blinded, bool):
         raise EvaluationAuthorityError("blinded must be boolean")
+    _not_after(case.payload["cutoff_at"], recorded_at, boundary="Case to label")
     payload = {
         "case_id": case.case_id,
         "case_digest": case.digest,
@@ -425,6 +692,12 @@ def build_adjudication(
         secondary.payload["reviewer_identity_digest"],
     }:
         raise EvaluationAuthorityError("adjudicator must be independent")
+    _not_after(
+        primary.payload["recorded_at"], decided_at, boundary="label to adjudication"
+    )
+    _not_after(
+        secondary.payload["recorded_at"], decided_at, boundary="label to adjudication"
+    )
     payload = {
         "case_id": case.case_id,
         "primary_label_digest": primary.digest,
@@ -439,58 +712,45 @@ def build_adjudication(
 def build_release_decision(
     *,
     run: EvaluationRun,
-    report_digest: str,
+    report_canonical_bytes: bytes,
+    evidence_manifest_digest: str,
     verdict: ReleaseVerdict,
     owner_identity_digest: str,
     decided_at: str,
-    metrics_passed: bool,
-    required_slices_passed: bool,
-    zero_tolerance_failure_count: int,
     early_stopped: bool = False,
 ) -> ReleaseEvidenceDecision:
     if not isinstance(run, EvaluationRun) or not isinstance(verdict, ReleaseVerdict):
         raise EvaluationAuthorityError("decision requires typed run and verdict")
-    if (
-        isinstance(zero_tolerance_failure_count, bool)
-        or not isinstance(zero_tolerance_failure_count, int)
-        or zero_tolerance_failure_count < 0
-    ):
-        raise EvaluationAuthorityError(
-            "zero_tolerance_failure_count must be non-negative"
-        )
-    if not all(
-        isinstance(value, bool)
-        for value in (metrics_passed, required_slices_passed, early_stopped)
-    ):
-        raise EvaluationAuthorityError("decision gates must be boolean")
+    if not isinstance(early_stopped, bool):
+        raise EvaluationAuthorityError("early_stopped must be boolean")
+    report, report_digest, report_summary = _verified_metric_report(
+        report_canonical_bytes, run
+    )
+    report_passed = report_summary["overall_status"] == "PASS"
     if verdict is ReleaseVerdict.PASS and (
         run.payload["run_kind"] != RunKind.QUALIFICATION.value
         or early_stopped
-        or not metrics_passed
-        or not required_slices_passed
-        or zero_tolerance_failure_count != 0
+        or not report_passed
     ):
-        raise EvaluationAuthorityError(
-            "PASS differs from the pre-registered release rule"
-        )
-    if verdict is ReleaseVerdict.PASS and not corrective_gate_authorised(
-        CorrectiveGate.QUALIFICATION_EVIDENCE_ACCEPTANCE
-    ):
-        raise EvaluationAuthorityError(
-            "qualification evidence acceptance is blocked by corrective readiness"
-        )
+        raise EvaluationAuthorityError("PASS differs from the retained Metric Report")
     payload = {
         "run_id": run.run_id,
         "run_digest": run.digest,
-        "report_digest": _digest(report_digest, "report_digest"),
+        "report_digest": report_digest,
+        "metric_report": _thaw(report),
+        "evidence_manifest_digest": _digest(
+            evidence_manifest_digest, "evidence_manifest_digest"
+        ),
         "verdict": verdict.value,
         "owner_identity_digest": _digest(
             owner_identity_digest, "owner_identity_digest"
         ),
         "decided_at": _timestamp(decided_at, "decided_at"),
-        "metrics_passed": metrics_passed,
-        "required_slices_passed": required_slices_passed,
-        "zero_tolerance_failure_count": zero_tolerance_failure_count,
+        "metrics_passed": report_summary["metric_status"] == "PASS",
+        "required_slices_passed": report_summary["slice_status"] == "PASS",
+        "zero_tolerance_failure_count": 0
+        if report_summary["zero_tolerance_status"] == "PASS"
+        else 1,
         "early_stopped": early_stopped,
         "production_activation_authorised": False,
     }
@@ -503,19 +763,108 @@ class EvaluationAuthority:
     def __init__(self, connection: sqlite3.Connection) -> None:
         if not isinstance(connection, sqlite3.Connection):
             raise EvaluationAuthorityError("connection must be sqlite3.Connection")
-        connection.execute("PRAGMA foreign_keys=ON")
+        if connection.in_transaction:
+            raise EvaluationAuthorityError("caller-owned transaction is active")
+        if connection.execute("PRAGMA foreign_keys").fetchone()[0] != 1:
+            raise EvaluationAuthorityError("foreign keys must already be active")
         if connection.execute("PRAGMA user_version").fetchone()[0] < 30:
             raise EvaluationAuthorityError("evaluation authority requires schema v30")
         self._connection = connection
 
-    def _insert(self, sql: str, values: tuple[object, ...]) -> None:
+    def _require_connection_ready(self) -> None:
+        if self._connection.in_transaction:
+            raise EvaluationAuthorityError("caller-owned transaction is active")
+        if self._connection.execute("PRAGMA foreign_keys").fetchone()[0] != 1:
+            raise EvaluationAuthorityError("foreign keys must remain active")
+
+    def _write(self, action: Callable[[], None]) -> None:
+        self._require_connection_ready()
         try:
-            with self._connection:
-                self._connection.execute(sql, values)
+            self._connection.execute("BEGIN IMMEDIATE")
+            action()
+            self._connection.execute("COMMIT")
         except sqlite3.IntegrityError as exc:
+            if self._connection.in_transaction:
+                self._connection.execute("ROLLBACK")
             raise EvaluationAuthorityError(
                 "evaluation authority rejected the record"
             ) from exc
+        except Exception:
+            if self._connection.in_transaction:
+                self._connection.execute("ROLLBACK")
+            raise
+
+    def _insert(self, sql: str, values: tuple[object, ...]) -> None:
+        self._write(lambda: self._connection.execute(sql, values))
+
+    def _plan_for_run(self, run_id: str) -> EvaluationPlan:
+        row = self._connection.execute(
+            "SELECT p.plan_bytes FROM evaluation_plans p "
+            "JOIN evaluation_runs r ON r.plan_id=p.plan_id WHERE r.run_id=?",
+            (run_id,),
+        ).fetchone()
+        if row is None:
+            raise EvaluationAuthorityError("Run Plan is absent")
+        return EvaluationPlan.from_canonical_bytes(bytes(row[0]))
+
+    def _run_for_case(self, case_id: str) -> EvaluationRun:
+        row = self._connection.execute(
+            "SELECT r.run_bytes FROM evaluation_runs r "
+            "JOIN evaluation_cases c ON c.run_id=r.run_id WHERE c.case_id=?",
+            (case_id,),
+        ).fetchone()
+        if row is None:
+            raise EvaluationAuthorityError("Case Run is absent")
+        return EvaluationRun.from_canonical_bytes(bytes(row[0]))
+
+    def _require_unsealed(self, run_id: str) -> None:
+        if (
+            self._connection.execute(
+                "SELECT 1 FROM evaluation_release_decisions WHERE run_id=?", (run_id,)
+            ).fetchone()
+            is not None
+        ):
+            raise EvaluationAuthorityError("Run evidence is sealed by its decision")
+
+    def evidence_manifest_digest(self, run_id: str) -> str:
+        self._require_connection_ready()
+        return self._evidence_manifest_digest(run_id)
+
+    def _evidence_manifest_digest(self, run_id: str) -> str:
+        run_row = self._connection.execute(
+            "SELECT run_digest FROM evaluation_runs WHERE run_id=?", (run_id,)
+        ).fetchone()
+        if run_row is None:
+            raise EvaluationAuthorityError("Run is absent")
+        inventory: dict[str, list[str] | str] = {"run_digest": str(run_row[0])}
+        for name, table, digest_column, join in (
+            ("case_digests", "evaluation_cases", "case_digest", "run_id=?"),
+            (
+                "label_digests",
+                "evaluation_labels",
+                "label_digest",
+                "case_id IN (SELECT case_id FROM evaluation_cases WHERE run_id=?)",
+            ),
+            (
+                "adjudication_digests",
+                "evaluation_adjudications",
+                "adjudication_digest",
+                "case_id IN (SELECT case_id FROM evaluation_cases WHERE run_id=?)",
+            ),
+        ):
+            inventory[name] = [
+                str(row[0])
+                for row in self._connection.execute(
+                    f"SELECT {digest_column} FROM {table} WHERE {join} ORDER BY {digest_column}",
+                    (run_id,),
+                )
+            ]
+        return digest_canonical(
+            {
+                "schema_version": "newsroom.increment8.evidence-manifest.v1",
+                "inventory": inventory,
+            }
+        )
 
     @staticmethod
     def _require_record(
@@ -542,6 +891,7 @@ class EvaluationAuthority:
                     "component_manifest_digest",
                     "approved_by_digest",
                     "approved_at",
+                    "authorised_human_manifest",
                     "qualification_allowed",
                     "calibration_may_qualify_selected_values",
                     "production_activation_authorised",
@@ -560,6 +910,23 @@ class EvaluationAuthority:
             or plan.payload["production_activation_authorised"] is not False
         ):
             raise EvaluationAuthorityError("plan authority boundary differs")
+        minimum_primary = int(
+            INCREMENT_8_READINESS.evaluation_plan[
+                "minimum_authorised_primary_reviewers"
+            ]
+        )
+        minimum_adjudicators = int(
+            INCREMENT_8_READINESS.evaluation_plan["minimum_authorised_adjudicators"]
+        )
+        if (
+            len(_authorised_identities(plan, HumanAuthorityRole.PRIMARY))
+            < minimum_primary
+            or len(_authorised_identities(plan, HumanAuthorityRole.ADJUDICATOR))
+            < minimum_adjudicators
+            or not _authorised_identities(plan, HumanAuthorityRole.SECONDARY)
+            or not _authorised_identities(plan, HumanAuthorityRole.RELEASE_OWNER)
+        ):
+            raise EvaluationAuthorityError("authorised human manifest is insufficient")
         self._insert(
             "INSERT INTO evaluation_plans VALUES(?,?,?,?,?,?,?,?)",
             (
@@ -592,7 +959,7 @@ class EvaluationAuthority:
             ),
         )
         plan = self._connection.execute(
-            "SELECT plan_digest FROM evaluation_plans WHERE plan_id=?",
+            "SELECT plan_digest,plan_bytes,approved_at FROM evaluation_plans WHERE plan_id=?",
             (epoch.payload["plan_id"],),
         ).fetchone()
         if (
@@ -601,6 +968,15 @@ class EvaluationAuthority:
             or epoch.payload["frozen"] is not True
         ):
             raise EvaluationAuthorityError("epoch Plan or frozen boundary differs")
+        retained_plan = EvaluationPlan.from_canonical_bytes(bytes(plan[1]))
+        if retained_plan.digest != plan[0]:
+            raise EvaluationAuthorityError("retained Plan identity differs")
+        _not_after(plan[2], epoch.payload["cutoff_at"], boundary="Plan to Epoch cutoff")
+        _not_after(
+            epoch.payload["cutoff_at"],
+            epoch.payload["opened_at"],
+            boundary="Epoch cutoff to open",
+        )
         self._insert(
             "INSERT INTO evaluation_epochs VALUES(?,?,?,?,?,?,?,?)",
             (
@@ -635,6 +1011,24 @@ class EvaluationAuthority:
             or run.payload["production_effect_allowed"] is not False
         ):
             raise EvaluationAuthorityError("run authority boundary differs")
+        epoch_row = self._connection.execute(
+            "SELECT epoch_bytes,epoch_digest,plan_id FROM evaluation_epochs WHERE epoch_id=?",
+            (run.payload["epoch_id"],),
+        ).fetchone()
+        if epoch_row is None:
+            raise EvaluationAuthorityError("Run Epoch is absent")
+        retained_epoch = EvaluationEpoch.from_canonical_bytes(bytes(epoch_row[0]))
+        if (
+            retained_epoch.digest != epoch_row[1]
+            or retained_epoch.digest != run.payload["epoch_digest"]
+            or retained_epoch.payload["plan_id"] != run.payload["plan_id"]
+        ):
+            raise EvaluationAuthorityError("Run Epoch binding differs")
+        _not_after(
+            retained_epoch.payload["opened_at"],
+            run.payload["started_at"],
+            boundary="Epoch to Run",
+        )
         self._insert(
             "INSERT INTO evaluation_runs VALUES(?,?,?,?,?,?,?,?)",
             (
@@ -657,8 +1051,10 @@ class EvaluationAuthority:
                 {
                     "run_id",
                     "input_manifest_digest",
+                    "membership_facts",
                     "cutoff_at",
                     "required_slices",
+                    "case_strata",
                     "rights_status",
                     "prospective",
                     "launch_blocker",
@@ -668,7 +1064,7 @@ class EvaluationAuthority:
             ),
         )
         run = self._connection.execute(
-            "SELECT run_kind FROM evaluation_runs WHERE run_id=?",
+            "SELECT run_kind,run_bytes FROM evaluation_runs WHERE run_id=?",
             (case.payload["run_id"],),
         ).fetchone()
         if run is None:
@@ -680,19 +1076,45 @@ class EvaluationAuthority:
             raise EvaluationAuthorityError("qualification Cases must be prospective")
         if case.payload["rights_status"] not in {item.value for item in RightsStatus}:
             raise EvaluationAuthorityError("Case rights status differs")
-        self._insert(
-            "INSERT INTO evaluation_cases VALUES(?,?,?,?,?,?,?,?)",
-            (
-                case.case_id,
-                case.canonical_bytes,
-                case.digest,
-                case.payload["run_id"],
-                int(case.payload["prospective"]),
-                case.payload["cutoff_at"],
-                case.payload["input_manifest_digest"],
-                case.payload["rights_status"],
-            ),
+        retained_run = EvaluationRun.from_canonical_bytes(bytes(run[1]))
+        _not_after(
+            retained_run.payload["started_at"],
+            case.payload["cutoff_at"],
+            boundary="Run to Case cutoff",
         )
+        facts = _membership_facts(case.payload["membership_facts"])  # type: ignore[arg-type]
+        slices, strata = _memberships(facts)
+        if (
+            tuple(case.payload["required_slices"]) != slices  # type: ignore[arg-type]
+            or tuple(case.payload["case_strata"]) != strata  # type: ignore[arg-type]
+        ):
+            raise EvaluationAuthorityError("Case membership differs from frozen rules")
+
+        def insert_case() -> None:
+            self._require_unsealed(str(case.payload["run_id"]))
+            duplicate = self._connection.execute(
+                "SELECT 1 FROM evaluation_cases WHERE run_id=? AND input_manifest_digest=?",
+                (case.payload["run_id"], case.payload["input_manifest_digest"]),
+            ).fetchone()
+            if duplicate is not None:
+                raise EvaluationAuthorityError(
+                    "Run input manifests must represent distinct events"
+                )
+            self._connection.execute(
+                "INSERT INTO evaluation_cases VALUES(?,?,?,?,?,?,?,?)",
+                (
+                    case.case_id,
+                    case.canonical_bytes,
+                    case.digest,
+                    case.payload["run_id"],
+                    int(case.payload["prospective"]),
+                    case.payload["cutoff_at"],
+                    case.payload["input_manifest_digest"],
+                    case.payload["rights_status"],
+                ),
+            )
+
+        self._write(insert_case)
 
     def record_label(self, label: ReviewLabel) -> None:
         self._require_record(
@@ -711,7 +1133,7 @@ class EvaluationAuthority:
             ),
         )
         case = self._connection.execute(
-            "SELECT case_digest,rights_status FROM evaluation_cases WHERE case_id=?",
+            "SELECT case_digest,rights_status,case_bytes,run_id FROM evaluation_cases WHERE case_id=?",
             (label.payload["case_id"],),
         ).fetchone()
         if case is None or case[0] != label.payload["case_digest"]:
@@ -722,25 +1144,50 @@ class EvaluationAuthority:
             item.value for item in ReviewRole
         } or not isinstance(label.payload["blinded"], bool):
             raise EvaluationAuthorityError("review authority boundary differs")
-        duplicate = self._connection.execute(
-            "SELECT 1 FROM evaluation_labels WHERE case_id=? AND reviewer_identity_digest=?",
-            (label.payload["case_id"], label.payload["reviewer_identity_digest"]),
-        ).fetchone()
-        if duplicate is not None:
-            raise EvaluationAuthorityError("second review must be independent")
-        self._insert(
-            "INSERT INTO evaluation_labels VALUES(?,?,?,?,?,?,?,?)",
-            (
-                label.label_id,
-                label.canonical_bytes,
-                label.digest,
-                label.payload["case_id"],
-                label.payload["reviewer_identity_digest"],
-                label.payload["review_role"],
-                int(label.payload["blinded"]),
-                label.payload["recorded_at"],
-            ),
+        retained_case = EvaluationCase.from_canonical_bytes(bytes(case[2]))
+        _not_after(
+            retained_case.payload["cutoff_at"],
+            label.payload["recorded_at"],
+            boundary="Case to label",
         )
+        plan = self._plan_for_run(str(case[3]))
+        required_role = (
+            HumanAuthorityRole.PRIMARY
+            if label.payload["review_role"] == ReviewRole.PRIMARY.value
+            else HumanAuthorityRole.SECONDARY
+        )
+        if label.payload["reviewer_identity_digest"] not in _authorised_identities(
+            plan, required_role
+        ):
+            raise EvaluationAuthorityError("reviewer is not an authorised human")
+
+        def insert_label() -> None:
+            self._require_unsealed(str(case[3]))
+            duplicate = self._connection.execute(
+                "SELECT reviewer_identity_digest,review_role FROM evaluation_labels WHERE case_id=?",
+                (label.payload["case_id"],),
+            ).fetchall()
+            if any(row[1] == label.payload["review_role"] for row in duplicate):
+                raise EvaluationAuthorityError("a Case may retain one label per role")
+            if any(
+                row[0] == label.payload["reviewer_identity_digest"] for row in duplicate
+            ):
+                raise EvaluationAuthorityError("second review must be independent")
+            self._connection.execute(
+                "INSERT INTO evaluation_labels VALUES(?,?,?,?,?,?,?,?)",
+                (
+                    label.label_id,
+                    label.canonical_bytes,
+                    label.digest,
+                    label.payload["case_id"],
+                    label.payload["reviewer_identity_digest"],
+                    label.payload["review_role"],
+                    int(label.payload["blinded"]),
+                    label.payload["recorded_at"],
+                ),
+            )
+
+        self._write(insert_label)
 
     def record_adjudication(self, adjudication: AdjudicationDecision) -> None:
         self._require_record(
@@ -783,19 +1230,42 @@ class EvaluationAuthority:
             == ReviewLabel.from_canonical_bytes(bytes(secondary[4])).payload["label"]
         ):
             raise EvaluationAuthorityError("adjudication authority boundary differs")
-        self._insert(
-            "INSERT INTO evaluation_adjudications VALUES(?,?,?,?,?,?,?,?)",
-            (
-                adjudication.adjudication_id,
-                adjudication.canonical_bytes,
-                adjudication.digest,
-                adjudication.payload["case_id"],
-                adjudication.payload["primary_label_digest"],
-                adjudication.payload["secondary_label_digest"],
-                adjudication.payload["adjudicator_identity_digest"],
-                adjudication.payload["decided_at"],
-            ),
+        primary_label = ReviewLabel.from_canonical_bytes(bytes(primary[4]))
+        secondary_label = ReviewLabel.from_canonical_bytes(bytes(secondary[4]))
+        _not_after(
+            primary_label.payload["recorded_at"],
+            adjudication.payload["decided_at"],
+            boundary="label to adjudication",
         )
+        _not_after(
+            secondary_label.payload["recorded_at"],
+            adjudication.payload["decided_at"],
+            boundary="label to adjudication",
+        )
+        run = self._run_for_case(str(adjudication.payload["case_id"]))
+        plan = self._plan_for_run(run.run_id)
+        if adjudication.payload[
+            "adjudicator_identity_digest"
+        ] not in _authorised_identities(plan, HumanAuthorityRole.ADJUDICATOR):
+            raise EvaluationAuthorityError("adjudicator is not an authorised human")
+
+        def insert_adjudication() -> None:
+            self._require_unsealed(run.run_id)
+            self._connection.execute(
+                "INSERT INTO evaluation_adjudications VALUES(?,?,?,?,?,?,?,?)",
+                (
+                    adjudication.adjudication_id,
+                    adjudication.canonical_bytes,
+                    adjudication.digest,
+                    adjudication.payload["case_id"],
+                    adjudication.payload["primary_label_digest"],
+                    adjudication.payload["secondary_label_digest"],
+                    adjudication.payload["adjudicator_identity_digest"],
+                    adjudication.payload["decided_at"],
+                ),
+            )
+
+        self._write(insert_adjudication)
 
     def decide_release(self, decision: ReleaseEvidenceDecision) -> None:
         self._require_record(
@@ -806,6 +1276,8 @@ class EvaluationAuthority:
                     "run_id",
                     "run_digest",
                     "report_digest",
+                    "metric_report",
+                    "evidence_manifest_digest",
                     "verdict",
                     "owner_identity_digest",
                     "decided_at",
@@ -829,43 +1301,102 @@ class EvaluationAuthority:
             item.value for item in ReleaseVerdict
         }:
             raise EvaluationAuthorityError("release authority boundary differs")
+        retained_run_row = self._connection.execute(
+            "SELECT run_bytes FROM evaluation_runs WHERE run_id=?",
+            (decision.payload["run_id"],),
+        ).fetchone()
+        if retained_run_row is None:
+            raise EvaluationAuthorityError("decision Run is absent")
+        retained_run = EvaluationRun.from_canonical_bytes(bytes(retained_run_row[0]))
+        report_raw = canonical_json_bytes(decision.payload["metric_report"])
+        _, report_digest, report_summary = _verified_metric_report(
+            report_raw, retained_run
+        )
+        if report_digest != decision.payload["report_digest"]:
+            raise EvaluationAuthorityError("decision Metric Report digest differs")
+        current_manifest = self.evidence_manifest_digest(retained_run.run_id)
+        if current_manifest != decision.payload["evidence_manifest_digest"]:
+            raise EvaluationAuthorityError("decision evidence manifest differs")
+        plan = self._plan_for_run(retained_run.run_id)
+        if decision.payload["owner_identity_digest"] not in _authorised_identities(
+            plan, HumanAuthorityRole.RELEASE_OWNER
+        ):
+            raise EvaluationAuthorityError("release owner is not an authorised human")
+        latest_evidence_at = self._latest_evidence_at(retained_run.run_id)
+        _not_after(
+            latest_evidence_at,
+            decision.payload["decided_at"],
+            boundary="evidence to release decision",
+        )
         if decision.payload["verdict"] == ReleaseVerdict.PASS.value:
-            if not corrective_gate_authorised(
-                CorrectiveGate.QUALIFICATION_EVIDENCE_ACCEPTANCE
-            ):
-                raise EvaluationAuthorityError(
-                    "qualification evidence acceptance is blocked by corrective readiness"
-                )
             if (
                 run[0] != RunKind.QUALIFICATION.value
-                or decision.payload["metrics_passed"] is not True
-                or decision.payload["required_slices_passed"] is not True
-                or decision.payload["zero_tolerance_failure_count"] != 0
+                or report_summary["overall_status"] != "PASS"
+                or report_summary["metric_status"] != "PASS"
+                or report_summary["slice_status"] != "PASS"
+                or report_summary["zero_tolerance_status"] != "PASS"
                 or decision.payload["early_stopped"] is not False
             ):
                 raise EvaluationAuthorityError(
                     "PASS differs from the pre-registered release rule"
                 )
             self._require_pass_exposure(str(decision.payload["run_id"]))
-        self._insert(
-            "INSERT INTO evaluation_release_decisions VALUES(?,?,?,?,?,?,?,?,?,?)",
-            (
-                decision.decision_id,
-                decision.canonical_bytes,
-                decision.digest,
-                decision.payload["run_id"],
-                decision.payload["report_digest"],
-                decision.payload["verdict"],
-                decision.payload["owner_identity_digest"],
-                decision.payload["decided_at"],
-                int(decision.payload["early_stopped"]),
-                0,
-            ),
+            if not corrective_gate_authorised(
+                CorrectiveGate.QUALIFICATION_EVIDENCE_ACCEPTANCE
+            ):
+                raise EvaluationAuthorityError(
+                    "qualification evidence acceptance is blocked by corrective readiness"
+                )
+
+        def insert_decision() -> None:
+            if (
+                self._evidence_manifest_digest(retained_run.run_id)
+                != decision.payload["evidence_manifest_digest"]
+            ):
+                raise EvaluationAuthorityError(
+                    "decision evidence changed before sealing"
+                )
+            self._connection.execute(
+                "INSERT INTO evaluation_release_decisions VALUES(?,?,?,?,?,?,?,?,?,?)",
+                (
+                    decision.decision_id,
+                    decision.canonical_bytes,
+                    decision.digest,
+                    decision.payload["run_id"],
+                    decision.payload["report_digest"],
+                    decision.payload["verdict"],
+                    decision.payload["owner_identity_digest"],
+                    decision.payload["decided_at"],
+                    int(decision.payload["early_stopped"]),
+                    0,
+                ),
+            )
+
+        self._write(insert_decision)
+
+    def _latest_evidence_at(self, run_id: str) -> str:
+        values = [
+            str(row[0])
+            for query in (
+                "SELECT started_at FROM evaluation_runs WHERE run_id=?",
+                "SELECT cutoff_at FROM evaluation_cases WHERE run_id=?",
+                "SELECT recorded_at FROM evaluation_labels WHERE case_id IN "
+                "(SELECT case_id FROM evaluation_cases WHERE run_id=?)",
+                "SELECT decided_at FROM evaluation_adjudications WHERE case_id IN "
+                "(SELECT case_id FROM evaluation_cases WHERE run_id=?)",
+            )
+            for row in self._connection.execute(query, (run_id,))
+        ]
+        if not values:
+            raise EvaluationAuthorityError("release evidence inventory is empty")
+        return max(
+            values, key=lambda item: _parse_timestamp(item, "evidence timestamp")
         )
 
     def _require_pass_exposure(self, run_id: str) -> None:
         rows = self._connection.execute(
-            "SELECT case_id,case_bytes,rights_status FROM evaluation_cases WHERE run_id=? ORDER BY case_id",
+            "SELECT case_id,case_bytes,case_digest,rights_status,input_manifest_digest "
+            "FROM evaluation_cases WHERE run_id=? ORDER BY case_id",
             (run_id,),
         ).fetchall()
         exposure = INCREMENT_8_READINESS.evaluation_plan["qualification_exposure"]
@@ -873,15 +1404,42 @@ class EvaluationAuthority:
         if len(rows) < minimum:
             raise EvaluationAuthorityError("qualification exposure is insufficient")
 
-        slice_counts: dict[str, int] = {}
+        slice_manifest = {
+            str(item["slice_id"]): int(item["minimum_completed_cases"])
+            for item in INCREMENT_8_READINESS.evaluation_plan["required_slice_manifest"]  # type: ignore[union-attr]
+        }
+        stratum_manifest = {
+            str(item["stratum_id"]): int(item["minimum_completed_cases"])
+            for item in INCREMENT_8_READINESS.evaluation_plan["case_strata_manifest"]  # type: ignore[union-attr]
+        }
+        slice_cases: dict[str, set[str]] = {name: set() for name in slice_manifest}
+        stratum_cases: dict[str, set[str]] = {name: set() for name in stratum_manifest}
         required_secondary: set[str] = set()
         reviewable: set[str] = set()
-        for case_id, raw, rights_status in rows:
+        input_manifests: set[str] = set()
+        for case_id, raw, case_digest, rights_status, input_manifest_digest in rows:
             case = EvaluationCase.from_canonical_bytes(bytes(raw))
-            if case.case_id != case_id or case.payload["run_id"] != run_id:
+            facts = _membership_facts(case.payload["membership_facts"])  # type: ignore[arg-type]
+            expected_slices, expected_strata = _memberships(facts)
+            if (
+                case.case_id != case_id
+                or case.digest != case_digest
+                or case.payload["run_id"] != run_id
+                or case.payload["rights_status"] != rights_status
+                or case.payload["input_manifest_digest"] != input_manifest_digest
+                or tuple(case.payload["required_slices"]) != expected_slices  # type: ignore[arg-type]
+                or tuple(case.payload["case_strata"]) != expected_strata  # type: ignore[arg-type]
+            ):
                 raise EvaluationAuthorityError("retained Case identity differs")
-            for slice_name in case.payload["required_slices"]:  # type: ignore[union-attr]
-                slice_counts[str(slice_name)] = slice_counts.get(str(slice_name), 0) + 1
+            if input_manifest_digest in input_manifests:
+                raise EvaluationAuthorityError(
+                    "qualification exposure repeats an event manifest"
+                )
+            input_manifests.add(str(input_manifest_digest))
+            for slice_name in expected_slices:
+                slice_cases[slice_name].add(str(case_digest))
+            for stratum_name in expected_strata:
+                stratum_cases[stratum_name].add(str(case_digest))
             if rights_status == RightsStatus.REVIEWABLE.value:
                 reviewable.add(str(case_id))
             if any(
@@ -890,14 +1448,26 @@ class EvaluationAuthority:
             ):
                 required_secondary.add(str(case_id))
 
-        minimum_slices = int(exposure["minimum_completed_required_slices"])  # type: ignore[index]
-        minimum_per_slice = int(
-            INCREMENT_8_READINESS.evaluation_plan["required_slice_minimum_cases"]
-        )
-        if len(slice_counts) < minimum_slices or any(
-            count < minimum_per_slice for count in slice_counts.values()
+        if any(
+            len(slice_cases[name]) < minimum_cases
+            for name, minimum_cases in slice_manifest.items()
         ):
             raise EvaluationAuthorityError("required-slice exposure is insufficient")
+        stratum_exposure = exposure
+        expected_stratum_minima = {
+            "NEGATIVE": int(stratum_exposure["minimum_negative_cases"]),  # type: ignore[index]
+            "UNCHANGED": int(stratum_exposure["minimum_no_change_cases"]),  # type: ignore[index]
+            "FAILURE_HEAVY": int(
+                stratum_exposure["minimum_failure_heavy_cases"]  # type: ignore[index]
+            ),
+        }
+        if expected_stratum_minima != stratum_manifest or any(
+            len(stratum_cases[name]) < minimum_cases
+            for name, minimum_cases in stratum_manifest.items()
+        ):
+            raise EvaluationAuthorityError("Case-stratum exposure is insufficient")
+        if not reviewable:
+            raise EvaluationAuthorityError("reviewable exposure is empty")
 
         labels = self._connection.execute(
             "SELECT case_id,label_bytes,review_role FROM evaluation_labels "
@@ -908,9 +1478,14 @@ class EvaluationAuthority:
         secondary: dict[str, ReviewLabel] = {}
         for case_id, raw, role in labels:
             label = ReviewLabel.from_canonical_bytes(bytes(raw))
-            if label.payload["case_id"] != case_id:
+            if label.payload["case_id"] != case_id or role not in {
+                ReviewRole.PRIMARY.value,
+                ReviewRole.SECONDARY.value,
+            }:
                 raise EvaluationAuthorityError("retained label identity differs")
             target = primary if role == ReviewRole.PRIMARY.value else secondary
+            if str(case_id) in target:
+                raise EvaluationAuthorityError("duplicate same-role label is retained")
             target[str(case_id)] = label
         if set(primary) != reviewable:
             raise EvaluationAuthorityError("primary review exposure is incomplete")
@@ -920,12 +1495,36 @@ class EvaluationAuthority:
                 "ordinary_independent_second_review_percent"
             ]
         )
-        ordinary_minimum = (len(reviewable) * second_percent + 99) // 100
-        if len(secondary) < ordinary_minimum or not required_secondary <= set(
+        ordinary = reviewable - required_secondary
+        ordinary_secondary = ordinary.intersection(secondary)
+        ordinary_minimum = (len(ordinary) * second_percent + 99) // 100
+        if len(ordinary_secondary) < ordinary_minimum or not required_secondary <= set(
             secondary
         ):
             raise EvaluationAuthorityError(
                 "independent second-review exposure is incomplete"
+            )
+        plan = self._plan_for_run(run_id)
+        used_primary = {
+            str(item.payload["reviewer_identity_digest"]) for item in primary.values()
+        }
+        minimum_primary = int(
+            INCREMENT_8_READINESS.evaluation_plan[
+                "minimum_authorised_primary_reviewers"
+            ]
+        )
+        if (
+            len(used_primary) < minimum_primary
+            or not used_primary
+            <= _authorised_identities(plan, HumanAuthorityRole.PRIMARY)
+            or any(
+                item.payload["reviewer_identity_digest"]
+                not in _authorised_identities(plan, HumanAuthorityRole.SECONDARY)
+                for item in secondary.values()
+            )
+        ):
+            raise EvaluationAuthorityError(
+                "authorised reviewer exposure is insufficient"
             )
         adjudicated = {
             str(row[0])
@@ -972,6 +1571,7 @@ __all__ = [
     "EvaluationEpoch",
     "EvaluationPlan",
     "EvaluationRun",
+    "HumanAuthorityRole",
     "ReleaseEvidenceDecision",
     "ReleaseVerdict",
     "ReviewLabel",

--- a/newsroom/increment8/evaluation.py
+++ b/newsroom/increment8/evaluation.py
@@ -722,6 +722,16 @@ def build_release_decision(
     report, report_digest, report_summary = _verified_metric_report(
         report_canonical_bytes, run
     )
+    report_payload = report["payload"]
+    assert isinstance(report_payload, Mapping)
+    manifest_digest = _digest(evidence_manifest_digest, "evidence_manifest_digest")
+    if (
+        report_payload["sampling_manifest_digest"] != manifest_digest
+        or report_payload["label_manifest_digest"] != manifest_digest
+    ):
+        raise EvaluationAuthorityError(
+            "Metric Report differs from the authority evidence manifest"
+        )
     report_passed = report_summary["overall_status"] == "PASS"
     if verdict is ReleaseVerdict.PASS and (
         run.payload["run_kind"] != RunKind.QUALIFICATION.value
@@ -734,9 +744,7 @@ def build_release_decision(
         "run_digest": run.digest,
         "report_digest": report_digest,
         "metric_report": _thaw(report),
-        "evidence_manifest_digest": _digest(
-            evidence_manifest_digest, "evidence_manifest_digest"
-        ),
+        "evidence_manifest_digest": manifest_digest,
         "verdict": verdict.value,
         "owner_identity_digest": _digest(
             owner_identity_digest, "owner_identity_digest"
@@ -1305,7 +1313,7 @@ class EvaluationAuthority:
             raise EvaluationAuthorityError("decision Run is absent")
         retained_run = EvaluationRun.from_canonical_bytes(bytes(retained_run_row[0]))
         report_raw = canonical_json_bytes(decision.payload["metric_report"])
-        _, report_digest, report_summary = _verified_metric_report(
+        report_document, report_digest, report_summary = _verified_metric_report(
             report_raw, retained_run
         )
         if report_digest != decision.payload["report_digest"]:
@@ -1324,6 +1332,14 @@ class EvaluationAuthority:
         current_manifest = self.evidence_manifest_digest(retained_run.run_id)
         if current_manifest != decision.payload["evidence_manifest_digest"]:
             raise EvaluationAuthorityError("decision evidence manifest differs")
+        report_payload = report_document["payload"]
+        if not isinstance(report_payload, Mapping) or any(
+            report_payload[field] != current_manifest
+            for field in ("sampling_manifest_digest", "label_manifest_digest")
+        ):
+            raise EvaluationAuthorityError(
+                "Metric Report differs from the authority evidence manifest"
+            )
         plan = self._plan_for_run(retained_run.run_id)
         if decision.payload["owner_identity_digest"] not in _authorised_identities(
             plan, HumanAuthorityRole.RELEASE_OWNER
@@ -1347,7 +1363,10 @@ class EvaluationAuthority:
                 raise EvaluationAuthorityError(
                     "PASS differs from the pre-registered release rule"
                 )
-            self._require_pass_exposure(str(decision.payload["run_id"]))
+            self._require_pass_exposure(
+                str(decision.payload["run_id"]),
+                report_document["payload"],  # type: ignore[arg-type]
+            )
             if not corrective_gate_authorised(
                 CorrectiveGate.QUALIFICATION_EVIDENCE_ACCEPTANCE
             ):
@@ -1400,7 +1419,9 @@ class EvaluationAuthority:
             values, key=lambda item: _parse_timestamp(item, "evidence timestamp")
         )
 
-    def _require_pass_exposure(self, run_id: str) -> None:
+    def _require_pass_exposure(
+        self, run_id: str, report_payload: Mapping[str, object]
+    ) -> None:
         rows = self._connection.execute(
             "SELECT case_id,case_bytes,case_digest,rights_status,input_manifest_digest "
             "FROM evaluation_cases WHERE run_id=? ORDER BY case_id",
@@ -1424,7 +1445,9 @@ class EvaluationAuthority:
         required_secondary: set[str] = set()
         reviewable: set[str] = set()
         input_manifests: set[str] = set()
-        case_memberships: dict[str, tuple[str, tuple[str, ...], tuple[str, ...]]] = {}
+        case_memberships: dict[
+            str, tuple[str, tuple[str, ...], tuple[str, ...], bool]
+        ] = {}
         for case_id, raw, case_digest, rights_status, input_manifest_digest in rows:
             case = EvaluationCase.from_canonical_bytes(bytes(raw))
             facts = _membership_facts(case.payload["membership_facts"])  # type: ignore[arg-type]
@@ -1450,6 +1473,7 @@ class EvaluationAuthority:
                 str(case_digest),
                 expected_slices,
                 expected_strata,
+                bool(case.payload["zero_tolerance"]),
             )
             for slice_name in expected_slices:
                 slice_cases[slice_name].add(str(case_digest))
@@ -1515,7 +1539,7 @@ class EvaluationAuthority:
             name: set() for name in stratum_manifest
         }
         for case_id in primary:
-            case_digest, slices, strata = case_memberships[case_id]
+            case_digest, slices, strata, _ = case_memberships[case_id]
             for name in slices:
                 reviewed_slice_cases[name].add(case_digest)
             for name in strata:
@@ -1533,6 +1557,44 @@ class EvaluationAuthority:
         ):
             raise EvaluationAuthorityError(
                 "reviewed Case-stratum exposure is insufficient"
+            )
+        if report_payload.get("case_count") != len(primary):
+            raise EvaluationAuthorityError(
+                "Metric Report Case count differs from reviewed evidence"
+            )
+        slice_evidence = report_payload.get("required_slice_evidence")
+        if not isinstance(slice_evidence, list):
+            raise EvaluationAuthorityError("Metric Report slice evidence differs")
+        reported_slice_counts: dict[str, int] = {}
+        for document in slice_evidence:
+            if not isinstance(document, Mapping) or not isinstance(
+                document.get("payload"), Mapping
+            ):
+                raise EvaluationAuthorityError("Metric Report slice evidence differs")
+            payload = document["payload"]
+            reported_slice_counts[str(payload["slice_id"])] = int(
+                payload["completed_cases"]
+            )
+        if reported_slice_counts != {
+            name: len(cases) for name, cases in reviewed_slice_cases.items()
+        }:
+            raise EvaluationAuthorityError(
+                "Metric Report slices differ from reviewed evidence"
+            )
+        zero_document = report_payload.get("zero_tolerance_evidence")
+        if not isinstance(zero_document, Mapping) or not isinstance(
+            zero_document.get("payload"), Mapping
+        ):
+            raise EvaluationAuthorityError(
+                "Metric Report zero-tolerance evidence differs"
+            )
+        zero_payload = zero_document["payload"]
+        counts = zero_payload.get("counts")
+        if not isinstance(counts, Mapping) or sum(counts.values()) != sum(  # type: ignore[arg-type]
+            int(case_memberships[case_id][3]) for case_id in primary
+        ):
+            raise EvaluationAuthorityError(
+                "Metric Report zero-tolerance count differs from reviewed evidence"
             )
 
         second_percent = int(

--- a/newsroom/increment8/metrics.py
+++ b/newsroom/increment8/metrics.py
@@ -761,6 +761,12 @@ def build_metric_report(
     )
     if len(deviations) != len(set(deviations)):
         raise MetricReportError("deviation digests must be unique")
+    sampling_digest = _digest(sampling_manifest_digest, "sampling_manifest_digest")
+    label_digest = _digest(label_manifest_digest, "label_manifest_digest")
+    if sampling_digest != label_digest:
+        raise MetricReportError(
+            "sampling and label evidence must share one authority manifest"
+        )
     payload: dict[str, object] = {
         "run_id": run.run_id,
         "run_digest": run.digest,
@@ -789,12 +795,8 @@ def build_metric_report(
         "ablation_evidence": [_embedded(item.canonical_bytes) for item in ablations],
         "metric_code_digest": _digest(metric_code_digest, "metric_code_digest"),
         "environment_digest": _digest(environment_digest, "environment_digest"),
-        "sampling_manifest_digest": _digest(
-            sampling_manifest_digest, "sampling_manifest_digest"
-        ),
-        "label_manifest_digest": _digest(
-            label_manifest_digest, "label_manifest_digest"
-        ),
+        "sampling_manifest_digest": sampling_digest,
+        "label_manifest_digest": label_digest,
         "deviation_digests": list(deviations),
         "metric_status": metric_status.value,
         "performance_status": performance_status.value,

--- a/newsroom/increment8/metrics.py
+++ b/newsroom/increment8/metrics.py
@@ -7,6 +7,7 @@ production authority.
 
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from enum import StrEnum
@@ -139,6 +140,28 @@ def _record(schema_version: str, payload: Mapping[str, object]) -> tuple[bytes, 
         {"schema_version": schema_version, "payload": dict(payload)}
     )
     return raw, digest_bytes(raw)
+
+
+def _document(raw: bytes, schema_version: str) -> Mapping[str, object]:
+    try:
+        value = json.loads(raw.decode("utf-8", errors="strict"))
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        raise MetricReportError("metric evidence is not canonical JSON") from exc
+    if (
+        not isinstance(value, dict)
+        or set(value) != {"schema_version", "payload"}
+        or value["schema_version"] != schema_version
+        or not isinstance(value["payload"], dict)
+        or canonical_json_bytes(value) != raw
+    ):
+        raise MetricReportError("metric evidence envelope differs")
+    return MappingProxyType(value)
+
+
+def _embedded(raw: bytes) -> dict[str, object]:
+    value = json.loads(raw.decode("utf-8", errors="strict"))
+    assert isinstance(value, dict)
+    return value
 
 
 @dataclass(frozen=True, slots=True)
@@ -541,6 +564,10 @@ class MetricReport:
     digest: str
     payload: Mapping[str, object]
 
+    @classmethod
+    def from_canonical_bytes(cls, raw: bytes) -> MetricReport:
+        return verify_metric_report_canonical_bytes(raw)
+
 
 def _exact_named(
     records: Sequence[object], expected: tuple[str, ...], field: str
@@ -719,7 +746,9 @@ def build_metric_report(
         slice_status = MeasurementStatus.NOT_EVALUATED
     else:
         slice_status = MeasurementStatus.PASS
-    if total_cases < minimum_cases or slice_status is MeasurementStatus.NOT_EVALUATED:
+    if zero_tolerance.status is MeasurementStatus.FAIL:
+        overall = MeasurementStatus.FAIL
+    elif total_cases < minimum_cases or slice_status is MeasurementStatus.NOT_EVALUATED:
         overall = MeasurementStatus.NOT_EVALUATED
     elif all(
         status is MeasurementStatus.PASS
@@ -741,16 +770,29 @@ def build_metric_report(
     payload: dict[str, object] = {
         "run_id": run.run_id,
         "run_digest": run.digest,
+        "run": _embedded(run.canonical_bytes),
         "readiness_digest": INCREMENT_8_READINESS_DIGEST,
         "case_count": total_cases,
         "minimum_case_count": minimum_cases,
         "coverage_scope": "REVIEWED_PROSPECTIVE_UNIVERSE_ONLY_NOT_ABSOLUTE_RECALL",
         "rates": [item.digest for item in checked_rates],
+        "rate_evidence": [_embedded(item.canonical_bytes) for item in checked_rates],
         "performance": [item.digest for item in checked_performance],
+        "performance_evidence": [
+            _embedded(item.canonical_bytes) for item in checked_performance
+        ],
         "required_slices": [item.digest for item in checked_slices],
+        "required_slice_evidence": [
+            _embedded(item.canonical_bytes) for item in checked_slices
+        ],
         "zero_tolerance_digest": zero_tolerance.digest,
+        "zero_tolerance_evidence": _embedded(zero_tolerance.canonical_bytes),
         "source_contribution_digests": [item.digest for item in contributions],
+        "source_contribution_evidence": [
+            _embedded(item.canonical_bytes) for item in contributions
+        ],
         "ablation_digests": [item.digest for item in ablations],
+        "ablation_evidence": [_embedded(item.canonical_bytes) for item in ablations],
         "metric_code_digest": _digest(metric_code_digest, "metric_code_digest"),
         "environment_digest": _digest(environment_digest, "environment_digest"),
         "sampling_manifest_digest": _digest(
@@ -784,6 +826,155 @@ def build_metric_report(
     )
 
 
+def _evidence_payload(
+    value: object, schema_version: str
+) -> tuple[bytes, Mapping[str, object]]:
+    if not isinstance(value, dict):
+        raise MetricReportError("embedded metric evidence must be an object")
+    raw = canonical_json_bytes(value)
+    document = _document(raw, schema_version)
+    payload = document["payload"]
+    assert isinstance(payload, Mapping)
+    return raw, payload
+
+
+def verify_metric_report_canonical_bytes(raw: bytes) -> MetricReport:
+    """Reconstruct a Metric Report and every retained measurement from bytes."""
+
+    document = _document(raw, "newsroom.increment8.metric-report.v1")
+    payload = document["payload"]
+    assert isinstance(payload, Mapping)
+    try:
+        run_raw = canonical_json_bytes(payload["run"])
+        run = EvaluationRun.from_canonical_bytes(run_raw)
+
+        rates: list[RateMeasurement] = []
+        for value in payload["rate_evidence"]:  # type: ignore[union-attr]
+            item_raw, item = _evidence_payload(
+                value, "newsroom.increment8.rate-measurement.v1"
+            )
+            rebuilt = RateMeasurement.build(
+                metric_name=item["metric_name"],  # type: ignore[arg-type]
+                count=item["count"],  # type: ignore[arg-type]
+                denominator=item["denominator"],  # type: ignore[arg-type]
+                sampling_method=SamplingMethod(item["sampling_method"]),
+                uncertainty_ppm=item["uncertainty_ppm"],  # type: ignore[arg-type]
+            )
+            if rebuilt.canonical_bytes != item_raw:
+                raise MetricReportError("rate evidence differs after reconstruction")
+            rates.append(rebuilt)
+
+        performance: list[PerformanceMeasurement] = []
+        for value in payload["performance_evidence"]:  # type: ignore[union-attr]
+            item_raw, item = _evidence_payload(
+                value, "newsroom.increment8.performance-measurement.v1"
+            )
+            rebuilt = PerformanceMeasurement.build(
+                metric_name=item["metric_name"],  # type: ignore[arg-type]
+                observed_value=item["observed_value"],  # type: ignore[arg-type]
+            )
+            if rebuilt.canonical_bytes != item_raw:
+                raise MetricReportError(
+                    "performance evidence differs after reconstruction"
+                )
+            performance.append(rebuilt)
+
+        slices: list[RequiredSliceResult] = []
+        for value in payload["required_slice_evidence"]:  # type: ignore[union-attr]
+            item_raw, item = _evidence_payload(
+                value, "newsroom.increment8.required-slice-result.v1"
+            )
+            rebuilt = RequiredSliceResult.build(
+                slice_id=item["slice_id"],  # type: ignore[arg-type]
+                completed_cases=item["completed_cases"],  # type: ignore[arg-type]
+                success_count=item["success_count"],  # type: ignore[arg-type]
+            )
+            if rebuilt.canonical_bytes != item_raw:
+                raise MetricReportError("slice evidence differs after reconstruction")
+            slices.append(rebuilt)
+
+        zero_raw, zero_payload = _evidence_payload(
+            payload["zero_tolerance_evidence"],
+            "newsroom.increment8.zero-tolerance-evidence.v1",
+        )
+        zero = ZeroToleranceEvidence.build(zero_payload["counts"])  # type: ignore[arg-type]
+        if zero.canonical_bytes != zero_raw:
+            raise MetricReportError(
+                "zero-tolerance evidence differs after reconstruction"
+            )
+
+        contributions: list[SourceContribution] = []
+        for value in payload["source_contribution_evidence"]:  # type: ignore[union-attr]
+            item_raw, item = _evidence_payload(
+                value, "newsroom.increment8.source-contribution.v1"
+            )
+            rebuilt = SourceContribution.build(
+                source_id=item["source_id"],  # type: ignore[arg-type]
+                role=SourceRole(item["role"]),
+                provider_version_digest=item["provider_version_digest"],  # type: ignore[arg-type]
+                search_purpose=item["search_purpose"],  # type: ignore[arg-type]
+                unique_detection_count=item["unique_detection_count"],  # type: ignore[arg-type]
+                earlier_detection_count=item["earlier_detection_count"],  # type: ignore[arg-type]
+                resilience_case_count=item["resilience_case_count"],  # type: ignore[arg-type]
+                overlap_count=item["overlap_count"],  # type: ignore[arg-type]
+                noise_count=item["noise_count"],  # type: ignore[arg-type]
+                gross_cost_microunits=item["gross_cost_microunits"],  # type: ignore[arg-type]
+                rights_permitted=item["rights_permitted"],  # type: ignore[arg-type]
+                recommendation=RoleRecommendation(item["recommendation"]),
+                rationale_digest=item["rationale_digest"],  # type: ignore[arg-type]
+            )
+            if rebuilt.canonical_bytes != item_raw:
+                raise MetricReportError(
+                    "source contribution differs after reconstruction"
+                )
+            contributions.append(rebuilt)
+
+        ablations: list[AblationResult] = []
+        for value in payload["ablation_evidence"]:  # type: ignore[union-attr]
+            item_raw, item = _evidence_payload(
+                value, "newsroom.increment8.ablation-result.v1"
+            )
+            rebuilt = AblationResult.build(
+                component_id=item["component_id"],  # type: ignore[arg-type]
+                component_version_digest=item["component_version_digest"],  # type: ignore[arg-type]
+                evaluated_case_count=item["evaluated_case_count"],  # type: ignore[arg-type]
+                lost_detection_count=item["lost_detection_count"],  # type: ignore[arg-type]
+                earlier_detection_lost_count=item["earlier_detection_lost_count"],  # type: ignore[arg-type]
+                resilience_loss_count=item["resilience_loss_count"],  # type: ignore[arg-type]
+                noise_removed_count=item["noise_removed_count"],  # type: ignore[arg-type]
+                cost_removed_microunits=item["cost_removed_microunits"],  # type: ignore[arg-type]
+                affected_slices=item["affected_slices"],  # type: ignore[arg-type]
+            )
+            if rebuilt.canonical_bytes != item_raw:
+                raise MetricReportError(
+                    "ablation evidence differs after reconstruction"
+                )
+            ablations.append(rebuilt)
+
+        rebuilt_report = build_metric_report(
+            run=run,
+            case_count=payload["case_count"],  # type: ignore[arg-type]
+            rates=rates,
+            performance=performance,
+            slices=slices,
+            zero_tolerance=zero,
+            contributions=contributions,
+            ablations=ablations,
+            metric_code_digest=payload["metric_code_digest"],  # type: ignore[arg-type]
+            environment_digest=payload["environment_digest"],  # type: ignore[arg-type]
+            sampling_manifest_digest=payload["sampling_manifest_digest"],  # type: ignore[arg-type]
+            label_manifest_digest=payload["label_manifest_digest"],  # type: ignore[arg-type]
+            deviation_digests=payload["deviation_digests"],  # type: ignore[arg-type]
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        if isinstance(exc, MetricReportError):
+            raise
+        raise MetricReportError("Metric Report reconstruction failed") from exc
+    if rebuilt_report.canonical_bytes != raw:
+        raise MetricReportError("Metric Report differs after reconstruction")
+    return rebuilt_report
+
+
 __all__ = [
     "REQUIRED_SLICES",
     "AblationResult",
@@ -799,4 +990,5 @@ __all__ = [
     "SourceRole",
     "ZeroToleranceEvidence",
     "build_metric_report",
+    "verify_metric_report_canonical_bytes",
 ]

--- a/newsroom/increment8/metrics.py
+++ b/newsroom/increment8/metrics.py
@@ -54,15 +54,9 @@ class RoleRecommendation(StrEnum):
     NO_CHANGE = "NO_CHANGE"
 
 
-REQUIRED_SLICES = (
-    "GEOGRAPHY_GLOBAL",
-    "GEOGRAPHY_HONG_KONG",
-    "GEOGRAPHY_UNITED_KINGDOM",
-    "LANGUAGE_EN_GB",
-    "LANGUAGE_MIXED_EN_GB_ZH_HANT_HK",
-    "LANGUAGE_ZH_HANT_HK",
-    "TRANSITION_FAILURE_HEAVY",
-    "URGENCY_URGENT",
+REQUIRED_SLICES = tuple(
+    str(item["slice_id"])
+    for item in INCREMENT_8_READINESS.evaluation_plan["required_slice_manifest"]  # type: ignore[union-attr]
 )
 
 _MINIMUM_METRICS = frozenset(

--- a/newsroom/tests/test_increment8a_corrective_authority.py
+++ b/newsroom/tests/test_increment8a_corrective_authority.py
@@ -269,6 +269,16 @@ def test_case_membership_and_distinct_event_manifest_are_reconstructed(
         forged_payload["required_slices"] = ["INVENTED"]
         with pytest.raises(EvaluationAuthorityError, match="membership"):
             authority.register_case(EvaluationCase.build(forged_payload))
+        with pytest.raises(EvaluationAuthorityError, match="urgent flag"):
+            build_case(
+                run=run,
+                input_manifest_digest=D2,
+                cutoff_at=T2,
+                membership_facts=_facts(urgency="URGENT"),
+                rights_status=RightsStatus.REVIEWABLE,
+                prospective=True,
+                urgent=False,
+            )
         authority.register_case(case)
         duplicate_event = build_case(
             run=run,
@@ -277,6 +287,7 @@ def test_case_membership_and_distinct_event_manifest_are_reconstructed(
             membership_facts=_facts(urgency="URGENT"),
             rights_status=RightsStatus.REVIEWABLE,
             prospective=True,
+            urgent=True,
         )
         with pytest.raises(EvaluationAuthorityError, match="distinct events"):
             authority.register_case(duplicate_event)

--- a/newsroom/tests/test_increment8a_corrective_authority.py
+++ b/newsroom/tests/test_increment8a_corrective_authority.py
@@ -63,6 +63,7 @@ def _populate(
     run,
     *,
     reviewable: bool = True,
+    reviewable_count: int | None = None,
     positive_changed: bool = False,
     ordinary_second_reviews: bool = True,
 ):
@@ -72,6 +73,9 @@ def _populate(
     ordinary_second_count = 0
     for index in range(120):
         urgent = index % 5 == 0
+        is_reviewable = reviewable and (
+            reviewable_count is None or index < reviewable_count
+        )
         case = build_case(
             run=run,
             input_manifest_digest=_digest(index + 100),
@@ -85,14 +89,14 @@ def _populate(
                 transition="CHANGED" if positive_changed else "UNCHANGED",
             ),
             rights_status=(
-                RightsStatus.REVIEWABLE if reviewable else RightsStatus.UNREVIEWABLE
+                RightsStatus.REVIEWABLE if is_reviewable else RightsStatus.UNREVIEWABLE
             ),
             prospective=True,
             urgent=urgent,
         )
         authority.register_case(case)
         cases.append(case)
-        if not reviewable:
+        if not is_reviewable:
             continue
         primary_identity = REVIEWER_1 if index % 2 == 0 else REVIEWER_2
         secondary_identity = (
@@ -386,6 +390,16 @@ def test_all_unreviewable_exposure_cannot_vacuously_pass(tmp_path: Path) -> None
         connection.close()
 
 
+def test_unreviewable_cases_do_not_fill_reviewed_exposure(tmp_path: Path) -> None:
+    connection, authority, run = _registered(tmp_path)
+    try:
+        _populate(authority, run, reviewable_count=2)
+        with pytest.raises(EvaluationAuthorityError, match="reviewed qualification"):
+            authority.decide_release(_pass_candidate(authority, run))
+    finally:
+        connection.close()
+
+
 def test_mandatory_second_reviews_do_not_satisfy_ordinary_sample(
     tmp_path: Path,
 ) -> None:
@@ -473,3 +487,20 @@ def test_report_is_retained_and_reconstructed_not_a_caller_boolean(
             authority.decide_release(contradictory)
     finally:
         connection.close()
+
+
+def test_release_decision_retains_actual_zero_tolerance_failure_count() -> None:
+    _, _, run = _records()
+    decision = build_release_decision(
+        run=run,
+        report_canonical_bytes=_report_bytes(
+            run,
+            status="FAIL",
+            zero_failures=("temporal_rewrite", "rights_breach"),
+        ),
+        evidence_manifest_digest=D1,
+        verdict=ReleaseVerdict.FAIL,
+        owner_identity_digest=OWNER,
+        decided_at=T5,
+    )
+    assert decision.payload["zero_tolerance_failure_count"] == 2

--- a/newsroom/tests/test_increment8a_corrective_authority.py
+++ b/newsroom/tests/test_increment8a_corrective_authority.py
@@ -129,10 +129,26 @@ def _populate(
 
 
 def _pass_candidate(authority: EvaluationAuthority, run):
+    manifest = authority.evidence_manifest_digest(run.run_id)
+    slice_counts = {
+        "GEOGRAPHY_GLOBAL": 40,
+        "GEOGRAPHY_HONG_KONG": 40,
+        "GEOGRAPHY_UNITED_KINGDOM": 40,
+        "LANGUAGE_EN_GB": 40,
+        "LANGUAGE_MIXED_EN_GB_ZH_HANT_HK": 40,
+        "LANGUAGE_ZH_HANT_HK": 40,
+        "SOURCE_MULTI_DOMAIN_CORROBORATED": 120,
+        "TRANSITION_FAILURE_HEAVY": 120,
+        "URGENCY_URGENT": 24,
+    }
     return build_release_decision(
         run=run,
-        report_canonical_bytes=_report_bytes(run),
-        evidence_manifest_digest=authority.evidence_manifest_digest(run.run_id),
+        report_canonical_bytes=_report_bytes(
+            run,
+            evidence_manifest_digest=manifest,
+            slice_counts=slice_counts,
+        ),
+        evidence_manifest_digest=manifest,
         verdict=ReleaseVerdict.PASS,
         owner_identity_digest=OWNER,
         decided_at=T5,
@@ -324,10 +340,13 @@ def test_release_decision_seals_the_complete_evidence_manifest(tmp_path: Path) -
             prospective=True,
         )
         authority.register_case(case)
+        manifest = authority.evidence_manifest_digest(run.run_id)
         decision = build_release_decision(
             run=run,
-            report_canonical_bytes=_report_bytes(run, status="FAIL"),
-            evidence_manifest_digest=authority.evidence_manifest_digest(run.run_id),
+            report_canonical_bytes=_report_bytes(
+                run, status="FAIL", evidence_manifest_digest=manifest
+            ),
+            evidence_manifest_digest=manifest,
             verdict=ReleaseVerdict.INCONCLUSIVE,
             owner_identity_digest=OWNER,
             decided_at=T5,
@@ -455,7 +474,10 @@ def test_report_is_retained_and_reconstructed_not_a_caller_boolean(
 
     connection, authority, retained_run = _registered(tmp_path / "direct")
     try:
-        report_raw = _report_bytes(retained_run, status="FAIL")
+        manifest = authority.evidence_manifest_digest(retained_run.run_id)
+        report_raw = _report_bytes(
+            retained_run, status="FAIL", evidence_manifest_digest=manifest
+        )
         report = json.loads(report_raw)
         direct = ReleaseEvidenceDecision.build(
             {
@@ -463,9 +485,7 @@ def test_report_is_retained_and_reconstructed_not_a_caller_boolean(
                 "run_digest": retained_run.digest,
                 "report_digest": _digest(500),
                 "metric_report": report,
-                "evidence_manifest_digest": authority.evidence_manifest_digest(
-                    retained_run.run_id
-                ),
+                "evidence_manifest_digest": manifest,
                 "verdict": ReleaseVerdict.INCONCLUSIVE.value,
                 "owner_identity_digest": OWNER,
                 "decided_at": T5,
@@ -498,7 +518,7 @@ def test_release_decision_retains_actual_zero_tolerance_failure_count() -> None:
             status="FAIL",
             zero_failures=("temporal_rewrite", "rights_breach"),
         ),
-        evidence_manifest_digest=D1,
+        evidence_manifest_digest=D2,
         verdict=ReleaseVerdict.FAIL,
         owner_identity_digest=OWNER,
         decided_at=T5,

--- a/newsroom/tests/test_increment8a_corrective_authority.py
+++ b/newsroom/tests/test_increment8a_corrective_authority.py
@@ -279,6 +279,19 @@ def test_case_membership_and_distinct_event_manifest_are_reconstructed(
                 prospective=True,
                 urgent=False,
             )
+        urgent_case = build_case(
+            run=run,
+            input_manifest_digest=D2,
+            cutoff_at=T2,
+            membership_facts=_facts(urgency="URGENT"),
+            rights_status=RightsStatus.REVIEWABLE,
+            prospective=True,
+            urgent=True,
+        )
+        direct_payload = dict(urgent_case.payload)
+        direct_payload["urgent"] = False
+        with pytest.raises(EvaluationAuthorityError, match="membership"):
+            authority.register_case(EvaluationCase.build(direct_payload))
         authority.register_case(case)
         duplicate_event = build_case(
             run=run,
@@ -402,7 +415,7 @@ def test_report_is_retained_and_reconstructed_not_a_caller_boolean(
             "live_shadow_execution_authorised": False,
         },
     }
-    with pytest.raises(EvaluationAuthorityError, match="fields differ"):
+    with pytest.raises(EvaluationAuthorityError, match="canonical reconstruction"):
         build_release_decision(
             run=run,
             report_canonical_bytes=json.dumps(
@@ -416,7 +429,7 @@ def test_report_is_retained_and_reconstructed_not_a_caller_boolean(
     inconsistent = json.loads(_report_bytes(run))
     inconsistent["payload"]["metric_status"] = "FAIL"
     raw = json.dumps(inconsistent, sort_keys=True, separators=(",", ":")).encode()
-    with pytest.raises(EvaluationAuthorityError, match="internally inconsistent"):
+    with pytest.raises(EvaluationAuthorityError, match="canonical reconstruction"):
         build_release_decision(
             run=run,
             report_canonical_bytes=raw,

--- a/newsroom/tests/test_increment8a_corrective_authority.py
+++ b/newsroom/tests/test_increment8a_corrective_authority.py
@@ -389,6 +389,30 @@ def test_report_is_retained_and_reconstructed_not_a_caller_boolean(
     tmp_path: Path,
 ) -> None:
     _, _, run = _records()
+    minimal = {
+        "schema_version": "newsroom.increment8.metric-report.v1",
+        "payload": {
+            "run_id": run.run_id,
+            "run_digest": run.digest,
+            "metric_status": "PASS",
+            "slice_status": "PASS",
+            "zero_tolerance_status": "PASS",
+            "overall_status": "PASS",
+            "production_activation_authorised": False,
+            "live_shadow_execution_authorised": False,
+        },
+    }
+    with pytest.raises(EvaluationAuthorityError, match="fields differ"):
+        build_release_decision(
+            run=run,
+            report_canonical_bytes=json.dumps(
+                minimal, sort_keys=True, separators=(",", ":")
+            ).encode(),
+            evidence_manifest_digest=D1,
+            verdict=ReleaseVerdict.PASS,
+            owner_identity_digest=OWNER,
+            decided_at=T5,
+        )
     inconsistent = json.loads(_report_bytes(run))
     inconsistent["payload"]["metric_status"] = "FAIL"
     raw = json.dumps(inconsistent, sort_keys=True, separators=(",", ":")).encode()
@@ -428,5 +452,11 @@ def test_report_is_retained_and_reconstructed_not_a_caller_boolean(
         assert digest_bytes(report_raw) != direct.payload["report_digest"]
         with pytest.raises(EvaluationAuthorityError, match="Report digest"):
             authority.decide_release(direct)
+        contradictory_payload = dict(direct.payload)
+        contradictory_payload["report_digest"] = digest_bytes(report_raw)
+        contradictory_payload["metrics_passed"] = True
+        contradictory = ReleaseEvidenceDecision.build(contradictory_payload)
+        with pytest.raises(EvaluationAuthorityError, match="decision gates"):
+            authority.decide_release(contradictory)
     finally:
         connection.close()

--- a/newsroom/tests/test_increment8a_corrective_authority.py
+++ b/newsroom/tests/test_increment8a_corrective_authority.py
@@ -1,0 +1,421 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from newsroom.authority.canonical import digest_bytes
+from newsroom.increment8.evaluation import (
+    EvaluationAuthority,
+    EvaluationAuthorityError,
+    EvaluationCase,
+    ReleaseEvidenceDecision,
+    ReleaseVerdict,
+    ReviewRole,
+    RightsStatus,
+    RunKind,
+    build_adjudication,
+    build_case,
+    build_evaluation_plan,
+    build_release_decision,
+    build_review_label,
+    freeze_epoch,
+    open_run,
+)
+from newsroom.tests.test_increment8a_evaluation_authority import (
+    D1,
+    D2,
+    OWNER,
+    REVIEWER_1,
+    REVIEWER_2,
+    T0,
+    T1,
+    T2,
+    T3,
+    T4,
+    T5,
+    _database,
+    _facts,
+    _plan_kwargs,
+    _records,
+    _report_bytes,
+)
+
+
+def _digest(index: int) -> str:
+    return f"sha256:{index:064x}"
+
+
+def _registered(tmp_path: Path):
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    connection = _database(tmp_path / "authority.sqlite3")
+    authority = EvaluationAuthority(connection)
+    plan, epoch, run = _records()
+    authority.register_plan(plan)
+    authority.register_epoch(epoch)
+    authority.register_run(run)
+    return connection, authority, run
+
+
+def _populate(
+    authority: EvaluationAuthority,
+    run,
+    *,
+    reviewable: bool = True,
+    positive_changed: bool = False,
+    ordinary_second_reviews: bool = True,
+):
+    geographies = ("GLOBAL", "HONG_KONG", "UNITED_KINGDOM")
+    languages = ("EN_GB", "MIXED_EN_GB_ZH_HANT_HK", "ZH_HANT_HK")
+    cases = []
+    ordinary_second_count = 0
+    for index in range(120):
+        urgent = index % 5 == 0
+        case = build_case(
+            run=run,
+            input_manifest_digest=_digest(index + 100),
+            cutoff_at=T2,
+            membership_facts=_facts(
+                geography=geographies[index % len(geographies)],
+                language=languages[index % len(languages)],
+                urgency="URGENT" if urgent else "ROUTINE",
+                failures=2,
+                candidate="CANDIDATE" if positive_changed else "NO_CANDIDATE",
+                transition="CHANGED" if positive_changed else "UNCHANGED",
+            ),
+            rights_status=(
+                RightsStatus.REVIEWABLE if reviewable else RightsStatus.UNREVIEWABLE
+            ),
+            prospective=True,
+            urgent=urgent,
+        )
+        authority.register_case(case)
+        cases.append(case)
+        if not reviewable:
+            continue
+        primary_identity = REVIEWER_1 if index % 2 == 0 else REVIEWER_2
+        secondary_identity = (
+            REVIEWER_2 if primary_identity == REVIEWER_1 else REVIEWER_1
+        )
+        authority.record_label(
+            build_review_label(
+                case=case,
+                reviewer_identity_digest=primary_identity,
+                role=ReviewRole.PRIMARY,
+                label="expected-route",
+                blinded=True,
+                recorded_at=T3,
+            )
+        )
+        if urgent or (ordinary_second_reviews and ordinary_second_count < 20):
+            authority.record_label(
+                build_review_label(
+                    case=case,
+                    reviewer_identity_digest=secondary_identity,
+                    role=ReviewRole.SECONDARY,
+                    label="expected-route",
+                    blinded=True,
+                    recorded_at=T3,
+                )
+            )
+            if not urgent:
+                ordinary_second_count += 1
+    return tuple(cases)
+
+
+def _pass_candidate(authority: EvaluationAuthority, run):
+    return build_release_decision(
+        run=run,
+        report_canonical_bytes=_report_bytes(run),
+        evidence_manifest_digest=authority.evidence_manifest_digest(run.run_id),
+        verdict=ReleaseVerdict.PASS,
+        owner_identity_digest=OWNER,
+        decided_at=T5,
+    )
+
+
+def test_connection_must_be_transaction_free_with_foreign_keys_active(
+    tmp_path: Path,
+) -> None:
+    connection = _database(tmp_path / "authority.sqlite3")
+    try:
+        connection.execute("PRAGMA foreign_keys=OFF")
+        with pytest.raises(EvaluationAuthorityError, match="foreign keys"):
+            EvaluationAuthority(connection)
+        connection.execute("PRAGMA foreign_keys=ON")
+        connection.execute("BEGIN")
+        with pytest.raises(EvaluationAuthorityError, match="caller-owned"):
+            EvaluationAuthority(connection)
+        assert connection.in_transaction is True
+        connection.execute("ROLLBACK")
+    finally:
+        connection.close()
+
+
+def test_plan_epoch_run_case_and_review_chronology_is_enforced() -> None:
+    plan = build_evaluation_plan(
+        approved_by_digest=OWNER,
+        approved_at=T2,
+        component_manifest_digest=D1,
+        **_plan_kwargs(),
+    )
+    with pytest.raises(EvaluationAuthorityError, match="chronology"):
+        freeze_epoch(
+            plan=plan,
+            target_manifest_digest=D1,
+            universe_manifest_digest=D2,
+            sampling_method_digest=D1,
+            cutoff_at=T0,
+            opened_at=T1,
+        )
+    _, epoch, _ = _records()
+    with pytest.raises(EvaluationAuthorityError, match="chronology"):
+        open_run(
+            epoch=epoch, kind=RunKind.QUALIFICATION, started_at="2026-08-13T00:00:00Z"
+        )
+    _, _, run = _records()
+    with pytest.raises(EvaluationAuthorityError, match="chronology"):
+        build_case(
+            run=run,
+            input_manifest_digest=D1,
+            cutoff_at=T0,
+            membership_facts=_facts(),
+            rights_status=RightsStatus.REVIEWABLE,
+            prospective=True,
+        )
+
+
+def test_authorised_human_roles_and_same_role_uniqueness_are_enforced(
+    tmp_path: Path,
+) -> None:
+    connection, authority, run = _registered(tmp_path)
+    try:
+        case = build_case(
+            run=run,
+            input_manifest_digest=D1,
+            cutoff_at=T2,
+            membership_facts=_facts(),
+            rights_status=RightsStatus.REVIEWABLE,
+            prospective=True,
+        )
+        authority.register_case(case)
+        unauthorised = build_review_label(
+            case=case,
+            reviewer_identity_digest=_digest(999),
+            role=ReviewRole.PRIMARY,
+            label="route-a",
+            blinded=True,
+            recorded_at=T3,
+        )
+        with pytest.raises(EvaluationAuthorityError, match="authorised human"):
+            authority.record_label(unauthorised)
+        primary = build_review_label(
+            case=case,
+            reviewer_identity_digest=REVIEWER_1,
+            role=ReviewRole.PRIMARY,
+            label="route-a",
+            blinded=True,
+            recorded_at=T3,
+        )
+        authority.record_label(primary)
+        same_role = build_review_label(
+            case=case,
+            reviewer_identity_digest=REVIEWER_2,
+            role=ReviewRole.PRIMARY,
+            label="route-b",
+            blinded=True,
+            recorded_at=T3,
+        )
+        with pytest.raises(EvaluationAuthorityError, match="one label per role"):
+            authority.record_label(same_role)
+        secondary = build_review_label(
+            case=case,
+            reviewer_identity_digest=REVIEWER_2,
+            role=ReviewRole.SECONDARY,
+            label="route-b",
+            blinded=True,
+            recorded_at=T3,
+        )
+        authority.record_label(secondary)
+        unauthorised_adjudication = build_adjudication(
+            case=case,
+            primary=primary,
+            secondary=secondary,
+            adjudicator_identity_digest=_digest(998),
+            final_label="route-a",
+            decided_at=T4,
+        )
+        with pytest.raises(EvaluationAuthorityError, match="adjudicator"):
+            authority.record_adjudication(unauthorised_adjudication)
+    finally:
+        connection.close()
+
+
+def test_case_membership_and_distinct_event_manifest_are_reconstructed(
+    tmp_path: Path,
+) -> None:
+    connection, authority, run = _registered(tmp_path)
+    try:
+        case = build_case(
+            run=run,
+            input_manifest_digest=D1,
+            cutoff_at=T2,
+            membership_facts=_facts(),
+            rights_status=RightsStatus.REVIEWABLE,
+            prospective=True,
+        )
+        forged_payload = dict(case.payload)
+        forged_payload["required_slices"] = ["INVENTED"]
+        with pytest.raises(EvaluationAuthorityError, match="membership"):
+            authority.register_case(EvaluationCase.build(forged_payload))
+        authority.register_case(case)
+        duplicate_event = build_case(
+            run=run,
+            input_manifest_digest=D1,
+            cutoff_at=T3,
+            membership_facts=_facts(urgency="URGENT"),
+            rights_status=RightsStatus.REVIEWABLE,
+            prospective=True,
+        )
+        with pytest.raises(EvaluationAuthorityError, match="distinct events"):
+            authority.register_case(duplicate_event)
+    finally:
+        connection.close()
+
+
+def test_release_decision_seals_the_complete_evidence_manifest(tmp_path: Path) -> None:
+    connection, authority, run = _registered(tmp_path)
+    try:
+        case = build_case(
+            run=run,
+            input_manifest_digest=D1,
+            cutoff_at=T2,
+            membership_facts=_facts(),
+            rights_status=RightsStatus.REVIEWABLE,
+            prospective=True,
+        )
+        authority.register_case(case)
+        decision = build_release_decision(
+            run=run,
+            report_canonical_bytes=_report_bytes(run, status="FAIL"),
+            evidence_manifest_digest=authority.evidence_manifest_digest(run.run_id),
+            verdict=ReleaseVerdict.INCONCLUSIVE,
+            owner_identity_digest=OWNER,
+            decided_at=T5,
+            early_stopped=True,
+        )
+        authority.decide_release(decision)
+        later_case = build_case(
+            run=run,
+            input_manifest_digest=D2,
+            cutoff_at=T3,
+            membership_facts=_facts(),
+            rights_status=RightsStatus.REVIEWABLE,
+            prospective=True,
+        )
+        with pytest.raises(EvaluationAuthorityError, match="sealed"):
+            authority.register_case(later_case)
+        later_label = build_review_label(
+            case=case,
+            reviewer_identity_digest=REVIEWER_1,
+            role=ReviewRole.PRIMARY,
+            label="route-a",
+            blinded=True,
+            recorded_at=T4,
+        )
+        with pytest.raises(EvaluationAuthorityError, match="sealed"):
+            authority.record_label(later_label)
+    finally:
+        connection.close()
+
+
+def test_complete_valid_exposure_reaches_only_the_corrective_blockade(
+    tmp_path: Path,
+) -> None:
+    connection, authority, run = _registered(tmp_path)
+    try:
+        _populate(authority, run)
+        with pytest.raises(EvaluationAuthorityError, match="corrective readiness"):
+            authority.decide_release(_pass_candidate(authority, run))
+    finally:
+        connection.close()
+
+
+def test_positive_changed_only_exposure_fails_frozen_strata(tmp_path: Path) -> None:
+    connection, authority, run = _registered(tmp_path)
+    try:
+        _populate(authority, run, positive_changed=True)
+        with pytest.raises(EvaluationAuthorityError, match="stratum"):
+            authority.decide_release(_pass_candidate(authority, run))
+    finally:
+        connection.close()
+
+
+def test_all_unreviewable_exposure_cannot_vacuously_pass(tmp_path: Path) -> None:
+    connection, authority, run = _registered(tmp_path)
+    try:
+        _populate(authority, run, reviewable=False)
+        with pytest.raises(EvaluationAuthorityError, match="reviewable exposure"):
+            authority.decide_release(_pass_candidate(authority, run))
+    finally:
+        connection.close()
+
+
+def test_mandatory_second_reviews_do_not_satisfy_ordinary_sample(
+    tmp_path: Path,
+) -> None:
+    connection, authority, run = _registered(tmp_path)
+    try:
+        _populate(authority, run, ordinary_second_reviews=False)
+        with pytest.raises(EvaluationAuthorityError, match="second-review exposure"):
+            authority.decide_release(_pass_candidate(authority, run))
+    finally:
+        connection.close()
+
+
+def test_report_is_retained_and_reconstructed_not_a_caller_boolean(
+    tmp_path: Path,
+) -> None:
+    _, _, run = _records()
+    inconsistent = json.loads(_report_bytes(run))
+    inconsistent["payload"]["metric_status"] = "FAIL"
+    raw = json.dumps(inconsistent, sort_keys=True, separators=(",", ":")).encode()
+    with pytest.raises(EvaluationAuthorityError, match="internally inconsistent"):
+        build_release_decision(
+            run=run,
+            report_canonical_bytes=raw,
+            evidence_manifest_digest=D1,
+            verdict=ReleaseVerdict.PASS,
+            owner_identity_digest=OWNER,
+            decided_at=T5,
+        )
+
+    connection, authority, retained_run = _registered(tmp_path / "direct")
+    try:
+        report_raw = _report_bytes(retained_run, status="FAIL")
+        report = json.loads(report_raw)
+        direct = ReleaseEvidenceDecision.build(
+            {
+                "run_id": retained_run.run_id,
+                "run_digest": retained_run.digest,
+                "report_digest": _digest(500),
+                "metric_report": report,
+                "evidence_manifest_digest": authority.evidence_manifest_digest(
+                    retained_run.run_id
+                ),
+                "verdict": ReleaseVerdict.INCONCLUSIVE.value,
+                "owner_identity_digest": OWNER,
+                "decided_at": T5,
+                "metrics_passed": False,
+                "required_slices_passed": False,
+                "zero_tolerance_failure_count": 1,
+                "early_stopped": True,
+                "production_activation_authorised": False,
+            }
+        )
+        assert digest_bytes(report_raw) != direct.payload["report_digest"]
+        with pytest.raises(EvaluationAuthorityError, match="Report digest"):
+            authority.decide_release(direct)
+    finally:
+        connection.close()

--- a/newsroom/tests/test_increment8a_evaluation_authority.py
+++ b/newsroom/tests/test_increment8a_evaluation_authority.py
@@ -12,7 +12,7 @@ from newsroom.authority.increment8_evaluation_migrations import (
     Increment8EvaluationBackupError,
     prepare_increment8_evaluation_backup,
 )
-from newsroom.authority.canonical import canonical_json_bytes, digest_bytes
+from newsroom.authority.canonical import digest_bytes
 from newsroom.authority.migrations import (
     EXPECTED_MIGRATION_HISTORY,
     EXPECTED_SCHEMA_FINGERPRINT,
@@ -93,37 +93,31 @@ def _facts(
 
 
 def _report_bytes(run, *, status: str = "PASS") -> bytes:
-    digests = [f"sha256:{index:064x}" for index in range(20, 30)]
-    payload = {
-        "run_id": run.run_id,
-        "run_digest": run.digest,
-        "readiness_digest": INCREMENT_8_READINESS_DIGEST,
-        "case_count": 120,
-        "minimum_case_count": 120,
-        "coverage_scope": "REVIEWED_PROSPECTIVE_UNIVERSE_ONLY_NOT_ABSOLUTE_RECALL",
-        "rates": digests[0:2],
-        "performance": digests[2:4],
-        "required_slices": digests[4:6],
-        "zero_tolerance_digest": digests[6],
-        "source_contribution_digests": [digests[7]],
-        "ablation_digests": [digests[8]],
-        "metric_code_digest": digests[9],
-        "environment_digest": D1,
-        "sampling_manifest_digest": D2,
-        "label_manifest_digest": D3,
-        "deviation_digests": [],
-        "metric_status": status,
-        "performance_status": status,
-        "slice_status": status,
-        "zero_tolerance_status": status,
-        "overall_status": status,
-        "ablation_is_decision_bearing": False,
-        "production_activation_authorised": False,
-        "live_shadow_execution_authorised": False,
-    }
-    return canonical_json_bytes(
-        {"schema_version": "newsroom.increment8.metric-report.v1", "payload": payload}
+    from newsroom.increment8.metrics import build_metric_report
+    from newsroom.tests.test_increment8b_metrics import (
+        _ablations,
+        _contributions,
+        _performance,
+        _rates,
+        _slices,
+        _zero,
     )
+
+    report = build_metric_report(
+        run=run,
+        case_count=120,
+        rates=_rates(fail="candidate_precision" if status == "FAIL" else None),
+        performance=_performance(),
+        slices=_slices(),
+        zero_tolerance=_zero(),
+        contributions=_contributions(),
+        ablations=_ablations(),
+        metric_code_digest="sha256:" + "9" * 64,
+        environment_digest="sha256:" + "a" * 64,
+        sampling_manifest_digest="sha256:" + "b" * 64,
+        label_manifest_digest="sha256:" + "c" * 64,
+    )
+    return report.canonical_bytes
 
 
 def _database(path: Path) -> sqlite3.Connection:
@@ -295,10 +289,10 @@ def test_independent_review_and_adjudication_are_enforced() -> None:
 
 def test_calibration_and_early_stop_never_pass() -> None:
     _, _, calibration = _records(RunKind.CALIBRATION)
-    with pytest.raises(EvaluationAuthorityError, match="retained Metric Report"):
+    with pytest.raises(EvaluationAuthorityError, match="release rule"):
         build_release_decision(
             run=calibration,
-            report_canonical_bytes=_report_bytes(calibration),
+            report_canonical_bytes=b"not used for a calibration PASS",
             evidence_manifest_digest=D2,
             verdict=ReleaseVerdict.PASS,
             owner_identity_digest=OWNER,

--- a/newsroom/tests/test_increment8a_evaluation_authority.py
+++ b/newsroom/tests/test_increment8a_evaluation_authority.py
@@ -93,13 +93,31 @@ def _facts(
 
 
 def _report_bytes(run, *, status: str = "PASS") -> bytes:
+    digests = [f"sha256:{index:064x}" for index in range(20, 30)]
     payload = {
         "run_id": run.run_id,
         "run_digest": run.digest,
+        "readiness_digest": INCREMENT_8_READINESS_DIGEST,
+        "case_count": 120,
+        "minimum_case_count": 120,
+        "coverage_scope": "REVIEWED_PROSPECTIVE_UNIVERSE_ONLY_NOT_ABSOLUTE_RECALL",
+        "rates": digests[0:2],
+        "performance": digests[2:4],
+        "required_slices": digests[4:6],
+        "zero_tolerance_digest": digests[6],
+        "source_contribution_digests": [digests[7]],
+        "ablation_digests": [digests[8]],
+        "metric_code_digest": digests[9],
+        "environment_digest": D1,
+        "sampling_manifest_digest": D2,
+        "label_manifest_digest": D3,
+        "deviation_digests": [],
         "metric_status": status,
+        "performance_status": status,
         "slice_status": status,
         "zero_tolerance_status": status,
         "overall_status": status,
+        "ablation_is_decision_bearing": False,
         "production_activation_authorised": False,
         "live_shadow_execution_authorised": False,
     }

--- a/newsroom/tests/test_increment8a_evaluation_authority.py
+++ b/newsroom/tests/test_increment8a_evaluation_authority.py
@@ -92,7 +92,9 @@ def _facts(
     }
 
 
-def _report_bytes(run, *, status: str = "PASS") -> bytes:
+def _report_bytes(
+    run, *, status: str = "PASS", zero_failures: tuple[str, ...] = ()
+) -> bytes:
     from newsroom.increment8.metrics import build_metric_report
     from newsroom.tests.test_increment8b_metrics import (
         _ablations,
@@ -109,7 +111,7 @@ def _report_bytes(run, *, status: str = "PASS") -> bytes:
         rates=_rates(fail="candidate_precision" if status == "FAIL" else None),
         performance=_performance(),
         slices=_slices(),
-        zero_tolerance=_zero(),
+        zero_tolerance=_zero(**{name: 1 for name in zero_failures}),
         contributions=_contributions(),
         ablations=_ablations(),
         metric_code_digest="sha256:" + "9" * 64,

--- a/newsroom/tests/test_increment8a_evaluation_authority.py
+++ b/newsroom/tests/test_increment8a_evaluation_authority.py
@@ -12,6 +12,7 @@ from newsroom.authority.increment8_evaluation_migrations import (
     Increment8EvaluationBackupError,
     prepare_increment8_evaluation_backup,
 )
+from newsroom.authority.canonical import canonical_json_bytes, digest_bytes
 from newsroom.authority.migrations import (
     EXPECTED_MIGRATION_HISTORY,
     EXPECTED_SCHEMA_FINGERPRINT,
@@ -37,7 +38,6 @@ from newsroom.increment8.evaluation import (
     open_run,
 )
 from newsroom.increment8.readiness import (
-    INCREMENT_8_READINESS,
     INCREMENT_8_READINESS_DIGEST,
     READINESS_CONTRACT_PATH,
 )
@@ -52,7 +52,60 @@ REVIEWER_2 = "sha256:" + "c" * 64
 ADJUDICATOR = "sha256:" + "d" * 64
 T0 = "2026-08-14T12:00:00Z"
 T1 = "2026-08-14T12:01:00Z"
-SLICES = tuple(f"slice-{index:02d}" for index in range(8))
+T2 = "2026-08-14T12:02:00Z"
+T3 = "2026-08-14T12:03:00Z"
+T4 = "2026-08-14T12:04:00Z"
+T5 = "2026-08-14T12:05:00Z"
+
+
+def _plan_kwargs():
+    return {
+        "authorised_primary_reviewer_digests": (REVIEWER_1, REVIEWER_2),
+        "authorised_secondary_reviewer_digests": (REVIEWER_1, REVIEWER_2),
+        "authorised_adjudicator_digests": (ADJUDICATOR,),
+        "authorised_release_owner_digests": (OWNER,),
+    }
+
+
+def _facts(
+    *,
+    geography: str = "GLOBAL",
+    language: str = "EN_GB",
+    urgency: str = "ROUTINE",
+    domains: int = 2,
+    failures: int = 2,
+    candidate: str = "NO_CANDIDATE",
+    transition: str = "UNCHANGED",
+):
+    return {
+        "case_metadata": {
+            "geography": geography,
+            "language": language,
+            "urgency": urgency,
+        },
+        "source_evidence": {"distinct_domain_count": domains},
+        "fixture": {"injected_failure_count": failures},
+        "expected": {
+            "candidate_outcome": candidate,
+            "transition_outcome": transition,
+        },
+    }
+
+
+def _report_bytes(run, *, status: str = "PASS") -> bytes:
+    payload = {
+        "run_id": run.run_id,
+        "run_digest": run.digest,
+        "metric_status": status,
+        "slice_status": status,
+        "zero_tolerance_status": status,
+        "overall_status": status,
+        "production_activation_authorised": False,
+        "live_shadow_execution_authorised": False,
+    }
+    return canonical_json_bytes(
+        {"schema_version": "newsroom.increment8.metric-report.v1", "payload": payload}
+    )
 
 
 def _database(path: Path) -> sqlite3.Connection:
@@ -67,6 +120,7 @@ def _records(kind: RunKind = RunKind.QUALIFICATION):
         approved_by_digest=OWNER,
         approved_at=T0,
         component_manifest_digest=D1,
+        **_plan_kwargs(),
     )
     epoch = freeze_epoch(
         plan=plan,
@@ -123,9 +177,12 @@ def test_v29_upgrade_fails_without_prepared_backup(tmp_path: Path) -> None:
 def test_plan_binds_exact_pre_measurement_values_and_round_trips() -> None:
     plan, epoch, run = _records()
     assert plan.payload["readiness_digest"] == INCREMENT_8_READINESS_DIGEST
-    assert plan.payload["plan_definition"] == json.loads(
-        READINESS_CONTRACT_PATH.read_bytes()
-    )["payload"]["evaluation_plan"]
+    assert (
+        plan.payload["plan_definition"]
+        == json.loads(READINESS_CONTRACT_PATH.read_bytes())["payload"][
+            "evaluation_plan"
+        ]
+    )
     assert plan.payload["calibration_may_qualify_selected_values"] is False
     assert epoch.payload["frozen"] is True
     assert run.payload["run_kind"] == "QUALIFICATION"
@@ -138,16 +195,16 @@ def test_qualification_cases_are_prospective_and_unreviewable_is_explicit() -> N
         build_case(
             run=run,
             input_manifest_digest=D1,
-            cutoff_at=T0,
-            required_slices=SLICES,
+            cutoff_at=T2,
+            membership_facts=_facts(),
             rights_status=RightsStatus.REVIEWABLE,
             prospective=False,
         )
     case = build_case(
         run=run,
         input_manifest_digest=D1,
-        cutoff_at=T0,
-        required_slices=SLICES,
+        cutoff_at=T2,
+        membership_facts=_facts(),
         rights_status=RightsStatus.UNREVIEWABLE,
         prospective=True,
     )
@@ -167,8 +224,8 @@ def test_independent_review_and_adjudication_are_enforced() -> None:
     case = build_case(
         run=run,
         input_manifest_digest=D1,
-        cutoff_at=T0,
-        required_slices=SLICES,
+        cutoff_at=T2,
+        membership_facts=_facts(urgency="URGENT"),
         rights_status=RightsStatus.REVIEWABLE,
         prospective=True,
         launch_blocker=True,
@@ -179,7 +236,7 @@ def test_independent_review_and_adjudication_are_enforced() -> None:
         role=ReviewRole.PRIMARY,
         label="route-a",
         blinded=True,
-        recorded_at=T1,
+        recorded_at=T3,
     )
     same_reviewer = build_review_label(
         case=case,
@@ -187,7 +244,7 @@ def test_independent_review_and_adjudication_are_enforced() -> None:
         role=ReviewRole.SECONDARY,
         label="route-b",
         blinded=True,
-        recorded_at=T1,
+        recorded_at=T3,
     )
     with pytest.raises(EvaluationAuthorityError, match="independent"):
         build_adjudication(
@@ -196,7 +253,7 @@ def test_independent_review_and_adjudication_are_enforced() -> None:
             secondary=same_reviewer,
             adjudicator_identity_digest=ADJUDICATOR,
             final_label="route-a",
-            decided_at=T1,
+            decided_at=T4,
         )
     secondary = build_review_label(
         case=case,
@@ -204,7 +261,7 @@ def test_independent_review_and_adjudication_are_enforced() -> None:
         role=ReviewRole.SECONDARY,
         label="route-b",
         blinded=True,
-        recorded_at=T1,
+        recorded_at=T3,
     )
     adjudication = build_adjudication(
         case=case,
@@ -212,35 +269,31 @@ def test_independent_review_and_adjudication_are_enforced() -> None:
         secondary=secondary,
         adjudicator_identity_digest=ADJUDICATOR,
         final_label="route-a",
-        decided_at=T1,
+        decided_at=T4,
     )
     assert adjudication.payload["primary_label_digest"] == primary.digest
 
 
 def test_calibration_and_early_stop_never_pass() -> None:
     _, _, calibration = _records(RunKind.CALIBRATION)
-    with pytest.raises(EvaluationAuthorityError, match="release rule"):
+    with pytest.raises(EvaluationAuthorityError, match="retained Metric Report"):
         build_release_decision(
             run=calibration,
-            report_digest=D1,
+            report_canonical_bytes=_report_bytes(calibration),
+            evidence_manifest_digest=D2,
             verdict=ReleaseVerdict.PASS,
             owner_identity_digest=OWNER,
             decided_at=T1,
-            metrics_passed=True,
-            required_slices_passed=True,
-            zero_tolerance_failure_count=0,
         )
     _, _, qualification = _records()
-    with pytest.raises(EvaluationAuthorityError, match="release rule"):
+    with pytest.raises(EvaluationAuthorityError, match="retained Metric Report"):
         build_release_decision(
             run=qualification,
-            report_digest=D1,
+            report_canonical_bytes=_report_bytes(qualification),
+            evidence_manifest_digest=D2,
             verdict=ReleaseVerdict.PASS,
             owner_identity_digest=OWNER,
             decided_at=T1,
-            metrics_passed=True,
-            required_slices_passed=True,
-            zero_tolerance_failure_count=0,
             early_stopped=True,
         )
 
@@ -258,8 +311,8 @@ def test_append_only_authority_retains_failed_run_and_rejects_mutation(
         case = build_case(
             run=run,
             input_manifest_digest=D1,
-            cutoff_at=T0,
-            required_slices=SLICES,
+            cutoff_at=T2,
+            membership_facts=_facts(),
             rights_status=RightsStatus.REVIEWABLE,
             prospective=True,
         )
@@ -270,18 +323,16 @@ def test_append_only_authority_retains_failed_run_and_rejects_mutation(
             role=ReviewRole.PRIMARY,
             label="route-a",
             blinded=True,
-            recorded_at=T1,
+            recorded_at=T3,
         )
         authority.record_label(label)
         decision = build_release_decision(
             run=run,
-            report_digest=D2,
+            report_canonical_bytes=_report_bytes(run, status="FAIL"),
+            evidence_manifest_digest=authority.evidence_manifest_digest(run.run_id),
             verdict=ReleaseVerdict.INCONCLUSIVE,
             owner_identity_digest=OWNER,
-            decided_at=T1,
-            metrics_passed=False,
-            required_slices_passed=False,
-            zero_tolerance_failure_count=0,
+            decided_at=T5,
             early_stopped=True,
         )
         authority.decide_release(decision)
@@ -315,28 +366,32 @@ def test_pass_requires_full_exposure_primary_labels_and_second_review_sample(
         authority.register_plan(plan)
         authority.register_epoch(epoch)
         authority.register_run(run)
-        with pytest.raises(EvaluationAuthorityError, match="corrective readiness"):
-            build_release_decision(
-                run=run,
-                report_digest=D2,
-                verdict=ReleaseVerdict.PASS,
-                owner_identity_digest=OWNER,
-                decided_at=T1,
-                metrics_passed=True,
-                required_slices_passed=True,
-                zero_tolerance_failure_count=0,
-            )
+        candidate = build_release_decision(
+            run=run,
+            report_canonical_bytes=_report_bytes(run),
+            evidence_manifest_digest=authority.evidence_manifest_digest(run.run_id),
+            verdict=ReleaseVerdict.PASS,
+            owner_identity_digest=OWNER,
+            decided_at=T5,
+        )
+        with pytest.raises(EvaluationAuthorityError, match="exposure"):
+            authority.decide_release(candidate)
 
         # The authority gate also rejects a caller that bypasses the public
         # builder and assembles canonical PASS-shaped bytes directly.
+        report = json.loads(_report_bytes(run))
         direct = ReleaseEvidenceDecision.build(
             {
                 "run_id": run.run_id,
                 "run_digest": run.digest,
-                "report_digest": D2,
+                "report_digest": digest_bytes(_report_bytes(run)),
+                "metric_report": report,
+                "evidence_manifest_digest": authority.evidence_manifest_digest(
+                    run.run_id
+                ),
                 "verdict": ReleaseVerdict.PASS.value,
                 "owner_identity_digest": OWNER,
-                "decided_at": T1,
+                "decided_at": T5,
                 "metrics_passed": True,
                 "required_slices_passed": True,
                 "zero_tolerance_failure_count": 0,
@@ -344,7 +399,7 @@ def test_pass_requires_full_exposure_primary_labels_and_second_review_sample(
                 "production_activation_authorised": False,
             }
         )
-        with pytest.raises(EvaluationAuthorityError, match="corrective readiness"):
+        with pytest.raises(EvaluationAuthorityError, match="exposure"):
             authority.decide_release(direct)
         assert connection.execute(
             "SELECT COUNT(*) FROM evaluation_release_decisions"

--- a/newsroom/tests/test_increment8a_evaluation_authority.py
+++ b/newsroom/tests/test_increment8a_evaluation_authority.py
@@ -93,9 +93,18 @@ def _facts(
 
 
 def _report_bytes(
-    run, *, status: str = "PASS", zero_failures: tuple[str, ...] = ()
+    run,
+    *,
+    status: str = "PASS",
+    zero_failures: tuple[str, ...] = (),
+    evidence_manifest_digest: str = D2,
+    slice_counts: dict[str, int] | None = None,
 ) -> bytes:
-    from newsroom.increment8.metrics import build_metric_report
+    from newsroom.increment8.metrics import (
+        REQUIRED_SLICES,
+        RequiredSliceResult,
+        build_metric_report,
+    )
     from newsroom.tests.test_increment8b_metrics import (
         _ablations,
         _contributions,
@@ -105,19 +114,31 @@ def _report_bytes(
         _zero,
     )
 
+    slices = (
+        _slices()
+        if slice_counts is None
+        else tuple(
+            RequiredSliceResult.build(
+                slice_id=name,
+                completed_cases=slice_counts[name],
+                success_count=slice_counts[name],
+            )
+            for name in REQUIRED_SLICES
+        )
+    )
     report = build_metric_report(
         run=run,
         case_count=120,
         rates=_rates(fail="candidate_precision" if status == "FAIL" else None),
         performance=_performance(),
-        slices=_slices(),
+        slices=slices,
         zero_tolerance=_zero(**{name: 1 for name in zero_failures}),
         contributions=_contributions(),
         ablations=_ablations(),
         metric_code_digest="sha256:" + "9" * 64,
         environment_digest="sha256:" + "a" * 64,
-        sampling_manifest_digest="sha256:" + "b" * 64,
-        label_manifest_digest="sha256:" + "c" * 64,
+        sampling_manifest_digest=evidence_manifest_digest,
+        label_manifest_digest=evidence_manifest_digest,
     )
     return report.canonical_bytes
 
@@ -341,10 +362,13 @@ def test_append_only_authority_retains_failed_run_and_rejects_mutation(
             recorded_at=T3,
         )
         authority.record_label(label)
+        manifest = authority.evidence_manifest_digest(run.run_id)
         decision = build_release_decision(
             run=run,
-            report_canonical_bytes=_report_bytes(run, status="FAIL"),
-            evidence_manifest_digest=authority.evidence_manifest_digest(run.run_id),
+            report_canonical_bytes=_report_bytes(
+                run, status="FAIL", evidence_manifest_digest=manifest
+            ),
+            evidence_manifest_digest=manifest,
             verdict=ReleaseVerdict.INCONCLUSIVE,
             owner_identity_digest=OWNER,
             decided_at=T5,
@@ -381,10 +405,13 @@ def test_pass_requires_full_exposure_primary_labels_and_second_review_sample(
         authority.register_plan(plan)
         authority.register_epoch(epoch)
         authority.register_run(run)
+        manifest = authority.evidence_manifest_digest(run.run_id)
         candidate = build_release_decision(
             run=run,
-            report_canonical_bytes=_report_bytes(run),
-            evidence_manifest_digest=authority.evidence_manifest_digest(run.run_id),
+            report_canonical_bytes=_report_bytes(
+                run, evidence_manifest_digest=manifest
+            ),
+            evidence_manifest_digest=manifest,
             verdict=ReleaseVerdict.PASS,
             owner_identity_digest=OWNER,
             decided_at=T5,
@@ -394,16 +421,15 @@ def test_pass_requires_full_exposure_primary_labels_and_second_review_sample(
 
         # The authority gate also rejects a caller that bypasses the public
         # builder and assembles canonical PASS-shaped bytes directly.
-        report = json.loads(_report_bytes(run))
+        report_raw = _report_bytes(run, evidence_manifest_digest=manifest)
+        report = json.loads(report_raw)
         direct = ReleaseEvidenceDecision.build(
             {
                 "run_id": run.run_id,
                 "run_digest": run.digest,
-                "report_digest": digest_bytes(_report_bytes(run)),
+                "report_digest": digest_bytes(report_raw),
                 "metric_report": report,
-                "evidence_manifest_digest": authority.evidence_manifest_digest(
-                    run.run_id
-                ),
+                "evidence_manifest_digest": manifest,
                 "verdict": ReleaseVerdict.PASS.value,
                 "owner_identity_digest": OWNER,
                 "decided_at": T5,

--- a/newsroom/tests/test_increment8a_evaluation_authority.py
+++ b/newsroom/tests/test_increment8a_evaluation_authority.py
@@ -229,6 +229,7 @@ def test_independent_review_and_adjudication_are_enforced() -> None:
         rights_status=RightsStatus.REVIEWABLE,
         prospective=True,
         launch_blocker=True,
+        urgent=True,
     )
     primary = build_review_label(
         case=case,

--- a/newsroom/tests/test_increment8b_metrics.py
+++ b/newsroom/tests/test_increment8b_metrics.py
@@ -14,6 +14,7 @@ from newsroom.increment8.metrics import (
     REQUIRED_SLICES,
     AblationResult,
     MeasurementStatus,
+    MetricReport,
     MetricReportError,
     PerformanceMeasurement,
     RateMeasurement,
@@ -196,6 +197,7 @@ def test_complete_report_is_canonical_bounded_and_non_activating() -> None:
     assert b'"schema_version":"newsroom.increment8.metric-report.v1"' in (
         report.canonical_bytes
     )
+    assert MetricReport.from_canonical_bytes(report.canonical_bytes) == report
 
 
 def test_every_rate_retains_count_denominator_sampling_and_uncertainty() -> None:
@@ -243,6 +245,10 @@ def test_required_slice_failure_and_insufficient_exposure_override_aggregate() -
 def test_zero_tolerance_failure_blocks_report() -> None:
     report = _report(zero_tolerance=_zero(temporal_rewrite=1))
     assert report.zero_tolerance_status is MeasurementStatus.FAIL
+    assert (
+        _report(case_count=1, zero_tolerance=_zero(temporal_rewrite=1)).overall_status
+        is MeasurementStatus.FAIL
+    )
     assert report.overall_status is MeasurementStatus.FAIL
 
 

--- a/newsroom/tests/test_increment8b_metrics.py
+++ b/newsroom/tests/test_increment8b_metrics.py
@@ -36,6 +36,13 @@ def _run(kind: RunKind = RunKind.QUALIFICATION):
         component_manifest_digest=_D,
         approved_by_digest="sha256:" + "2" * 64,
         approved_at=_AT,
+        authorised_primary_reviewer_digests=(
+            "sha256:" + "2" * 64,
+            "sha256:" + "6" * 64,
+        ),
+        authorised_secondary_reviewer_digests=("sha256:" + "7" * 64,),
+        authorised_adjudicator_digests=("sha256:" + "8" * 64,),
+        authorised_release_owner_digests=("sha256:" + "9" * 64,),
     )
     epoch = freeze_epoch(
         plan=plan,

--- a/newsroom/tests/test_increment8b_metrics.py
+++ b/newsroom/tests/test_increment8b_metrics.py
@@ -178,7 +178,7 @@ def _report(**changes):
         "metric_code_digest": "sha256:" + "9" * 64,
         "environment_digest": "sha256:" + "a" * 64,
         "sampling_manifest_digest": "sha256:" + "b" * 64,
-        "label_manifest_digest": "sha256:" + "c" * 64,
+        "label_manifest_digest": "sha256:" + "b" * 64,
     }
     values.update(changes)
     return build_metric_report(**values)

--- a/newsroom/tests/test_increment8f_admission.py
+++ b/newsroom/tests/test_increment8f_admission.py
@@ -14,7 +14,6 @@ from newsroom.increment8.admission import (
     build_qualification_packet,
 )
 from newsroom.increment8.evaluation import (
-    EvaluationAuthorityError,
     ReleaseVerdict,
     build_release_decision,
 )
@@ -126,9 +125,9 @@ def _packet(tmp_path, **changes):
     connection.close()
     report = _report()
     release = build_release_decision(
-        run=_run(), report_digest=report.digest, verdict=ReleaseVerdict.PASS,
-        owner_identity_digest=_D, decided_at=_AT, metrics_passed=True,
-        required_slices_passed=True, zero_tolerance_failure_count=0,
+        run=_run(), report_canonical_bytes=report.canonical_bytes,
+        evidence_manifest_digest=_D, verdict=ReleaseVerdict.PASS,
+        owner_identity_digest=_D, decided_at=_AT,
     )
     capacity = _capacity()
     anchor = _handoff_anchor(
@@ -155,7 +154,7 @@ def _packet(tmp_path, **changes):
 
 
 def test_complete_packet_binds_every_gate_and_admits_only_fixture_operation(tmp_path) -> None:
-    with pytest.raises(EvaluationAuthorityError, match="corrective readiness"):
+    with pytest.raises(AdmissionError, match="corrective readiness"):
         _packet(tmp_path)
 
 

--- a/newsroom/tests/test_increment8f_admission.py
+++ b/newsroom/tests/test_increment8f_admission.py
@@ -126,7 +126,7 @@ def _packet(tmp_path, **changes):
     report = _report()
     release = build_release_decision(
         run=_run(), report_canonical_bytes=report.canonical_bytes,
-        evidence_manifest_digest=_D, verdict=ReleaseVerdict.PASS,
+        evidence_manifest_digest=report.payload["sampling_manifest_digest"], verdict=ReleaseVerdict.PASS,
         owner_identity_digest=_D, decided_at=_AT,
     )
     capacity = _capacity()


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: 8a
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

Closes #463. Parent: #148. Depends on closed #462.

## Corrective scope
- retain an exact authorised-human reviewer, adjudicator and release-owner manifest in every Evaluation Plan
- enforce Plan approval -> Epoch freeze/open -> Run -> Case cutoff -> labels -> adjudication -> release-decision chronology
- derive exact required-slice and negative/unchanged/failure-heavy Case-stratum memberships from frozen pre-result facts
- enforce distinct event/input manifests within each Run
- reject caller-owned transactions and connections without active SQLite foreign keys
- reject duplicate same-role labels; authenticate every human role and preserve every disagreement for adjudication
- calculate the ordinary 20% second-review sample separately from mandatory blocker, Urgent and zero-tolerance reviews
- require non-vacuous reviewable exposure, all nine exact slices, all three strata and the frozen distinct-primary-reviewer minimum
- embed the canonical Metric Report and derive decision gates from it instead of accepting caller booleans or an arbitrary digest
- bind and seal the complete Case/label/adjudication evidence manifest at decision time

## Evidence
- `uv run pytest -q newsroom/tests/test_increment8*.py` — 87 passed
- `ruff check` on every changed Python file — passed
- direct corrective regressions cover all eleven retained P1 bypass classes from PR #470

## Non-effects
No evaluation execution, accepted PASS, live provider, credential, egress, spend, publication, production-equivalent shadow, canary, permanent locality, production effect, or Increment 9 activation. The corrected complete exposure reaches the retained corrective blockade until the downstream atoms finish.
