### PR TITLE
Increment 8F4: bind corrected signed inventory

### DIFF
--- a/.github/workflows/evidence.yml
+++ b/.github/workflows/evidence.yml
@@ -1212,7 +1212,7 @@ jobs:
               or not isinstance(increment8_inventory, dict)
               or increment8_inventory.get('case_count') != 13
               or increment8_inventory.get('digest')
-              != 'sha256:72ea45af5392106cd40968792097d6fd85960f16686795d45857e9da618e0429'
+              != 'sha256:948b6f6224c21d5a9f015188030ce476c203e7965f2ed52bb89037fed18ed123'
               or increment8_inventory.get('schema_version') != 32
               or increment8_inventory.get('schema_fingerprint')
               != 'sha256:3439b82ec6d212116e54765d50cace4d7f147b6ecc3e6ff84146b523c6fd5676'

--- a/newsroom/tests/test_sdlc_evidence_workflow.py
+++ b/newsroom/tests/test_sdlc_evidence_workflow.py
@@ -7,6 +7,10 @@ from typing import Any
 
 import yaml
 
+from newsroom.increment8.closeout import (
+    INCREMENT8_FINAL_CLOSEOUT_INVENTORY_DIGEST,
+)
+
 REPO_ROOT = Path(__file__).parents[2]
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "evidence.yml"
 
@@ -445,6 +449,7 @@ def test_signed_closeout_attests_only_the_validated_exact_main_receipt() -> None
         "signed decision binding differs",
     ):
         assert expected in validation
+    assert INCREMENT8_FINAL_CLOSEOUT_INVENTORY_DIGEST in validation
 
     attest = _step(
         "signed-closeout",


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: 8f4
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

Tracks #468. Supersedes the failed exact-main attempt `31870802049`; do not close #468, #428 or #148 until a fresh changed-main signed exact-main run succeeds.

## Exact failure

Run `31870802049` passed route, source integrity, authenticated Neo4j service, all 16 core shards, core reduction, SDLC decision, substantive-review collection, Qualification Packet construction, Operational Admission construction and independent product-subject reconstruction. The later inline signing validator alone failed because it retained the superseded pre-#485 inventory digest.

## Summary

- pin the independent signed exact-main validator to the corrected Increment 8 inventory digest emitted after #485;
- bind the workflow regression test to `INCREMENT8_FINAL_CLOSEOUT_INVENTORY_DIGEST`, so a future product inventory change cannot merge without updating the independent validator;
- preserve the separate independent inline inventory check rather than bypassing it;
- preserve every existing topology, timeout, budget, test, review, packet, admission, Handoff-anchor and attestation gate.

## Evidence

- `uv run pytest -q newsroom/tests/test_sdlc_evidence_workflow.py newsroom/tests/test_increment8f_closeout_receipt.py` — 24 passed;
- `uv run pytest -q newsroom/tests/test_increment8*.py` — 142 passed;
- ordinary CI on exact head `68e24c559af3347b7f8bc1ebea2154c4635dd045` — PASS;
- exact-head SDLC route is in progress and must complete before merge.

## Merge and final closeout gate

Merge only with zero P1, zero material P2 and zero unresolved threads. After merge, run one fresh manual exact-main workflow on the changed `main`. Close #468, #428 and #148 only when all 16 shards, reducer, decision and signed-closeout pass and the attestation bundle retains the exact Qualification Packet, Operational Admission decision, Handoff anchor and Increment 8 receipt.

## Boundary

Fixture/replay proof only. No live provider/model, credentials, egress, spend, locality activation, publication, production-equivalent shadow, canary or production effect. Increment 9 remains blocked.
