### PR TITLE
Increment 8E: correct recovery authority

### DIFF
--- a/docs/plans/2026-08-15-018-increment-8e-corrective-recovery.md
+++ b/docs/plans/2026-08-15-018-increment-8e-corrective-recovery.md
@@ -14,20 +14,22 @@ canary, permanent-locality or production effect.
   scenario, expected outcome, observed outcome, derived status and non-effect
   flag are checked before retained scalar columns are written.
 - `RecoveryAuthority` accepts only an idle schema-v32 SQLite connection with
-  foreign-key enforcement already enabled; the authority does not silently
-  change caller connection policy.
-- Every `DueWork` supplied to catch-up planning is reconstructed and compared
-  with the supplied object before parsed-deadline ordering or bounded selection.
+  foreign-key enforcement already enabled and rechecks that setting immediately
+  before every write; the authority does not silently change caller policy.
+- Every `DueWork` supplied to catch-up planning is reconstructed, checked against
+  the complete operational payload/state rules and compared with the supplied
+  object before parsed-deadline ordering or bounded selection.
 - A failed backup removes only the incomplete destination created by that
   attempt, so the same absent path can be retried while pre-existing paths remain
   protected by exclusive creation.
-- Restore rejects an absent destination parent and removes its own incomplete
-  destination after copy or logical-integrity failure.
+- Restore validates completion evidence before copying, rejects an absent
+  destination parent and removes its own incomplete destination after copy or
+  logical-integrity failure.
 
 ## Evidence
 
-- focused recovery suite: 14 passed;
-- complete Increment 8 suite: 129 passed;
+- focused recovery suite: 16 passed;
+- complete Increment 8 suite: 131 passed;
 - new regressions cover disabled foreign keys, active transactions,
   self-consistent fault forgery, detached DueWork, retry after failed backup,
   missing restore parent and partial-restore cleanup.

--- a/docs/plans/2026-08-15-018-increment-8e-corrective-recovery.md
+++ b/docs/plans/2026-08-15-018-increment-8e-corrective-recovery.md
@@ -1,0 +1,36 @@
+# Increment 8E corrective recovery authority
+
+Issue: #467
+
+## Boundary
+
+This correction remains fixture and replay evidence only. It introduces no live
+recovery authority, provider, credential, egress, spend, publication, shadow,
+canary, permanent-locality or production effect.
+
+## Corrected invariants
+
+- `FaultInjectionRun` is reconstructed from canonical bytes and its exact
+  scenario, expected outcome, observed outcome, derived status and non-effect
+  flag are checked before retained scalar columns are written.
+- `RecoveryAuthority` accepts only an idle schema-v32 SQLite connection with
+  foreign-key enforcement already enabled; the authority does not silently
+  change caller connection policy.
+- Every `DueWork` supplied to catch-up planning is reconstructed and compared
+  with the supplied object before parsed-deadline ordering or bounded selection.
+- A failed backup removes only the incomplete destination created by that
+  attempt, so the same absent path can be retried while pre-existing paths remain
+  protected by exclusive creation.
+- Restore rejects an absent destination parent and removes its own incomplete
+  destination after copy or logical-integrity failure.
+
+## Evidence
+
+- focused recovery suite: 14 passed;
+- complete Increment 8 suite: 129 passed;
+- new regressions cover disabled foreign keys, active transactions,
+  self-consistent fault forgery, detached DueWork, retry after failed backup,
+  missing restore parent and partial-restore cleanup.
+
+Authoritative exact-head CI, substantive review and merge evidence are recorded
+on the canonical pull request before issue closure.

--- a/newsroom/increment8/recovery.py
+++ b/newsroom/increment8/recovery.py
@@ -502,8 +502,27 @@ def _reconstruct_due_work(raw: bytes) -> DueWork:
             raise RecoveryError("catch-up initial DueWork semantics differ")
     elif previous != _digest(previous, "previous_digest"):
         raise RecoveryError("catch-up DueWork predecessor differs")
-    if state in {WorkState.LEASED, WorkState.RETRY_PENDING, WorkState.COMPLETED} and attempts < 1:
+    lineage_is_reachable = (
+        (state is WorkState.QUEUED and version == 1 and attempts == 0)
+        or (state is WorkState.LEASED and attempts >= 1 and version == 2 * attempts)
+        or (
+            state in {WorkState.RETRY_PENDING, WorkState.COMPLETED}
+            and attempts >= 1
+            and version == 2 * attempts + 1
+        )
+        or (state is WorkState.EXPLICITLY_CLOSED and version == 2 * attempts + 2)
+        or (
+            state is WorkState.QUARANTINED
+            and (
+                (attempts == 0 and version == 2)
+                or (attempts >= 1 and version in {2 * attempts + 1, 2 * attempts + 2})
+            )
+        )
+    )
+    if not lineage_is_reachable:
         raise RecoveryError("catch-up DueWork attempt lineage differs")
+    if state not in {WorkState.QUEUED, WorkState.RETRY_PENDING}:
+        raise RecoveryError("catch-up DueWork is not operationally due")
     return work
 
 

--- a/newsroom/increment8/recovery.py
+++ b/newsroom/increment8/recovery.py
@@ -167,6 +167,35 @@ class FaultInjectionRun(_Record):
     ID_FIELD = "fault_run_id"
     PREFIX = "fault-run"
 
+    @classmethod
+    def from_canonical_bytes(cls, raw: bytes) -> Self:
+        identifier, payload = _decode(raw, cls.SCHEMA, cls.ID_FIELD, cls.PREFIX)
+        required = {
+            "profile_digest", "scenario", "expected_outcome", "observed_outcome",
+            "completed_at", "status", "live_effect_authorised",
+        }
+        if set(payload) != required:
+            raise RecoveryError("fault Injection Run payload differs")
+        try:
+            scenario = FaultScenario(payload["scenario"])
+        except (TypeError, ValueError) as exc:
+            raise RecoveryError("fault scenario differs") from exc
+        expected = _EXPECTED_FAULT_OUTCOME[scenario]
+        observed = _token(payload["observed_outcome"], "observed_outcome")
+        status = RecoveryStatus.PASS.value if observed == expected else RecoveryStatus.FAIL.value
+        if (
+            payload["profile_digest"] != _digest(payload["profile_digest"], "profile_digest")
+            or payload["expected_outcome"] != expected
+            or payload["completed_at"] != _time(payload["completed_at"], "completed_at")
+            or payload["status"] != status
+            or payload["live_effect_authorised"] is not False
+        ):
+            raise RecoveryError("fault Injection Run semantics differ")
+        rebuilt = cls.build(dict(payload))
+        if rebuilt.identifier != identifier or rebuilt.canonical_bytes != raw:
+            raise RecoveryError("fault Injection Run identity differs")
+        return cls(identifier, raw, digest_bytes(raw), payload)
+
 
 @dataclass(frozen=True, slots=True)
 class ReplayReceipt(_Record):
@@ -232,30 +261,39 @@ def create_checked_backup(
     if connection.execute("PRAGMA integrity_check").fetchone() != ("ok",):
         raise RecoveryError("source integrity check failed")
     logical = _helpers._logical_database_digest(connection)
-    destination.open("xb").close()
-    target = sqlite3.connect(destination, isolation_level=None)
+    created_destination = False
+    target: sqlite3.Connection | None = None
     try:
+        destination.open("xb").close()
+        created_destination = True
+        target = sqlite3.connect(destination, isolation_level=None)
         connection.backup(target)
         if target.execute("PRAGMA integrity_check").fetchone() != ("ok",) or _helpers._logical_database_digest(target) != logical:
             raise RecoveryError("backup integrity differs")
-    finally:
         target.close()
-    file_digest = _helpers._file_digest(destination)
-    return BackupManifest.build(
-        {
-            "profile_digest": _digest(profile_digest, "profile_digest"),
-            "authority_version_digest": _digest(authority_version_digest, "authority_version_digest"),
-            "audit_state_digest": _digest(audit_state_digest, "audit_state_digest"),
-            "authority_logical_digest": logical,
-            "backup_file_digest": file_digest,
-            "created_at": created,
-            "retain_until": retained,
-            "rpo_seconds": int(INCREMENT_8_READINESS.operational_profile["recovery"]["backup_rpo_seconds"]),  # type: ignore[index]
-            "included_state": ["AUDIT", "AUTHORITY", "BASELINE", "DEDUPE", "PENDING_WORK"],
-            "integrity_status": RecoveryStatus.PASS.value,
-            "live_effect_authorised": False,
-        }
-    )
+        target = None
+        file_digest = _helpers._file_digest(destination)
+        return BackupManifest.build(
+            {
+                "profile_digest": _digest(profile_digest, "profile_digest"),
+                "authority_version_digest": _digest(authority_version_digest, "authority_version_digest"),
+                "audit_state_digest": _digest(audit_state_digest, "audit_state_digest"),
+                "authority_logical_digest": logical,
+                "backup_file_digest": file_digest,
+                "created_at": created,
+                "retain_until": retained,
+                "rpo_seconds": int(INCREMENT_8_READINESS.operational_profile["recovery"]["backup_rpo_seconds"]),  # type: ignore[index]
+                "included_state": ["AUDIT", "AUTHORITY", "BASELINE", "DEDUPE", "PENDING_WORK"],
+                "integrity_status": RecoveryStatus.PASS.value,
+                "live_effect_authorised": False,
+            }
+        )
+    except Exception:
+        if target is not None:
+            target.close()
+        if created_destination:
+            destination.unlink(missing_ok=True)
+        raise
 
 
 def restore_checked_backup(
@@ -269,19 +307,30 @@ def restore_checked_backup(
         raise RecoveryError("backup Manifest is forged")
     if not all(isinstance(path, Path) and path.is_absolute() for path in (source, destination)) or not source.is_file() or destination.exists():
         raise RecoveryError("restore path boundary differs")
+    if not destination.parent.is_dir():
+        raise RecoveryError("restore destination parent is absent")
     if _helpers._file_digest(source) != manifest.payload["backup_file_digest"]:
         raise RecoveryError("backup file digest differs")
     incoming = sqlite3.connect(f"file:{source}?mode=ro", uri=True, isolation_level=None)
     target: sqlite3.Connection | None = None
+    created_destination = False
     try:
         if incoming.execute("PRAGMA integrity_check").fetchone() != ("ok",) or _helpers._logical_database_digest(incoming) != manifest.payload["authority_logical_digest"]:
             raise RecoveryError("backup logical state differs")
         destination.open("xb").close()
+        created_destination = True
         target = sqlite3.connect(destination, isolation_level=None)
         incoming.backup(target)
         restored = _helpers._logical_database_digest(target)
         if target.execute("PRAGMA integrity_check").fetchone() != ("ok",) or restored != manifest.payload["authority_logical_digest"]:
             raise RecoveryError("restored authority differs")
+    except Exception:
+        if target is not None:
+            target.close()
+            target = None
+        if created_destination:
+            destination.unlink(missing_ok=True)
+        raise
     finally:
         incoming.close()
         if target is not None:
@@ -388,9 +437,18 @@ def build_fault_injection_run(
 def bounded_catch_up(work: Sequence[DueWork]) -> tuple[DueWork, ...]:
     if any(not isinstance(item, DueWork) for item in work):
         raise RecoveryError("catch-up requires typed due work")
+    try:
+        reconstructed = tuple(DueWork.from_canonical_bytes(item.canonical_bytes) for item in work)
+    except (TypeError, ValueError) as exc:
+        raise RecoveryError("catch-up DueWork is forged") from exc
+    if any(rebuilt != supplied for rebuilt, supplied in zip(reconstructed, work, strict=True)):
+        raise RecoveryError("catch-up DueWork is forged")
     maximum = int(INCREMENT_8_READINESS.operational_profile["schedule"]["maximum_catch_up_items"])  # type: ignore[index]
     urgency = {Urgency.URGENT.value: 0, Urgency.TIME_SENSITIVE.value: 1, Urgency.PLANNED.value: 2, Urgency.ROUTINE.value: 3}
-    ordered = sorted(work, key=lambda item: (urgency[str(item.payload["urgency"])], str(item.payload["deadline_at"]), item.work_id))
+    try:
+        ordered = sorted(reconstructed, key=lambda item: (urgency[str(item.payload["urgency"])], _dt(str(item.payload["deadline_at"])), item.work_id))
+    except (KeyError, TypeError, ValueError) as exc:
+        raise RecoveryError("catch-up DueWork semantics differ") from exc
     return tuple(ordered[:maximum])
 
 
@@ -398,8 +456,13 @@ class RecoveryAuthority:
     """Append-only schema-v32 fixture recovery authority."""
 
     def __init__(self, connection: sqlite3.Connection) -> None:
-        if not isinstance(connection, sqlite3.Connection) or connection.in_transaction or connection.execute("PRAGMA user_version").fetchone()[0] < 32:
-            raise RecoveryError("recovery authority requires idle schema v32 connection")
+        if (
+            not isinstance(connection, sqlite3.Connection)
+            or connection.in_transaction
+            or connection.execute("PRAGMA user_version").fetchone()[0] < 32
+            or connection.execute("PRAGMA foreign_keys").fetchone() != (1,)
+        ):
+            raise RecoveryError("recovery authority requires idle foreign-key-enabled schema v32 connection")
         self._connection = connection
 
     def _insert(self, sql: str, values: tuple[object, ...]) -> None:

--- a/newsroom/increment8/recovery.py
+++ b/newsroom/increment8/recovery.py
@@ -14,7 +14,7 @@ from typing import Any, ClassVar, Self
 
 from newsroom.authority.canonical import canonical_json_bytes, digest_bytes, digest_canonical, validate_sha256_digest
 from newsroom.authority.increment8_recovery_migrations import _helpers
-from newsroom.increment8.operations import DueWork, Urgency
+from newsroom.increment8.operations import DueWork, Urgency, WorkState
 from newsroom.increment8.readiness import INCREMENT_8_READINESS
 
 
@@ -309,6 +309,7 @@ def restore_checked_backup(
         raise RecoveryError("restore path boundary differs")
     if not destination.parent.is_dir():
         raise RecoveryError("restore destination parent is absent")
+    completed = _time(completed_at, "completed_at")
     if _helpers._file_digest(source) != manifest.payload["backup_file_digest"]:
         raise RecoveryError("backup file digest differs")
     incoming = sqlite3.connect(f"file:{source}?mode=ro", uri=True, isolation_level=None)
@@ -340,7 +341,7 @@ def restore_checked_backup(
             "backup_id": manifest.identifier,
             "backup_manifest_digest": manifest.digest,
             "restored_logical_digest": str(manifest.payload["authority_logical_digest"]),
-            "completed_at": _time(completed_at, "completed_at"),
+            "completed_at": completed,
             "status": "RECONCILIATION_REQUIRED",
             "automatic_operation_resumed": False,
             "baselines_reconciled": False,
@@ -438,7 +439,7 @@ def bounded_catch_up(work: Sequence[DueWork]) -> tuple[DueWork, ...]:
     if any(not isinstance(item, DueWork) for item in work):
         raise RecoveryError("catch-up requires typed due work")
     try:
-        reconstructed = tuple(DueWork.from_canonical_bytes(item.canonical_bytes) for item in work)
+        reconstructed = tuple(_reconstruct_due_work(item.canonical_bytes) for item in work)
     except (TypeError, ValueError) as exc:
         raise RecoveryError("catch-up DueWork is forged") from exc
     if any(rebuilt != supplied for rebuilt, supplied in zip(reconstructed, work, strict=True)):
@@ -450,6 +451,60 @@ def bounded_catch_up(work: Sequence[DueWork]) -> tuple[DueWork, ...]:
     except (KeyError, TypeError, ValueError) as exc:
         raise RecoveryError("catch-up DueWork semantics differ") from exc
     return tuple(ordered[:maximum])
+
+
+def _reconstruct_due_work(raw: bytes) -> DueWork:
+    work = DueWork.from_canonical_bytes(raw)
+    payload = work.payload
+    required = {
+        "work_id", "state_version", "profile_record_id", "profile_digest",
+        "logical_due_key", "scope_kind", "urgency", "state", "attempt_count",
+        "due_at", "deadline_at", "previous_digest", "authority_version_digest",
+        "editorial_rejection", "model_scheduling_used",
+    }
+    if set(payload) != required:
+        raise RecoveryError("catch-up DueWork payload differs")
+    version = _integer(payload["state_version"], "state_version", minimum=1)
+    attempts = _integer(payload["attempt_count"], "attempt_count")
+    profile_digest = _digest(payload["profile_digest"], "profile_digest")
+    profile_record_id = _token(payload["profile_record_id"], "profile_record_id")
+    key = _token(payload["logical_due_key"], "logical_due_key")
+    kind = _token(payload["scope_kind"], "scope_kind")
+    try:
+        urgency = Urgency(payload["urgency"])
+        state = WorkState(payload["state"])
+    except (TypeError, ValueError) as exc:
+        raise RecoveryError("catch-up DueWork state or urgency differs") from exc
+    due = _time(payload["due_at"], "due_at")
+    deadline = _time(payload["deadline_at"], "deadline_at")
+    expected_work_id = "work:" + digest_canonical(
+        {"profile_digest": profile_digest, "logical_due_key": key}
+    ).removeprefix("sha256:")
+    previous = payload["previous_digest"]
+    if (
+        payload["work_id"] != expected_work_id
+        or len(profile_record_id) != len("profile:") + 64
+        or not profile_record_id.startswith("profile:")
+        or any(character not in "0123456789abcdef" for character in profile_record_id.removeprefix("profile:"))
+        or kind not in INCREMENT_8_READINESS.operational_profile["scope_kinds"]
+        or payload["urgency"] != urgency.value
+        or payload["state"] != state.value
+        or _dt(deadline) < _dt(due)
+        or attempts >= version
+        or payload["authority_version_digest"]
+        != _digest(payload["authority_version_digest"], "authority_version_digest")
+        or payload["editorial_rejection"] is not False
+        or payload["model_scheduling_used"] is not False
+    ):
+        raise RecoveryError("catch-up DueWork semantics differ")
+    if version == 1:
+        if state is not WorkState.QUEUED or attempts != 0 or previous is not None:
+            raise RecoveryError("catch-up initial DueWork semantics differ")
+    elif previous != _digest(previous, "previous_digest"):
+        raise RecoveryError("catch-up DueWork predecessor differs")
+    if state in {WorkState.LEASED, WorkState.RETRY_PENDING, WorkState.COMPLETED} and attempts < 1:
+        raise RecoveryError("catch-up DueWork attempt lineage differs")
+    return work
 
 
 class RecoveryAuthority:
@@ -466,6 +521,11 @@ class RecoveryAuthority:
         self._connection = connection
 
     def _insert(self, sql: str, values: tuple[object, ...]) -> None:
+        if (
+            self._connection.in_transaction
+            or self._connection.execute("PRAGMA foreign_keys").fetchone() != (1,)
+        ):
+            raise RecoveryError("recovery write requires idle foreign-key-enabled connection")
         self._connection.execute("BEGIN IMMEDIATE")
         try:
             self._connection.execute(sql, values)

--- a/newsroom/tests/test_increment8e_corrective_recovery.py
+++ b/newsroom/tests/test_increment8e_corrective_recovery.py
@@ -9,6 +9,7 @@ import pytest
 from newsroom.authority import migrations
 from newsroom.authority.increment8_recovery_migrations import _helpers
 from newsroom.increment8.operations import (
+    DueWork,
     OperationalAuthority,
     Urgency,
     build_operational_profile,
@@ -130,6 +131,11 @@ def test_catch_up_reconstructs_every_due_work_before_sorting(tmp_path) -> None:
     )
     with pytest.raises(RecoveryError, match="forged"):
         bounded_catch_up([detached])
+    semantically_incomplete = DueWork.build(
+        {"work_id": "work:bogus", "urgency": "URGENT", "deadline_at": _LATER}
+    )
+    with pytest.raises(RecoveryError, match="forged"):
+        bounded_catch_up([semantically_incomplete])
     connection.close()
 
 
@@ -183,6 +189,30 @@ def test_restore_rejects_missing_parent_without_creating_partial_destination(
     with pytest.raises(RecoveryError, match="parent is absent"):
         restore_checked_backup(manifest, source, destination, completed_at=_LATER)
     assert not destination.exists()
+    connection.close()
+
+
+def test_invalid_restore_completion_time_has_no_copy_and_allows_retry(tmp_path) -> None:
+    connection, source, manifest = _manifest(tmp_path)
+    destination = (tmp_path / "restored.sqlite3").absolute()
+    with pytest.raises(RecoveryError, match="completed_at"):
+        restore_checked_backup(manifest, source, destination, completed_at="not-a-time")
+    assert not destination.exists()
+    receipt = restore_checked_backup(manifest, source, destination, completed_at=_LATER)
+    assert receipt.payload["completed_at"] == _LATER
+    connection.close()
+
+
+def test_foreign_keys_are_rechecked_immediately_before_every_write(tmp_path) -> None:
+    connection, source, manifest = _manifest(tmp_path)
+    restore = restore_checked_backup(
+        manifest, source, (tmp_path / "restored.sqlite3").absolute(), completed_at=_LATER
+    )
+    authority = RecoveryAuthority(connection)
+    connection.execute("PRAGMA foreign_keys=OFF")
+    with pytest.raises(RecoveryError, match="foreign-key-enabled"):
+        authority.append_restore(restore)
+    assert connection.execute("SELECT COUNT(*) FROM restore_runs").fetchone() == (0,)
     connection.close()
 
 

--- a/newsroom/tests/test_increment8e_corrective_recovery.py
+++ b/newsroom/tests/test_increment8e_corrective_recovery.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import replace
+from types import MappingProxyType
+
+import pytest
+
+from newsroom.authority import migrations
+from newsroom.authority.increment8_recovery_migrations import _helpers
+from newsroom.increment8.operations import (
+    OperationalAuthority,
+    Urgency,
+    build_operational_profile,
+    enqueue_due_work,
+)
+from newsroom.increment8.recovery import (
+    FaultInjectionRun,
+    FaultScenario,
+    RecoveryAuthority,
+    RecoveryError,
+    bounded_catch_up,
+    build_fault_injection_run,
+    create_checked_backup,
+    restore_checked_backup,
+)
+
+_AT = "2042-01-05T00:00:00.000000Z"
+_LATER = "2042-01-05T00:10:00.000000Z"
+_RETAIN = "2042-02-05T00:00:00.000000Z"
+_D = "sha256:" + "1" * 64
+
+
+def _database(tmp_path):
+    path = tmp_path / "authority.sqlite3"
+    connection = sqlite3.connect(path, isolation_level=None)
+    migrations.apply_pending_migrations(connection, applied_at=_AT)
+    connection.execute("PRAGMA foreign_keys=ON")
+    return connection
+
+
+def _manifest(tmp_path):
+    connection = _database(tmp_path)
+    source = (tmp_path / "backup.sqlite3").absolute()
+    manifest = create_checked_backup(
+        connection,
+        source,
+        profile_digest=_D,
+        authority_version_digest=_D,
+        audit_state_digest=_D,
+        created_at=_AT,
+        retain_until=_RETAIN,
+    )
+    return connection, source, manifest
+
+
+def test_recovery_authority_requires_idle_foreign_key_enabled_connection(
+    tmp_path,
+) -> None:
+    connection = _database(tmp_path)
+    connection.execute("PRAGMA foreign_keys=OFF")
+    with pytest.raises(RecoveryError, match="foreign-key-enabled"):
+        RecoveryAuthority(connection)
+    connection.execute("PRAGMA foreign_keys=ON")
+    connection.execute("BEGIN")
+    with pytest.raises(RecoveryError, match="idle"):
+        RecoveryAuthority(connection)
+    connection.execute("ROLLBACK")
+    RecoveryAuthority(connection)
+    connection.close()
+
+
+def test_fault_run_reconstruction_rejects_self_consistent_semantic_forgery(
+    tmp_path,
+) -> None:
+    connection = _database(tmp_path)
+    authority = RecoveryAuthority(connection)
+    forged = FaultInjectionRun.build(
+        {
+            "profile_digest": _D,
+            "scenario": FaultScenario.STORE_FAILURE.value,
+            "expected_outcome": "FAIL_CLOSED",
+            "observed_outcome": "NOT_CLOSED",
+            "completed_at": _AT,
+            "status": "PASS",
+            "live_effect_authorised": False,
+        }
+    )
+    with pytest.raises(RecoveryError, match="semantics differ"):
+        authority.append_fault(forged)
+
+    valid = build_fault_injection_run(
+        profile_digest=_D,
+        scenario=FaultScenario.STORE_FAILURE,
+        observed_outcome="FAIL_CLOSED",
+        completed_at=_AT,
+    )
+    detached = replace(
+        valid,
+        payload=MappingProxyType({**valid.payload, "live_effect_authorised": True}),
+    )
+    with pytest.raises(RecoveryError, match="forged"):
+        authority.append_fault(detached)
+    assert connection.execute(
+        "SELECT COUNT(*) FROM fault_injection_runs"
+    ).fetchone() == (0,)
+    connection.close()
+
+
+def test_catch_up_reconstructs_every_due_work_before_sorting(tmp_path) -> None:
+    connection = _database(tmp_path)
+    operational = OperationalAuthority(connection)
+    profile = build_operational_profile(approved_by_digest=_D, approved_at=_AT)
+    operational.register_profile(profile)
+    due = enqueue_due_work(
+        profile=profile,
+        logical_due_key="urgent",
+        scope_kind="FIXTURE_SOURCE",
+        urgency=Urgency.URGENT,
+        due_at=_AT,
+        deadline_at=_LATER,
+        authority_version_digest=_D,
+    )
+    forged_bytes = replace(due, canonical_bytes=b"{}")
+    with pytest.raises(RecoveryError, match="forged"):
+        bounded_catch_up([forged_bytes])
+    detached = replace(
+        due,
+        payload=MappingProxyType({**due.payload, "urgency": Urgency.ROUTINE.value}),
+    )
+    with pytest.raises(RecoveryError, match="forged"):
+        bounded_catch_up([detached])
+    connection.close()
+
+
+def test_failed_backup_removes_partial_destination_and_same_path_can_retry(
+    tmp_path, monkeypatch
+) -> None:
+    connection = _database(tmp_path)
+    destination = (tmp_path / "backup.sqlite3").absolute()
+    original_digest = _helpers._file_digest
+    first = True
+
+    def fail_once(path):
+        nonlocal first
+        if path == destination and first:
+            first = False
+            raise RuntimeError("injected digest failure")
+        return original_digest(path)
+
+    monkeypatch.setattr(_helpers, "_file_digest", fail_once)
+    with pytest.raises(RuntimeError, match="injected digest failure"):
+        create_checked_backup(
+            connection,
+            destination,
+            profile_digest=_D,
+            authority_version_digest=_D,
+            audit_state_digest=_D,
+            created_at=_AT,
+            retain_until=_RETAIN,
+        )
+    assert not destination.exists()
+
+    manifest = create_checked_backup(
+        connection,
+        destination,
+        profile_digest=_D,
+        authority_version_digest=_D,
+        audit_state_digest=_D,
+        created_at=_AT,
+        retain_until=_RETAIN,
+    )
+    assert destination.is_file()
+    assert manifest.payload["backup_file_digest"] == original_digest(destination)
+    connection.close()
+
+
+def test_restore_rejects_missing_parent_without_creating_partial_destination(
+    tmp_path,
+) -> None:
+    connection, source, manifest = _manifest(tmp_path)
+    destination = (tmp_path / "absent" / "restored.sqlite3").absolute()
+    with pytest.raises(RecoveryError, match="parent is absent"):
+        restore_checked_backup(manifest, source, destination, completed_at=_LATER)
+    assert not destination.exists()
+    connection.close()
+
+
+def test_restore_failure_removes_partial_destination(tmp_path, monkeypatch) -> None:
+    connection, source, manifest = _manifest(tmp_path)
+    destination = (tmp_path / "restored.sqlite3").absolute()
+    original_logical = _helpers._logical_database_digest
+    calls = 0
+
+    def diverge_after_copy(database):
+        nonlocal calls
+        calls += 1
+        value = original_logical(database)
+        if calls == 2:
+            return "sha256:" + "f" * 64
+        return value
+
+    monkeypatch.setattr(_helpers, "_logical_database_digest", diverge_after_copy)
+    with pytest.raises(RecoveryError, match="restored authority differs"):
+        restore_checked_backup(manifest, source, destination, completed_at=_LATER)
+    assert not destination.exists()
+    connection.close()

--- a/newsroom/tests/test_increment8e_corrective_recovery.py
+++ b/newsroom/tests/test_increment8e_corrective_recovery.py
@@ -136,6 +136,17 @@ def test_catch_up_reconstructs_every_due_work_before_sorting(tmp_path) -> None:
     )
     with pytest.raises(RecoveryError, match="forged"):
         bounded_catch_up([semantically_incomplete])
+    forged_completed_v2 = DueWork.build(
+        {
+            **due.payload,
+            "state_version": 2,
+            "state": "COMPLETED",
+            "attempt_count": 1,
+            "previous_digest": due.digest,
+        }
+    )
+    with pytest.raises(RecoveryError, match="forged"):
+        bounded_catch_up([forged_completed_v2])
     connection.close()
 
 

--- a/newsroom/tests/test_increment8e_recovery.py
+++ b/newsroom/tests/test_increment8e_recovery.py
@@ -33,6 +33,7 @@ def _database(tmp_path):
     path = tmp_path / "authority.sqlite3"
     connection = sqlite3.connect(path, isolation_level=None)
     migrations.apply_pending_migrations(connection, applied_at=_AT)
+    connection.execute("PRAGMA foreign_keys=ON")
     return path, connection
 
 


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: 8e
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

Closes #467
Parent: #148
Depends on: #465 (satisfied)

## Corrective scope

- reconstruct and semantically validate every retained `FaultInjectionRun` before scalar insertion;
- reject transaction-active and foreign-key-disabled schema-v32 recovery connections, and recheck both immediately before every write;
- reconstruct and fully validate every `DueWork` before parsed-deadline catch-up ordering;
- remove incomplete backup and restore destinations after failure while preserving exclusive no-overwrite creation;
- validate restore completion evidence before copy and reject restore into a missing parent directory;
- retain regression evidence for forgery, boundary and safe-retry paths.

## Evidence

- `uv run pytest -q newsroom/tests/test_increment8e_recovery.py newsroom/tests/test_increment8e_corrective_recovery.py` — 16 passed
- `uv run pytest -q newsroom/tests/test_increment8*.py` — 131 passed
- Ruff passed for the new corrective test module; `git diff --check` passed

## Non-effects

Fixture/replay recovery evidence only. No production recovery authority, live provider/model, credentials, external egress or spend, publication, production-equivalent shadow, canary, permanent locality or production activation.
