### PR TITLE
Correct Increment 8B metrics authority

### DIFF
--- a/docs/plans/2026-08-14-016-increment-8b-corrective-metrics.md
+++ b/docs/plans/2026-08-14-016-increment-8b-corrective-metrics.md
@@ -53,3 +53,8 @@ new release value outside the frozen readiness contract.
 This correction performs deterministic fixture/replay measurement only. It
 adds no persistence migration and authorises no live provider, credential,
 egress, spend, locality activation, shadow, canary or production effect.
+
+## Review correction
+
+- Disputed per-Case measurements now retain the canonical adjudication and derive decision-bearing values only from the adjudicator-selected ReviewLabel; the report identity check also binds that exact retained adjudication.
+- Development/correction error opportunity counts remain explicit measurements, but no unregistered post-hoc minimum is allowed to alter the frozen qualification decision.

--- a/docs/plans/2026-08-14-016-increment-8b-corrective-metrics.md
+++ b/docs/plans/2026-08-14-016-increment-8b-corrective-metrics.md
@@ -10,8 +10,9 @@ A Metric Report is now constructed from the exact canonical Evaluation Plan,
 Epoch and qualification Run, plus one canonical `ReviewedCaseOutcome` for each
 prospective, reviewable Case. Each outcome embeds the frozen Case and the
 primary human ReviewLabel. The label token is the digest of the complete
-per-Case assessment, so caller-supplied aggregate counts or booleans cannot be
-substituted for reviewed evidence.
+per-Case assessment, including metric and triage opportunity eligibility, so
+caller-supplied aggregate counts or booleans cannot be substituted for
+reviewed evidence.
 
 The report derives, rather than accepts:
 
@@ -26,8 +27,11 @@ The report derives, rather than accepts:
 Canonical reconstruction checks the complete Plan/Epoch/Run chain, every Case,
 ReviewLabel, assessment, rate, performance result, slice result, zero-tolerance
 record, source contribution and ablation. The release authority additionally
-compares the report's exact Case and primary-label identities with its retained
-append-only records.
+compares the report's exact Case, primary-label and secondary-label identities
+with its retained append-only records for `PASS`, `FAIL` and `INCONCLUSIVE`
+verdicts. Reviewer agreement is derived only from retained independent
+primary/secondary label pairs; it is not accepted from the primary assessment
+mapping.
 
 Source contribution evidence retains sorted dependency-root digests and the
 report emits the root-to-source inventory. Shared wire or upstream roots are

--- a/docs/plans/2026-08-14-016-increment-8b-corrective-metrics.md
+++ b/docs/plans/2026-08-14-016-increment-8b-corrective-metrics.md
@@ -1,7 +1,7 @@
 # Increment 8B corrective metrics authority
 
-Issue: #464  
-Parent: #148  
+Issue: #464
+Parent: #148
 Dependency: #463
 
 ## Corrected authority boundary

--- a/docs/plans/2026-08-14-016-increment-8b-corrective-metrics.md
+++ b/docs/plans/2026-08-14-016-increment-8b-corrective-metrics.md
@@ -1,0 +1,51 @@
+# Increment 8B corrective metrics authority
+
+Issue: #464  
+Parent: #148  
+Dependency: #463
+
+## Corrected authority boundary
+
+A Metric Report is now constructed from the exact canonical Evaluation Plan,
+Epoch and qualification Run, plus one canonical `ReviewedCaseOutcome` for each
+prospective, reviewable Case. Each outcome embeds the frozen Case and the
+primary human ReviewLabel. The label token is the digest of the complete
+per-Case assessment, so caller-supplied aggregate counts or booleans cannot be
+substituted for reviewed evidence.
+
+The report derives, rather than accepts:
+
+- total reviewed Case exposure;
+- every pre-registered rate numerator and denominator;
+- all nine Required Slice memberships, completed counts and successes;
+- negative, unchanged and failure-heavy stratum exposure;
+- every zero-tolerance count; and
+- the separately reported false-development, missed-development and
+  false-correction error measurements.
+
+Canonical reconstruction checks the complete Plan/Epoch/Run chain, every Case,
+ReviewLabel, assessment, rate, performance result, slice result, zero-tolerance
+record, source contribution and ablation. The release authority additionally
+compares the report's exact Case and primary-label identities with its retained
+append-only records.
+
+Source contribution evidence retains sorted dependency-root digests and the
+report emits the root-to-source inventory. Shared wire or upstream roots are
+therefore visible and cannot masquerade as independently attributable sources.
+
+## Decision rules
+
+A confirmed zero-tolerance finding is always `FAIL`, including when another
+exposure is insufficient. Missing total, slice, stratum or authorised-reviewer
+exposure is `NOT_EVALUATED`. Target metric, slice or performance failure is
+`FAIL`; ablation evidence remains non-decision-bearing.
+
+Development and correction errors are mandatory separate measurements. Their
+record explicitly forbids a post-hoc threshold; Increment 8B does not invent a
+new release value outside the frozen readiness contract.
+
+## Non-effects
+
+This correction performs deterministic fixture/replay measurement only. It
+adds no persistence migration and authorises no live provider, credential,
+egress, spend, locality activation, shadow, canary or production effect.

--- a/newsroom/increment8/evaluation.py
+++ b/newsroom/increment8/evaluation.py
@@ -1340,6 +1340,7 @@ class EvaluationAuthority:
             raise EvaluationAuthorityError(
                 "Metric Report differs from the authority evidence manifest"
             )
+        self._require_report_evidence_identity(retained_run.run_id, report_payload)
         plan = self._plan_for_run(retained_run.run_id)
         if decision.payload["owner_identity_digest"] not in _authorised_identities(
             plan, HumanAuthorityRole.RELEASE_OWNER
@@ -1418,6 +1419,58 @@ class EvaluationAuthority:
         return max(
             values, key=lambda item: _parse_timestamp(item, "evidence timestamp")
         )
+
+    def _require_report_evidence_identity(
+        self, run_id: str, report_payload: Mapping[str, object]
+    ) -> None:
+        evidence = report_payload.get("reviewed_case_outcome_evidence")
+        if not isinstance(evidence, list):
+            raise EvaluationAuthorityError(
+                "Metric Report reviewed Case evidence differs"
+            )
+        reported: dict[str, tuple[str, str, str | None]] = {}
+        for document in evidence:
+            if not isinstance(document, Mapping) or not isinstance(
+                document.get("payload"), Mapping
+            ):
+                raise EvaluationAuthorityError(
+                    "Metric Report reviewed Case evidence differs"
+                )
+            outcome = document["payload"]
+            case_id = str(outcome.get("case_id"))
+            secondary = outcome.get("secondary_review_label_digest")
+            if (
+                case_id in reported
+                or secondary is not None
+                and not isinstance(secondary, str)
+            ):
+                raise EvaluationAuthorityError(
+                    "Metric Report reviewed Case evidence differs"
+                )
+            reported[case_id] = (
+                str(outcome.get("case_digest")),
+                str(outcome.get("review_label_digest")),
+                secondary,
+            )
+        retained: dict[str, tuple[str, str, str | None]] = {}
+        rows = self._connection.execute(
+            "SELECT c.case_id,c.case_digest,p.label_digest,"
+            "(SELECT s.label_digest FROM evaluation_labels s "
+            "WHERE s.case_id=c.case_id AND s.review_role='SECONDARY') "
+            "FROM evaluation_cases c JOIN evaluation_labels p ON p.case_id=c.case_id "
+            "WHERE c.run_id=? AND p.review_role='PRIMARY' ORDER BY c.case_id",
+            (run_id,),
+        ).fetchall()
+        for case_id, case_digest, primary_digest, secondary_digest in rows:
+            retained[str(case_id)] = (
+                str(case_digest),
+                str(primary_digest),
+                None if secondary_digest is None else str(secondary_digest),
+            )
+        if reported != retained:
+            raise EvaluationAuthorityError(
+                "Metric Report outcomes differ from retained reviews"
+            )
 
     def _require_pass_exposure(
         self, run_id: str, report_payload: Mapping[str, object]

--- a/newsroom/increment8/evaluation.py
+++ b/newsroom/increment8/evaluation.py
@@ -1407,10 +1407,14 @@ class EvaluationAuthority:
             for query in (
                 "SELECT started_at FROM evaluation_runs WHERE run_id=?",
                 "SELECT cutoff_at FROM evaluation_cases WHERE run_id=?",
-                "SELECT recorded_at FROM evaluation_labels WHERE case_id IN "
-                "(SELECT case_id FROM evaluation_cases WHERE run_id=?)",
-                "SELECT decided_at FROM evaluation_adjudications WHERE case_id IN "
-                "(SELECT case_id FROM evaluation_cases WHERE run_id=?)",
+                (
+                    "SELECT recorded_at FROM evaluation_labels WHERE case_id IN "
+                    "(SELECT case_id FROM evaluation_cases WHERE run_id=?)"
+                ),
+                (
+                    "SELECT decided_at FROM evaluation_adjudications WHERE case_id IN "
+                    "(SELECT case_id FROM evaluation_cases WHERE run_id=?)"
+                ),
             )
             for row in self._connection.execute(query, (run_id,))
         ]
@@ -1428,7 +1432,7 @@ class EvaluationAuthority:
             raise EvaluationAuthorityError(
                 "Metric Report reviewed Case evidence differs"
             )
-        reported: dict[str, tuple[str, str, str | None]] = {}
+        reported: dict[str, tuple[str, str, str | None, str | None]] = {}
         for document in evidence:
             if not isinstance(document, Mapping) or not isinstance(
                 document.get("payload"), Mapping
@@ -1439,10 +1443,13 @@ class EvaluationAuthority:
             outcome = document["payload"]
             case_id = str(outcome.get("case_id"))
             secondary = outcome.get("secondary_review_label_digest")
+            adjudication = outcome.get("adjudication_digest")
             if (
                 case_id in reported
                 or secondary is not None
                 and not isinstance(secondary, str)
+                or adjudication is not None
+                and not isinstance(adjudication, str)
             ):
                 raise EvaluationAuthorityError(
                     "Metric Report reviewed Case evidence differs"
@@ -1451,21 +1458,31 @@ class EvaluationAuthority:
                 str(outcome.get("case_digest")),
                 str(outcome.get("review_label_digest")),
                 secondary,
+                adjudication,
             )
-        retained: dict[str, tuple[str, str, str | None]] = {}
+        retained: dict[str, tuple[str, str, str | None, str | None]] = {}
         rows = self._connection.execute(
             "SELECT c.case_id,c.case_digest,p.label_digest,"
             "(SELECT s.label_digest FROM evaluation_labels s "
-            "WHERE s.case_id=c.case_id AND s.review_role='SECONDARY') "
+            "WHERE s.case_id=c.case_id AND s.review_role='SECONDARY'),"
+            "(SELECT a.adjudication_digest FROM evaluation_adjudications a "
+            "WHERE a.case_id=c.case_id) "
             "FROM evaluation_cases c JOIN evaluation_labels p ON p.case_id=c.case_id "
             "WHERE c.run_id=? AND p.review_role='PRIMARY' ORDER BY c.case_id",
             (run_id,),
         ).fetchall()
-        for case_id, case_digest, primary_digest, secondary_digest in rows:
+        for (
+            case_id,
+            case_digest,
+            primary_digest,
+            secondary_digest,
+            adjudication_digest,
+        ) in rows:
             retained[str(case_id)] = (
                 str(case_digest),
                 str(primary_digest),
                 None if secondary_digest is None else str(secondary_digest),
+                None if adjudication_digest is None else str(adjudication_digest),
             )
         if reported != retained:
             raise EvaluationAuthorityError(

--- a/newsroom/increment8/evaluation.py
+++ b/newsroom/increment8/evaluation.py
@@ -1532,6 +1532,39 @@ class EvaluationAuthority:
             raise EvaluationAuthorityError(
                 "reviewed qualification exposure is insufficient"
             )
+        outcome_evidence = report_payload.get("reviewed_case_outcome_evidence")
+        if not isinstance(outcome_evidence, list):
+            raise EvaluationAuthorityError(
+                "Metric Report reviewed Case evidence differs"
+            )
+        reported_outcomes: dict[str, tuple[str, str]] = {}
+        for document in outcome_evidence:
+            if not isinstance(document, Mapping) or not isinstance(
+                document.get("payload"), Mapping
+            ):
+                raise EvaluationAuthorityError(
+                    "Metric Report reviewed Case evidence differs"
+                )
+            outcome = document["payload"]
+            case_id = str(outcome.get("case_id"))
+            if case_id in reported_outcomes:
+                raise EvaluationAuthorityError(
+                    "Metric Report repeats reviewed Case evidence"
+                )
+            reported_outcomes[case_id] = (
+                str(outcome.get("case_digest")),
+                str(outcome.get("review_label_digest")),
+            )
+        if reported_outcomes != {
+            case_id: (
+                case_memberships[case_id][0],
+                label.digest,
+            )
+            for case_id, label in primary.items()
+        }:
+            raise EvaluationAuthorityError(
+                "Metric Report outcomes differ from retained reviews"
+            )
         reviewed_slice_cases: dict[str, set[str]] = {
             name: set() for name in slice_manifest
         }

--- a/newsroom/increment8/metrics.py
+++ b/newsroom/increment8/metrics.py
@@ -18,7 +18,16 @@ from newsroom.authority.canonical import (
     digest_bytes,
     validate_sha256_digest,
 )
-from newsroom.increment8.evaluation import EvaluationRun, RunKind
+from newsroom.increment8.evaluation import (
+    EvaluationCase,
+    EvaluationEpoch,
+    EvaluationPlan,
+    EvaluationRun,
+    ReviewLabel,
+    RunKind,
+    _membership_facts,
+    _memberships,
+)
 from newsroom.increment8.readiness import (
     INCREMENT_8_READINESS,
     INCREMENT_8_READINESS_DIGEST,
@@ -80,6 +89,11 @@ _MAXIMUM_METRICS = frozenset(
     }
 )
 _EXPECTED_METRICS = tuple(sorted(_MINIMUM_METRICS | _MAXIMUM_METRICS))
+_TRIAGE_ERROR_METRICS = (
+    "false_correction",
+    "false_development",
+    "missed_development",
+)
 _EXPECTED_PERFORMANCE = tuple(
     sorted(
         str(name)
@@ -156,6 +170,185 @@ def _embedded(raw: bytes) -> dict[str, object]:
     value = json.loads(raw.decode("utf-8", errors="strict"))
     assert isinstance(value, dict)
     return value
+
+
+def reviewed_case_assessment_label(
+    *,
+    case: EvaluationCase,
+    metric_success: Mapping[str, bool],
+    triage_error: Mapping[str, bool],
+    slice_success: bool,
+    zero_tolerance_findings: Sequence[str] = (),
+) -> str:
+    """Return the exact token a human ReviewLabel must attest."""
+
+    findings = tuple(zero_tolerance_findings)
+    assessment = canonical_json_bytes(
+        {
+            "schema_version": "newsroom.increment8.reviewed-case-assessment.v1",
+            "case_digest": case.digest,
+            "metric_success": dict(sorted(metric_success.items())),
+            "triage_error": dict(sorted(triage_error.items())),
+            "slice_success": slice_success,
+            "zero_tolerance_findings": list(findings),
+        }
+    )
+    return "metrics:" + digest_bytes(assessment).removeprefix("sha256:")
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewedCaseOutcome:
+    """One immutable, human-review-bound measurement row for one frozen Case."""
+
+    case_id: str
+    case_digest: str
+    review_label_digest: str
+    metric_success: Mapping[str, bool]
+    triage_error: Mapping[str, bool]
+    slice_success: bool
+    zero_tolerance_findings: tuple[str, ...]
+    canonical_bytes: bytes
+    digest: str
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        case: EvaluationCase,
+        review_label: ReviewLabel,
+        metric_success: Mapping[str, bool],
+        triage_error: Mapping[str, bool],
+        slice_success: bool,
+        zero_tolerance_findings: Sequence[str] = (),
+    ) -> ReviewedCaseOutcome:
+        try:
+            checked_case = EvaluationCase.from_canonical_bytes(case.canonical_bytes)
+            checked_label = ReviewLabel.from_canonical_bytes(
+                review_label.canonical_bytes
+            )
+        except (AttributeError, TypeError, ValueError) as exc:
+            raise MetricReportError("reviewed Case evidence is not canonical") from exc
+        if (
+            checked_case != case
+            or checked_label != review_label
+            or checked_label.payload.get("case_id") != checked_case.case_id
+            or checked_label.payload.get("case_digest") != checked_case.digest
+            or checked_label.payload.get("review_role") != "PRIMARY"
+            or checked_case.payload.get("rights_status") != "REVIEWABLE"
+            or checked_case.payload.get("prospective") is not True
+        ):
+            raise MetricReportError("reviewed Case or label binding differs")
+        try:
+            facts = _membership_facts(checked_case.payload["membership_facts"])  # type: ignore[arg-type]
+            expected_slices, expected_strata = _memberships(facts)
+        except (KeyError, TypeError, ValueError) as exc:
+            raise MetricReportError("frozen Case membership facts differ") from exc
+        if (
+            tuple(checked_case.payload.get("required_slices", ())) != expected_slices
+            or tuple(checked_case.payload.get("case_strata", ())) != expected_strata
+            or checked_case.payload.get("urgent")
+            is not (facts["case_metadata"]["urgency"] == "URGENT")  # type: ignore[index]
+        ):
+            raise MetricReportError("frozen Case membership differs")
+        if not isinstance(metric_success, Mapping) or tuple(sorted(metric_success)) != (
+            _EXPECTED_METRICS
+        ):
+            raise MetricReportError("per-Case metric inventory differs")
+        if not isinstance(triage_error, Mapping) or tuple(sorted(triage_error)) != (
+            _TRIAGE_ERROR_METRICS
+        ):
+            raise MetricReportError("per-Case triage-error inventory differs")
+        if not isinstance(slice_success, bool) or any(
+            not isinstance(value, bool)
+            for value in (*metric_success.values(), *triage_error.values())
+        ):
+            raise MetricReportError("per-Case outcomes must be boolean")
+        findings = _sorted_tokens(
+            zero_tolerance_findings, "zero_tolerance_findings", empty=True
+        )
+        if any(item not in _EXPECTED_ZERO_TOLERANCE for item in findings):
+            raise MetricReportError("unknown zero-tolerance finding")
+        if bool(findings) is not bool(checked_case.payload.get("zero_tolerance")):
+            raise MetricReportError("zero-tolerance findings differ from the Case")
+        expected_label = reviewed_case_assessment_label(
+            case=checked_case,
+            metric_success=metric_success,
+            triage_error=triage_error,
+            slice_success=slice_success,
+            zero_tolerance_findings=findings,
+        )
+        if checked_label.payload.get("label") != expected_label:
+            raise MetricReportError(
+                "human ReviewLabel does not attest the per-Case outcomes"
+            )
+        payload = {
+            "case": _embedded(checked_case.canonical_bytes),
+            "case_id": checked_case.case_id,
+            "case_digest": checked_case.digest,
+            "review_label": _embedded(checked_label.canonical_bytes),
+            "review_label_digest": checked_label.digest,
+            "metric_success": dict(sorted(metric_success.items())),
+            "triage_error": dict(sorted(triage_error.items())),
+            "slice_success": slice_success,
+            "zero_tolerance_findings": list(findings),
+        }
+        raw, record_digest = _record(
+            "newsroom.increment8.reviewed-case-outcome.v1", payload
+        )
+        return cls(
+            checked_case.case_id,
+            checked_case.digest,
+            checked_label.digest,
+            MappingProxyType(dict(sorted(metric_success.items()))),
+            MappingProxyType(dict(sorted(triage_error.items()))),
+            slice_success,
+            findings,
+            raw,
+            record_digest,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class TriageErrorMeasurement:
+    metric_name: str
+    error_count: int
+    denominator: int
+    rate_ppm: int
+    decision_treatment: str
+    canonical_bytes: bytes
+    digest: str
+
+    @classmethod
+    def build(
+        cls, *, metric_name: str, error_count: int, denominator: int
+    ) -> TriageErrorMeasurement:
+        name = _token(metric_name, "metric_name")
+        if name not in _TRIAGE_ERROR_METRICS:
+            raise MetricReportError("triage error metric is not pre-registered")
+        errors = _integer(error_count, "error_count")
+        total = _integer(denominator, "denominator", minimum=1)
+        if errors > total:
+            raise MetricReportError("triage errors exceed eligible opportunities")
+        rate = errors * 1_000_000 // total
+        payload = {
+            "metric_name": name,
+            "error_count": errors,
+            "denominator": total,
+            "rate_ppm": rate,
+            "decision_treatment": "MANDATORY_SEPARATE_REPORT_NO_POST_HOC_THRESHOLD",
+        }
+        raw, record_digest = _record(
+            "newsroom.increment8.triage-error-measurement.v1", payload
+        )
+        return cls(
+            name,
+            errors,
+            total,
+            rate,
+            "MANDATORY_SEPARATE_REPORT_NO_POST_HOC_THRESHOLD",
+            raw,
+            record_digest,
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -354,6 +547,7 @@ class SourceContribution:
     source_id: str
     role: SourceRole
     provider_version_digest: str
+    dependency_root_digests: tuple[str, ...]
     search_purpose: str | None
     unique_detection_count: int
     earlier_detection_count: int
@@ -374,6 +568,7 @@ class SourceContribution:
         source_id: str,
         role: SourceRole,
         provider_version_digest: str,
+        dependency_root_digests: Sequence[str],
         unique_detection_count: int,
         earlier_detection_count: int,
         resilience_case_count: int,
@@ -394,6 +589,15 @@ class SourceContribution:
         purpose = (
             None if search_purpose is None else _token(search_purpose, "search_purpose")
         )
+        dependency_roots = tuple(
+            _digest(item, "dependency_root_digest") for item in dependency_root_digests
+        )
+        if not dependency_roots or dependency_roots != tuple(
+            sorted(set(dependency_roots))
+        ):
+            raise MetricReportError(
+                "source dependency roots must be non-empty, sorted and unique"
+            )
         if (role is SourceRole.SEARCH_PURPOSE) != (purpose is not None):
             raise MetricReportError(
                 "Search contribution requires exact Purpose attribution"
@@ -437,6 +641,7 @@ class SourceContribution:
             "provider_version_digest": _digest(
                 provider_version_digest, "provider_version_digest"
             ),
+            "dependency_root_digests": list(dependency_roots),
             "search_purpose": purpose,
             "unique_detection_count": unique,
             "earlier_detection_count": earlier,
@@ -455,6 +660,7 @@ class SourceContribution:
             str(payload["source_id"]),
             role,
             str(payload["provider_version_digest"]),
+            dependency_roots,
             purpose,
             unique,
             earlier,
@@ -634,6 +840,7 @@ def _verify_records(
                     source_id=item.source_id,
                     role=item.role,
                     provider_version_digest=item.provider_version_digest,
+                    dependency_root_digests=item.dependency_root_digests,
                     search_purpose=item.search_purpose,
                     unique_detection_count=item.unique_detection_count,
                     earlier_detection_count=item.earlier_detection_count,
@@ -670,14 +877,182 @@ def _verify_records(
         raise MetricReportError("measurement evidence is forged or non-canonical")
 
 
+def _verify_run_context(
+    plan: EvaluationPlan, epoch: EvaluationEpoch, run: EvaluationRun
+) -> tuple[EvaluationPlan, EvaluationEpoch, EvaluationRun]:
+    try:
+        checked_plan = EvaluationPlan.from_canonical_bytes(plan.canonical_bytes)
+        checked_epoch = EvaluationEpoch.from_canonical_bytes(epoch.canonical_bytes)
+        checked_run = EvaluationRun.from_canonical_bytes(run.canonical_bytes)
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise MetricReportError("evaluation Run context is not canonical") from exc
+    if (
+        checked_plan != plan
+        or checked_epoch != epoch
+        or checked_run != run
+        or checked_plan.payload.get("readiness_digest") != INCREMENT_8_READINESS_DIGEST
+        or checked_epoch.payload.get("plan_id") != checked_plan.plan_id
+        or checked_epoch.payload.get("plan_digest") != checked_plan.digest
+        or checked_run.payload.get("epoch_id") != checked_epoch.epoch_id
+        or checked_run.payload.get("epoch_digest") != checked_epoch.digest
+        or checked_run.payload.get("plan_id") != checked_plan.plan_id
+        or checked_run.payload.get("run_kind") != RunKind.QUALIFICATION.value
+        or checked_run.payload.get("production_effect_allowed") is not False
+    ):
+        raise MetricReportError("evaluation Plan, Epoch or Run linkage differs")
+    return checked_plan, checked_epoch, checked_run
+
+
+def _verify_case_outcomes(
+    outcomes: Sequence[ReviewedCaseOutcome],
+    run: EvaluationRun,
+    plan: EvaluationPlan,
+) -> tuple[tuple[ReviewedCaseOutcome, ...], int]:
+    checked = tuple(outcomes)
+    if not checked:
+        raise MetricReportError("reviewed per-Case outcome evidence is required")
+    if tuple(item.case_id for item in checked) != tuple(
+        sorted({item.case_id for item in checked})
+    ):
+        raise MetricReportError("reviewed Case outcomes must be sorted and unique")
+    rebuilt: list[ReviewedCaseOutcome] = []
+    input_manifests: set[object] = set()
+    label_digests: set[str] = set()
+    manifest = plan.payload.get("authorised_human_manifest")
+    if not isinstance(manifest, list):
+        raise MetricReportError("authorised primary reviewer manifest differs")
+    authorised_primary = {
+        str(item.get("identity_digest"))
+        for item in manifest
+        if isinstance(item, Mapping)
+        and isinstance(item.get("roles"), list)
+        and "PRIMARY" in item["roles"]
+        and item.get("human") is True
+    }
+    used_primary: set[str] = set()
+    for item in checked:
+        if not isinstance(item, ReviewedCaseOutcome):
+            raise MetricReportError("reviewed Case outcome must be typed")
+        document = _document(
+            item.canonical_bytes, "newsroom.increment8.reviewed-case-outcome.v1"
+        )
+        payload = document["payload"]
+        assert isinstance(payload, Mapping)
+        case = EvaluationCase.from_canonical_bytes(
+            canonical_json_bytes(payload["case"])
+        )
+        label = ReviewLabel.from_canonical_bytes(
+            canonical_json_bytes(payload["review_label"])
+        )
+        rebuilt_item = ReviewedCaseOutcome.build(
+            case=case,
+            review_label=label,
+            metric_success=payload["metric_success"],  # type: ignore[arg-type]
+            triage_error=payload["triage_error"],  # type: ignore[arg-type]
+            slice_success=payload["slice_success"],  # type: ignore[arg-type]
+            zero_tolerance_findings=payload["zero_tolerance_findings"],  # type: ignore[arg-type]
+        )
+        if rebuilt_item != item or case.payload.get("run_id") != run.run_id:
+            raise MetricReportError("reviewed Case outcome is forged or cross-Run")
+        reviewer = str(label.payload.get("reviewer_identity_digest"))
+        if reviewer not in authorised_primary:
+            raise MetricReportError(
+                "reviewed Case outcome uses an unauthorised reviewer"
+            )
+        used_primary.add(reviewer)
+        manifest = case.payload.get("input_manifest_digest")
+        if manifest in input_manifests or label.digest in label_digests:
+            raise MetricReportError("reviewed Case evidence is duplicated")
+        input_manifests.add(manifest)
+        label_digests.add(label.digest)
+        rebuilt.append(rebuilt_item)
+    return tuple(rebuilt), len(used_primary)
+
+
+def _derive_measurements(
+    outcomes: tuple[ReviewedCaseOutcome, ...],
+) -> tuple[
+    tuple[RateMeasurement, ...],
+    tuple[TriageErrorMeasurement, ...],
+    tuple[RequiredSliceResult, ...],
+    ZeroToleranceEvidence,
+    Mapping[str, int],
+]:
+    total = len(outcomes)
+    rates = tuple(
+        RateMeasurement.build(
+            metric_name=name,
+            count=(
+                sum(item.metric_success[name] for item in outcomes)
+                if name in _MINIMUM_METRICS
+                else sum(not item.metric_success[name] for item in outcomes)
+            ),
+            denominator=total,
+            sampling_method=SamplingMethod.POPULATION,
+            uncertainty_ppm=0,
+        )
+        for name in _EXPECTED_METRICS
+    )
+    triage = tuple(
+        TriageErrorMeasurement.build(
+            metric_name=name,
+            error_count=sum(item.triage_error[name] for item in outcomes),
+            denominator=total,
+        )
+        for name in _TRIAGE_ERROR_METRICS
+    )
+    slice_members: dict[str, list[ReviewedCaseOutcome]] = {
+        name: [] for name in REQUIRED_SLICES
+    }
+    stratum_counts = {
+        str(item["stratum_id"]): 0
+        for item in INCREMENT_8_READINESS.evaluation_plan["case_strata_manifest"]  # type: ignore[union-attr]
+    }
+    zero_counts = {name: 0 for name in _EXPECTED_ZERO_TOLERANCE}
+    for outcome in outcomes:
+        document = _document(
+            outcome.canonical_bytes, "newsroom.increment8.reviewed-case-outcome.v1"
+        )
+        payload = document["payload"]
+        assert isinstance(payload, Mapping)
+        case_document = payload["case"]
+        assert isinstance(case_document, Mapping)
+        case_payload = case_document["payload"]
+        assert isinstance(case_payload, Mapping)
+        for name in case_payload["required_slices"]:  # type: ignore[union-attr]
+            if name not in slice_members:
+                raise MetricReportError("Case contains an invented required slice")
+            slice_members[str(name)].append(outcome)
+        for name in case_payload["case_strata"]:  # type: ignore[union-attr]
+            if name not in stratum_counts:
+                raise MetricReportError("Case contains an invented stratum")
+            stratum_counts[str(name)] += 1
+        for name in outcome.zero_tolerance_findings:
+            zero_counts[name] += 1
+    slices = tuple(
+        RequiredSliceResult.build(
+            slice_id=name,
+            completed_cases=len(slice_members[name]),
+            success_count=sum(item.slice_success for item in slice_members[name]),
+        )
+        for name in REQUIRED_SLICES
+    )
+    return (
+        rates,
+        triage,
+        slices,
+        ZeroToleranceEvidence.build(zero_counts),
+        MappingProxyType(stratum_counts),
+    )
+
+
 def build_metric_report(
     *,
+    plan: EvaluationPlan,
+    epoch: EvaluationEpoch,
     run: EvaluationRun,
-    case_count: int,
-    rates: Sequence[RateMeasurement],
+    case_outcomes: Sequence[ReviewedCaseOutcome],
     performance: Sequence[PerformanceMeasurement],
-    slices: Sequence[RequiredSliceResult],
-    zero_tolerance: ZeroToleranceEvidence,
     contributions: Sequence[SourceContribution],
     ablations: Sequence[AblationResult],
     metric_code_digest: str,
@@ -686,17 +1061,19 @@ def build_metric_report(
     label_manifest_digest: str,
     deviation_digests: Sequence[str] = (),
 ) -> MetricReport:
-    if (
-        not isinstance(run, EvaluationRun)
-        or run.payload["run_kind"] != RunKind.QUALIFICATION.value
-    ):
-        raise MetricReportError("metric report requires a frozen qualification Run")
-    total_cases = _integer(case_count, "case_count")
-    checked_rates = _exact_named(tuple(rates), _EXPECTED_METRICS, "metric_name")
+    checked_plan, checked_epoch, checked_run = _verify_run_context(plan, epoch, run)
+    checked_outcomes, primary_reviewer_count = _verify_case_outcomes(
+        case_outcomes, checked_run, checked_plan
+    )
+    derived_rates, triage, derived_slices, zero_tolerance, stratum_counts = (
+        _derive_measurements(checked_outcomes)
+    )
+    total_cases = len(checked_outcomes)
+    checked_rates = _exact_named(derived_rates, _EXPECTED_METRICS, "metric_name")
     checked_performance = _exact_named(
         tuple(performance), _EXPECTED_PERFORMANCE, "metric_name"
     )
-    checked_slices = _exact_named(tuple(slices), REQUIRED_SLICES, "slice_id")
+    checked_slices = _exact_named(derived_slices, REQUIRED_SLICES, "slice_id")
     if not contributions or any(
         not isinstance(item, SourceContribution) for item in contributions
     ):
@@ -711,6 +1088,10 @@ def build_metric_report(
         raise MetricReportError(
             "contribution and ablation inventories must be sorted and unique"
         )
+    dependency_inventory: dict[str, list[str]] = {}
+    for contribution in contributions:
+        for root in contribution.dependency_root_digests:
+            dependency_inventory.setdefault(root, []).append(contribution.source_id)
     _verify_records(
         checked_rates,  # type: ignore[arg-type]
         checked_performance,  # type: ignore[arg-type]
@@ -724,6 +1105,16 @@ def build_metric_report(
             "minimum_completed_cases"
         ]
     )  # type: ignore[index]
+    stratum_minima = {
+        str(item["stratum_id"]): int(item["minimum_completed_cases"])
+        for item in INCREMENT_8_READINESS.evaluation_plan["case_strata_manifest"]  # type: ignore[union-attr]
+    }
+    stratum_exposure_sufficient = all(
+        stratum_counts[name] >= minimum for name, minimum in stratum_minima.items()
+    )
+    minimum_primary_reviewers = int(
+        INCREMENT_8_READINESS.evaluation_plan["minimum_authorised_primary_reviewers"]
+    )
     metric_status = (
         MeasurementStatus.PASS
         if all(item.status is MeasurementStatus.PASS for item in checked_rates)
@@ -742,7 +1133,12 @@ def build_metric_report(
         slice_status = MeasurementStatus.PASS
     if zero_tolerance.status is MeasurementStatus.FAIL:
         overall = MeasurementStatus.FAIL
-    elif total_cases < minimum_cases or slice_status is MeasurementStatus.NOT_EVALUATED:
+    elif (
+        total_cases < minimum_cases
+        or primary_reviewer_count < minimum_primary_reviewers
+        or not stratum_exposure_sufficient
+        or slice_status is MeasurementStatus.NOT_EVALUATED
+    ):
         overall = MeasurementStatus.NOT_EVALUATED
     elif all(
         status is MeasurementStatus.PASS
@@ -768,15 +1164,31 @@ def build_metric_report(
             "sampling and label evidence must share one authority manifest"
         )
     payload: dict[str, object] = {
-        "run_id": run.run_id,
-        "run_digest": run.digest,
-        "run": _embedded(run.canonical_bytes),
+        "plan_id": checked_plan.plan_id,
+        "plan_digest": checked_plan.digest,
+        "plan": _embedded(checked_plan.canonical_bytes),
+        "epoch_id": checked_epoch.epoch_id,
+        "epoch_digest": checked_epoch.digest,
+        "epoch": _embedded(checked_epoch.canonical_bytes),
+        "run_id": checked_run.run_id,
+        "run_digest": checked_run.digest,
+        "run": _embedded(checked_run.canonical_bytes),
         "readiness_digest": INCREMENT_8_READINESS_DIGEST,
         "case_count": total_cases,
+        "primary_reviewer_count": primary_reviewer_count,
+        "minimum_primary_reviewer_count": minimum_primary_reviewers,
+        "reviewed_case_outcome_digests": [item.digest for item in checked_outcomes],
+        "reviewed_case_outcome_evidence": [
+            _embedded(item.canonical_bytes) for item in checked_outcomes
+        ],
+        "case_stratum_counts": dict(stratum_counts),
+        "case_stratum_minima": stratum_minima,
         "minimum_case_count": minimum_cases,
         "coverage_scope": "REVIEWED_PROSPECTIVE_UNIVERSE_ONLY_NOT_ABSOLUTE_RECALL",
         "rates": [item.digest for item in checked_rates],
         "rate_evidence": [_embedded(item.canonical_bytes) for item in checked_rates],
+        "triage_error_digests": [item.digest for item in triage],
+        "triage_error_evidence": [_embedded(item.canonical_bytes) for item in triage],
         "performance": [item.digest for item in checked_performance],
         "performance_evidence": [
             _embedded(item.canonical_bytes) for item in checked_performance
@@ -791,6 +1203,10 @@ def build_metric_report(
         "source_contribution_evidence": [
             _embedded(item.canonical_bytes) for item in contributions
         ],
+        "source_dependency_inventory": {
+            root: sorted(source_ids)
+            for root, source_ids in sorted(dependency_inventory.items())
+        },
         "ablation_digests": [item.digest for item in ablations],
         "ablation_evidence": [_embedded(item.canonical_bytes) for item in ablations],
         "metric_code_digest": _digest(metric_code_digest, "metric_code_digest"),
@@ -809,7 +1225,7 @@ def build_metric_report(
     }
     raw, record_digest = _record("newsroom.increment8.metric-report.v1", payload)
     return MetricReport(
-        run.run_id,
+        checked_run.run_id,
         total_cases,
         metric_status,
         slice_status,
@@ -841,8 +1257,39 @@ def verify_metric_report_canonical_bytes(raw: bytes) -> MetricReport:
     payload = document["payload"]
     assert isinstance(payload, Mapping)
     try:
+        plan = EvaluationPlan.from_canonical_bytes(
+            canonical_json_bytes(payload["plan"])
+        )
+        epoch = EvaluationEpoch.from_canonical_bytes(
+            canonical_json_bytes(payload["epoch"])
+        )
         run_raw = canonical_json_bytes(payload["run"])
         run = EvaluationRun.from_canonical_bytes(run_raw)
+
+        outcomes: list[ReviewedCaseOutcome] = []
+        for value in payload["reviewed_case_outcome_evidence"]:  # type: ignore[union-attr]
+            item_raw, item = _evidence_payload(
+                value, "newsroom.increment8.reviewed-case-outcome.v1"
+            )
+            case = EvaluationCase.from_canonical_bytes(
+                canonical_json_bytes(item["case"])
+            )
+            label = ReviewLabel.from_canonical_bytes(
+                canonical_json_bytes(item["review_label"])
+            )
+            rebuilt = ReviewedCaseOutcome.build(
+                case=case,
+                review_label=label,
+                metric_success=item["metric_success"],  # type: ignore[arg-type]
+                triage_error=item["triage_error"],  # type: ignore[arg-type]
+                slice_success=item["slice_success"],  # type: ignore[arg-type]
+                zero_tolerance_findings=item["zero_tolerance_findings"],  # type: ignore[arg-type]
+            )
+            if rebuilt.canonical_bytes != item_raw:
+                raise MetricReportError(
+                    "reviewed Case outcome differs after reconstruction"
+                )
+            outcomes.append(rebuilt)
 
         rates: list[RateMeasurement] = []
         for value in payload["rate_evidence"]:  # type: ignore[union-attr]
@@ -908,6 +1355,7 @@ def verify_metric_report_canonical_bytes(raw: bytes) -> MetricReport:
                 source_id=item["source_id"],  # type: ignore[arg-type]
                 role=SourceRole(item["role"]),
                 provider_version_digest=item["provider_version_digest"],  # type: ignore[arg-type]
+                dependency_root_digests=item["dependency_root_digests"],  # type: ignore[arg-type]
                 search_purpose=item["search_purpose"],  # type: ignore[arg-type]
                 unique_detection_count=item["unique_detection_count"],  # type: ignore[arg-type]
                 earlier_detection_count=item["earlier_detection_count"],  # type: ignore[arg-type]
@@ -948,12 +1396,11 @@ def verify_metric_report_canonical_bytes(raw: bytes) -> MetricReport:
             ablations.append(rebuilt)
 
         rebuilt_report = build_metric_report(
+            plan=plan,
+            epoch=epoch,
             run=run,
-            case_count=payload["case_count"],  # type: ignore[arg-type]
-            rates=rates,
+            case_outcomes=outcomes,
             performance=performance,
-            slices=slices,
-            zero_tolerance=zero,
             contributions=contributions,
             ablations=ablations,
             metric_code_digest=payload["metric_code_digest"],  # type: ignore[arg-type]
@@ -979,12 +1426,15 @@ __all__ = [
     "MetricReportError",
     "PerformanceMeasurement",
     "RateMeasurement",
+    "ReviewedCaseOutcome",
     "RequiredSliceResult",
     "RoleRecommendation",
     "SamplingMethod",
     "SourceContribution",
     "SourceRole",
+    "TriageErrorMeasurement",
     "ZeroToleranceEvidence",
     "build_metric_report",
+    "reviewed_case_assessment_label",
     "verify_metric_report_canonical_bytes",
 ]

--- a/newsroom/increment8/metrics.py
+++ b/newsroom/increment8/metrics.py
@@ -19,6 +19,7 @@ from newsroom.authority.canonical import (
     validate_sha256_digest,
 )
 from newsroom.increment8.evaluation import (
+    AdjudicationDecision,
     EvaluationCase,
     EvaluationEpoch,
     EvaluationPlan,
@@ -97,7 +98,6 @@ _TRIAGE_ERROR_METRICS = (
     "false_development",
     "missed_development",
 )
-_MINIMUM_TRIAGE_OPPORTUNITIES = 10
 _EXPECTED_PERFORMANCE = tuple(
     sorted(
         str(name)
@@ -212,6 +212,7 @@ class ReviewedCaseOutcome:
     case_digest: str
     review_label_digest: str
     secondary_review_label_digest: str | None
+    adjudication_digest: str | None
     metric_eligible: Mapping[str, bool]
     metric_success: Mapping[str, bool]
     triage_eligible: Mapping[str, bool]
@@ -228,6 +229,7 @@ class ReviewedCaseOutcome:
         case: EvaluationCase,
         review_label: ReviewLabel,
         secondary_review_label: ReviewLabel | None = None,
+        adjudication: AdjudicationDecision | None = None,
         metric_eligible: Mapping[str, bool],
         metric_success: Mapping[str, bool],
         triage_eligible: Mapping[str, bool],
@@ -245,6 +247,13 @@ class ReviewedCaseOutcome:
                 if secondary_review_label is None
                 else ReviewLabel.from_canonical_bytes(
                     secondary_review_label.canonical_bytes
+                )
+            )
+            checked_adjudication = (
+                None
+                if adjudication is None
+                else AdjudicationDecision.from_canonical_bytes(
+                    adjudication.canonical_bytes
                 )
             )
         except (AttributeError, TypeError, ValueError) as exc:
@@ -268,6 +277,29 @@ class ReviewedCaseOutcome:
             == checked_label.payload.get("reviewer_identity_digest")
         ):
             raise MetricReportError("secondary ReviewLabel binding differs")
+        labels_disagree = (
+            checked_secondary is not None
+            and checked_secondary.payload.get("label")
+            != checked_label.payload.get("label")
+        )
+        if labels_disagree:
+            if (
+                checked_adjudication is None
+                or checked_adjudication != adjudication
+                or checked_adjudication.payload.get("case_id") != checked_case.case_id
+                or checked_adjudication.payload.get("primary_label_digest")
+                != checked_label.digest
+                or checked_adjudication.payload.get("secondary_label_digest")
+                != checked_secondary.digest
+                or checked_adjudication.payload.get("final_label")
+                not in {
+                    checked_label.payload.get("label"),
+                    checked_secondary.payload.get("label"),
+                }
+            ):
+                raise MetricReportError("adjudication binding differs")
+        elif checked_adjudication is not None:
+            raise MetricReportError("adjudication is only valid for a disagreement")
         try:
             facts = _membership_facts(checked_case.payload["membership_facts"])  # type: ignore[arg-type]
             expected_slices, expected_strata = _memberships(facts)
@@ -322,9 +354,14 @@ class ReviewedCaseOutcome:
             slice_success=slice_success,
             zero_tolerance_findings=findings,
         )
-        if checked_label.payload.get("label") != expected_label:
+        decision_label = (
+            checked_label.payload.get("label")
+            if checked_adjudication is None
+            else checked_adjudication.payload.get("final_label")
+        )
+        if decision_label != expected_label:
             raise MetricReportError(
-                "human ReviewLabel does not attest the per-Case outcomes"
+                "decision-bearing ReviewLabel does not attest the per-Case outcomes"
             )
         payload = {
             "case": _embedded(checked_case.canonical_bytes),
@@ -339,6 +376,14 @@ class ReviewedCaseOutcome:
             ),
             "secondary_review_label_digest": (
                 None if checked_secondary is None else checked_secondary.digest
+            ),
+            "adjudication": (
+                None
+                if checked_adjudication is None
+                else _embedded(checked_adjudication.canonical_bytes)
+            ),
+            "adjudication_digest": (
+                None if checked_adjudication is None else checked_adjudication.digest
             ),
             "metric_eligible": dict(sorted(metric_eligible.items())),
             "metric_success": dict(sorted(metric_success.items())),
@@ -355,6 +400,7 @@ class ReviewedCaseOutcome:
             checked_case.digest,
             checked_label.digest,
             None if checked_secondary is None else checked_secondary.digest,
+            None if checked_adjudication is None else checked_adjudication.digest,
             MappingProxyType(dict(sorted(metric_eligible.items()))),
             MappingProxyType(dict(sorted(metric_success.items()))),
             MappingProxyType(dict(sorted(triage_eligible.items()))),
@@ -389,17 +435,13 @@ class TriageErrorMeasurement:
         if errors > total:
             raise MetricReportError("triage errors exceed eligible opportunities")
         rate = 0 if total == 0 else errors * 1_000_000 // total
-        exposure_status = (
-            MeasurementStatus.PASS
-            if total >= _MINIMUM_TRIAGE_OPPORTUNITIES
-            else MeasurementStatus.NOT_EVALUATED
-        )
+        exposure_status = MeasurementStatus.PASS
         payload = {
             "metric_name": name,
             "error_count": errors,
             "denominator": total,
             "rate_ppm": rate,
-            "minimum_opportunities": _MINIMUM_TRIAGE_OPPORTUNITIES,
+            "minimum_opportunities": 0,
             "exposure_status": exposure_status.value,
             "decision_treatment": "MANDATORY_SEPARATE_REPORT_NO_POST_HOC_THRESHOLD",
         }
@@ -1014,6 +1056,14 @@ def _verify_case_outcomes(
         and "SECONDARY" in item["roles"]
         and item.get("human") is True
     }
+    authorised_adjudicators = {
+        str(item.get("identity_digest"))
+        for item in manifest
+        if isinstance(item, Mapping)
+        and isinstance(item.get("roles"), list)
+        and "ADJUDICATOR" in item["roles"]
+        and item.get("human") is True
+    }
     used_primary: set[str] = set()
     for item in checked:
         if not isinstance(item, ReviewedCaseOutcome):
@@ -1035,10 +1085,19 @@ def _verify_case_outcomes(
             if secondary_value is None
             else ReviewLabel.from_canonical_bytes(canonical_json_bytes(secondary_value))
         )
+        adjudication_value = payload["adjudication"]
+        adjudication = (
+            None
+            if adjudication_value is None
+            else AdjudicationDecision.from_canonical_bytes(
+                canonical_json_bytes(adjudication_value)
+            )
+        )
         rebuilt_item = ReviewedCaseOutcome.build(
             case=case,
             review_label=label,
             secondary_review_label=secondary,
+            adjudication=adjudication,
             metric_eligible=payload["metric_eligible"],  # type: ignore[arg-type]
             metric_success=payload["metric_success"],  # type: ignore[arg-type]
             triage_eligible=payload["triage_eligible"],  # type: ignore[arg-type]
@@ -1061,6 +1120,14 @@ def _verify_case_outcomes(
         ):
             raise MetricReportError(
                 "reviewed Case outcome uses an unauthorised secondary reviewer"
+            )
+        if (
+            adjudication is not None
+            and str(adjudication.payload.get("adjudicator_identity_digest"))
+            not in authorised_adjudicators
+        ):
+            raise MetricReportError(
+                "reviewed Case outcome uses an unauthorised adjudicator"
             )
         manifest = case.payload.get("input_manifest_digest")
         retained_label_digests = {label.digest}
@@ -1249,9 +1316,6 @@ def build_metric_report(
     stratum_exposure_sufficient = all(
         stratum_counts[name] >= minimum for name, minimum in stratum_minima.items()
     )
-    triage_exposure_sufficient = all(
-        item.exposure_status is MeasurementStatus.PASS for item in triage
-    )
     minimum_primary_reviewers = int(
         INCREMENT_8_READINESS.evaluation_plan["minimum_authorised_primary_reviewers"]
     )
@@ -1278,7 +1342,6 @@ def build_metric_report(
         total_cases < minimum_cases
         or primary_reviewer_count < minimum_primary_reviewers
         or not stratum_exposure_sufficient
-        or not triage_exposure_sufficient
         or metric_status is MeasurementStatus.NOT_EVALUATED
         or slice_status is MeasurementStatus.NOT_EVALUATED
     ):
@@ -1427,10 +1490,18 @@ def verify_metric_report_canonical_bytes(raw: bytes) -> MetricReport:
                     canonical_json_bytes(item["secondary_review_label"])
                 )
             )
+            adjudication = (
+                None
+                if item["adjudication"] is None
+                else AdjudicationDecision.from_canonical_bytes(
+                    canonical_json_bytes(item["adjudication"])
+                )
+            )
             rebuilt = ReviewedCaseOutcome.build(
                 case=case,
                 review_label=label,
                 secondary_review_label=secondary,
+                adjudication=adjudication,
                 metric_eligible=item["metric_eligible"],  # type: ignore[arg-type]
                 metric_success=item["metric_success"],  # type: ignore[arg-type]
                 triage_eligible=item["triage_eligible"],  # type: ignore[arg-type]
@@ -1579,8 +1650,8 @@ __all__ = [
     "MetricReportError",
     "PerformanceMeasurement",
     "RateMeasurement",
-    "ReviewedCaseOutcome",
     "RequiredSliceResult",
+    "ReviewedCaseOutcome",
     "RoleRecommendation",
     "SamplingMethod",
     "SourceContribution",

--- a/newsroom/increment8/metrics.py
+++ b/newsroom/increment8/metrics.py
@@ -89,11 +89,15 @@ _MAXIMUM_METRICS = frozenset(
     }
 )
 _EXPECTED_METRICS = tuple(sorted(_MINIMUM_METRICS | _MAXIMUM_METRICS))
+_CASE_ATTESTED_METRICS = tuple(
+    name for name in _EXPECTED_METRICS if name != "reviewer_agreement"
+)
 _TRIAGE_ERROR_METRICS = (
     "false_correction",
     "false_development",
     "missed_development",
 )
+_MINIMUM_TRIAGE_OPPORTUNITIES = 10
 _EXPECTED_PERFORMANCE = tuple(
     sorted(
         str(name)
@@ -175,7 +179,9 @@ def _embedded(raw: bytes) -> dict[str, object]:
 def reviewed_case_assessment_label(
     *,
     case: EvaluationCase,
+    metric_eligible: Mapping[str, bool],
     metric_success: Mapping[str, bool],
+    triage_eligible: Mapping[str, bool],
     triage_error: Mapping[str, bool],
     slice_success: bool,
     zero_tolerance_findings: Sequence[str] = (),
@@ -187,7 +193,9 @@ def reviewed_case_assessment_label(
         {
             "schema_version": "newsroom.increment8.reviewed-case-assessment.v1",
             "case_digest": case.digest,
+            "metric_eligible": dict(sorted(metric_eligible.items())),
             "metric_success": dict(sorted(metric_success.items())),
+            "triage_eligible": dict(sorted(triage_eligible.items())),
             "triage_error": dict(sorted(triage_error.items())),
             "slice_success": slice_success,
             "zero_tolerance_findings": list(findings),
@@ -203,7 +211,10 @@ class ReviewedCaseOutcome:
     case_id: str
     case_digest: str
     review_label_digest: str
+    secondary_review_label_digest: str | None
+    metric_eligible: Mapping[str, bool]
     metric_success: Mapping[str, bool]
+    triage_eligible: Mapping[str, bool]
     triage_error: Mapping[str, bool]
     slice_success: bool
     zero_tolerance_findings: tuple[str, ...]
@@ -216,7 +227,10 @@ class ReviewedCaseOutcome:
         *,
         case: EvaluationCase,
         review_label: ReviewLabel,
+        secondary_review_label: ReviewLabel | None = None,
+        metric_eligible: Mapping[str, bool],
         metric_success: Mapping[str, bool],
+        triage_eligible: Mapping[str, bool],
         triage_error: Mapping[str, bool],
         slice_success: bool,
         zero_tolerance_findings: Sequence[str] = (),
@@ -225,6 +239,13 @@ class ReviewedCaseOutcome:
             checked_case = EvaluationCase.from_canonical_bytes(case.canonical_bytes)
             checked_label = ReviewLabel.from_canonical_bytes(
                 review_label.canonical_bytes
+            )
+            checked_secondary = (
+                None
+                if secondary_review_label is None
+                else ReviewLabel.from_canonical_bytes(
+                    secondary_review_label.canonical_bytes
+                )
             )
         except (AttributeError, TypeError, ValueError) as exc:
             raise MetricReportError("reviewed Case evidence is not canonical") from exc
@@ -238,6 +259,15 @@ class ReviewedCaseOutcome:
             or checked_case.payload.get("prospective") is not True
         ):
             raise MetricReportError("reviewed Case or label binding differs")
+        if checked_secondary is not None and (
+            checked_secondary != secondary_review_label
+            or checked_secondary.payload.get("case_id") != checked_case.case_id
+            or checked_secondary.payload.get("case_digest") != checked_case.digest
+            or checked_secondary.payload.get("review_role") != "SECONDARY"
+            or checked_secondary.payload.get("reviewer_identity_digest")
+            == checked_label.payload.get("reviewer_identity_digest")
+        ):
+            raise MetricReportError("secondary ReviewLabel binding differs")
         try:
             facts = _membership_facts(checked_case.payload["membership_facts"])  # type: ignore[arg-type]
             expected_slices, expected_strata = _memberships(facts)
@@ -250,17 +280,30 @@ class ReviewedCaseOutcome:
             is not (facts["case_metadata"]["urgency"] == "URGENT")  # type: ignore[index]
         ):
             raise MetricReportError("frozen Case membership differs")
+        if not isinstance(metric_eligible, Mapping) or tuple(
+            sorted(metric_eligible)
+        ) != (_CASE_ATTESTED_METRICS):
+            raise MetricReportError("per-Case metric eligibility inventory differs")
         if not isinstance(metric_success, Mapping) or tuple(sorted(metric_success)) != (
-            _EXPECTED_METRICS
+            _CASE_ATTESTED_METRICS
         ):
             raise MetricReportError("per-Case metric inventory differs")
         if not isinstance(triage_error, Mapping) or tuple(sorted(triage_error)) != (
             _TRIAGE_ERROR_METRICS
         ):
             raise MetricReportError("per-Case triage-error inventory differs")
+        if not isinstance(triage_eligible, Mapping) or tuple(
+            sorted(triage_eligible)
+        ) != (_TRIAGE_ERROR_METRICS):
+            raise MetricReportError("per-Case triage eligibility inventory differs")
         if not isinstance(slice_success, bool) or any(
             not isinstance(value, bool)
-            for value in (*metric_success.values(), *triage_error.values())
+            for value in (
+                *metric_eligible.values(),
+                *metric_success.values(),
+                *triage_eligible.values(),
+                *triage_error.values(),
+            )
         ):
             raise MetricReportError("per-Case outcomes must be boolean")
         findings = _sorted_tokens(
@@ -272,7 +315,9 @@ class ReviewedCaseOutcome:
             raise MetricReportError("zero-tolerance findings differ from the Case")
         expected_label = reviewed_case_assessment_label(
             case=checked_case,
+            metric_eligible=metric_eligible,
             metric_success=metric_success,
+            triage_eligible=triage_eligible,
             triage_error=triage_error,
             slice_success=slice_success,
             zero_tolerance_findings=findings,
@@ -287,7 +332,17 @@ class ReviewedCaseOutcome:
             "case_digest": checked_case.digest,
             "review_label": _embedded(checked_label.canonical_bytes),
             "review_label_digest": checked_label.digest,
+            "secondary_review_label": (
+                None
+                if checked_secondary is None
+                else _embedded(checked_secondary.canonical_bytes)
+            ),
+            "secondary_review_label_digest": (
+                None if checked_secondary is None else checked_secondary.digest
+            ),
+            "metric_eligible": dict(sorted(metric_eligible.items())),
             "metric_success": dict(sorted(metric_success.items())),
+            "triage_eligible": dict(sorted(triage_eligible.items())),
             "triage_error": dict(sorted(triage_error.items())),
             "slice_success": slice_success,
             "zero_tolerance_findings": list(findings),
@@ -299,7 +354,10 @@ class ReviewedCaseOutcome:
             checked_case.case_id,
             checked_case.digest,
             checked_label.digest,
+            None if checked_secondary is None else checked_secondary.digest,
+            MappingProxyType(dict(sorted(metric_eligible.items()))),
             MappingProxyType(dict(sorted(metric_success.items()))),
+            MappingProxyType(dict(sorted(triage_eligible.items()))),
             MappingProxyType(dict(sorted(triage_error.items()))),
             slice_success,
             findings,
@@ -314,6 +372,7 @@ class TriageErrorMeasurement:
     error_count: int
     denominator: int
     rate_ppm: int
+    exposure_status: MeasurementStatus
     decision_treatment: str
     canonical_bytes: bytes
     digest: str
@@ -326,15 +385,22 @@ class TriageErrorMeasurement:
         if name not in _TRIAGE_ERROR_METRICS:
             raise MetricReportError("triage error metric is not pre-registered")
         errors = _integer(error_count, "error_count")
-        total = _integer(denominator, "denominator", minimum=1)
+        total = _integer(denominator, "denominator")
         if errors > total:
             raise MetricReportError("triage errors exceed eligible opportunities")
-        rate = errors * 1_000_000 // total
+        rate = 0 if total == 0 else errors * 1_000_000 // total
+        exposure_status = (
+            MeasurementStatus.PASS
+            if total >= _MINIMUM_TRIAGE_OPPORTUNITIES
+            else MeasurementStatus.NOT_EVALUATED
+        )
         payload = {
             "metric_name": name,
             "error_count": errors,
             "denominator": total,
             "rate_ppm": rate,
+            "minimum_opportunities": _MINIMUM_TRIAGE_OPPORTUNITIES,
+            "exposure_status": exposure_status.value,
             "decision_treatment": "MANDATORY_SEPARATE_REPORT_NO_POST_HOC_THRESHOLD",
         }
         raw, record_digest = _record(
@@ -345,6 +411,7 @@ class TriageErrorMeasurement:
             errors,
             total,
             rate,
+            exposure_status,
             "MANDATORY_SEPARATE_REPORT_NO_POST_HOC_THRESHOLD",
             raw,
             record_digest,
@@ -380,11 +447,11 @@ class RateMeasurement:
         ):
             raise MetricReportError("metric is not pre-registered")
         numerator = _integer(count, "count")
-        total = _integer(denominator, "denominator", minimum=1)
+        total = _integer(denominator, "denominator")
         uncertainty = _integer(uncertainty_ppm, "uncertainty_ppm")
         if numerator > total or uncertainty > 1_000_000:
             raise MetricReportError("rate evidence exceeds its denominator")
-        rate = numerator * 1_000_000 // total
+        rate = 0 if total == 0 else numerator * 1_000_000 // total
         threshold_name = f"{name}_{'min' if name in _MINIMUM_METRICS else 'max'}"
         threshold = int(
             INCREMENT_8_READINESS.evaluation_plan["thresholds_ppm"][threshold_name]
@@ -399,9 +466,13 @@ class RateMeasurement:
             "direction": "MINIMUM" if name in _MINIMUM_METRICS else "MAXIMUM",
             "sampling_method": sampling_method.value,
             "uncertainty_ppm": uncertainty,
-            "status": MeasurementStatus.PASS.value
-            if passed
-            else MeasurementStatus.FAIL.value,
+            "status": (
+                MeasurementStatus.NOT_EVALUATED.value
+                if total == 0
+                else MeasurementStatus.PASS.value
+                if passed
+                else MeasurementStatus.FAIL.value
+            ),
         }
         raw, record_digest = _record("newsroom.increment8.rate-measurement.v1", payload)
         return cls(
@@ -412,7 +483,13 @@ class RateMeasurement:
             threshold,
             sampling_method,
             uncertainty,
-            MeasurementStatus.PASS if passed else MeasurementStatus.FAIL,
+            (
+                MeasurementStatus.NOT_EVALUATED
+                if total == 0
+                else MeasurementStatus.PASS
+                if passed
+                else MeasurementStatus.FAIL
+            ),
             raw,
             record_digest,
         )
@@ -929,6 +1006,14 @@ def _verify_case_outcomes(
         and "PRIMARY" in item["roles"]
         and item.get("human") is True
     }
+    authorised_secondary = {
+        str(item.get("identity_digest"))
+        for item in manifest
+        if isinstance(item, Mapping)
+        and isinstance(item.get("roles"), list)
+        and "SECONDARY" in item["roles"]
+        and item.get("human") is True
+    }
     used_primary: set[str] = set()
     for item in checked:
         if not isinstance(item, ReviewedCaseOutcome):
@@ -944,10 +1029,19 @@ def _verify_case_outcomes(
         label = ReviewLabel.from_canonical_bytes(
             canonical_json_bytes(payload["review_label"])
         )
+        secondary_value = payload["secondary_review_label"]
+        secondary = (
+            None
+            if secondary_value is None
+            else ReviewLabel.from_canonical_bytes(canonical_json_bytes(secondary_value))
+        )
         rebuilt_item = ReviewedCaseOutcome.build(
             case=case,
             review_label=label,
+            secondary_review_label=secondary,
+            metric_eligible=payload["metric_eligible"],  # type: ignore[arg-type]
             metric_success=payload["metric_success"],  # type: ignore[arg-type]
+            triage_eligible=payload["triage_eligible"],  # type: ignore[arg-type]
             triage_error=payload["triage_error"],  # type: ignore[arg-type]
             slice_success=payload["slice_success"],  # type: ignore[arg-type]
             zero_tolerance_findings=payload["zero_tolerance_findings"],  # type: ignore[arg-type]
@@ -960,11 +1054,24 @@ def _verify_case_outcomes(
                 "reviewed Case outcome uses an unauthorised reviewer"
             )
         used_primary.add(reviewer)
+        if (
+            secondary is not None
+            and str(secondary.payload.get("reviewer_identity_digest"))
+            not in authorised_secondary
+        ):
+            raise MetricReportError(
+                "reviewed Case outcome uses an unauthorised secondary reviewer"
+            )
         manifest = case.payload.get("input_manifest_digest")
-        if manifest in input_manifests or label.digest in label_digests:
+        retained_label_digests = {label.digest}
+        if secondary is not None:
+            retained_label_digests.add(secondary.digest)
+        if manifest in input_manifests or retained_label_digests.intersection(
+            label_digests
+        ):
             raise MetricReportError("reviewed Case evidence is duplicated")
         input_manifests.add(manifest)
-        label_digests.add(label.digest)
+        label_digests.update(retained_label_digests)
         rebuilt.append(rebuilt_item)
     return tuple(rebuilt), len(used_primary)
 
@@ -978,26 +1085,56 @@ def _derive_measurements(
     ZeroToleranceEvidence,
     Mapping[str, int],
 ]:
-    total = len(outcomes)
-    rates = tuple(
-        RateMeasurement.build(
-            metric_name=name,
-            count=(
-                sum(item.metric_success[name] for item in outcomes)
+    rates: list[RateMeasurement] = []
+    for name in _EXPECTED_METRICS:
+        if name == "reviewer_agreement":
+            agreements: list[bool] = []
+            for outcome in outcomes:
+                document = _document(
+                    outcome.canonical_bytes,
+                    "newsroom.increment8.reviewed-case-outcome.v1",
+                )
+                payload = document["payload"]
+                assert isinstance(payload, Mapping)
+                secondary = payload["secondary_review_label"]
+                if secondary is not None:
+                    assert isinstance(secondary, Mapping)
+                    primary = payload["review_label"]
+                    assert isinstance(primary, Mapping)
+                    agreements.append(
+                        primary["payload"]["label"]  # type: ignore[index]
+                        == secondary["payload"]["label"]  # type: ignore[index]
+                    )
+            eligible = len(agreements)
+            numerator = sum(agreements)
+        else:
+            eligible_outcomes = [
+                item for item in outcomes if item.metric_eligible[name]
+            ]
+            eligible = len(eligible_outcomes)
+            numerator = (
+                sum(item.metric_success[name] for item in eligible_outcomes)
                 if name in _MINIMUM_METRICS
-                else sum(not item.metric_success[name] for item in outcomes)
-            ),
-            denominator=total,
-            sampling_method=SamplingMethod.POPULATION,
-            uncertainty_ppm=0,
+                else sum(not item.metric_success[name] for item in eligible_outcomes)
+            )
+        rates.append(
+            RateMeasurement.build(
+                metric_name=name,
+                count=numerator,
+                denominator=eligible,
+                sampling_method=SamplingMethod.POPULATION,
+                uncertainty_ppm=0,
+            )
         )
-        for name in _EXPECTED_METRICS
-    )
     triage = tuple(
         TriageErrorMeasurement.build(
             metric_name=name,
-            error_count=sum(item.triage_error[name] for item in outcomes),
-            denominator=total,
+            error_count=sum(
+                item.triage_error[name]
+                for item in outcomes
+                if item.triage_eligible[name]
+            ),
+            denominator=sum(item.triage_eligible[name] for item in outcomes),
         )
         for name in _TRIAGE_ERROR_METRICS
     )
@@ -1038,7 +1175,7 @@ def _derive_measurements(
         for name in REQUIRED_SLICES
     )
     return (
-        rates,
+        tuple(rates),
         triage,
         slices,
         ZeroToleranceEvidence.build(zero_counts),
@@ -1112,14 +1249,18 @@ def build_metric_report(
     stratum_exposure_sufficient = all(
         stratum_counts[name] >= minimum for name, minimum in stratum_minima.items()
     )
+    triage_exposure_sufficient = all(
+        item.exposure_status is MeasurementStatus.PASS for item in triage
+    )
     minimum_primary_reviewers = int(
         INCREMENT_8_READINESS.evaluation_plan["minimum_authorised_primary_reviewers"]
     )
-    metric_status = (
-        MeasurementStatus.PASS
-        if all(item.status is MeasurementStatus.PASS for item in checked_rates)
-        else MeasurementStatus.FAIL
-    )
+    if any(item.status is MeasurementStatus.FAIL for item in checked_rates):
+        metric_status = MeasurementStatus.FAIL
+    elif any(item.status is MeasurementStatus.NOT_EVALUATED for item in checked_rates):
+        metric_status = MeasurementStatus.NOT_EVALUATED
+    else:
+        metric_status = MeasurementStatus.PASS
     performance_status = (
         MeasurementStatus.PASS
         if all(item.status is MeasurementStatus.PASS for item in checked_performance)
@@ -1137,6 +1278,8 @@ def build_metric_report(
         total_cases < minimum_cases
         or primary_reviewer_count < minimum_primary_reviewers
         or not stratum_exposure_sufficient
+        or not triage_exposure_sufficient
+        or metric_status is MeasurementStatus.NOT_EVALUATED
         or slice_status is MeasurementStatus.NOT_EVALUATED
     ):
         overall = MeasurementStatus.NOT_EVALUATED
@@ -1277,10 +1420,20 @@ def verify_metric_report_canonical_bytes(raw: bytes) -> MetricReport:
             label = ReviewLabel.from_canonical_bytes(
                 canonical_json_bytes(item["review_label"])
             )
+            secondary = (
+                None
+                if item["secondary_review_label"] is None
+                else ReviewLabel.from_canonical_bytes(
+                    canonical_json_bytes(item["secondary_review_label"])
+                )
+            )
             rebuilt = ReviewedCaseOutcome.build(
                 case=case,
                 review_label=label,
+                secondary_review_label=secondary,
+                metric_eligible=item["metric_eligible"],  # type: ignore[arg-type]
                 metric_success=item["metric_success"],  # type: ignore[arg-type]
+                triage_eligible=item["triage_eligible"],  # type: ignore[arg-type]
                 triage_error=item["triage_error"],  # type: ignore[arg-type]
                 slice_success=item["slice_success"],  # type: ignore[arg-type]
                 zero_tolerance_findings=item["zero_tolerance_findings"],  # type: ignore[arg-type]

--- a/newsroom/increment8/metrics.py
+++ b/newsroom/increment8/metrics.py
@@ -338,6 +338,11 @@ class ReviewedCaseOutcome:
             )
         ):
             raise MetricReportError("per-Case outcomes must be boolean")
+        if any(
+            triage_error[name] and not triage_eligible[name]
+            for name in _TRIAGE_ERROR_METRICS
+        ):
+            raise MetricReportError("triage error cannot be marked ineligible")
         findings = _sorted_tokens(
             zero_tolerance_findings, "zero_tolerance_findings", empty=True
         )
@@ -435,7 +440,9 @@ class TriageErrorMeasurement:
         if errors > total:
             raise MetricReportError("triage errors exceed eligible opportunities")
         rate = 0 if total == 0 else errors * 1_000_000 // total
-        exposure_status = MeasurementStatus.PASS
+        exposure_status = (
+            MeasurementStatus.NOT_EVALUATED if total == 0 else MeasurementStatus.PASS
+        )
         payload = {
             "metric_name": name,
             "error_count": errors,

--- a/newsroom/increment8/metrics.py
+++ b/newsroom/increment8/metrics.py
@@ -343,6 +343,18 @@ class ReviewedCaseOutcome:
             for name in _TRIAGE_ERROR_METRICS
         ):
             raise MetricReportError("triage error cannot be marked ineligible")
+        development_blockers = {
+            "false_development": "candidate_precision",
+            "missed_development": "candidate_recall",
+        }
+        if any(
+            triage_error[error_name]
+            and (not metric_eligible[metric_name] or metric_success[metric_name])
+            for error_name, metric_name in development_blockers.items()
+        ):
+            raise MetricReportError(
+                "development error differs from its decision-bearing blocker metric"
+            )
         findings = _sorted_tokens(
             zero_tolerance_findings, "zero_tolerance_findings", empty=True
         )

--- a/newsroom/tests/test_increment8a_corrective_authority.py
+++ b/newsroom/tests/test_increment8a_corrective_authority.py
@@ -69,7 +69,10 @@ def _populate(
     ordinary_second_reviews: bool = True,
 ):
     from newsroom.increment8.metrics import reviewed_case_assessment_label
-    from newsroom.tests.test_increment8b_metrics import _RATE_NAMES, _TRIAGE_NAMES
+    from newsroom.tests.test_increment8b_metrics import (
+        _CASE_RATE_NAMES,
+        _TRIAGE_NAMES,
+    )
 
     geographies = ("GLOBAL", "HONG_KONG", "UNITED_KINGDOM")
     languages = ("EN_GB", "MIXED_EN_GB_ZH_HANT_HK", "ZH_HANT_HK")
@@ -108,7 +111,9 @@ def _populate(
         )
         assessment_label = reviewed_case_assessment_label(
             case=case,
-            metric_success={name: True for name in _RATE_NAMES},
+            metric_eligible={name: True for name in _CASE_RATE_NAMES},
+            metric_success={name: True for name in _CASE_RATE_NAMES},
+            triage_eligible={name: True for name in _TRIAGE_NAMES},
             triage_error={name: False for name in _TRIAGE_NAMES},
             slice_success=True,
         )
@@ -141,35 +146,36 @@ def _populate(
 def _pass_candidate(authority: EvaluationAuthority, run):
     manifest = authority.evidence_manifest_digest(run.run_id)
     from newsroom.increment8.metrics import ReviewedCaseOutcome
-    from newsroom.tests.test_increment8b_metrics import _RATE_NAMES, _TRIAGE_NAMES
+    from newsroom.tests.test_increment8b_metrics import (
+        _CASE_RATE_NAMES,
+        _TRIAGE_NAMES,
+    )
 
     rows = authority._connection.execute(  # noqa: SLF001 - authority fixture proof
-        "SELECT c.case_bytes,l.label_bytes FROM evaluation_cases c "
-        "JOIN evaluation_labels l ON l.case_id=c.case_id "
-        "WHERE c.run_id=? AND l.review_role='PRIMARY' ORDER BY c.case_id",
+        "SELECT c.case_bytes,p.label_bytes,(SELECT s.label_bytes FROM evaluation_labels s "
+        "WHERE s.case_id=c.case_id AND s.review_role='SECONDARY') "
+        "FROM evaluation_cases c JOIN evaluation_labels p ON p.case_id=c.case_id "
+        "WHERE c.run_id=? AND p.review_role='PRIMARY' ORDER BY c.case_id",
         (run.run_id,),
     ).fetchall()
     outcomes = tuple(
         ReviewedCaseOutcome.build(
             case=EvaluationCase.from_canonical_bytes(bytes(case_raw)),
             review_label=ReviewLabel.from_canonical_bytes(bytes(label_raw)),
-            metric_success={name: True for name in _RATE_NAMES},
+            secondary_review_label=(
+                None
+                if secondary_raw is None
+                else ReviewLabel.from_canonical_bytes(bytes(secondary_raw))
+            ),
+            metric_eligible={name: True for name in _CASE_RATE_NAMES},
+            metric_success={name: True for name in _CASE_RATE_NAMES},
+            triage_eligible={name: True for name in _TRIAGE_NAMES},
             triage_error={name: False for name in _TRIAGE_NAMES},
             slice_success=True,
         )
-        for case_raw, label_raw in rows
+        for case_raw, label_raw, secondary_raw in rows
     )
-    stratum_counts = {"NEGATIVE": 0, "UNCHANGED": 0, "FAILURE_HEAVY": 0}
-    for case_raw, _ in rows:
-        case = EvaluationCase.from_canonical_bytes(bytes(case_raw))
-        for name in case.payload["case_strata"]:
-            stratum_counts[str(name)] += 1
-    retained_outcomes = (
-        outcomes
-        if len(outcomes) == 120
-        and all(value >= 12 for value in stratum_counts.values())
-        else None
-    )
+    retained_outcomes = outcomes or None
     return build_release_decision(
         run=run,
         report_canonical_bytes=_report_bytes(
@@ -369,11 +375,53 @@ def test_release_decision_seals_the_complete_evidence_manifest(tmp_path: Path) -
             prospective=True,
         )
         authority.register_case(case)
+        from newsroom.increment8.metrics import (
+            ReviewedCaseOutcome,
+            reviewed_case_assessment_label,
+        )
+        from newsroom.tests.test_increment8b_metrics import (
+            _CASE_RATE_NAMES,
+            _TRIAGE_NAMES,
+        )
+
+        metric_eligible = {name: True for name in _CASE_RATE_NAMES}
+        metric_success = {name: True for name in _CASE_RATE_NAMES}
+        metric_success["candidate_precision"] = False
+        triage_eligible = {name: True for name in _TRIAGE_NAMES}
+        triage_error = {name: False for name in _TRIAGE_NAMES}
+        primary = build_review_label(
+            case=case,
+            reviewer_identity_digest=REVIEWER_1,
+            role=ReviewRole.PRIMARY,
+            label=reviewed_case_assessment_label(
+                case=case,
+                metric_eligible=metric_eligible,
+                metric_success=metric_success,
+                triage_eligible=triage_eligible,
+                triage_error=triage_error,
+                slice_success=True,
+            ),
+            blinded=True,
+            recorded_at=T3,
+        )
+        authority.record_label(primary)
+        outcome = ReviewedCaseOutcome.build(
+            case=case,
+            review_label=primary,
+            metric_eligible=metric_eligible,
+            metric_success=metric_success,
+            triage_eligible=triage_eligible,
+            triage_error=triage_error,
+            slice_success=True,
+        )
         manifest = authority.evidence_manifest_digest(run.run_id)
         decision = build_release_decision(
             run=run,
             report_canonical_bytes=_report_bytes(
-                run, status="FAIL", evidence_manifest_digest=manifest
+                run,
+                status="FAIL",
+                evidence_manifest_digest=manifest,
+                case_outcomes=(outcome,),
             ),
             evidence_manifest_digest=manifest,
             verdict=ReleaseVerdict.INCONCLUSIVE,
@@ -422,7 +470,7 @@ def test_positive_changed_only_exposure_fails_frozen_strata(tmp_path: Path) -> N
     connection, authority, run = _registered(tmp_path)
     try:
         _populate(authority, run, positive_changed=True)
-        with pytest.raises(EvaluationAuthorityError, match="stratum"):
+        with pytest.raises(EvaluationAuthorityError, match="retained Metric Report"):
             authority.decide_release(_pass_candidate(authority, run))
     finally:
         connection.close()
@@ -432,7 +480,7 @@ def test_all_unreviewable_exposure_cannot_vacuously_pass(tmp_path: Path) -> None
     connection, authority, run = _registered(tmp_path)
     try:
         _populate(authority, run, reviewable=False)
-        with pytest.raises(EvaluationAuthorityError, match="reviewable exposure"):
+        with pytest.raises(EvaluationAuthorityError, match="outcomes differ"):
             authority.decide_release(_pass_candidate(authority, run))
     finally:
         connection.close()
@@ -442,7 +490,7 @@ def test_unreviewable_cases_do_not_fill_reviewed_exposure(tmp_path: Path) -> Non
     connection, authority, run = _registered(tmp_path)
     try:
         _populate(authority, run, reviewable_count=2)
-        with pytest.raises(EvaluationAuthorityError, match="reviewed qualification"):
+        with pytest.raises(EvaluationAuthorityError, match="retained Metric Report"):
             authority.decide_release(_pass_candidate(authority, run))
     finally:
         connection.close()
@@ -534,6 +582,31 @@ def test_report_is_retained_and_reconstructed_not_a_caller_boolean(
         contradictory = ReleaseEvidenceDecision.build(contradictory_payload)
         with pytest.raises(EvaluationAuthorityError, match="decision gates"):
             authority.decide_release(contradictory)
+    finally:
+        connection.close()
+
+
+@pytest.mark.parametrize("verdict", [ReleaseVerdict.FAIL, ReleaseVerdict.INCONCLUSIVE])
+def test_non_pass_decisions_reject_foreign_reviewed_case_evidence(
+    tmp_path: Path, verdict: ReleaseVerdict
+) -> None:
+    connection, authority, run = _registered(tmp_path / verdict.value.lower())
+    try:
+        manifest = authority.evidence_manifest_digest(run.run_id)
+        report_raw = _report_bytes(
+            run, status="FAIL", evidence_manifest_digest=manifest
+        )
+        decision = build_release_decision(
+            run=run,
+            report_canonical_bytes=report_raw,
+            evidence_manifest_digest=manifest,
+            verdict=verdict,
+            owner_identity_digest=OWNER,
+            decided_at=T5,
+            early_stopped=True,
+        )
+        with pytest.raises(EvaluationAuthorityError, match="outcomes differ"):
+            authority.decide_release(decision)
     finally:
         connection.close()
 

--- a/newsroom/tests/test_increment8a_corrective_authority.py
+++ b/newsroom/tests/test_increment8a_corrective_authority.py
@@ -12,6 +12,7 @@ from newsroom.increment8.evaluation import (
     EvaluationCase,
     ReleaseEvidenceDecision,
     ReleaseVerdict,
+    ReviewLabel,
     ReviewRole,
     RightsStatus,
     RunKind,
@@ -67,6 +68,9 @@ def _populate(
     positive_changed: bool = False,
     ordinary_second_reviews: bool = True,
 ):
+    from newsroom.increment8.metrics import reviewed_case_assessment_label
+    from newsroom.tests.test_increment8b_metrics import _RATE_NAMES, _TRIAGE_NAMES
+
     geographies = ("GLOBAL", "HONG_KONG", "UNITED_KINGDOM")
     languages = ("EN_GB", "MIXED_EN_GB_ZH_HANT_HK", "ZH_HANT_HK")
     cases = []
@@ -102,12 +106,18 @@ def _populate(
         secondary_identity = (
             REVIEWER_2 if primary_identity == REVIEWER_1 else REVIEWER_1
         )
+        assessment_label = reviewed_case_assessment_label(
+            case=case,
+            metric_success={name: True for name in _RATE_NAMES},
+            triage_error={name: False for name in _TRIAGE_NAMES},
+            slice_success=True,
+        )
         authority.record_label(
             build_review_label(
                 case=case,
                 reviewer_identity_digest=primary_identity,
                 role=ReviewRole.PRIMARY,
-                label="expected-route",
+                label=assessment_label,
                 blinded=True,
                 recorded_at=T3,
             )
@@ -118,7 +128,7 @@ def _populate(
                     case=case,
                     reviewer_identity_digest=secondary_identity,
                     role=ReviewRole.SECONDARY,
-                    label="expected-route",
+                    label=assessment_label,
                     blinded=True,
                     recorded_at=T3,
                 )
@@ -130,23 +140,42 @@ def _populate(
 
 def _pass_candidate(authority: EvaluationAuthority, run):
     manifest = authority.evidence_manifest_digest(run.run_id)
-    slice_counts = {
-        "GEOGRAPHY_GLOBAL": 40,
-        "GEOGRAPHY_HONG_KONG": 40,
-        "GEOGRAPHY_UNITED_KINGDOM": 40,
-        "LANGUAGE_EN_GB": 40,
-        "LANGUAGE_MIXED_EN_GB_ZH_HANT_HK": 40,
-        "LANGUAGE_ZH_HANT_HK": 40,
-        "SOURCE_MULTI_DOMAIN_CORROBORATED": 120,
-        "TRANSITION_FAILURE_HEAVY": 120,
-        "URGENCY_URGENT": 24,
-    }
+    from newsroom.increment8.metrics import ReviewedCaseOutcome
+    from newsroom.tests.test_increment8b_metrics import _RATE_NAMES, _TRIAGE_NAMES
+
+    rows = authority._connection.execute(  # noqa: SLF001 - authority fixture proof
+        "SELECT c.case_bytes,l.label_bytes FROM evaluation_cases c "
+        "JOIN evaluation_labels l ON l.case_id=c.case_id "
+        "WHERE c.run_id=? AND l.review_role='PRIMARY' ORDER BY c.case_id",
+        (run.run_id,),
+    ).fetchall()
+    outcomes = tuple(
+        ReviewedCaseOutcome.build(
+            case=EvaluationCase.from_canonical_bytes(bytes(case_raw)),
+            review_label=ReviewLabel.from_canonical_bytes(bytes(label_raw)),
+            metric_success={name: True for name in _RATE_NAMES},
+            triage_error={name: False for name in _TRIAGE_NAMES},
+            slice_success=True,
+        )
+        for case_raw, label_raw in rows
+    )
+    stratum_counts = {"NEGATIVE": 0, "UNCHANGED": 0, "FAILURE_HEAVY": 0}
+    for case_raw, _ in rows:
+        case = EvaluationCase.from_canonical_bytes(bytes(case_raw))
+        for name in case.payload["case_strata"]:
+            stratum_counts[str(name)] += 1
+    retained_outcomes = (
+        outcomes
+        if len(outcomes) == 120
+        and all(value >= 12 for value in stratum_counts.values())
+        else None
+    )
     return build_release_decision(
         run=run,
         report_canonical_bytes=_report_bytes(
             run,
             evidence_manifest_digest=manifest,
-            slice_counts=slice_counts,
+            case_outcomes=retained_outcomes,
         ),
         evidence_manifest_digest=manifest,
         verdict=ReleaseVerdict.PASS,

--- a/newsroom/tests/test_increment8a_evaluation_authority.py
+++ b/newsroom/tests/test_increment8a_evaluation_authority.py
@@ -6,13 +6,13 @@ from pathlib import Path
 
 import pytest
 
+from newsroom.authority.canonical import digest_bytes
 from newsroom.authority.increment8_evaluation_migrations import (
     INCREMENT8_EVALUATION_MIGRATION_CHECKSUM,
     INCREMENT8_EVALUATION_MIGRATION_NAME,
     Increment8EvaluationBackupError,
     prepare_increment8_evaluation_backup,
 )
-from newsroom.authority.canonical import digest_bytes
 from newsroom.authority.migrations import (
     EXPECTED_MIGRATION_HISTORY,
     EXPECTED_SCHEMA_FINGERPRINT,
@@ -129,8 +129,8 @@ def _report_bytes(
         )
         target = outcomes[target_index]
         case_document = json.loads(target.canonical_bytes)["payload"]
-        from newsroom.increment8.evaluation import EvaluationCase, ReviewLabel
         from newsroom.authority.canonical import canonical_json_bytes
+        from newsroom.increment8.evaluation import EvaluationCase, ReviewLabel
 
         case = EvaluationCase.from_canonical_bytes(
             canonical_json_bytes(case_document["case"])
@@ -162,10 +162,24 @@ def _report_bytes(
             blinded=previous_label.payload["blinded"],
             recorded_at=previous_label.payload["recorded_at"],
         )
+        replacement_secondary = (
+            None
+            if previous_secondary is None
+            else build_review_label(
+                case=case,
+                reviewer_identity_digest=previous_secondary.payload[
+                    "reviewer_identity_digest"
+                ],
+                role=ReviewRole.SECONDARY,
+                label=replacement_label.payload["label"],
+                blinded=previous_secondary.payload["blinded"],
+                recorded_at=previous_secondary.payload["recorded_at"],
+            )
+        )
         replacement = ReviewedCaseOutcome.build(
             case=case,
             review_label=replacement_label,
-            secondary_review_label=previous_secondary,
+            secondary_review_label=replacement_secondary,
             metric_eligible=target.metric_eligible,
             metric_success=target.metric_success,
             triage_eligible=target.triage_eligible,

--- a/newsroom/tests/test_increment8a_evaluation_authority.py
+++ b/newsroom/tests/test_increment8a_evaluation_authority.py
@@ -138,6 +138,13 @@ def _report_bytes(
         previous_label = ReviewLabel.from_canonical_bytes(
             canonical_json_bytes(case_document["review_label"])
         )
+        previous_secondary = (
+            None
+            if case_document["secondary_review_label"] is None
+            else ReviewLabel.from_canonical_bytes(
+                canonical_json_bytes(case_document["secondary_review_label"])
+            )
+        )
         findings = tuple(sorted(zero_failures))
         replacement_label = build_review_label(
             case=case,
@@ -145,7 +152,9 @@ def _report_bytes(
             role=ReviewRole.PRIMARY,
             label=reviewed_case_assessment_label(
                 case=case,
+                metric_eligible=target.metric_eligible,
                 metric_success=target.metric_success,
+                triage_eligible=target.triage_eligible,
                 triage_error=target.triage_error,
                 slice_success=target.slice_success,
                 zero_tolerance_findings=findings,
@@ -156,7 +165,10 @@ def _report_bytes(
         replacement = ReviewedCaseOutcome.build(
             case=case,
             review_label=replacement_label,
+            secondary_review_label=previous_secondary,
+            metric_eligible=target.metric_eligible,
             metric_success=target.metric_success,
+            triage_eligible=target.triage_eligible,
             triage_error=target.triage_error,
             slice_success=target.slice_success,
             zero_tolerance_findings=findings,
@@ -393,20 +405,53 @@ def test_append_only_authority_retains_failed_run_and_rejects_mutation(
             prospective=True,
         )
         authority.register_case(case)
+        from newsroom.increment8.metrics import (
+            ReviewedCaseOutcome,
+            reviewed_case_assessment_label,
+        )
+        from newsroom.tests.test_increment8b_metrics import (
+            _CASE_RATE_NAMES,
+            _TRIAGE_NAMES,
+        )
+
+        metric_eligible = {name: True for name in _CASE_RATE_NAMES}
+        metric_success = {name: True for name in _CASE_RATE_NAMES}
+        metric_success["candidate_precision"] = False
+        triage_error = {name: False for name in _TRIAGE_NAMES}
+        triage_eligible = {name: True for name in _TRIAGE_NAMES}
         label = build_review_label(
             case=case,
             reviewer_identity_digest=REVIEWER_1,
             role=ReviewRole.PRIMARY,
-            label="route-a",
+            label=reviewed_case_assessment_label(
+                case=case,
+                metric_eligible=metric_eligible,
+                metric_success=metric_success,
+                triage_eligible=triage_eligible,
+                triage_error=triage_error,
+                slice_success=True,
+            ),
             blinded=True,
             recorded_at=T3,
         )
         authority.record_label(label)
+        case_outcome = ReviewedCaseOutcome.build(
+            case=case,
+            review_label=label,
+            metric_eligible=metric_eligible,
+            metric_success=metric_success,
+            triage_eligible=triage_eligible,
+            triage_error=triage_error,
+            slice_success=True,
+        )
         manifest = authority.evidence_manifest_digest(run.run_id)
         decision = build_release_decision(
             run=run,
             report_canonical_bytes=_report_bytes(
-                run, status="FAIL", evidence_manifest_digest=manifest
+                run,
+                status="FAIL",
+                evidence_manifest_digest=manifest,
+                case_outcomes=(case_outcome,),
             ),
             evidence_manifest_digest=manifest,
             verdict=ReleaseVerdict.INCONCLUSIVE,
@@ -456,7 +501,7 @@ def test_pass_requires_full_exposure_primary_labels_and_second_review_sample(
             owner_identity_digest=OWNER,
             decided_at=T5,
         )
-        with pytest.raises(EvaluationAuthorityError, match="exposure"):
+        with pytest.raises(EvaluationAuthorityError, match="outcomes differ"):
             authority.decide_release(candidate)
 
         # The authority gate also rejects a caller that bypasses the public
@@ -480,7 +525,7 @@ def test_pass_requires_full_exposure_primary_labels_and_second_review_sample(
                 "production_activation_authorised": False,
             }
         )
-        with pytest.raises(EvaluationAuthorityError, match="exposure"):
+        with pytest.raises(EvaluationAuthorityError, match="outcomes differ"):
             authority.decide_release(direct)
         assert connection.execute(
             "SELECT COUNT(*) FROM evaluation_release_decisions"

--- a/newsroom/tests/test_increment8a_evaluation_authority.py
+++ b/newsroom/tests/test_increment8a_evaluation_authority.py
@@ -98,41 +98,81 @@ def _report_bytes(
     status: str = "PASS",
     zero_failures: tuple[str, ...] = (),
     evidence_manifest_digest: str = D2,
-    slice_counts: dict[str, int] | None = None,
+    case_outcomes=None,
 ) -> bytes:
-    from newsroom.increment8.metrics import (
-        REQUIRED_SLICES,
-        RequiredSliceResult,
-        build_metric_report,
-    )
+    from newsroom.increment8.metrics import build_metric_report
     from newsroom.tests.test_increment8b_metrics import (
         _ablations,
+        _case_outcomes,
         _contributions,
         _performance,
-        _rates,
-        _slices,
-        _zero,
     )
 
-    slices = (
-        _slices()
-        if slice_counts is None
-        else tuple(
-            RequiredSliceResult.build(
-                slice_id=name,
-                completed_cases=slice_counts[name],
-                success_count=slice_counts[name],
-            )
-            for name in REQUIRED_SLICES
-        )
+    plan, epoch, expected_run = _records(RunKind(str(run.payload["run_kind"])))
+    assert expected_run == run
+    context = (plan, epoch, run)
+    outcomes = case_outcomes or _case_outcomes(
+        context=context,
+        metric_fail="candidate_precision" if status == "FAIL" else None,
+        zero_finding=zero_failures[0] if zero_failures else None,
     )
+    if len(zero_failures) > 1:
+        from newsroom.increment8.metrics import (
+            ReviewedCaseOutcome,
+            reviewed_case_assessment_label,
+        )
+
+        target_index = next(
+            index
+            for index, outcome in enumerate(outcomes)
+            if outcome.zero_tolerance_findings
+        )
+        target = outcomes[target_index]
+        case_document = json.loads(target.canonical_bytes)["payload"]
+        from newsroom.increment8.evaluation import EvaluationCase, ReviewLabel
+        from newsroom.authority.canonical import canonical_json_bytes
+
+        case = EvaluationCase.from_canonical_bytes(
+            canonical_json_bytes(case_document["case"])
+        )
+        previous_label = ReviewLabel.from_canonical_bytes(
+            canonical_json_bytes(case_document["review_label"])
+        )
+        findings = tuple(sorted(zero_failures))
+        replacement_label = build_review_label(
+            case=case,
+            reviewer_identity_digest=previous_label.payload["reviewer_identity_digest"],
+            role=ReviewRole.PRIMARY,
+            label=reviewed_case_assessment_label(
+                case=case,
+                metric_success=target.metric_success,
+                triage_error=target.triage_error,
+                slice_success=target.slice_success,
+                zero_tolerance_findings=findings,
+            ),
+            blinded=previous_label.payload["blinded"],
+            recorded_at=previous_label.payload["recorded_at"],
+        )
+        replacement = ReviewedCaseOutcome.build(
+            case=case,
+            review_label=replacement_label,
+            metric_success=target.metric_success,
+            triage_error=target.triage_error,
+            slice_success=target.slice_success,
+            zero_tolerance_findings=findings,
+        )
+        outcomes = (
+            *outcomes[:target_index],
+            replacement,
+            *outcomes[target_index + 1 :],
+        )
+        outcomes = tuple(sorted(outcomes, key=lambda item: item.case_id))
     report = build_metric_report(
+        plan=plan,
+        epoch=epoch,
         run=run,
-        case_count=120,
-        rates=_rates(fail="candidate_precision" if status == "FAIL" else None),
+        case_outcomes=outcomes,
         performance=_performance(),
-        slices=slices,
-        zero_tolerance=_zero(**{name: 1 for name in zero_failures}),
         contributions=_contributions(),
         ablations=_ablations(),
         metric_code_digest="sha256:" + "9" * 64,

--- a/newsroom/tests/test_increment8b_metrics.py
+++ b/newsroom/tests/test_increment8b_metrics.py
@@ -1,38 +1,58 @@
 from __future__ import annotations
 
+import json
 from dataclasses import replace
 
 import pytest
 
+from newsroom.authority.canonical import canonical_json_bytes
 from newsroom.increment8.evaluation import (
+    EvaluationCase,
+    ReviewLabel,
+    RightsStatus,
+    ReviewRole,
     RunKind,
+    build_case,
     build_evaluation_plan,
+    build_review_label,
     freeze_epoch,
     open_run,
 )
 from newsroom.increment8.metrics import (
-    REQUIRED_SLICES,
     AblationResult,
     MeasurementStatus,
     MetricReport,
     MetricReportError,
     PerformanceMeasurement,
-    RateMeasurement,
-    RequiredSliceResult,
+    ReviewedCaseOutcome,
     RoleRecommendation,
-    SamplingMethod,
     SourceContribution,
     SourceRole,
-    ZeroToleranceEvidence,
     build_metric_report,
+    reviewed_case_assessment_label,
 )
 from newsroom.increment8.readiness import INCREMENT_8_READINESS
 
 _D = "sha256:" + "1" * 64
 _AT = "2042-01-05T00:00:00.000000Z"
+_RATE_NAMES = (
+    "bounded_event_coverage",
+    "candidate_precision",
+    "candidate_recall",
+    "duplicate_candidate",
+    "false_merge",
+    "fragmentation",
+    "grouping_precision",
+    "grouping_recall",
+    "reviewer_agreement",
+    "route_decision_agreement",
+    "snowball_absorption",
+    "unnecessary_candidate",
+)
+_TRIAGE_NAMES = ("false_correction", "false_development", "missed_development")
 
 
-def _run(kind: RunKind = RunKind.QUALIFICATION):
+def _context(kind: RunKind = RunKind.QUALIFICATION):
     plan = build_evaluation_plan(
         component_manifest_digest=_D,
         approved_by_digest="sha256:" + "2" * 64,
@@ -53,48 +73,117 @@ def _run(kind: RunKind = RunKind.QUALIFICATION):
         cutoff_at=_AT,
         opened_at=_AT,
     )
-    return open_run(epoch=epoch, kind=kind, started_at=_AT)
+    return plan, epoch, open_run(epoch=epoch, kind=kind, started_at=_AT)
 
 
-def _rates(*, fail: str | None = None):
-    thresholds = INCREMENT_8_READINESS.evaluation_plan["thresholds_ppm"]
-    minimum = {
-        "bounded_event_coverage",
-        "candidate_precision",
-        "candidate_recall",
-        "grouping_precision",
-        "grouping_recall",
-        "reviewer_agreement",
-        "route_decision_agreement",
-    }
+def _run(kind: RunKind = RunKind.QUALIFICATION):
+    return _context(kind)[2]
+
+
+def _case_outcomes(
+    *,
+    context=None,
+    count: int = 120,
+    metric_fail: str | None = None,
+    slice_fail: str | None = None,
+    insufficient_slice: str | None = None,
+    insufficient_stratum: str | None = None,
+    zero_finding: str | None = None,
+    triage_error: str | None = None,
+):
+    plan, epoch, run = context or _context()
+    del epoch
+    primary_reviewers = tuple(
+        str(item["identity_digest"])
+        for item in plan.payload["authorised_human_manifest"]
+        if "PRIMARY" in item["roles"]
+    )
     output = []
-    for name in sorted(
-        minimum
-        | {
-            "duplicate_candidate",
-            "false_merge",
-            "fragmentation",
-            "snowball_absorption",
-            "unnecessary_candidate",
-        }
-    ):
-        threshold = int(thresholds[f"{name}_{'min' if name in minimum else 'max'}"])
-        if name in minimum:
-            count = threshold // 10_000
-            count = count - 1 if fail == name else count
-        else:
-            count = threshold // 10_000
-            count = count + 1 if fail == name else count
-        output.append(
-            RateMeasurement.build(
-                metric_name=name,
-                count=count,
-                denominator=100,
-                sampling_method=SamplingMethod.POPULATION,
-                uncertainty_ppm=0,
-            )
+    for index in range(count):
+        geography = ("GLOBAL", "HONG_KONG", "UNITED_KINGDOM")[index % 3]
+        language = ("EN_GB", "MIXED_EN_GB_ZH_HANT_HK", "ZH_HANT_HK")[index % 3]
+        source_member = index < (
+            11 if insufficient_slice == "SOURCE_MULTI_DOMAIN_CORROBORATED" else 20
         )
-    return tuple(output)
+        failure_member = index < 20
+        urgent_member = index < 20
+        negative_member = index < (11 if insufficient_stratum == "NEGATIVE" else 20)
+        unchanged_member = 20 <= index < 40
+        case = build_case(
+            run=run,
+            input_manifest_digest="sha256:" + f"{index + 1000:064x}",
+            cutoff_at=_AT,
+            membership_facts={
+                "case_metadata": {
+                    "geography": geography,
+                    "language": language,
+                    "urgency": "URGENT" if urgent_member else "ROUTINE",
+                },
+                "source_evidence": {"distinct_domain_count": 2 if source_member else 1},
+                "fixture": {"injected_failure_count": 2 if failure_member else 0},
+                "expected": {
+                    "candidate_outcome": "NO_CANDIDATE"
+                    if negative_member
+                    else "CANDIDATE",
+                    "transition_outcome": "UNCHANGED"
+                    if unchanged_member
+                    else "CHANGED",
+                },
+            },
+            rights_status=RightsStatus.REVIEWABLE,
+            prospective=True,
+            urgent=urgent_member,
+            zero_tolerance=zero_finding is not None and index == 0,
+        )
+        metric_success = {name: True for name in _RATE_NAMES}
+        if metric_fail is not None:
+            failures_needed = (
+                7
+                if metric_fail
+                in {
+                    "bounded_event_coverage",
+                    "candidate_precision",
+                    "candidate_recall",
+                    "grouping_precision",
+                    "grouping_recall",
+                    "reviewer_agreement",
+                    "route_decision_agreement",
+                }
+                else 3
+            )
+            if index < failures_needed:
+                metric_success[metric_fail] = False
+        triage = {name: False for name in _TRIAGE_NAMES}
+        if triage_error is not None and index == 0:
+            triage[triage_error] = True
+        slice_success = not (
+            slice_fail in case.payload["required_slices"] and index < 8
+        )
+        findings = (zero_finding,) if index == 0 and zero_finding else ()
+        label = build_review_label(
+            case=case,
+            reviewer_identity_digest=primary_reviewers[index % len(primary_reviewers)],
+            role=ReviewRole.PRIMARY,
+            label=reviewed_case_assessment_label(
+                case=case,
+                metric_success=metric_success,
+                triage_error=triage,
+                slice_success=slice_success,
+                zero_tolerance_findings=findings,
+            ),
+            blinded=True,
+            recorded_at=_AT,
+        )
+        outcome = ReviewedCaseOutcome.build(
+            case=case,
+            review_label=label,
+            metric_success=metric_success,
+            triage_error=triage,
+            slice_success=slice_success,
+            zero_tolerance_findings=findings,
+        )
+        output.append(outcome)
+    return tuple(sorted(output, key=lambda item: item.case_id))
 
 
 def _performance(*, fail: str | None = None):
@@ -108,34 +197,13 @@ def _performance(*, fail: str | None = None):
     )
 
 
-def _slices(*, low: str | None = None, insufficient: str | None = None):
-    output = []
-    for name in REQUIRED_SLICES:
-        completed = 11 if name == insufficient else 20
-        success = completed if name != low else 16
-        output.append(
-            RequiredSliceResult.build(
-                slice_id=name,
-                completed_cases=completed,
-                success_count=success,
-            )
-        )
-    return tuple(output)
-
-
-def _zero(**changed: int):
-    names = INCREMENT_8_READINESS.evaluation_plan["zero_tolerance_counts"]
-    return ZeroToleranceEvidence.build(
-        {name: changed.get(str(name), 0) for name in sorted(names)}
-    )
-
-
 def _contributions():
     return (
         SourceContribution.build(
             source_id="anchor-fixture",
             role=SourceRole.ANCHOR,
             provider_version_digest="sha256:" + "6" * 64,
+            dependency_root_digests=("sha256:" + "d" * 64,),
             unique_detection_count=1,
             earlier_detection_count=2,
             resilience_case_count=3,
@@ -166,13 +234,14 @@ def _ablations():
 
 
 def _report(**changes):
+    context = changes.pop("context", _context())
+    case_outcomes = changes.pop("case_outcomes", _case_outcomes(context=context))
     values = {
-        "run": _run(),
-        "case_count": 120,
-        "rates": _rates(),
+        "plan": context[0],
+        "epoch": context[1],
+        "run": context[2],
+        "case_outcomes": case_outcomes,
         "performance": _performance(),
-        "slices": _slices(),
-        "zero_tolerance": _zero(),
         "contributions": _contributions(),
         "ablations": _ablations(),
         "metric_code_digest": "sha256:" + "9" * 64,
@@ -184,149 +253,196 @@ def _report(**changes):
     return build_metric_report(**values)
 
 
-def test_complete_report_is_canonical_bounded_and_non_activating() -> None:
+def test_complete_report_is_reconstructed_from_frozen_context_and_reviewed_cases() -> (
+    None
+):
     report = _report()
     assert report.overall_status is MeasurementStatus.PASS
-    assert report.payload["coverage_scope"] == (
-        "REVIEWED_PROSPECTIVE_UNIVERSE_ONLY_NOT_ABSOLUTE_RECALL"
+    assert report.case_count == 120
+    assert set(report.payload["case_stratum_counts"]) == {
+        "NEGATIVE",
+        "UNCHANGED",
+        "FAILURE_HEAVY",
+    }
+    assert len(report.payload["reviewed_case_outcome_evidence"]) == 120
+    assert (
+        report.payload["coverage_scope"]
+        == "REVIEWED_PROSPECTIVE_UNIVERSE_ONLY_NOT_ABSOLUTE_RECALL"
     )
-    assert report.payload["ablation_is_decision_bearing"] is False
     assert report.payload["production_activation_authorised"] is False
     assert report.payload["live_shadow_execution_authorised"] is False
-    assert report.digest.startswith("sha256:")
-    assert b'"schema_version":"newsroom.increment8.metric-report.v1"' in (
-        report.canonical_bytes
-    )
     assert MetricReport.from_canonical_bytes(report.canonical_bytes) == report
 
 
-def test_every_rate_retains_count_denominator_sampling_and_uncertainty() -> None:
-    measurement = RateMeasurement.build(
-        metric_name="candidate_precision",
-        count=95,
-        denominator=100,
-        sampling_method=SamplingMethod.STRATIFIED_SAMPLE,
-        uncertainty_ppm=20_000,
+def test_rate_slice_and_zero_results_are_derived_not_caller_supplied() -> None:
+    context = _context()
+    metric_failure = _report(
+        context=context,
+        case_outcomes=_case_outcomes(
+            context=context, metric_fail="candidate_precision"
+        ),
     )
-    assert measurement.rate_ppm == 950_000
-    assert measurement.status is MeasurementStatus.PASS
-    with pytest.raises(MetricReportError, match="denominator"):
-        RateMeasurement.build(
-            metric_name="candidate_precision",
-            count=1,
-            denominator=0,
-            sampling_method=SamplingMethod.POPULATION,
-            uncertainty_ppm=0,
-        )
+    assert metric_failure.metric_status is MeasurementStatus.FAIL
+    assert metric_failure.overall_status is MeasurementStatus.FAIL
+    slice_failure = _report(
+        context=context,
+        case_outcomes=_case_outcomes(
+            context=context, slice_fail="SOURCE_MULTI_DOMAIN_CORROBORATED"
+        ),
+    )
+    assert slice_failure.slice_status is MeasurementStatus.FAIL
+    blocker = _report(
+        context=context,
+        case_outcomes=_case_outcomes(
+            context=context, count=1, zero_finding="temporal_rewrite"
+        ),
+    )
+    assert blocker.overall_status is MeasurementStatus.FAIL
 
 
-def test_metric_or_performance_failure_cannot_be_rescued_by_ablation() -> None:
-    report = _report(rates=_rates(fail="candidate_precision"))
-    assert report.metric_status is MeasurementStatus.FAIL
-    assert report.overall_status is MeasurementStatus.FAIL
-    assert report.payload["ablation_is_decision_bearing"] is False
-    slow = _report(performance=_performance(fail="case_latency_p95_ms"))
-    assert slow.performance_status is MeasurementStatus.FAIL
-    assert slow.overall_status is MeasurementStatus.FAIL
-
-
-def test_required_slice_failure_and_insufficient_exposure_override_aggregate() -> None:
-    failed = _report(slices=_slices(low="GEOGRAPHY_HONG_KONG"))
-    assert failed.metric_status is MeasurementStatus.PASS
-    assert failed.slice_status is MeasurementStatus.FAIL
-    assert failed.overall_status is MeasurementStatus.FAIL
-    insufficient = _report(slices=_slices(insufficient="LANGUAGE_ZH_HANT_HK"))
-    assert insufficient.slice_status is MeasurementStatus.NOT_EVALUATED
-    assert insufficient.overall_status is MeasurementStatus.NOT_EVALUATED
-    too_short = _report(case_count=119)
-    assert too_short.overall_status is MeasurementStatus.NOT_EVALUATED
-
-
-def test_zero_tolerance_failure_blocks_report() -> None:
-    report = _report(zero_tolerance=_zero(temporal_rewrite=1))
-    assert report.zero_tolerance_status is MeasurementStatus.FAIL
+def test_every_frozen_exposure_minimum_is_enforced() -> None:
+    context = _context()
     assert (
-        _report(case_count=1, zero_tolerance=_zero(temporal_rewrite=1)).overall_status
-        is MeasurementStatus.FAIL
+        _report(
+            context=context,
+            case_outcomes=_case_outcomes(context=context, count=119),
+        ).overall_status
+        is MeasurementStatus.NOT_EVALUATED
     )
-    assert report.overall_status is MeasurementStatus.FAIL
+    assert (
+        _report(
+            context=context,
+            case_outcomes=_case_outcomes(
+                context=context, insufficient_slice="SOURCE_MULTI_DOMAIN_CORROBORATED"
+            ),
+        ).overall_status
+        is MeasurementStatus.NOT_EVALUATED
+    )
+    assert (
+        _report(
+            context=context,
+            case_outcomes=_case_outcomes(
+                context=context, insufficient_stratum="NEGATIVE"
+            ),
+        ).overall_status
+        is MeasurementStatus.NOT_EVALUATED
+    )
 
 
-def test_report_requires_exact_sorted_measurement_and_slice_inventories() -> None:
-    with pytest.raises(MetricReportError, match="metric_name inventory"):
-        _report(rates=_rates()[:-1])
-    with pytest.raises(MetricReportError, match="slice_id inventory"):
-        _report(slices=tuple(reversed(_slices())))
-    with pytest.raises(MetricReportError, match="qualification Run"):
-        _report(run=_run(RunKind.CALIBRATION))
-
-
-def test_source_role_decisions_require_rights_and_event_level_value() -> None:
-    common = {
-        "source_id": "source",
-        "provider_version_digest": _D,
-        "unique_detection_count": 0,
-        "earlier_detection_count": 0,
-        "resilience_case_count": 0,
-        "overlap_count": 12,
-        "noise_count": 0,
-        "gross_cost_microunits": 0,
-        "rights_permitted": True,
-        "rationale_digest": _D,
+def test_required_development_and_correction_errors_are_retained_separately() -> None:
+    context = _context()
+    report = _report(
+        context=context,
+        case_outcomes=_case_outcomes(context=context, triage_error="false_correction"),
+    )
+    evidence = {
+        item["payload"]["metric_name"]: item["payload"]
+        for item in report.payload["triage_error_evidence"]
     }
-    with pytest.raises(MetricReportError, match="quiet Anchor"):
-        SourceContribution.build(
-            **common, role=SourceRole.ANCHOR, recommendation=RoleRecommendation.REMOVE
+    assert tuple(sorted(evidence)) == _TRIAGE_NAMES
+    assert evidence["false_correction"]["error_count"] == 1
+    assert all(
+        item["decision_treatment"] == "MANDATORY_SEPARATE_REPORT_NO_POST_HOC_THRESHOLD"
+        for item in evidence.values()
+    )
+
+
+def test_forged_run_case_or_report_bytes_fail_canonical_reconstruction() -> None:
+    context = _context()
+    forged_run = replace(
+        context[2], payload={**context[2].payload, "production_effect_allowed": True}
+    )
+    with pytest.raises(MetricReportError, match="linkage"):
+        _report(context=(context[0], context[1], forged_run))
+    outcome = _case_outcomes(context=context)[0]
+    forged = replace(outcome, slice_success=False)
+    with pytest.raises(MetricReportError, match="forged"):
+        _report(
+            context=context,
+            case_outcomes=(forged, *_case_outcomes(context=context)[1:]),
         )
-    with pytest.raises(MetricReportError, match="volume alone"):
-        SourceContribution.build(
-            **common,
-            role=SourceRole.COMPARATOR,
-            recommendation=RoleRecommendation.PROMOTE,
+    raw = _report().canonical_bytes.replace(
+        b'"slice_success":true', b'"slice_success":false', 1
+    )
+    with pytest.raises(MetricReportError):
+        MetricReport.from_canonical_bytes(raw)
+
+
+def test_outcomes_require_exact_human_attestation_and_frozen_membership() -> None:
+    context = _context()
+    outcome = _case_outcomes(context=context)[0]
+    document = json.loads(outcome.canonical_bytes)["payload"]
+
+    case = EvaluationCase.from_canonical_bytes(canonical_json_bytes(document["case"]))
+    label = ReviewLabel.from_canonical_bytes(
+        canonical_json_bytes(document["review_label"])
+    )
+    arbitrary = build_review_label(
+        case=case,
+        reviewer_identity_digest=label.payload["reviewer_identity_digest"],
+        role=ReviewRole.PRIMARY,
+        label="PASS",
+        blinded=True,
+        recorded_at=_AT,
+    )
+    with pytest.raises(MetricReportError, match="does not attest"):
+        ReviewedCaseOutcome.build(
+            case=case,
+            review_label=arbitrary,
+            metric_success=outcome.metric_success,
+            triage_error=outcome.triage_error,
+            slice_success=outcome.slice_success,
         )
-    with pytest.raises(MetricReportError, match="rights-limited"):
+    forged_case = EvaluationCase.build(
+        {**case.payload, "required_slices": ["URGENCY_URGENT"]}
+    )
+    forged_label = build_review_label(
+        case=forged_case,
+        reviewer_identity_digest=label.payload["reviewer_identity_digest"],
+        role=ReviewRole.PRIMARY,
+        label=reviewed_case_assessment_label(
+            case=forged_case,
+            metric_success=outcome.metric_success,
+            triage_error=outcome.triage_error,
+            slice_success=outcome.slice_success,
+        ),
+        blinded=True,
+        recorded_at=_AT,
+    )
+    with pytest.raises(MetricReportError, match="membership"):
+        ReviewedCaseOutcome.build(
+            case=forged_case,
+            review_label=forged_label,
+            metric_success=outcome.metric_success,
+            triage_error=outcome.triage_error,
+            slice_success=outcome.slice_success,
+        )
+
+
+def test_source_dependency_evidence_is_explicit_and_reconstructed() -> None:
+    report = _report()
+    inventory = report.payload["source_dependency_inventory"]
+    assert inventory == {"sha256:" + "d" * 64: ["anchor-fixture"]}
+    with pytest.raises(MetricReportError, match="dependency roots"):
         SourceContribution.build(
-            **{**common, "rights_permitted": False},
+            source_id="source",
             role=SourceRole.COMPLEMENT,
-            recommendation=RoleRecommendation.RETAIN,
-        )
-
-
-def test_search_contribution_is_bound_to_exact_purpose_and_provider_version() -> None:
-    with pytest.raises(MetricReportError, match="exact Purpose"):
-        SourceContribution.build(
-            source_id="search",
-            role=SourceRole.SEARCH_PURPOSE,
             provider_version_digest=_D,
-            unique_detection_count=1,
+            dependency_root_digests=(),
+            unique_detection_count=0,
             earlier_detection_count=0,
             resilience_case_count=0,
-            overlap_count=0,
+            overlap_count=1,
             noise_count=0,
             gross_cost_microunits=0,
             rights_permitted=True,
-            recommendation=RoleRecommendation.RETAIN,
+            recommendation=RoleRecommendation.NO_CHANGE,
             rationale_digest=_D,
         )
 
 
-def test_typed_records_reject_forged_status_and_unknown_ablation_slice() -> None:
-    rate = _rates()[0]
-    with pytest.raises(AttributeError):
-        rate.status = MeasurementStatus.FAIL  # type: ignore[misc]
-    with pytest.raises(MetricReportError, match="unknown required slice"):
-        AblationResult.build(
-            component_id="bad",
-            component_version_digest=_D,
-            evaluated_case_count=1,
-            lost_detection_count=0,
-            earlier_detection_lost_count=0,
-            resilience_loss_count=0,
-            noise_removed_count=0,
-            cost_removed_microunits=0,
-            affected_slices=("UNKNOWN",),
-        )
-    forged = replace(rate, status=MeasurementStatus.FAIL)
-    assert forged.canonical_bytes == rate.canonical_bytes
-    with pytest.raises(MetricReportError, match="forged"):
-        _report(rates=(forged, *_rates()[1:]))
+def test_performance_failure_and_ablation_cannot_rescue_target() -> None:
+    report = _report(performance=_performance(fail="case_latency_p95_ms"))
+    assert report.performance_status is MeasurementStatus.FAIL
+    assert report.overall_status is MeasurementStatus.FAIL
+    assert report.payload["ablation_is_decision_bearing"] is False

--- a/newsroom/tests/test_increment8b_metrics.py
+++ b/newsroom/tests/test_increment8b_metrics.py
@@ -468,6 +468,39 @@ def test_triage_opportunity_count_is_reported_but_not_a_post_hoc_gate() -> None:
         == "MANDATORY_SEPARATE_REPORT_NO_POST_HOC_THRESHOLD"
         for item in report.payload["triage_error_evidence"]
     )
+    empty_report = _report(
+        context=context,
+        case_outcomes=_case_outcomes(context=context, triage_eligible_count=0),
+    )
+    assert empty_report.overall_status is MeasurementStatus.PASS
+    assert all(
+        item["payload"]["exposure_status"] == "NOT_EVALUATED"
+        for item in empty_report.payload["triage_error_evidence"]
+    )
+
+
+def test_triage_error_cannot_be_hidden_as_ineligible() -> None:
+    context = _context()
+    outcome = _case_outcomes(context=context)[0]
+    payload = json.loads(outcome.canonical_bytes)["payload"]
+    case = EvaluationCase.from_canonical_bytes(canonical_json_bytes(payload["case"]))
+    primary = ReviewLabel.from_canonical_bytes(
+        canonical_json_bytes(payload["review_label"])
+    )
+    triage_eligible = dict(outcome.triage_eligible)
+    triage_error = dict(outcome.triage_error)
+    triage_eligible["false_correction"] = False
+    triage_error["false_correction"] = True
+    with pytest.raises(MetricReportError, match="cannot be marked ineligible"):
+        ReviewedCaseOutcome.build(
+            case=case,
+            review_label=primary,
+            metric_eligible=outcome.metric_eligible,
+            metric_success=outcome.metric_success,
+            triage_eligible=triage_eligible,
+            triage_error=triage_error,
+            slice_success=outcome.slice_success,
+        )
 
 
 def test_every_frozen_exposure_minimum_is_enforced() -> None:

--- a/newsroom/tests/test_increment8b_metrics.py
+++ b/newsroom/tests/test_increment8b_metrics.py
@@ -503,6 +503,38 @@ def test_triage_error_cannot_be_hidden_as_ineligible() -> None:
         )
 
 
+@pytest.mark.parametrize(
+    ("error_name", "blocker_metric"),
+    (
+        ("false_development", "candidate_precision"),
+        ("missed_development", "candidate_recall"),
+    ),
+)
+def test_development_error_must_fail_its_frozen_blocker_metric(
+    error_name: str, blocker_metric: str
+) -> None:
+    context = _context()
+    outcome = _case_outcomes(context=context)[0]
+    payload = json.loads(outcome.canonical_bytes)["payload"]
+    case = EvaluationCase.from_canonical_bytes(canonical_json_bytes(payload["case"]))
+    primary = ReviewLabel.from_canonical_bytes(
+        canonical_json_bytes(payload["review_label"])
+    )
+    triage_error = dict(outcome.triage_error)
+    triage_error[error_name] = True
+    assert outcome.metric_success[blocker_metric] is True
+    with pytest.raises(MetricReportError, match="decision-bearing blocker"):
+        ReviewedCaseOutcome.build(
+            case=case,
+            review_label=primary,
+            metric_eligible=outcome.metric_eligible,
+            metric_success=outcome.metric_success,
+            triage_eligible=outcome.triage_eligible,
+            triage_error=triage_error,
+            slice_success=outcome.slice_success,
+        )
+
+
 def test_every_frozen_exposure_minimum_is_enforced() -> None:
     context = _context()
     assert (

--- a/newsroom/tests/test_increment8b_metrics.py
+++ b/newsroom/tests/test_increment8b_metrics.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from dataclasses import replace
 
 import pytest
@@ -49,6 +50,7 @@ _RATE_NAMES = (
     "snowball_absorption",
     "unnecessary_candidate",
 )
+_CASE_RATE_NAMES = tuple(name for name in _RATE_NAMES if name != "reviewer_agreement")
 _TRIAGE_NAMES = ("false_correction", "false_development", "missed_development")
 
 
@@ -85,6 +87,8 @@ def _case_outcomes(
     context=None,
     count: int = 120,
     metric_fail: str | None = None,
+    metric_failure_count: int | None = None,
+    metric_eligible_counts: Mapping[str, int] | None = None,
     slice_fail: str | None = None,
     insufficient_slice: str | None = None,
     insufficient_stratum: str | None = None,
@@ -97,6 +101,11 @@ def _case_outcomes(
         str(item["identity_digest"])
         for item in plan.payload["authorised_human_manifest"]
         if "PRIMARY" in item["roles"]
+    )
+    secondary_reviewers = tuple(
+        str(item["identity_digest"])
+        for item in plan.payload["authorised_human_manifest"]
+        if "SECONDARY" in item["roles"]
     )
     output = []
     for index in range(count):
@@ -135,9 +144,13 @@ def _case_outcomes(
             urgent=urgent_member,
             zero_tolerance=zero_finding is not None and index == 0,
         )
-        metric_success = {name: True for name in _RATE_NAMES}
+        metric_eligible = {
+            name: index < (metric_eligible_counts or {}).get(name, count)
+            for name in _CASE_RATE_NAMES
+        }
+        metric_success = {name: True for name in _CASE_RATE_NAMES}
         if metric_fail is not None:
-            failures_needed = (
+            failures_needed = metric_failure_count or (
                 7
                 if metric_fail
                 in {
@@ -151,9 +164,10 @@ def _case_outcomes(
                 }
                 else 3
             )
-            if index < failures_needed:
+            if metric_fail != "reviewer_agreement" and index < failures_needed:
                 metric_success[metric_fail] = False
         triage = {name: False for name in _TRIAGE_NAMES}
+        triage_eligible = {name: True for name in _TRIAGE_NAMES}
         if triage_error is not None and index == 0:
             triage[triage_error] = True
         slice_success = not (
@@ -166,7 +180,9 @@ def _case_outcomes(
             role=ReviewRole.PRIMARY,
             label=reviewed_case_assessment_label(
                 case=case,
+                metric_eligible=metric_eligible,
                 metric_success=metric_success,
+                triage_eligible=triage_eligible,
                 triage_error=triage,
                 slice_success=slice_success,
                 zero_tolerance_findings=findings,
@@ -174,10 +190,32 @@ def _case_outcomes(
             blinded=True,
             recorded_at=_AT,
         )
+        secondary_label = None
+        if index < 24:
+            secondary_identity = next(
+                identity
+                for identity in secondary_reviewers
+                if identity != label.payload["reviewer_identity_digest"]
+            )
+            secondary_label = build_review_label(
+                case=case,
+                reviewer_identity_digest=secondary_identity,
+                role=ReviewRole.SECONDARY,
+                label=(
+                    "disagreement"
+                    if metric_fail == "reviewer_agreement" and index < 4
+                    else label.payload["label"]
+                ),
+                blinded=True,
+                recorded_at=_AT,
+            )
         outcome = ReviewedCaseOutcome.build(
             case=case,
             review_label=label,
+            secondary_review_label=secondary_label,
+            metric_eligible=metric_eligible,
             metric_success=metric_success,
+            triage_eligible=triage_eligible,
             triage_error=triage,
             slice_success=slice_success,
             zero_tolerance_findings=findings,
@@ -300,6 +338,45 @@ def test_rate_slice_and_zero_results_are_derived_not_caller_supplied() -> None:
     assert blocker.overall_status is MeasurementStatus.FAIL
 
 
+def test_conditional_rate_denominators_come_from_eligible_opportunities() -> None:
+    context = _context()
+    report = _report(
+        context=context,
+        case_outcomes=_case_outcomes(
+            context=context,
+            metric_fail="candidate_precision",
+            metric_failure_count=2,
+            metric_eligible_counts={"candidate_precision": 10},
+        ),
+    )
+    precision = next(
+        item["payload"]
+        for item in report.payload["rate_evidence"]
+        if item["payload"]["metric_name"] == "candidate_precision"
+    )
+    assert precision["denominator"] == 10
+    assert precision["count"] == 8
+    assert precision["rate_ppm"] == 800_000
+    assert report.overall_status is MeasurementStatus.FAIL
+
+
+def test_reviewer_agreement_is_derived_from_independent_label_pairs() -> None:
+    context = _context()
+    report = _report(
+        context=context,
+        case_outcomes=_case_outcomes(context=context, metric_fail="reviewer_agreement"),
+    )
+    agreement = next(
+        item["payload"]
+        for item in report.payload["rate_evidence"]
+        if item["payload"]["metric_name"] == "reviewer_agreement"
+    )
+    assert agreement["denominator"] == 24
+    assert agreement["count"] == 20
+    assert agreement["status"] == "FAIL"
+    assert report.overall_status is MeasurementStatus.FAIL
+
+
 def test_every_frozen_exposure_minimum_is_enforced() -> None:
     context = _context()
     assert (
@@ -389,7 +466,9 @@ def test_outcomes_require_exact_human_attestation_and_frozen_membership() -> Non
         ReviewedCaseOutcome.build(
             case=case,
             review_label=arbitrary,
+            metric_eligible=outcome.metric_eligible,
             metric_success=outcome.metric_success,
+            triage_eligible=outcome.triage_eligible,
             triage_error=outcome.triage_error,
             slice_success=outcome.slice_success,
         )
@@ -402,7 +481,9 @@ def test_outcomes_require_exact_human_attestation_and_frozen_membership() -> Non
         role=ReviewRole.PRIMARY,
         label=reviewed_case_assessment_label(
             case=forged_case,
+            metric_eligible=outcome.metric_eligible,
             metric_success=outcome.metric_success,
+            triage_eligible=outcome.triage_eligible,
             triage_error=outcome.triage_error,
             slice_success=outcome.slice_success,
         ),
@@ -413,7 +494,9 @@ def test_outcomes_require_exact_human_attestation_and_frozen_membership() -> Non
         ReviewedCaseOutcome.build(
             case=forged_case,
             review_label=forged_label,
+            metric_eligible=outcome.metric_eligible,
             metric_success=outcome.metric_success,
+            triage_eligible=outcome.triage_eligible,
             triage_error=outcome.triage_error,
             slice_success=outcome.slice_success,
         )

--- a/newsroom/tests/test_increment8b_metrics.py
+++ b/newsroom/tests/test_increment8b_metrics.py
@@ -10,9 +10,10 @@ from newsroom.authority.canonical import canonical_json_bytes
 from newsroom.increment8.evaluation import (
     EvaluationCase,
     ReviewLabel,
-    RightsStatus,
     ReviewRole,
+    RightsStatus,
     RunKind,
+    build_adjudication,
     build_case,
     build_evaluation_plan,
     build_review_label,
@@ -88,6 +89,7 @@ def _case_outcomes(
     count: int = 120,
     metric_fail: str | None = None,
     metric_failure_count: int | None = None,
+    triage_eligible_count: int = 120,
     metric_eligible_counts: Mapping[str, int] | None = None,
     slice_fail: str | None = None,
     insufficient_slice: str | None = None,
@@ -106,6 +108,11 @@ def _case_outcomes(
         str(item["identity_digest"])
         for item in plan.payload["authorised_human_manifest"]
         if "SECONDARY" in item["roles"]
+    )
+    adjudicator = next(
+        str(item["identity_digest"])
+        for item in plan.payload["authorised_human_manifest"]
+        if "ADJUDICATOR" in item["roles"]
     )
     output = []
     for index in range(count):
@@ -167,7 +174,9 @@ def _case_outcomes(
             if metric_fail != "reviewer_agreement" and index < failures_needed:
                 metric_success[metric_fail] = False
         triage = {name: False for name in _TRIAGE_NAMES}
-        triage_eligible = {name: True for name in _TRIAGE_NAMES}
+        triage_eligible = {
+            name: index < triage_eligible_count for name in _TRIAGE_NAMES
+        }
         if triage_error is not None and index == 0:
             triage[triage_error] = True
         slice_success = not (
@@ -191,6 +200,7 @@ def _case_outcomes(
             recorded_at=_AT,
         )
         secondary_label = None
+        adjudication = None
         if index < 24:
             secondary_identity = next(
                 identity
@@ -209,10 +219,20 @@ def _case_outcomes(
                 blinded=True,
                 recorded_at=_AT,
             )
+            if secondary_label.payload["label"] != label.payload["label"]:
+                adjudication = build_adjudication(
+                    case=case,
+                    primary=label,
+                    secondary=secondary_label,
+                    adjudicator_identity_digest=adjudicator,
+                    final_label=label.payload["label"],
+                    decided_at=_AT,
+                )
         outcome = ReviewedCaseOutcome.build(
             case=case,
             review_label=label,
             secondary_review_label=secondary_label,
+            adjudication=adjudication,
             metric_eligible=metric_eligible,
             metric_success=metric_success,
             triage_eligible=triage_eligible,
@@ -375,6 +395,79 @@ def test_reviewer_agreement_is_derived_from_independent_label_pairs() -> None:
     assert agreement["count"] == 20
     assert agreement["status"] == "FAIL"
     assert report.overall_status is MeasurementStatus.FAIL
+
+
+def test_adjudicated_secondary_assessment_is_decision_bearing() -> None:
+    context = _context()
+    outcomes = list(_case_outcomes(context=context))
+    original = outcomes[0]
+    payload = json.loads(original.canonical_bytes)["payload"]
+    case = EvaluationCase.from_canonical_bytes(canonical_json_bytes(payload["case"]))
+    primary = ReviewLabel.from_canonical_bytes(
+        canonical_json_bytes(payload["review_label"])
+    )
+    changed_success = dict(original.metric_success)
+    changed_success["candidate_precision"] = False
+    selected_label = reviewed_case_assessment_label(
+        case=case,
+        metric_eligible=original.metric_eligible,
+        metric_success=changed_success,
+        triage_eligible=original.triage_eligible,
+        triage_error=original.triage_error,
+        slice_success=original.slice_success,
+        zero_tolerance_findings=original.zero_tolerance_findings,
+    )
+    secondary = build_review_label(
+        case=case,
+        reviewer_identity_digest="sha256:" + "7" * 64,
+        role=ReviewRole.SECONDARY,
+        label=selected_label,
+        blinded=True,
+        recorded_at=_AT,
+    )
+    adjudication = build_adjudication(
+        case=case,
+        primary=primary,
+        secondary=secondary,
+        adjudicator_identity_digest="sha256:" + "8" * 64,
+        final_label=selected_label,
+        decided_at=_AT,
+    )
+    outcomes[0] = ReviewedCaseOutcome.build(
+        case=case,
+        review_label=primary,
+        secondary_review_label=secondary,
+        adjudication=adjudication,
+        metric_eligible=original.metric_eligible,
+        metric_success=changed_success,
+        triage_eligible=original.triage_eligible,
+        triage_error=original.triage_error,
+        slice_success=original.slice_success,
+        zero_tolerance_findings=original.zero_tolerance_findings,
+    )
+    report = _report(context=context, case_outcomes=tuple(outcomes))
+    precision = next(
+        item["payload"]
+        for item in report.payload["rate_evidence"]
+        if item["payload"]["metric_name"] == "candidate_precision"
+    )
+    assert precision["count"] == 119
+
+
+def test_triage_opportunity_count_is_reported_but_not_a_post_hoc_gate() -> None:
+    context = _context()
+    report = _report(
+        context=context,
+        case_outcomes=_case_outcomes(context=context, triage_eligible_count=1),
+    )
+    assert report.overall_status is MeasurementStatus.PASS
+    assert all(
+        item["payload"]["denominator"] == 1
+        and item["payload"]["minimum_opportunities"] == 0
+        and item["payload"]["decision_treatment"]
+        == "MANDATORY_SEPARATE_REPORT_NO_POST_HOC_THRESHOLD"
+        for item in report.payload["triage_error_evidence"]
+    )
 
 
 def test_every_frozen_exposure_minimum_is_enforced() -> None:


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: 8b
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

Closes #464.
Parent #148.
Depends on closed #463.

## Corrective scope

- reconstructs and binds the exact canonical Evaluation Plan, Epoch and qualification Run before measurement;
- retains one canonical reviewed outcome per prospective Case, with the primary human ReviewLabel attesting the exact per-Case metric, triage, slice and zero-tolerance outcome digest;
- derives all aggregate rates, Case count, Required Slice results, Case-stratum exposure and zero-tolerance counts from those reviewed Cases;
- enforces the total, negative, unchanged, failure-heavy and every nine-slice exposure minima;
- retains false-development, missed-development and false-correction measurements as mandatory separate evidence without inventing a post-hoc threshold;
- retains explicit source dependency-root evidence and an independently attributable root-to-source inventory;
- reconstructs every embedded evidence record and makes zero-tolerance failure override underexposure;
- compares report Case and primary-label identities with the append-only EvaluationAuthority records before a PASS can reach release qualification.

## Evidence

- `uvx --from ruff==0.12.4 ruff check ...` — pass
- `uv run pytest -q newsroom/tests/test_increment8*.py` — 88 passed
- `git diff --check` — pass

## Non-effects

Deterministic fixture/replay measurement only. No persistence migration, live provider, credentials, egress, spend, locality activation, shadow, canary or production effect. No Operational Admission work.
