### PR TITLE
fix: correct Increment 8D observability authority

### DIFF
--- a/docs/plans/2026-08-15-018-increment-8d-corrective-observability.md
+++ b/docs/plans/2026-08-15-018-increment-8d-corrective-observability.md
@@ -1,0 +1,20 @@
+# Increment 8D corrective observability and security
+
+Issue: #466
+Parent: #148
+Dependencies satisfied: #462, #463 and #464
+
+## Corrective contract
+
+- HTTP `206 Partial Content` is retained as `PARTIAL`, never as a complete changed observation.
+- Health freshness is decided using the full timestamp precision. The rendered integer age is evidence only and cannot floor an over-threshold observation into a healthy verdict.
+- Every CLOSED Incident binds its exact closure-evidence digest in canonical bytes. Different closure evidence therefore produces a different immutable Incident digest.
+- Incident transitions reconstruct and validate the exact canonical retained record before deriving the next Version, rejecting caller-mutated dataclass fields and malformed closure evidence.
+
+## Evidence
+
+Focused regressions cover `206`, the exact freshness threshold and threshold plus one microsecond, malformed closure evidence, closure-digest identity and caller-mutated Incident objects. The complete Increment 8 test set remains green.
+
+## Non-effects
+
+Fixture observability and security evidence only. No live credential, provider, egress, incident action, spend, shadow, canary, publication, production or locality effect. This atom does not construct Operational Admission.

--- a/newsroom/increment8/observability.py
+++ b/newsroom/increment8/observability.py
@@ -9,8 +9,15 @@ from datetime import datetime, timedelta
 from enum import StrEnum
 from types import MappingProxyType
 
-from newsroom.authority.canonical import canonical_json_bytes, digest_bytes, validate_sha256_digest
-from newsroom.increment8.readiness import INCREMENT_8_READINESS, INCREMENT_8_READINESS_DIGEST
+from newsroom.authority.canonical import (
+    canonical_json_bytes,
+    digest_bytes,
+    validate_sha256_digest,
+)
+from newsroom.increment8.readiness import (
+    INCREMENT_8_READINESS,
+    INCREMENT_8_READINESS_DIGEST,
+)
 
 
 class ObservabilityError(ValueError):
@@ -201,16 +208,15 @@ class HealthPosture:
             raise ObservabilityError("complete success is in the future")
         if changed is not None and _dt(changed) > _dt(observed):
             raise ObservabilityError("source change is in the future")
-        age = None if success is None else int((_dt(observed) - _dt(success)).total_seconds())
+        elapsed = None if success is None else _dt(observed) - _dt(success)
+        age = None if elapsed is None else int(elapsed.total_seconds())
         freshness = int(INCREMENT_8_READINESS.operational_profile["schedule"]["freshness_objective_seconds"])  # type: ignore[index]
         states = {name: dimension_states[name].value for name in sorted(dimension_states)}
         if DimensionState.BLOCKED.value in states.values():
             verdict = HealthVerdict.BLOCKED
-        elif success is None or age is None or age > freshness:
+        elif success is None or elapsed is None or elapsed > timedelta(seconds=freshness):
             verdict = HealthVerdict.STALE
-        elif observation_outcome not in {ObservationOutcome.COMPLETE_CHANGED, ObservationOutcome.COMPLETE_UNCHANGED}:
-            verdict = HealthVerdict.DEGRADED
-        elif any(value is not DimensionState.HEALTHY for value in dimension_states.values()):
+        elif observation_outcome not in {ObservationOutcome.COMPLETE_CHANGED, ObservationOutcome.COMPLETE_UNCHANGED} or any(value is not DimensionState.HEALTHY for value in dimension_states.values()):
             verdict = HealthVerdict.DEGRADED
         elif observation_outcome is ObservationOutcome.COMPLETE_UNCHANGED:
             verdict = HealthVerdict.HEALTHY_UNCHANGED
@@ -401,6 +407,8 @@ def classify_transport_outcome(
         raise ObservabilityError("transport flags must be boolean")
     if code == 304:
         return "COMPLETE_UNCHANGED" if valid_baseline and validator_contract else "INVALID_NOT_MODIFIED"
+    if code == 206:
+        return "PARTIAL"
     if 200 <= code < 300:
         if body == 0:
             return "EMPTY_SUCCESS"
@@ -488,6 +496,7 @@ class IncidentRecord:
     root_cause_digest: str | None
     follow_up_digest: str | None
     regression_case_digest: str | None
+    closure_evidence_digest: str | None
     previous_digest: str | None
     canonical_bytes: bytes
     digest: str
@@ -510,10 +519,92 @@ class IncidentRecord:
             "scope_digest": _digest(scope_digest, "scope_digest"), "timeline_digest": _digest(timeline_digest, "timeline_digest"),
             "opened_at": _time(opened_at, "opened_at"), "containment_digest": None, "recovery_digest": None,
             "root_cause_digest": None, "follow_up_digest": None, "regression_case_digest": None,
+            "closure_evidence_digest": None,
             "integrity_related": integrity_related, "near_miss": near_miss, "previous_digest": None,
         }
-        raw, record_digest = _record("newsroom.increment8.incident-record.v1", payload)
-        return cls(str(payload["incident_id"]), 1, IncidentState.OPEN, integrity_related, near_miss, None, None, None, None, raw, record_digest)
+        raw, _ = _record("newsroom.increment8.incident-record.v1", payload)
+        return cls.from_canonical_bytes(raw)
+
+    @classmethod
+    def from_canonical_bytes(cls, canonical_bytes: bytes) -> IncidentRecord:
+        if not isinstance(canonical_bytes, bytes):
+            raise ObservabilityError("incident canonical evidence must be bytes")
+        try:
+            envelope = json.loads(canonical_bytes)
+        except (TypeError, ValueError, UnicodeDecodeError) as exc:
+            raise ObservabilityError("incident canonical evidence is malformed") from exc
+        if (
+            not isinstance(envelope, dict)
+            or set(envelope) != {"schema_version", "payload"}
+            or envelope.get("schema_version") != "newsroom.increment8.incident-record.v1"
+            or not isinstance(envelope.get("payload"), dict)
+            or canonical_json_bytes(envelope) != canonical_bytes
+        ):
+            raise ObservabilityError("incident canonical evidence differs")
+        value = envelope["payload"]
+        expected = {
+            "incident_id", "version", "state", "scope_digest", "timeline_digest", "opened_at",
+            "containment_digest", "recovery_digest", "root_cause_digest", "follow_up_digest",
+            "regression_case_digest", "closure_evidence_digest", "integrity_related", "near_miss",
+            "previous_digest",
+        }
+        if set(value) != expected:
+            raise ObservabilityError("incident canonical payload differs")
+        incident_id = _token(value["incident_id"], "incident_id")
+        version = _integer(value["version"], "version", minimum=1)
+        try:
+            state = IncidentState(value["state"])
+        except (TypeError, ValueError) as exc:
+            raise ObservabilityError("incident state differs") from exc
+        if not isinstance(value["integrity_related"], bool) or not isinstance(value["near_miss"], bool):
+            raise ObservabilityError("incident flags must be boolean")
+        _digest(value["scope_digest"], "scope_digest")
+        _digest(value["timeline_digest"], "timeline_digest")
+        _time(value["opened_at"], "opened_at")
+        digest_fields = (
+            "containment_digest", "recovery_digest", "root_cause_digest", "follow_up_digest",
+            "regression_case_digest", "closure_evidence_digest", "previous_digest",
+        )
+        for field in digest_fields:
+            if value[field] is not None:
+                _digest(value[field], field)
+        expected_version = {
+            IncidentState.OPEN: 1,
+            IncidentState.CONTAINED: 2,
+            IncidentState.RECOVERED: 3,
+            IncidentState.CLOSED: 4,
+        }[state]
+        if version != expected_version:
+            raise ObservabilityError("incident lifecycle version differs")
+        if state is IncidentState.OPEN:
+            required = ()
+            absent = digest_fields
+        elif state is IncidentState.CONTAINED:
+            required = ("containment_digest", "previous_digest")
+            absent = digest_fields[1:-1]
+        elif state is IncidentState.RECOVERED:
+            required = ("containment_digest", "recovery_digest", "previous_digest")
+            absent = digest_fields[2:-1]
+        else:
+            required = (
+                "containment_digest", "recovery_digest", "root_cause_digest", "follow_up_digest",
+                "closure_evidence_digest", "previous_digest",
+            )
+            absent = ()
+        if any(value[field] is None for field in required) or any(value[field] is not None for field in absent):
+            raise ObservabilityError("incident lifecycle evidence differs")
+        if (
+            state is IncidentState.CLOSED
+            and (value["integrity_related"] or value["near_miss"])
+            and value["regression_case_digest"] is None
+        ):
+            raise ObservabilityError("regression_case_digest must be a canonical digest")
+        return cls(
+            incident_id, version, state, value["integrity_related"], value["near_miss"],
+            value["root_cause_digest"], value["follow_up_digest"], value["regression_case_digest"],
+            value["closure_evidence_digest"], value["previous_digest"], canonical_bytes,
+            digest_bytes(canonical_bytes),
+        )
 
     def transition(
         self,
@@ -524,26 +615,28 @@ class IncidentRecord:
         follow_up_digest: str | None = None,
         regression_case_digest: str | None = None,
     ) -> IncidentRecord:
+        retained = type(self).from_canonical_bytes(self.canonical_bytes)
+        if retained != self:
+            raise ObservabilityError("incident object differs from canonical evidence")
         allowed = {IncidentState.OPEN: IncidentState.CONTAINED, IncidentState.CONTAINED: IncidentState.RECOVERED, IncidentState.RECOVERED: IncidentState.CLOSED}
-        if not isinstance(state, IncidentState) or allowed.get(self.state) is not state:
+        if not isinstance(state, IncidentState) or allowed.get(retained.state) is not state:
             raise ObservabilityError("incident transition is not allowed")
-        value = json.loads(self.canonical_bytes)["payload"]
-        value["version"] = self.version + 1
+        value = json.loads(retained.canonical_bytes)["payload"]
+        value["version"] = retained.version + 1
         value["state"] = state.value
-        value["previous_digest"] = self.digest
+        value["previous_digest"] = retained.digest
         if state is IncidentState.CONTAINED:
             value["containment_digest"] = _digest(evidence_digest, "evidence_digest")
         elif state is IncidentState.RECOVERED:
             value["recovery_digest"] = _digest(evidence_digest, "evidence_digest")
         else:
+            value["closure_evidence_digest"] = _digest(evidence_digest, "evidence_digest")
             value["root_cause_digest"] = _digest(root_cause_digest, "root_cause_digest")
             value["follow_up_digest"] = _digest(follow_up_digest, "follow_up_digest")
-            if self.integrity_related or self.near_miss:
+            if retained.integrity_related or retained.near_miss or regression_case_digest is not None:
                 value["regression_case_digest"] = _digest(regression_case_digest, "regression_case_digest")
-            elif regression_case_digest is not None:
-                value["regression_case_digest"] = _digest(regression_case_digest, "regression_case_digest")
-        raw, record_digest = _record("newsroom.increment8.incident-record.v1", value)
-        return IncidentRecord(self.incident_id, self.version + 1, state, self.integrity_related, self.near_miss, value["root_cause_digest"], value["follow_up_digest"], value["regression_case_digest"], self.digest, raw, record_digest)
+        raw, _ = _record("newsroom.increment8.incident-record.v1", value)
+        return type(self).from_canonical_bytes(raw)
 
 
 @dataclass(frozen=True, slots=True)
@@ -619,8 +712,24 @@ class SecurityAdmission:
 
 
 __all__ = [
-    "AccessContract", "AlertPriority", "CoveragePath", "CoveragePosture", "CoverageVerdict",
-    "DimensionState", "EventInputContract", "HealthDimension", "HealthPosture", "HealthVerdict", "IncidentRecord",
-    "IncidentState", "ManualAction", "ManualActionReceipt", "ObservationOutcome", "ObservabilityError",
-    "ObservabilityRecord", "PathRole", "SecurityAdmission", "classify_transport_outcome",
+    "AccessContract",
+    "AlertPriority",
+    "CoveragePath",
+    "CoveragePosture",
+    "CoverageVerdict",
+    "DimensionState",
+    "EventInputContract",
+    "HealthDimension",
+    "HealthPosture",
+    "HealthVerdict",
+    "IncidentRecord",
+    "IncidentState",
+    "ManualAction",
+    "ManualActionReceipt",
+    "ObservabilityError",
+    "ObservabilityRecord",
+    "ObservationOutcome",
+    "PathRole",
+    "SecurityAdmission",
+    "classify_transport_outcome",
 ]

--- a/newsroom/tests/test_increment8d_observability.py
+++ b/newsroom/tests/test_increment8d_observability.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 
 import pytest
 
@@ -19,15 +20,16 @@ from newsroom.increment8.observability import (
     IncidentState,
     ManualAction,
     ManualActionReceipt,
-    ObservationOutcome,
     ObservabilityError,
     ObservabilityRecord,
+    ObservationOutcome,
     PathRole,
     SecurityAdmission,
     classify_transport_outcome,
 )
 
 _D = "sha256:" + "1" * 64
+_D2 = "sha256:" + "2" * 64
 _AT = "2042-01-05T00:00:00.000000Z"
 _RECENT = "2042-01-04T23:59:00.000000Z"
 _STALE = "2042-01-04T23:40:00.000000Z"
@@ -68,6 +70,15 @@ def test_healthy_silence_requires_complete_success_and_uses_last_success_age() -
     assert stale.last_source_change_at != stale.last_complete_success_at
 
 
+def test_freshness_uses_full_precision_before_rendering_integer_age() -> None:
+    at_threshold = _health(success="2042-01-04T23:45:00.000000Z")
+    just_over = _health(success="2042-01-04T23:44:59.999999Z")
+    assert at_threshold.complete_success_age_seconds == 900
+    assert at_threshold.verdict is HealthVerdict.HEALTHY_UNCHANGED
+    assert just_over.complete_success_age_seconds == 900
+    assert just_over.verdict is HealthVerdict.STALE
+
+
 def test_failed_or_partial_observation_is_not_healthy_silence() -> None:
     assert _health(outcome=ObservationOutcome.FAILED).verdict is HealthVerdict.DEGRADED
     states = _dimensions()
@@ -98,6 +109,7 @@ def test_transport_status_and_shape_drift_retain_distinct_meanings() -> None:
     assert classify_transport_outcome(status_code=200, body_bytes=0, valid_baseline=False, validator_contract=False, shape_valid=True) == "EMPTY_SUCCESS"
     assert classify_transport_outcome(status_code=200, body_bytes=10, valid_baseline=False, validator_contract=False, shape_valid=False) == "SHAPE_DRIFT_QUARANTINE"
     assert classify_transport_outcome(status_code=429, body_bytes=0, valid_baseline=False, validator_contract=False, shape_valid=True) == "RATE_LIMITED"
+    assert classify_transport_outcome(status_code=206, body_bytes=10, valid_baseline=False, validator_contract=True, shape_valid=True) == "PARTIAL"
 
 
 def test_access_contract_is_strict_and_contains_no_live_egress_or_credentials() -> None:
@@ -152,11 +164,37 @@ def test_incident_lifecycle_is_append_only_and_integrity_close_requires_regressi
     with pytest.raises(ObservabilityError, match="regression_case_digest"):
         recovered.transition(state=IncidentState.CLOSED, evidence_digest=_D, root_cause_digest=_D, follow_up_digest=_D)
     closed = recovered.transition(
-        state=IncidentState.CLOSED, evidence_digest=_D, root_cause_digest=_D,
+        state=IncidentState.CLOSED, evidence_digest=_D2, root_cause_digest=_D,
         follow_up_digest=_D, regression_case_digest=_D,
     )
     assert closed.previous_digest == recovered.digest
     assert closed.version == 4
+    assert closed.closure_evidence_digest == _D2
+    assert json.loads(closed.canonical_bytes)["payload"]["closure_evidence_digest"] == _D2
+    alternate = recovered.transition(
+        state=IncidentState.CLOSED, evidence_digest=_D, root_cause_digest=_D,
+        follow_up_digest=_D, regression_case_digest=_D,
+    )
+    assert alternate.digest != closed.digest
+    with pytest.raises(ObservabilityError, match="evidence_digest"):
+        recovered.transition(
+            state=IncidentState.CLOSED, evidence_digest="not-a-digest", root_cause_digest=_D,
+            follow_up_digest=_D, regression_case_digest=_D,
+        )
+
+
+def test_incident_transition_reconstructs_exact_retained_record() -> None:
+    opened = IncidentRecord.open(
+        incident_id="incident:forged", scope_digest=_D, opened_at=_AT, timeline_digest=_D,
+        integrity_related=True, near_miss=False,
+    )
+    contained = opened.transition(state=IncidentState.CONTAINED, evidence_digest=_D)
+    recovered = contained.transition(state=IncidentState.RECOVERED, evidence_digest=_D)
+    with pytest.raises(ObservabilityError, match="canonical"):
+        replace(recovered, integrity_related=False).transition(
+            state=IncidentState.CLOSED, evidence_digest=_D2, root_cause_digest=_D,
+            follow_up_digest=_D, regression_case_digest=_D,
+        )
 
 
 def test_manual_actions_are_authenticated_audited_and_never_automatic() -> None:


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: 8d
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

## Summary

- classify HTTP 206 as partial rather than complete
- apply the frozen freshness threshold at full timestamp precision
- bind exact closure evidence into every CLOSED Incident and reconstruct canonical Incident authority before transition
- add focused boundary and integrity regressions

Closes #466
Parent: #148
Dependencies: #462, #463, #464

## Verification

- `uvx ruff check newsroom/increment8/observability.py newsroom/tests/test_increment8d_observability.py`
- `uv run pytest -q newsroom/tests/test_increment8d_observability.py` (12 passed)
- `uv run pytest -q newsroom/tests/test_increment8*.py` (99 passed)
- `git diff --check`

## Non-effects

Fixture observability and security evidence only. No live credential, provider, egress, incident action, spend, shadow, canary, publication, production or locality effect. No Operational Admission construction.
