### PR TITLE
Increment 9B1: add Evaluation Epoch and Run authority

### DIFF
--- a/docs/operations/increment-9b1-shadow-epoch.md
+++ b/docs/operations/increment-9b1-shadow-epoch.md
@@ -41,9 +41,13 @@ retrieval, triage, Candidate and Handoff identities.
 An unresolved identity is explicitly non-decision-bearing. Compatible changes
 to those implementation identities create a new `ManifestCohort` inside the
 same Epoch. They never alter an existing cohort. Each cohort has an ordinal,
-exact predecessor, exposure contract and required slices.
+exact predecessor, opening instant, exposure contract and required slices. A
+cohort does not carry a predicted closing instant; a successor opening or the
+final `CohortCloseout` supplies that later fact.
 
-Only the last cohort may be marked final at closeout. It qualifies only when:
+No cohort predicts at creation whether it will be final. A separate immutable
+`CohortCloseout` selects the last retained cohort only after its evidence has
+closed. That final cohort qualifies only when:
 
 - its manifest identity is resolved;
 - its own exposure minima pass;
@@ -52,7 +56,8 @@ Only the last cohort may be marked final at closeout. It qualifies only when:
 - it has no unresolved identity.
 
 Earlier cohorts remain retained comparative evidence and are never pooled to
-qualify the final manifest.
+qualify the final manifest. The closeout seals the Epoch authority, so no later
+cohort or evidence record can be appended under the closed Epoch.
 
 ## Run and Attempt lineage
 

--- a/docs/operations/increment-9b1-shadow-epoch.md
+++ b/docs/operations/increment-9b1-shadow-epoch.md
@@ -1,0 +1,126 @@
+# Increment 9B1 Evaluation Epoch and Shadow Run authority
+
+- **Status:** authority contract implemented; no external execution
+- **Issue:** [#491](https://github.com/fol2/newsroom/issues/491)
+- **Planning authority:** [#488](https://github.com/fol2/newsroom/issues/488)
+- **Contracts:** `newsroom.increment9.epoch`
+- **Isolated persistence:** `newsroom.authority.increment9_shadow_migrations`
+
+## Boundary
+
+9B1 defines immutable prospective authority records and one append-only SQLite
+persistence seam. It does not make source, provider, model or embedding calls;
+obtain credentials; create spend; start a shadow campaign; publish; ingest
+Evidence; or mutate production.
+
+The SQLite schema is standalone. It has a distinct application ID and migration
+receipt and is intentionally absent from the production authority migration
+registry. Installation rejects a database with a production `user_version`, an
+existing application identity or any unrelated table.
+
+## Evaluation Epoch
+
+`EvaluationEpoch` binds:
+
+- the exact owner-approved Increment 9 plan and Shadow Scope;
+- source portfolio and prospective universe;
+- slice, threshold, comparator and reviewer rules;
+- budget and rights rules; and
+- opening, cutoff and close instants.
+
+The Epoch is prospective-only. Hindsight changes are false and immutable.
+Changing any of the universe, source portfolio, slices, thresholds, comparator,
+reviewer, budget or rights dimensions requires a new Epoch.
+
+## Effective Manifest Cohorts
+
+`EffectiveManifest` records exact code, image, configuration, source, provider,
+model, prompt, embedding, index, ontology, projector, Operational Profile,
+retrieval, triage, Candidate and Handoff identities.
+
+An unresolved identity is explicitly non-decision-bearing. Compatible changes
+to those implementation identities create a new `ManifestCohort` inside the
+same Epoch. They never alter an existing cohort. Each cohort has an ordinal,
+exact predecessor, exposure contract and required slices.
+
+Only the last cohort may be marked final at closeout. It qualifies only when:
+
+- its manifest identity is resolved;
+- its own exposure minima pass;
+- its own complete denominator is retained;
+- its observed slices exactly cover every required slice; and
+- it has no unresolved identity.
+
+Earlier cohorts remain retained comparative evidence and are never pooled to
+qualify the final manifest.
+
+## Run and Attempt lineage
+
+Every `ShadowRun` binds one Epoch digest, cohort digest, Effective Manifest,
+production snapshot and pre-run production-non-mutation digest. Prospective
+baseline, comparator and fault Runs must be prospective. Replay qualification
+and readiness probes remain explicitly separate kinds.
+
+Every `RunAttempt` has a positive ordinal and exact predecessor. A restart needs
+a reason. Lost response and ambiguous effect are explicit retained outcomes;
+they cannot be rewritten as success.
+
+## Persist-before-effect
+
+Every proposed external operation is first represented by an `EffectIntent`
+with Attempt digest, monotonic sequence, request digest and budget reservation.
+An `EffectResult` is accepted only after the exact intent is already persisted.
+Its response, usage, outcome and completion time are correlated to that intent.
+A missing response is valid only for lost-response, ambiguous, unavailable or
+failed outcomes.
+
+The authority similarly retains checkpoints, source watermarks, inventory and
+ledger digests, provider/token/storage/money cost records, and terminal Run
+outcomes. Partial, stale, unavailable, blocked, failed, early-stopped,
+inconclusive, lost-response and ambiguous-effect outcomes are never
+decision-bearing.
+
+## Isolated persistence
+
+`ShadowEpochAuthority` verifies the standalone schema before every use. Records
+are canonical JSON bytes with SHA-256 identities. The schema provides:
+
+- unique schema/id and digest identities;
+- bounded record bytes;
+- ordered Epoch inventory;
+- unique per-record-kind Attempt sequences;
+- immutable update triggers; and
+- retained delete triggers.
+
+Before append, the authority reconstructs and verifies every referenced Epoch,
+manifest, cohort, Run, Attempt and effect intent. A missing or mismatched
+predecessor rolls back the transaction. Concurrent duplicate appends fail
+closed.
+
+`ReplayController` is a deterministic fake/replay path. It only appends supplied
+canonical records in dependency order and exposes no network or production
+effect capability.
+
+## Outcomes and currentness
+
+The closed Run/effect outcomes are complete, partial, stale, unavailable,
+blocked, failed, early-stopped, inconclusive, lost response and ambiguous
+effect. Checkpoints and retained inventories make restart and reconciliation
+explicit.
+
+`classify_manifest_change` returns exactly one of:
+
+- `UNCHANGED`;
+- `COMPATIBLE_NEW_COHORT`;
+- `INCOMPATIBLE_NEW_EPOCH`; or
+- `UNRESOLVED_NOT_DECISION_BEARING`.
+
+Unknown dimensions fail closed instead of receiving a guessed compatibility
+classification.
+
+## Completion boundary
+
+9B1 proves contracts and isolated persistence semantics only. It does not prove
+an actual Neo4j/Graphiti deployment, credentials, default-deny egress, a live
+provider path, production-equivalent controller integration or prospective
+campaign evidence. Those remain gated by #490, #492 and #493.

--- a/newsroom/authority/increment9_shadow_migrations.py
+++ b/newsroom/authority/increment9_shadow_migrations.py
@@ -1,0 +1,160 @@
+"""Standalone schema for the isolated Increment 9 shadow Epoch authority.
+
+It is intentionally absent from the production authority migration registry.
+Installation rejects a non-empty or production-versioned database.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from .canonical import digest_canonical
+
+INCREMENT9_SHADOW_APPLICATION_ID = 0x4E523931  # NR91
+INCREMENT9_SHADOW_SCHEMA_VERSION = 1
+INCREMENT9_SHADOW_MIGRATION_NAME = "increment9_isolated_shadow_epoch_v1"
+INCREMENT9_SHADOW_PLAN_DIGEST = (
+    "sha256:92510c8b3989bb25cfce187b3477a71d8909a691ad8f3b88ae4917e456e9216d"
+)
+_D = "substr({0},1,7)='sha256:' AND length({0})=71 AND substr({0},8) NOT GLOB '*[^0-9a-f]*'"
+
+INCREMENT9_SHADOW_MIGRATION_STATEMENTS = (
+    f"""CREATE TABLE increment9_shadow_meta(
+        singleton INTEGER PRIMARY KEY CHECK(singleton=1),
+        schema_version INTEGER NOT NULL CHECK(schema_version=1),
+        migration_name TEXT NOT NULL,
+        migration_checksum TEXT NOT NULL CHECK({_D.format('migration_checksum')}),
+        plan_digest TEXT NOT NULL CHECK({_D.format('plan_digest')})
+    ) STRICT""",
+    f"""CREATE TABLE shadow_epoch_records(
+        record_schema TEXT NOT NULL,
+        record_id TEXT NOT NULL,
+        record_bytes BLOB NOT NULL CHECK(length(record_bytes)>0 AND length(record_bytes)<=1048576),
+        record_digest TEXT PRIMARY KEY CHECK({_D.format('record_digest')}),
+        epoch_id TEXT NOT NULL,
+        cohort_digest TEXT CHECK(cohort_digest IS NULL OR ({_D.format('cohort_digest')})),
+        run_id TEXT,
+        attempt_id TEXT,
+        sequence INTEGER CHECK(sequence IS NULL OR sequence>=0),
+        UNIQUE(record_schema,record_id),
+        UNIQUE(record_schema,attempt_id,sequence)
+    ) STRICT""",
+    "CREATE INDEX shadow_epoch_records_epoch ON shadow_epoch_records(epoch_id,record_schema,record_id)",
+    "CREATE INDEX shadow_epoch_records_run ON shadow_epoch_records(run_id,attempt_id,sequence)",
+    "CREATE TRIGGER immutable_shadow_epoch_records BEFORE UPDATE ON shadow_epoch_records BEGIN SELECT RAISE(ABORT,'immutable Increment 9 shadow record'); END",
+    "CREATE TRIGGER retained_shadow_epoch_records BEFORE DELETE ON shadow_epoch_records BEGIN SELECT RAISE(ABORT,'retained Increment 9 shadow record'); END",
+    "CREATE TRIGGER immutable_increment9_shadow_meta BEFORE UPDATE ON increment9_shadow_meta BEGIN SELECT RAISE(ABORT,'immutable Increment 9 shadow metadata'); END",
+    "CREATE TRIGGER retained_increment9_shadow_meta BEFORE DELETE ON increment9_shadow_meta BEGIN SELECT RAISE(ABORT,'retained Increment 9 shadow metadata'); END",
+)
+INCREMENT9_SHADOW_MIGRATION_CHECKSUM = digest_canonical(
+    {
+        "application_id": INCREMENT9_SHADOW_APPLICATION_ID,
+        "name": INCREMENT9_SHADOW_MIGRATION_NAME,
+        "schema_version": INCREMENT9_SHADOW_SCHEMA_VERSION,
+        "statements": list(INCREMENT9_SHADOW_MIGRATION_STATEMENTS),
+    }
+)
+
+
+def _schema_fingerprint(connection: sqlite3.Connection) -> str:
+    return digest_canonical(
+        [
+            {
+                "name": row[1],
+                "sql": row[3],
+                "table": row[2],
+                "type": row[0],
+            }
+            for row in connection.execute(
+                "SELECT type,name,tbl_name,sql FROM sqlite_schema "
+                "WHERE name NOT LIKE 'sqlite_%' ORDER BY type,name"
+            )
+        ]
+    )
+
+
+def _expected_schema_fingerprint() -> str:
+    connection = sqlite3.connect(":memory:", isolation_level=None)
+    try:
+        for statement in INCREMENT9_SHADOW_MIGRATION_STATEMENTS:
+            connection.execute(statement)
+        return _schema_fingerprint(connection)
+    finally:
+        connection.close()
+
+
+INCREMENT9_SHADOW_SCHEMA_FINGERPRINT = _expected_schema_fingerprint()
+
+
+class Increment9ShadowMigrationError(ValueError):
+    """The isolated shadow schema is absent, contaminated or changed."""
+
+
+def _tables(connection: sqlite3.Connection) -> tuple[str, ...]:
+    return tuple(
+        row[0]
+        for row in connection.execute(
+            "SELECT name FROM sqlite_schema WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+        )
+    )
+
+
+def install_increment9_shadow_schema(connection: sqlite3.Connection) -> None:
+    if not isinstance(connection, sqlite3.Connection) or connection.in_transaction:
+        raise Increment9ShadowMigrationError("isolated schema requires an idle SQLite connection")
+    application_id = connection.execute("PRAGMA application_id").fetchone()[0]
+    user_version = connection.execute("PRAGMA user_version").fetchone()[0]
+    tables = _tables(connection)
+    if tables:
+        verify_increment9_shadow_schema(connection)
+        return
+    if application_id != 0 or user_version != 0:
+        raise Increment9ShadowMigrationError("refusing a non-empty or production authority identity")
+    try:
+        connection.execute("BEGIN EXCLUSIVE")
+        for statement in INCREMENT9_SHADOW_MIGRATION_STATEMENTS:
+            connection.execute(statement)
+        connection.execute(
+            "INSERT INTO increment9_shadow_meta VALUES(1,?,?,?,?)",
+            (
+                INCREMENT9_SHADOW_SCHEMA_VERSION,
+                INCREMENT9_SHADOW_MIGRATION_NAME,
+                INCREMENT9_SHADOW_MIGRATION_CHECKSUM,
+                INCREMENT9_SHADOW_PLAN_DIGEST,
+            ),
+        )
+        connection.execute(f"PRAGMA application_id={INCREMENT9_SHADOW_APPLICATION_ID}")
+        connection.execute(f"PRAGMA user_version={INCREMENT9_SHADOW_SCHEMA_VERSION}")
+        connection.commit()
+    except sqlite3.Error as exc:
+        if connection.in_transaction:
+            connection.rollback()
+        raise Increment9ShadowMigrationError("isolated shadow schema installation failed") from exc
+    verify_increment9_shadow_schema(connection)
+
+
+def verify_increment9_shadow_schema(connection: sqlite3.Connection) -> None:
+    if not isinstance(connection, sqlite3.Connection):
+        raise Increment9ShadowMigrationError("SQLite connection is required")
+    if (
+        connection.execute("PRAGMA application_id").fetchone()[0]
+        != INCREMENT9_SHADOW_APPLICATION_ID
+        or connection.execute("PRAGMA user_version").fetchone()[0]
+        != INCREMENT9_SHADOW_SCHEMA_VERSION
+        or _tables(connection) != ("increment9_shadow_meta", "shadow_epoch_records")
+    ):
+        raise Increment9ShadowMigrationError("isolated shadow schema identity differs")
+    row = connection.execute(
+        "SELECT schema_version,migration_name,migration_checksum,plan_digest FROM increment9_shadow_meta WHERE singleton=1"
+    ).fetchone()
+    if row != (
+        INCREMENT9_SHADOW_SCHEMA_VERSION,
+        INCREMENT9_SHADOW_MIGRATION_NAME,
+        INCREMENT9_SHADOW_MIGRATION_CHECKSUM,
+        INCREMENT9_SHADOW_PLAN_DIGEST,
+    ):
+        raise Increment9ShadowMigrationError("isolated shadow migration receipt differs")
+    if _schema_fingerprint(connection) != INCREMENT9_SHADOW_SCHEMA_FINGERPRINT:
+        raise Increment9ShadowMigrationError("isolated shadow schema fingerprint differs")
+    if connection.execute("PRAGMA quick_check").fetchone()[0] != "ok":
+        raise Increment9ShadowMigrationError("isolated shadow integrity differs")

--- a/newsroom/increment9/epoch.py
+++ b/newsroom/increment9/epoch.py
@@ -357,8 +357,6 @@ class ManifestCohort(_Record):
     exposure_contract_digest: str
     required_slices: tuple[str, ...]
     opened_at: str
-    closed_at: str | None
-    final_at_closeout: bool
     decision_bearing: bool
 
     def __post_init__(self) -> None:
@@ -372,20 +370,70 @@ class ManifestCohort(_Record):
             _digest(self.previous_cohort_digest, "previous_cohort_digest")
         _tokens(self.required_slices, "required_slices")
         _timestamp(self.opened_at, "opened_at")
-        if self.closed_at is not None:
-            _timestamp(self.closed_at, "closed_at")
-            if _instant(self.closed_at) <= _instant(self.opened_at):
-                raise EpochAuthorityError("cohort chronology differs")
-        _boolean(self.final_at_closeout, "final_at_closeout")
         _boolean(self.decision_bearing, "decision_bearing")
 
     def primitive(self) -> dict[str, object]:
-        return {"schema_version": self.schema_version, "cohort_id": self.cohort_id, "epoch_id": self.epoch_id, "epoch_digest": self.epoch_digest, "manifest_digest": self.manifest_digest, "ordinal": self.ordinal, "previous_cohort_digest": self.previous_cohort_digest, "exposure_contract_digest": self.exposure_contract_digest, "required_slices": list(self.required_slices), "opened_at": self.opened_at, "closed_at": self.closed_at, "final_at_closeout": self.final_at_closeout, "decision_bearing": self.decision_bearing}
+        return {"schema_version": self.schema_version, "cohort_id": self.cohort_id, "epoch_id": self.epoch_id, "epoch_digest": self.epoch_digest, "manifest_digest": self.manifest_digest, "ordinal": self.ordinal, "previous_cohort_digest": self.previous_cohort_digest, "exposure_contract_digest": self.exposure_contract_digest, "required_slices": list(self.required_slices), "opened_at": self.opened_at, "decision_bearing": self.decision_bearing}
 
     @classmethod
     def from_bytes(cls, raw: bytes) -> Self:
         value = cls._document(raw, frozenset(name for name in cls.__dataclass_fields__ if name != "schema_version"))
         value["required_slices"] = _tokens(value["required_slices"], "required_slices")
+        return cls(**value)  # type: ignore[arg-type]
+
+
+@dataclass(frozen=True, slots=True)
+class CohortCloseout(_Record):
+    schema_version: ClassVar[str] = "newsroom.increment9.cohort-closeout.v1"
+    closeout_id: str
+    epoch_id: str
+    epoch_digest: str
+    final_cohort_digest: str
+    observed_slice_ids: tuple[str, ...]
+    exposure_minima_met: bool
+    complete_denominators: bool
+    unresolved_identity_count: int
+    qualifies: bool
+    closed_at: str
+
+    def __post_init__(self) -> None:
+        _token(self.closeout_id, "closeout_id")
+        _token(self.epoch_id, "epoch_id")
+        _digest(self.epoch_digest, "epoch_digest")
+        _digest(self.final_cohort_digest, "final_cohort_digest")
+        _tokens(self.observed_slice_ids, "observed_slice_ids", allow_empty=True)
+        _boolean(self.exposure_minima_met, "exposure_minima_met")
+        _boolean(self.complete_denominators, "complete_denominators")
+        _integer(self.unresolved_identity_count, "unresolved_identity_count")
+        _boolean(self.qualifies, "qualifies")
+        _timestamp(self.closed_at, "closed_at")
+
+    def primitive(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "closeout_id": self.closeout_id,
+            "epoch_id": self.epoch_id,
+            "epoch_digest": self.epoch_digest,
+            "final_cohort_digest": self.final_cohort_digest,
+            "observed_slice_ids": list(self.observed_slice_ids),
+            "exposure_minima_met": self.exposure_minima_met,
+            "complete_denominators": self.complete_denominators,
+            "unresolved_identity_count": self.unresolved_identity_count,
+            "qualifies": self.qualifies,
+            "closed_at": self.closed_at,
+        }
+
+    @classmethod
+    def from_bytes(cls, raw: bytes) -> Self:
+        value = cls._document(
+            raw,
+            frozenset(
+                name for name in cls.__dataclass_fields__ if name != "schema_version"
+            ),
+        )
+        value["observed_slice_ids"] = _tokens(
+            value["observed_slice_ids"], "observed_slice_ids", allow_empty=True
+        )
         return cls(**value)  # type: ignore[arg-type]
 
 
@@ -548,7 +596,7 @@ class RunOutcome(_Record):
         v=cls._document(raw,frozenset(n for n in cls.__dataclass_fields__ if n!="schema_version"));v["outcome"]=_enum(RecordOutcome,v["outcome"],"outcome");return cls(**v)  # type: ignore[arg-type]
 
 
-RECORD_TYPES: Mapping[str,type[_Record]]=MappingProxyType({c.schema_version:c for c in (EvaluationEpoch,EffectiveManifest,ManifestCohort,ShadowRun,RunAttempt,EffectIntent,EffectResult,Checkpoint,CostRecord,RunOutcome)})
+RECORD_TYPES: Mapping[str,type[_Record]]=MappingProxyType({c.schema_version:c for c in (EvaluationEpoch,EffectiveManifest,ManifestCohort,CohortCloseout,ShadowRun,RunAttempt,EffectIntent,EffectResult,Checkpoint,CostRecord,RunOutcome)})
 
 
 def classify_manifest_change(changed_dimensions: tuple[str,...], *, identities_resolved: bool)->ChangeClassification:
@@ -564,21 +612,31 @@ def classify_manifest_change(changed_dimensions: tuple[str,...], *, identities_r
 def validate_cohort_chain(epoch:EvaluationEpoch, manifests:Mapping[str,EffectiveManifest], cohorts:tuple[ManifestCohort,...])->tuple[ManifestCohort,...]:
     if type(cohorts) is not tuple or not cohorts:raise EpochAuthorityError("cohort chain must be non-empty")
     previous=None
-    final_count=0
     for ordinal,cohort in enumerate(cohorts,1):
         if type(cohort) is not ManifestCohort or cohort.epoch_id!=epoch.epoch_id or cohort.epoch_digest!=epoch.canonical_digest or cohort.ordinal!=ordinal:raise EpochAuthorityError("cohort Epoch binding differs")
         expected=None if previous is None else previous.canonical_digest
         if cohort.previous_cohort_digest!=expected:raise EpochAuthorityError("cohort predecessor differs")
         manifest=manifests.get(cohort.manifest_digest)
         if type(manifest) is not EffectiveManifest or cohort.decision_bearing!=manifest.decision_bearing:raise EpochAuthorityError("cohort manifest identity differs")
-        final_count+=int(cohort.final_at_closeout);previous=cohort
-    if final_count>1 or (final_count==1 and not cohorts[-1].final_at_closeout):raise EpochAuthorityError("only the final cohort may qualify")
+        if not (_instant(epoch.cutoff_at)<=_instant(cohort.opened_at)<_instant(epoch.closes_at)):raise EpochAuthorityError("cohort Epoch chronology differs")
+        if previous is not None and _instant(previous.opened_at)>=_instant(cohort.opened_at):raise EpochAuthorityError("cohort transition chronology differs")
+        previous=cohort
     return cohorts
 
 
-def qualify_final_cohort(cohort:ManifestCohort, *, observed_slice_ids:tuple[str,...], exposure_minima_met:bool, complete_denominators:bool, unresolved_identity_count:int)->bool:
-    observed=_tokens(observed_slice_ids,"observed_slice_ids",allow_empty=True);_integer(unresolved_identity_count,"unresolved_identity_count")
-    return bool(cohort.final_at_closeout and cohort.decision_bearing and set(observed)==set(cohort.required_slices) and exposure_minima_met is True and complete_denominators is True and unresolved_identity_count==0)
+def validate_cohort_closeout(epoch:EvaluationEpoch, cohorts:tuple[ManifestCohort,...], closeout:CohortCloseout)->CohortCloseout:
+    if type(closeout) is not CohortCloseout or not cohorts:raise EpochAuthorityError("cohort closeout differs")
+    final=cohorts[-1]
+    if closeout.epoch_id!=epoch.epoch_id or closeout.epoch_digest!=epoch.canonical_digest or closeout.final_cohort_digest!=final.canonical_digest:raise EpochAuthorityError("only the final cohort may close out")
+    if _instant(closeout.closed_at)<=_instant(final.opened_at):raise EpochAuthorityError("final cohort is not closed")
+    expected=bool(final.decision_bearing and set(closeout.observed_slice_ids)==set(final.required_slices) and closeout.exposure_minima_met and closeout.complete_denominators and closeout.unresolved_identity_count==0)
+    if closeout.qualifies is not expected:raise EpochAuthorityError("cohort qualification truth differs")
+    if _instant(closeout.closed_at)>_instant(epoch.closes_at):raise EpochAuthorityError("cohort closeout exceeds Epoch")
+    return closeout
+
+
+def qualify_final_cohort(epoch:EvaluationEpoch, cohorts:tuple[ManifestCohort,...], closeout:CohortCloseout)->bool:
+    validate_cohort_closeout(epoch,cohorts,closeout);return closeout.qualifies
 
 
 class ShadowEpochAuthority(_NoExternalEffect):
@@ -586,20 +644,17 @@ class ShadowEpochAuthority(_NoExternalEffect):
     def __init__(self,connection:sqlite3.Connection)->None:
         if not isinstance(connection,sqlite3.Connection):raise EpochAuthorityError("SQLite connection is required")
         verify_increment9_shadow_schema(connection);self.__connection=connection
-    def append(self,record:_Record,*,epoch_id:str,cohort_digest:str|None=None,run_id:str|None=None,attempt_id:str|None=None,sequence:int|None=None)->str:
+    def append(self,record:_Record,*,epoch_id:str)->str:
+        verify_increment9_shadow_schema(self.__connection)
         if type(record) not in set(RECORD_TYPES.values()):raise EpochAuthorityError("record type is not admitted")
         _token(epoch_id,"epoch_id")
-        for value,field in ((cohort_digest,"cohort_digest"),):
-            if value is not None:_digest(value,field)
-        for value,field in ((run_id,"run_id"),(attempt_id,"attempt_id")):
-            if value is not None:_token(value,field)
-        if sequence is not None:_integer(sequence,"sequence",minimum=0)
         raw=record.canonical_bytes;digest=record.canonical_digest
         try:
             self.__connection.execute("BEGIN IMMEDIATE")
+            if self.__connection.execute("SELECT 1 FROM shadow_epoch_records WHERE epoch_id=? AND record_schema=? LIMIT 1",(epoch_id,CohortCloseout.schema_version)).fetchone() is not None:raise EpochAuthorityError("Epoch is already closed out")
             count=self.__connection.execute("SELECT count(*) FROM shadow_epoch_records WHERE epoch_id=?",(epoch_id,)).fetchone()[0]
             if count>=MAX_EPOCH_RECORDS:raise EpochAuthorityError("Epoch record inventory limit reached")
-            self._validate_dependencies(record, epoch_id)
+            cohort_digest,run_id,attempt_id,sequence=self._validate_dependencies(record,epoch_id)
             self.__connection.execute("INSERT INTO shadow_epoch_records(record_schema,record_id,record_bytes,record_digest,epoch_id,cohort_digest,run_id,attempt_id,sequence) VALUES(?,?,?,?,?,?,?,?,?)",(record.schema_version,_record_id(record),raw,digest,epoch_id,cohort_digest,run_id,attempt_id,sequence))
             self.__connection.commit()
         except sqlite3.Error as exc:
@@ -613,30 +668,56 @@ class ShadowEpochAuthority(_NoExternalEffect):
         row=self.__connection.execute("SELECT record_schema,record_bytes FROM shadow_epoch_records WHERE record_digest=?",(digest,)).fetchone()
         if row is None or row[0]!=schema:raise EpochAuthorityError("required predecessor record is absent")
         kind=RECORD_TYPES[schema];return kind.from_bytes(bytes(row[1]))
-    def _validate_dependencies(self,record:_Record,epoch_id:str)->None:
+    def _required_id(self,schema:str,record_id:str)->_Record:
+        row=self.__connection.execute("SELECT record_bytes FROM shadow_epoch_records WHERE record_schema=? AND record_id=?",(schema,record_id)).fetchone()
+        if row is None:raise EpochAuthorityError("required predecessor record is absent")
+        return RECORD_TYPES[schema].from_bytes(bytes(row[0]))
+    def _run_for_attempt(self,attempt:RunAttempt,epoch_id:str)->ShadowRun:
+        run=self._required(attempt.run_digest,ShadowRun.schema_version)
+        if not isinstance(run,ShadowRun) or run.run_id!=attempt.run_id or run.epoch_id!=epoch_id:raise EpochAuthorityError("Attempt Run binding differs")
+        return run
+    def _validate_dependencies(self,record:_Record,epoch_id:str)->tuple[str|None,str|None,str|None,int|None]:
         if isinstance(record,EvaluationEpoch):
             if record.epoch_id!=epoch_id:raise EpochAuthorityError("Epoch persistence identity differs")
-            return
-        if isinstance(record,EffectiveManifest):return
+            return None,None,None,None
+        persisted_epoch=self._required_id(EvaluationEpoch.schema_version,epoch_id)
+        if not isinstance(persisted_epoch,EvaluationEpoch):raise EpochAuthorityError("Epoch persistence identity differs")
+        if isinstance(record,EffectiveManifest):return None,None,None,None
         if isinstance(record,ManifestCohort):
             epoch=self._required(record.epoch_digest,EvaluationEpoch.schema_version)
             self._required(record.manifest_digest,EffectiveManifest.schema_version)
             if not isinstance(epoch,EvaluationEpoch) or epoch.epoch_id!=record.epoch_id or record.epoch_id!=epoch_id:raise EpochAuthorityError("cohort persistence binding differs")
             if record.previous_cohort_digest is not None:self._required(record.previous_cohort_digest,ManifestCohort.schema_version)
-            return
+            prior=tuple(sorted((ManifestCohort.from_bytes(bytes(row[0])) for row in self.__connection.execute("SELECT record_bytes FROM shadow_epoch_records WHERE epoch_id=? AND record_schema=?",(epoch_id,ManifestCohort.schema_version))),key=lambda item:item.ordinal))
+            cohorts=prior+(record,)
+            manifests={cohort.manifest_digest:self._required(cohort.manifest_digest,EffectiveManifest.schema_version) for cohort in cohorts}
+            validate_cohort_chain(epoch,manifests,cohorts)
+            return record.canonical_digest,None,None,None
+        if isinstance(record,CohortCloseout):
+            epoch=self._required(record.epoch_digest,EvaluationEpoch.schema_version);self._required(record.final_cohort_digest,ManifestCohort.schema_version)
+            if not isinstance(epoch,EvaluationEpoch) or epoch.epoch_id!=record.epoch_id:raise EpochAuthorityError("cohort closeout persistence binding differs")
+            cohorts=tuple(sorted((ManifestCohort.from_bytes(bytes(row[0])) for row in self.__connection.execute("SELECT record_bytes FROM shadow_epoch_records WHERE epoch_id=? AND record_schema=?",(epoch_id,ManifestCohort.schema_version))),key=lambda item:item.ordinal))
+            manifests={cohort.manifest_digest:self._required(cohort.manifest_digest,EffectiveManifest.schema_version) for cohort in cohorts}
+            validate_cohort_chain(epoch,manifests,cohorts)
+            validate_cohort_closeout(epoch,cohorts,record)
+            return record.final_cohort_digest,None,None,None
         if isinstance(record,ShadowRun):
             epoch=self._required(record.epoch_digest,EvaluationEpoch.schema_version);cohort=self._required(record.cohort_digest,ManifestCohort.schema_version);self._required(record.manifest_digest,EffectiveManifest.schema_version)
-            if not isinstance(epoch,EvaluationEpoch) or not isinstance(cohort,ManifestCohort) or epoch.epoch_id!=record.epoch_id or cohort.cohort_id!=record.cohort_id or epoch_id!=record.epoch_id:raise EpochAuthorityError("Run persistence binding differs")
-            return
+            if not isinstance(epoch,EvaluationEpoch) or not isinstance(cohort,ManifestCohort) or epoch.epoch_id!=record.epoch_id or cohort.cohort_id!=record.cohort_id or cohort.manifest_digest!=record.manifest_digest or epoch_id!=record.epoch_id:raise EpochAuthorityError("Run persistence binding differs")
+            cohorts=tuple(ManifestCohort.from_bytes(bytes(row[0])) for row in self.__connection.execute("SELECT record_bytes FROM shadow_epoch_records WHERE epoch_id=? AND record_schema=?",(epoch_id,ManifestCohort.schema_version)))
+            if not cohorts or max(cohorts,key=lambda item:item.ordinal).canonical_digest!=record.cohort_digest:raise EpochAuthorityError("Run cohort is not current")
+            return record.cohort_digest,record.run_id,None,None
         if isinstance(record,RunAttempt):
-            run=self._required(record.run_digest,ShadowRun.schema_version)
-            if not isinstance(run,ShadowRun) or run.run_id!=record.run_id:raise EpochAuthorityError("Attempt Run binding differs")
-            if record.previous_attempt_digest is not None:self._required(record.previous_attempt_digest,RunAttempt.schema_version)
-            return
+            run=self._run_for_attempt(record,epoch_id)
+            if record.previous_attempt_digest is not None:
+                previous=self._required(record.previous_attempt_digest,RunAttempt.schema_version)
+                if not isinstance(previous,RunAttempt) or previous.run_id!=record.run_id or previous.ordinal+1!=record.ordinal:raise EpochAuthorityError("Attempt predecessor binding differs")
+            return run.cohort_digest,run.run_id,record.attempt_id,None
         if isinstance(record,EffectIntent):
             attempt=self._required(record.attempt_digest,RunAttempt.schema_version)
-            if not isinstance(attempt,RunAttempt) or attempt.attempt_id!=record.attempt_id:raise EpochAuthorityError("intent Attempt binding differs")
-            return
+            if not isinstance(attempt,RunAttempt) or attempt.attempt_id!=record.attempt_id or _instant(record.persisted_at)<_instant(attempt.started_at):raise EpochAuthorityError("intent Attempt binding differs")
+            run=self._run_for_attempt(attempt,epoch_id)
+            return run.cohort_digest,run.run_id,attempt.attempt_id,record.sequence
         if isinstance(record,EffectResult):
             intent=self._required(record.intent_digest,EffectIntent.schema_version)
             if not isinstance(intent,EffectIntent) or intent.intent_id!=record.intent_id or _instant(record.completed_at)<_instant(intent.persisted_at):raise EpochAuthorityError("result intent binding differs")
@@ -646,13 +727,24 @@ class ShadowEpochAuthority(_NoExternalEffect):
             if not isinstance(run,ShadowRun):raise EpochAuthorityError("result Run binding differs")
             epoch=self._required(run.epoch_digest,EvaluationEpoch.schema_version)
             if not isinstance(epoch,EvaluationEpoch) or (run.prospective and _instant(record.observed_valid_at)<_instant(epoch.cutoff_at)):raise EpochAuthorityError("result prospective cutoff differs")
-            return
-        if isinstance(record,Checkpoint):self._required(record.attempt_digest,RunAttempt.schema_version);return
-        if isinstance(record,CostRecord):self._required(record.intent_digest,EffectIntent.schema_version);return
+            return run.cohort_digest,run.run_id,attempt.attempt_id,intent.sequence
+        if isinstance(record,Checkpoint):
+            attempt=self._required(record.attempt_digest,RunAttempt.schema_version)
+            if not isinstance(attempt,RunAttempt) or attempt.attempt_id!=record.attempt_id or _instant(record.recorded_at)<_instant(attempt.started_at):raise EpochAuthorityError("checkpoint Attempt binding differs")
+            run=self._run_for_attempt(attempt,epoch_id);return run.cohort_digest,run.run_id,attempt.attempt_id,record.sequence
+        if isinstance(record,CostRecord):
+            intent=self._required(record.intent_digest,EffectIntent.schema_version)
+            if not isinstance(intent,EffectIntent) or intent.attempt_id!=record.attempt_id or _instant(record.recorded_at)<_instant(intent.persisted_at):raise EpochAuthorityError("cost intent binding differs")
+            attempt=self._required(intent.attempt_digest,RunAttempt.schema_version)
+            if not isinstance(attempt,RunAttempt):raise EpochAuthorityError("cost Attempt binding differs")
+            run=self._run_for_attempt(attempt,epoch_id);return run.cohort_digest,run.run_id,attempt.attempt_id,intent.sequence
         if isinstance(record,RunOutcome):
-            self._required(record.run_digest,ShadowRun.schema_version);self._required(record.attempt_digest,RunAttempt.schema_version);self._required(record.cohort_digest,ManifestCohort.schema_version);return
+            run=self._required(record.run_digest,ShadowRun.schema_version);attempt=self._required(record.attempt_digest,RunAttempt.schema_version);cohort=self._required(record.cohort_digest,ManifestCohort.schema_version)
+            if not isinstance(run,ShadowRun) or not isinstance(attempt,RunAttempt) or not isinstance(cohort,ManifestCohort) or run.run_id!=record.run_id or run.epoch_id!=epoch_id or attempt.run_digest!=record.run_digest or record.cohort_digest!=run.cohort_digest or (record.decision_bearing and (record.outcome is not RecordOutcome.COMPLETE or not cohort.decision_bearing)) or _instant(record.recorded_at)<_instant(attempt.started_at):raise EpochAuthorityError("Run outcome binding differs")
+            return run.cohort_digest,run.run_id,attempt.attempt_id,None
         raise EpochAuthorityError("record dependency policy is absent")
     def read(self,digest:str)->_Record:
+        verify_increment9_shadow_schema(self.__connection)
         digest=_digest(digest,"record_digest");row=self.__connection.execute("SELECT record_schema,record_bytes FROM shadow_epoch_records WHERE record_digest=?",(digest,)).fetchone()
         if row is None:raise EpochAuthorityError("record is absent")
         kind=RECORD_TYPES.get(row[0])
@@ -661,14 +753,26 @@ class ShadowEpochAuthority(_NoExternalEffect):
         if record.canonical_digest!=digest:raise EpochAuthorityError("stored record digest differs")
         return record
     def inventory(self,epoch_id:str)->tuple[str,...]:
-        _token(epoch_id,"epoch_id");return tuple(row[0] for row in self.__connection.execute("SELECT record_digest FROM shadow_epoch_records WHERE epoch_id=? ORDER BY record_schema,record_id",(epoch_id,)))
+        verify_increment9_shadow_schema(self.__connection);_token(epoch_id,"epoch_id");return tuple(row[0] for row in self.__connection.execute("SELECT record_digest FROM shadow_epoch_records WHERE epoch_id=? ORDER BY record_schema,record_id",(epoch_id,)))
 
 
 def _record_id(record:_Record)->str:
-    for name in ("epoch_id","manifest_id","cohort_id","run_id","attempt_id","intent_id","result_id","checkpoint_id","cost_id","outcome_id"):
-        value=getattr(record,name,None)
-        if value is not None:return _token(value,"record_id")
-    raise EpochAuthorityError("record identity is absent")
+    fields:Mapping[type[_Record],str]=MappingProxyType({
+        EvaluationEpoch:"epoch_id",
+        EffectiveManifest:"manifest_id",
+        ManifestCohort:"cohort_id",
+        CohortCloseout:"closeout_id",
+        ShadowRun:"run_id",
+        RunAttempt:"attempt_id",
+        EffectIntent:"intent_id",
+        EffectResult:"result_id",
+        Checkpoint:"checkpoint_id",
+        CostRecord:"cost_id",
+        RunOutcome:"outcome_id",
+    })
+    name=fields.get(type(record))
+    if name is None:raise EpochAuthorityError("record identity is absent")
+    return _token(getattr(record,name),"record_id")
 
 
 def initialise_shadow_epoch_authority(connection:sqlite3.Connection)->ShadowEpochAuthority:
@@ -679,11 +783,7 @@ class ReplayController(_NoExternalEffect):
     """Deterministic fake/replay recorder; it never executes an intent."""
     def __init__(self,authority:ShadowEpochAuthority)->None:self._authority=authority
     def replay(self,records:tuple[_Record,...],*,epoch_id:str)->tuple[str,...]:
-        digests=[];cohort_digest=None;run_id=None;attempt_id=None
+        digests=[]
         for record in records:
-            if isinstance(record,ManifestCohort):cohort_digest=record.canonical_digest
-            if isinstance(record,ShadowRun):run_id=record.run_id
-            if isinstance(record,RunAttempt):attempt_id=record.attempt_id
-            record_sequence=getattr(record,"sequence",None) if attempt_id is not None else None
-            digests.append(self._authority.append(record,epoch_id=epoch_id,cohort_digest=cohort_digest,run_id=run_id,attempt_id=attempt_id,sequence=record_sequence))
+            digests.append(self._authority.append(record,epoch_id=epoch_id))
         return tuple(digests)

--- a/newsroom/increment9/epoch.py
+++ b/newsroom/increment9/epoch.py
@@ -1,0 +1,689 @@
+"""Immutable Increment 9B1 Epoch, cohort, Run and evidence authority.
+
+This module is effect-free apart from writes to an explicitly initialised,
+isolated SQLite shadow authority.  It performs no source/provider/model call and
+holds no external or production credential.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from types import MappingProxyType
+from typing import ClassVar, Mapping, Self
+
+from newsroom.authority.canonical import (
+    CanonicalizationError,
+    canonical_json_bytes,
+    digest_bytes,
+    validate_sha256_digest,
+)
+from newsroom.authority.increment9_shadow_migrations import (
+    INCREMENT9_SHADOW_APPLICATION_ID,
+    INCREMENT9_SHADOW_SCHEMA_VERSION,
+    install_increment9_shadow_schema,
+    verify_increment9_shadow_schema,
+)
+from newsroom.increment9.plan import INCREMENT_9_SHADOW_PLAN_DIGEST
+
+MAX_RECORD_BYTES = 1_048_576
+MAX_EPOCH_RECORDS = 200_000
+_TOKEN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:/\-]{0,255}\Z")
+_UTC = re.compile(
+    r"[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T"
+    r"(?:[01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]\.[0-9]{6}Z\Z"
+)
+
+EFFECTIVE_MANIFEST_IDENTITY_KEYS = frozenset(
+    {
+        "candidate",
+        "code",
+        "config",
+        "embedding",
+        "handoff",
+        "image",
+        "index",
+        "model",
+        "ontology",
+        "operational_profile",
+        "projector",
+        "prompt",
+        "provider",
+        "retrieval",
+        "source",
+        "triage",
+    }
+)
+INCOMPATIBLE_EVALUATION_DIMENSIONS = frozenset(
+    {
+        "budget_rules",
+        "comparator_rules",
+        "prospective_universe",
+        "reviewer_rules",
+        "rights_rules",
+        "slice_rules",
+        "source_portfolio",
+        "thresholds",
+    }
+)
+COMPATIBLE_COHORT_DIMENSIONS = EFFECTIVE_MANIFEST_IDENTITY_KEYS
+
+
+class EpochAuthorityError(ValueError):
+    """An Epoch record or isolated-authority operation failed closed."""
+
+
+class RunKind(StrEnum):
+    REPLAY_QUALIFICATION = "REPLAY_QUALIFICATION"
+    READINESS_PROBE = "READINESS_PROBE"
+    PROSPECTIVE_BASELINE = "PROSPECTIVE_BASELINE"
+    COMPARATOR = "COMPARATOR"
+    FAULT = "FAULT"
+    RECOVERY_PROOF = "RECOVERY_PROOF"
+
+
+class RecordOutcome(StrEnum):
+    COMPLETE = "COMPLETE"
+    PARTIAL = "PARTIAL"
+    STALE = "STALE"
+    UNAVAILABLE = "UNAVAILABLE"
+    BLOCKED = "BLOCKED"
+    FAILED = "FAILED"
+    EARLY_STOPPED = "EARLY_STOPPED"
+    INCONCLUSIVE = "INCONCLUSIVE"
+    LOST_RESPONSE = "LOST_RESPONSE"
+    AMBIGUOUS_EFFECT = "AMBIGUOUS_EFFECT"
+
+
+class EffectKind(StrEnum):
+    SOURCE_REQUEST = "SOURCE_REQUEST"
+    PROVIDER_CALL = "PROVIDER_CALL"
+    MODEL_CALL = "MODEL_CALL"
+    EMBEDDING_CALL = "EMBEDDING_CALL"
+
+
+class ChangeClassification(StrEnum):
+    UNCHANGED = "UNCHANGED"
+    COMPATIBLE_NEW_COHORT = "COMPATIBLE_NEW_COHORT"
+    INCOMPATIBLE_NEW_EPOCH = "INCOMPATIBLE_NEW_EPOCH"
+    UNRESOLVED_NOT_DECISION_BEARING = "UNRESOLVED_NOT_DECISION_BEARING"
+
+
+class _NoExternalEffect:
+    authorises_live_call = False
+    authorises_credentials = False
+    authorises_external_egress = False
+    authorises_spend = False
+    authorises_publication = False
+    authorises_evidence_intake = False
+    authorises_canary = False
+    authorises_production_mutation = False
+    authorises_production_activation = False
+
+
+def _pairs(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise EpochAuthorityError(f"duplicate object name: {key}")
+        result[key] = value
+    return result
+
+
+def _text(value: object, field: str, maximum: int = 2048) -> str:
+    if (
+        type(value) is not str
+        or not value
+        or value != value.strip()
+        or len(value.encode("utf-8", errors="strict")) > maximum
+        or any(ord(character) < 32 or ord(character) == 127 for character in value)
+    ):
+        raise EpochAuthorityError(f"{field} must be canonical text")
+    return value
+
+
+def _token(value: object, field: str) -> str:
+    value = _text(value, field, 256)
+    if _TOKEN.fullmatch(value) is None:
+        raise EpochAuthorityError(f"{field} must be a canonical token")
+    return value
+
+
+def _digest(value: object, field: str) -> str:
+    try:
+        return validate_sha256_digest(value, field=field)  # type: ignore[arg-type]
+    except (CanonicalizationError, TypeError, ValueError) as exc:
+        raise EpochAuthorityError(f"{field} must be a SHA-256 digest") from exc
+
+
+def _timestamp(value: object, field: str) -> str:
+    value = _text(value, field, 27)
+    if _UTC.fullmatch(value) is None:
+        raise EpochAuthorityError(f"{field} must be an exact UTC timestamp")
+    try:
+        datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=UTC)
+    except ValueError as exc:
+        raise EpochAuthorityError(f"{field} must be an exact UTC timestamp") from exc
+    return value
+
+
+def _instant(value: str) -> datetime:
+    return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=UTC)
+
+
+def _integer(value: object, field: str, *, minimum: int = 0) -> int:
+    if type(value) is not int or value < minimum:
+        raise EpochAuthorityError(f"{field} must be a bounded integer")
+    return value
+
+
+def _boolean(value: object, field: str) -> bool:
+    if type(value) is not bool:
+        raise EpochAuthorityError(f"{field} must be a boolean")
+    return value
+
+
+def _enum[T: StrEnum](kind: type[T], value: object, field: str) -> T:
+    try:
+        if type(value) is not str and type(value) is not kind:
+            raise ValueError
+        return kind(value)
+    except ValueError as exc:
+        raise EpochAuthorityError(f"{field} differs") from exc
+
+
+def _tokens(value: object, field: str, *, allow_empty: bool = False) -> tuple[str, ...]:
+    if (
+        type(value) not in (list, tuple)
+        or (not value and not allow_empty)
+        or len(value) > 256
+    ):
+        raise EpochAuthorityError(f"{field} must be a bounded array")
+    result = tuple(_token(item, field) for item in value)
+    if tuple(sorted(set(result))) != result:
+        raise EpochAuthorityError(f"{field} must be unique and sorted")
+    return result
+
+
+def _digests(value: object, field: str, *, allow_empty: bool = False) -> tuple[str, ...]:
+    if (
+        type(value) not in (list, tuple)
+        or (not value and not allow_empty)
+        or len(value) > 4096
+    ):
+        raise EpochAuthorityError(f"{field} must be a bounded array")
+    result = tuple(_digest(item, field) for item in value)
+    if tuple(sorted(set(result))) != result:
+        raise EpochAuthorityError(f"{field} must be unique and sorted")
+    return result
+
+
+def _mapping(value: object, fields: frozenset[str], field: str) -> dict[str, object]:
+    if type(value) is not dict or set(value) != fields:
+        raise EpochAuthorityError(f"{field} fields differ")
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class _Record(_NoExternalEffect):
+    schema_version: ClassVar[str]
+
+    def primitive(self) -> dict[str, object]:
+        raise NotImplementedError
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return canonical_json_bytes(self.primitive())
+
+    @property
+    def canonical_digest(self) -> str:
+        return digest_bytes(self.canonical_bytes)
+
+    @classmethod
+    def _document(cls, raw: bytes, fields: frozenset[str]) -> dict[str, object]:
+        if type(raw) is not bytes or not raw or len(raw) > MAX_RECORD_BYTES:
+            raise EpochAuthorityError("Epoch record bytes are not bounded")
+        try:
+            value = json.loads(raw.decode("utf-8"), object_pairs_hook=_pairs)
+            canonical = canonical_json_bytes(value)
+        except EpochAuthorityError:
+            raise
+        except (UnicodeError, json.JSONDecodeError, CanonicalizationError, RecursionError) as exc:
+            raise EpochAuthorityError("Epoch record bytes are invalid") from exc
+        if canonical != raw:
+            raise EpochAuthorityError("Epoch record bytes must be exact canonical JSON")
+        value = _mapping(value, fields | {"schema_version"}, "Epoch record")
+        if value.pop("schema_version") != cls.schema_version:
+            raise EpochAuthorityError("Epoch record schema differs")
+        return value
+
+
+@dataclass(frozen=True, slots=True)
+class EvaluationEpoch(_Record):
+    schema_version: ClassVar[str] = "newsroom.increment9.evaluation-epoch.v1"
+    epoch_id: str
+    plan_digest: str
+    shadow_scope_digest: str
+    source_portfolio_digest: str
+    prospective_universe_digest: str
+    slice_rules_digest: str
+    thresholds_digest: str
+    comparator_rules_digest: str
+    reviewer_rules_digest: str
+    budget_rules_digest: str
+    rights_rules_digest: str
+    opened_at: str
+    cutoff_at: str
+    closes_at: str
+    prospective_only: bool = True
+    hindsight_changes_allowed: bool = False
+
+    def __post_init__(self) -> None:
+        _token(self.epoch_id, "epoch_id")
+        for field in (
+            "plan_digest", "shadow_scope_digest", "source_portfolio_digest",
+            "prospective_universe_digest", "slice_rules_digest", "thresholds_digest",
+            "comparator_rules_digest", "reviewer_rules_digest", "budget_rules_digest",
+            "rights_rules_digest",
+        ):
+            _digest(getattr(self, field), field)
+        if self.plan_digest != INCREMENT_9_SHADOW_PLAN_DIGEST:
+            raise EpochAuthorityError("Epoch plan digest differs")
+        for field in ("opened_at", "cutoff_at", "closes_at"):
+            _timestamp(getattr(self, field), field)
+        if not (_instant(self.opened_at) <= _instant(self.cutoff_at) < _instant(self.closes_at)):
+            raise EpochAuthorityError("Epoch chronology differs")
+        if self.prospective_only is not True or self.hindsight_changes_allowed is not False:
+            raise EpochAuthorityError("Epoch prospective rules differ")
+
+    def primitive(self) -> dict[str, object]:
+        return {"schema_version": self.schema_version, **{name: getattr(self, name) for name in self.__dataclass_fields__ if name != "schema_version"}}
+
+    @classmethod
+    def from_bytes(cls, raw: bytes) -> Self:
+        value = cls._document(raw, frozenset(name for name in cls.__dataclass_fields__ if name != "schema_version"))
+        return cls(**value)  # type: ignore[arg-type]
+
+
+@dataclass(frozen=True, slots=True)
+class EffectiveManifest(_Record):
+    schema_version: ClassVar[str] = "newsroom.increment9.effective-manifest.v1"
+    manifest_id: str
+    identity_digests: Mapping[str, str]
+    observed_at: str
+    identity_resolved: bool
+
+    def __post_init__(self) -> None:
+        _token(self.manifest_id, "manifest_id")
+        if not isinstance(self.identity_digests, Mapping) or set(self.identity_digests) != EFFECTIVE_MANIFEST_IDENTITY_KEYS:
+            raise EpochAuthorityError("Effective Manifest identity fields differ")
+        frozen = {key: _digest(value, f"identity_digests.{key}") for key, value in self.identity_digests.items()}
+        object.__setattr__(self, "identity_digests", MappingProxyType(dict(sorted(frozen.items()))))
+        _timestamp(self.observed_at, "observed_at")
+        _boolean(self.identity_resolved, "identity_resolved")
+
+    @property
+    def decision_bearing(self) -> bool:
+        return self.identity_resolved
+
+    def primitive(self) -> dict[str, object]:
+        return {
+            "identity_digests": dict(self.identity_digests),
+            "identity_resolved": self.identity_resolved,
+            "manifest_id": self.manifest_id,
+            "observed_at": self.observed_at,
+            "schema_version": self.schema_version,
+        }
+
+    @classmethod
+    def from_bytes(cls, raw: bytes) -> Self:
+        value = cls._document(raw, frozenset({"manifest_id", "identity_digests", "observed_at", "identity_resolved"}))
+        return cls(**value)  # type: ignore[arg-type]
+
+
+@dataclass(frozen=True, slots=True)
+class ManifestCohort(_Record):
+    schema_version: ClassVar[str] = "newsroom.increment9.manifest-cohort.v1"
+    cohort_id: str
+    epoch_id: str
+    epoch_digest: str
+    manifest_digest: str
+    ordinal: int
+    previous_cohort_digest: str | None
+    exposure_contract_digest: str
+    required_slices: tuple[str, ...]
+    opened_at: str
+    closed_at: str | None
+    final_at_closeout: bool
+    decision_bearing: bool
+
+    def __post_init__(self) -> None:
+        _token(self.cohort_id, "cohort_id"); _token(self.epoch_id, "epoch_id")
+        for field in ("epoch_digest", "manifest_digest", "exposure_contract_digest"):
+            _digest(getattr(self, field), field)
+        _integer(self.ordinal, "ordinal", minimum=1)
+        if (self.ordinal == 1) != (self.previous_cohort_digest is None):
+            raise EpochAuthorityError("cohort predecessor differs")
+        if self.previous_cohort_digest is not None:
+            _digest(self.previous_cohort_digest, "previous_cohort_digest")
+        _tokens(self.required_slices, "required_slices")
+        _timestamp(self.opened_at, "opened_at")
+        if self.closed_at is not None:
+            _timestamp(self.closed_at, "closed_at")
+            if _instant(self.closed_at) <= _instant(self.opened_at):
+                raise EpochAuthorityError("cohort chronology differs")
+        _boolean(self.final_at_closeout, "final_at_closeout")
+        _boolean(self.decision_bearing, "decision_bearing")
+
+    def primitive(self) -> dict[str, object]:
+        return {"schema_version": self.schema_version, "cohort_id": self.cohort_id, "epoch_id": self.epoch_id, "epoch_digest": self.epoch_digest, "manifest_digest": self.manifest_digest, "ordinal": self.ordinal, "previous_cohort_digest": self.previous_cohort_digest, "exposure_contract_digest": self.exposure_contract_digest, "required_slices": list(self.required_slices), "opened_at": self.opened_at, "closed_at": self.closed_at, "final_at_closeout": self.final_at_closeout, "decision_bearing": self.decision_bearing}
+
+    @classmethod
+    def from_bytes(cls, raw: bytes) -> Self:
+        value = cls._document(raw, frozenset(name for name in cls.__dataclass_fields__ if name != "schema_version"))
+        value["required_slices"] = _tokens(value["required_slices"], "required_slices")
+        return cls(**value)  # type: ignore[arg-type]
+
+
+@dataclass(frozen=True, slots=True)
+class ShadowRun(_Record):
+    schema_version: ClassVar[str] = "newsroom.increment9.shadow-run.v1"
+    run_id: str
+    epoch_id: str
+    epoch_digest: str
+    cohort_id: str
+    cohort_digest: str
+    manifest_digest: str
+    production_snapshot_digest: str
+    production_nonmutation_before_digest: str
+    run_kind: RunKind
+    started_at: str
+    prospective: bool
+
+    def __post_init__(self) -> None:
+        for field in ("run_id", "epoch_id", "cohort_id"):
+            _token(getattr(self, field), field)
+        for field in ("epoch_digest", "cohort_digest", "manifest_digest", "production_snapshot_digest", "production_nonmutation_before_digest"):
+            _digest(getattr(self, field), field)
+        _enum(RunKind, self.run_kind, "run_kind")
+        _timestamp(self.started_at, "started_at")
+        _boolean(self.prospective, "prospective")
+        if self.run_kind not in {RunKind.REPLAY_QUALIFICATION, RunKind.READINESS_PROBE} and self.prospective is not True:
+            raise EpochAuthorityError("decision-bearing Run must be prospective")
+
+    def primitive(self) -> dict[str, object]:
+        return {"schema_version": self.schema_version, **{name: (str(getattr(self, name)) if name == "run_kind" else getattr(self, name)) for name in self.__dataclass_fields__ if name != "schema_version"}}
+
+    @classmethod
+    def from_bytes(cls, raw: bytes) -> Self:
+        value = cls._document(raw, frozenset(name for name in cls.__dataclass_fields__ if name != "schema_version"))
+        value["run_kind"] = _enum(RunKind, value["run_kind"], "run_kind")
+        return cls(**value)  # type: ignore[arg-type]
+
+
+@dataclass(frozen=True, slots=True)
+class RunAttempt(_Record):
+    schema_version: ClassVar[str] = "newsroom.increment9.run-attempt.v1"
+    attempt_id: str
+    run_id: str
+    run_digest: str
+    ordinal: int
+    previous_attempt_digest: str | None
+    started_at: str
+    restart_reason: str | None
+
+    def __post_init__(self) -> None:
+        _token(self.attempt_id, "attempt_id"); _token(self.run_id, "run_id"); _digest(self.run_digest, "run_digest")
+        _integer(self.ordinal, "ordinal", minimum=1)
+        if (self.ordinal == 1) != (self.previous_attempt_digest is None):
+            raise EpochAuthorityError("Attempt predecessor differs")
+        if self.previous_attempt_digest is not None: _digest(self.previous_attempt_digest, "previous_attempt_digest")
+        _timestamp(self.started_at, "started_at")
+        if self.ordinal > 1 and self.restart_reason is None: raise EpochAuthorityError("restart reason is required")
+        if self.restart_reason is not None: _token(self.restart_reason, "restart_reason")
+
+    def primitive(self) -> dict[str, object]:
+        return {"schema_version": self.schema_version, **{name: getattr(self, name) for name in self.__dataclass_fields__ if name != "schema_version"}}
+
+    @classmethod
+    def from_bytes(cls, raw: bytes) -> Self:
+        return cls(**cls._document(raw, frozenset(name for name in cls.__dataclass_fields__ if name != "schema_version")))  # type: ignore[arg-type]
+
+
+@dataclass(frozen=True, slots=True)
+class EffectIntent(_Record):
+    schema_version: ClassVar[str] = "newsroom.increment9.effect-intent.v1"
+    intent_id: str
+    attempt_id: str
+    attempt_digest: str
+    sequence: int
+    effect_kind: EffectKind
+    request_digest: str
+    budget_reservation_digest: str
+    persisted_at: str
+
+    def __post_init__(self) -> None:
+        _token(self.intent_id, "intent_id"); _token(self.attempt_id, "attempt_id"); _digest(self.attempt_digest, "attempt_digest")
+        _integer(self.sequence, "sequence", minimum=1); _enum(EffectKind, self.effect_kind, "effect_kind")
+        _digest(self.request_digest, "request_digest"); _digest(self.budget_reservation_digest, "budget_reservation_digest"); _timestamp(self.persisted_at, "persisted_at")
+
+    def primitive(self) -> dict[str, object]:
+        return {"schema_version": self.schema_version, **{name: (str(getattr(self, name)) if name == "effect_kind" else getattr(self, name)) for name in self.__dataclass_fields__ if name != "schema_version"}}
+
+    @classmethod
+    def from_bytes(cls, raw: bytes) -> Self:
+        value=cls._document(raw,frozenset(name for name in cls.__dataclass_fields__ if name != "schema_version")); value["effect_kind"]=_enum(EffectKind,value["effect_kind"],"effect_kind"); return cls(**value)  # type: ignore[arg-type]
+
+
+@dataclass(frozen=True, slots=True)
+class EffectResult(_Record):
+    schema_version: ClassVar[str] = "newsroom.increment9.effect-result.v1"
+    result_id: str
+    intent_id: str
+    intent_digest: str
+    response_digest: str | None
+    usage_digest: str
+    outcome: RecordOutcome
+    observed_valid_at: str
+    completed_at: str
+    recorded_at: str
+
+    def __post_init__(self) -> None:
+        _token(self.result_id,"result_id"); _token(self.intent_id,"intent_id"); _digest(self.intent_digest,"intent_digest")
+        if self.response_digest is not None: _digest(self.response_digest,"response_digest")
+        _digest(self.usage_digest,"usage_digest"); _enum(RecordOutcome,self.outcome,"outcome"); _timestamp(self.observed_valid_at,"observed_valid_at"); _timestamp(self.completed_at,"completed_at"); _timestamp(self.recorded_at,"recorded_at")
+        if _instant(self.recorded_at)<_instant(self.completed_at):raise EpochAuthorityError("result transaction time precedes completion")
+        if self.response_digest is None and self.outcome not in {RecordOutcome.LOST_RESPONSE,RecordOutcome.AMBIGUOUS_EFFECT,RecordOutcome.UNAVAILABLE,RecordOutcome.FAILED}:
+            raise EpochAuthorityError("missing response outcome differs")
+
+    def primitive(self)->dict[str,object]:
+        return {"schema_version":self.schema_version,**{name:(str(getattr(self,name)) if name=="outcome" else getattr(self,name)) for name in self.__dataclass_fields__ if name!="schema_version"}}
+
+    @classmethod
+    def from_bytes(cls,raw:bytes)->Self:
+        value=cls._document(raw,frozenset(name for name in cls.__dataclass_fields__ if name!="schema_version"));value["outcome"]=_enum(RecordOutcome,value["outcome"],"outcome");return cls(**value)  # type: ignore[arg-type]
+
+
+@dataclass(frozen=True, slots=True)
+class Checkpoint(_Record):
+    schema_version: ClassVar[str]="newsroom.increment9.checkpoint.v1"
+    checkpoint_id:str; attempt_id:str; attempt_digest:str; sequence:int; watermark:str; inventory_digest:str; ledger_digest:str; recorded_at:str
+    def __post_init__(self)->None:
+        _token(self.checkpoint_id,"checkpoint_id");_token(self.attempt_id,"attempt_id");_digest(self.attempt_digest,"attempt_digest");_integer(self.sequence,"sequence",minimum=0);_token(self.watermark,"watermark");_digest(self.inventory_digest,"inventory_digest");_digest(self.ledger_digest,"ledger_digest");_timestamp(self.recorded_at,"recorded_at")
+    def primitive(self)->dict[str,object]:return {"schema_version":self.schema_version,**{n:getattr(self,n) for n in self.__dataclass_fields__ if n!="schema_version"}}
+    @classmethod
+    def from_bytes(cls,raw:bytes)->Self:return cls(**cls._document(raw,frozenset(n for n in cls.__dataclass_fields__ if n!="schema_version")))  # type: ignore[arg-type]
+
+
+@dataclass(frozen=True, slots=True)
+class CostRecord(_Record):
+    schema_version: ClassVar[str]="newsroom.increment9.cost-record.v1"
+    cost_id:str; attempt_id:str; intent_digest:str; provider:str; input_units:int; output_units:int; monetary_minor_units:int; storage_byte_days:int; recorded_at:str
+    def __post_init__(self)->None:
+        _token(self.cost_id,"cost_id");_token(self.attempt_id,"attempt_id");_digest(self.intent_digest,"intent_digest");_token(self.provider,"provider")
+        for f in ("input_units","output_units","monetary_minor_units","storage_byte_days"):_integer(getattr(self,f),f)
+        _timestamp(self.recorded_at,"recorded_at")
+    def primitive(self)->dict[str,object]:return {"schema_version":self.schema_version,**{n:getattr(self,n) for n in self.__dataclass_fields__ if n!="schema_version"}}
+    @classmethod
+    def from_bytes(cls,raw:bytes)->Self:return cls(**cls._document(raw,frozenset(n for n in cls.__dataclass_fields__ if n!="schema_version")))  # type: ignore[arg-type]
+
+
+@dataclass(frozen=True, slots=True)
+class RunOutcome(_Record):
+    schema_version: ClassVar[str]="newsroom.increment9.run-outcome.v1"
+    outcome_id:str; run_id:str; run_digest:str; attempt_digest:str; cohort_digest:str; outcome:RecordOutcome; evidence_inventory_digest:str; production_nonmutation_after_digest:str; decision_bearing:bool; recorded_at:str
+    def __post_init__(self)->None:
+        _token(self.outcome_id,"outcome_id");_token(self.run_id,"run_id")
+        for f in ("run_digest","attempt_digest","cohort_digest","evidence_inventory_digest","production_nonmutation_after_digest"):_digest(getattr(self,f),f)
+        _enum(RecordOutcome,self.outcome,"outcome");_boolean(self.decision_bearing,"decision_bearing");_timestamp(self.recorded_at,"recorded_at")
+        if self.outcome in {RecordOutcome.PARTIAL,RecordOutcome.STALE,RecordOutcome.UNAVAILABLE,RecordOutcome.BLOCKED,RecordOutcome.FAILED,RecordOutcome.EARLY_STOPPED,RecordOutcome.INCONCLUSIVE,RecordOutcome.LOST_RESPONSE,RecordOutcome.AMBIGUOUS_EFFECT} and self.decision_bearing:
+            raise EpochAuthorityError("non-complete outcome cannot be decision-bearing")
+    def primitive(self)->dict[str,object]:return {"schema_version":self.schema_version,**{n:(str(getattr(self,n)) if n=="outcome" else getattr(self,n)) for n in self.__dataclass_fields__ if n!="schema_version"}}
+    @classmethod
+    def from_bytes(cls,raw:bytes)->Self:
+        v=cls._document(raw,frozenset(n for n in cls.__dataclass_fields__ if n!="schema_version"));v["outcome"]=_enum(RecordOutcome,v["outcome"],"outcome");return cls(**v)  # type: ignore[arg-type]
+
+
+RECORD_TYPES: Mapping[str,type[_Record]]=MappingProxyType({c.schema_version:c for c in (EvaluationEpoch,EffectiveManifest,ManifestCohort,ShadowRun,RunAttempt,EffectIntent,EffectResult,Checkpoint,CostRecord,RunOutcome)})
+
+
+def classify_manifest_change(changed_dimensions: tuple[str,...], *, identities_resolved: bool)->ChangeClassification:
+    dimensions=_tokens(changed_dimensions,"changed_dimensions",allow_empty=True)
+    if not identities_resolved:return ChangeClassification.UNRESOLVED_NOT_DECISION_BEARING
+    if not dimensions:return ChangeClassification.UNCHANGED
+    unknown=set(dimensions)-INCOMPATIBLE_EVALUATION_DIMENSIONS-COMPATIBLE_COHORT_DIMENSIONS
+    if unknown:raise EpochAuthorityError("change dimension is not classified")
+    if set(dimensions)&INCOMPATIBLE_EVALUATION_DIMENSIONS:return ChangeClassification.INCOMPATIBLE_NEW_EPOCH
+    return ChangeClassification.COMPATIBLE_NEW_COHORT
+
+
+def validate_cohort_chain(epoch:EvaluationEpoch, manifests:Mapping[str,EffectiveManifest], cohorts:tuple[ManifestCohort,...])->tuple[ManifestCohort,...]:
+    if type(cohorts) is not tuple or not cohorts:raise EpochAuthorityError("cohort chain must be non-empty")
+    previous=None
+    final_count=0
+    for ordinal,cohort in enumerate(cohorts,1):
+        if type(cohort) is not ManifestCohort or cohort.epoch_id!=epoch.epoch_id or cohort.epoch_digest!=epoch.canonical_digest or cohort.ordinal!=ordinal:raise EpochAuthorityError("cohort Epoch binding differs")
+        expected=None if previous is None else previous.canonical_digest
+        if cohort.previous_cohort_digest!=expected:raise EpochAuthorityError("cohort predecessor differs")
+        manifest=manifests.get(cohort.manifest_digest)
+        if type(manifest) is not EffectiveManifest or cohort.decision_bearing!=manifest.decision_bearing:raise EpochAuthorityError("cohort manifest identity differs")
+        final_count+=int(cohort.final_at_closeout);previous=cohort
+    if final_count>1 or (final_count==1 and not cohorts[-1].final_at_closeout):raise EpochAuthorityError("only the final cohort may qualify")
+    return cohorts
+
+
+def qualify_final_cohort(cohort:ManifestCohort, *, observed_slice_ids:tuple[str,...], exposure_minima_met:bool, complete_denominators:bool, unresolved_identity_count:int)->bool:
+    observed=_tokens(observed_slice_ids,"observed_slice_ids",allow_empty=True);_integer(unresolved_identity_count,"unresolved_identity_count")
+    return bool(cohort.final_at_closeout and cohort.decision_bearing and set(observed)==set(cohort.required_slices) and exposure_minima_met is True and complete_denominators is True and unresolved_identity_count==0)
+
+
+class ShadowEpochAuthority(_NoExternalEffect):
+    """Checked append-only persistence over an isolated Increment 9 database."""
+    def __init__(self,connection:sqlite3.Connection)->None:
+        if not isinstance(connection,sqlite3.Connection):raise EpochAuthorityError("SQLite connection is required")
+        verify_increment9_shadow_schema(connection);self.__connection=connection
+    def append(self,record:_Record,*,epoch_id:str,cohort_digest:str|None=None,run_id:str|None=None,attempt_id:str|None=None,sequence:int|None=None)->str:
+        if type(record) not in set(RECORD_TYPES.values()):raise EpochAuthorityError("record type is not admitted")
+        _token(epoch_id,"epoch_id")
+        for value,field in ((cohort_digest,"cohort_digest"),):
+            if value is not None:_digest(value,field)
+        for value,field in ((run_id,"run_id"),(attempt_id,"attempt_id")):
+            if value is not None:_token(value,field)
+        if sequence is not None:_integer(sequence,"sequence",minimum=0)
+        raw=record.canonical_bytes;digest=record.canonical_digest
+        try:
+            self.__connection.execute("BEGIN IMMEDIATE")
+            count=self.__connection.execute("SELECT count(*) FROM shadow_epoch_records WHERE epoch_id=?",(epoch_id,)).fetchone()[0]
+            if count>=MAX_EPOCH_RECORDS:raise EpochAuthorityError("Epoch record inventory limit reached")
+            self._validate_dependencies(record, epoch_id)
+            self.__connection.execute("INSERT INTO shadow_epoch_records(record_schema,record_id,record_bytes,record_digest,epoch_id,cohort_digest,run_id,attempt_id,sequence) VALUES(?,?,?,?,?,?,?,?,?)",(record.schema_version,_record_id(record),raw,digest,epoch_id,cohort_digest,run_id,attempt_id,sequence))
+            self.__connection.commit()
+        except sqlite3.Error as exc:
+            if self.__connection.in_transaction:self.__connection.rollback()
+            raise EpochAuthorityError("isolated shadow append failed") from exc
+        except EpochAuthorityError:
+            if self.__connection.in_transaction:self.__connection.rollback()
+            raise
+        return digest
+    def _required(self,digest:str,schema:str)->_Record:
+        row=self.__connection.execute("SELECT record_schema,record_bytes FROM shadow_epoch_records WHERE record_digest=?",(digest,)).fetchone()
+        if row is None or row[0]!=schema:raise EpochAuthorityError("required predecessor record is absent")
+        kind=RECORD_TYPES[schema];return kind.from_bytes(bytes(row[1]))
+    def _validate_dependencies(self,record:_Record,epoch_id:str)->None:
+        if isinstance(record,EvaluationEpoch):
+            if record.epoch_id!=epoch_id:raise EpochAuthorityError("Epoch persistence identity differs")
+            return
+        if isinstance(record,EffectiveManifest):return
+        if isinstance(record,ManifestCohort):
+            epoch=self._required(record.epoch_digest,EvaluationEpoch.schema_version)
+            self._required(record.manifest_digest,EffectiveManifest.schema_version)
+            if not isinstance(epoch,EvaluationEpoch) or epoch.epoch_id!=record.epoch_id or record.epoch_id!=epoch_id:raise EpochAuthorityError("cohort persistence binding differs")
+            if record.previous_cohort_digest is not None:self._required(record.previous_cohort_digest,ManifestCohort.schema_version)
+            return
+        if isinstance(record,ShadowRun):
+            epoch=self._required(record.epoch_digest,EvaluationEpoch.schema_version);cohort=self._required(record.cohort_digest,ManifestCohort.schema_version);self._required(record.manifest_digest,EffectiveManifest.schema_version)
+            if not isinstance(epoch,EvaluationEpoch) or not isinstance(cohort,ManifestCohort) or epoch.epoch_id!=record.epoch_id or cohort.cohort_id!=record.cohort_id or epoch_id!=record.epoch_id:raise EpochAuthorityError("Run persistence binding differs")
+            return
+        if isinstance(record,RunAttempt):
+            run=self._required(record.run_digest,ShadowRun.schema_version)
+            if not isinstance(run,ShadowRun) or run.run_id!=record.run_id:raise EpochAuthorityError("Attempt Run binding differs")
+            if record.previous_attempt_digest is not None:self._required(record.previous_attempt_digest,RunAttempt.schema_version)
+            return
+        if isinstance(record,EffectIntent):
+            attempt=self._required(record.attempt_digest,RunAttempt.schema_version)
+            if not isinstance(attempt,RunAttempt) or attempt.attempt_id!=record.attempt_id:raise EpochAuthorityError("intent Attempt binding differs")
+            return
+        if isinstance(record,EffectResult):
+            intent=self._required(record.intent_digest,EffectIntent.schema_version)
+            if not isinstance(intent,EffectIntent) or intent.intent_id!=record.intent_id or _instant(record.completed_at)<_instant(intent.persisted_at):raise EpochAuthorityError("result intent binding differs")
+            attempt=self._required(intent.attempt_digest,RunAttempt.schema_version)
+            if not isinstance(attempt,RunAttempt):raise EpochAuthorityError("result Attempt binding differs")
+            run=self._required(attempt.run_digest,ShadowRun.schema_version)
+            if not isinstance(run,ShadowRun):raise EpochAuthorityError("result Run binding differs")
+            epoch=self._required(run.epoch_digest,EvaluationEpoch.schema_version)
+            if not isinstance(epoch,EvaluationEpoch) or (run.prospective and _instant(record.observed_valid_at)<_instant(epoch.cutoff_at)):raise EpochAuthorityError("result prospective cutoff differs")
+            return
+        if isinstance(record,Checkpoint):self._required(record.attempt_digest,RunAttempt.schema_version);return
+        if isinstance(record,CostRecord):self._required(record.intent_digest,EffectIntent.schema_version);return
+        if isinstance(record,RunOutcome):
+            self._required(record.run_digest,ShadowRun.schema_version);self._required(record.attempt_digest,RunAttempt.schema_version);self._required(record.cohort_digest,ManifestCohort.schema_version);return
+        raise EpochAuthorityError("record dependency policy is absent")
+    def read(self,digest:str)->_Record:
+        digest=_digest(digest,"record_digest");row=self.__connection.execute("SELECT record_schema,record_bytes FROM shadow_epoch_records WHERE record_digest=?",(digest,)).fetchone()
+        if row is None:raise EpochAuthorityError("record is absent")
+        kind=RECORD_TYPES.get(row[0])
+        if kind is None:raise EpochAuthorityError("stored record schema differs")
+        record=kind.from_bytes(bytes(row[1]))
+        if record.canonical_digest!=digest:raise EpochAuthorityError("stored record digest differs")
+        return record
+    def inventory(self,epoch_id:str)->tuple[str,...]:
+        _token(epoch_id,"epoch_id");return tuple(row[0] for row in self.__connection.execute("SELECT record_digest FROM shadow_epoch_records WHERE epoch_id=? ORDER BY record_schema,record_id",(epoch_id,)))
+
+
+def _record_id(record:_Record)->str:
+    for name in ("epoch_id","manifest_id","cohort_id","run_id","attempt_id","intent_id","result_id","checkpoint_id","cost_id","outcome_id"):
+        value=getattr(record,name,None)
+        if value is not None:return _token(value,"record_id")
+    raise EpochAuthorityError("record identity is absent")
+
+
+def initialise_shadow_epoch_authority(connection:sqlite3.Connection)->ShadowEpochAuthority:
+    install_increment9_shadow_schema(connection);return ShadowEpochAuthority(connection)
+
+
+class ReplayController(_NoExternalEffect):
+    """Deterministic fake/replay recorder; it never executes an intent."""
+    def __init__(self,authority:ShadowEpochAuthority)->None:self._authority=authority
+    def replay(self,records:tuple[_Record,...],*,epoch_id:str)->tuple[str,...]:
+        digests=[];cohort_digest=None;run_id=None;attempt_id=None
+        for record in records:
+            if isinstance(record,ManifestCohort):cohort_digest=record.canonical_digest
+            if isinstance(record,ShadowRun):run_id=record.run_id
+            if isinstance(record,RunAttempt):attempt_id=record.attempt_id
+            record_sequence=getattr(record,"sequence",None) if attempt_id is not None else None
+            digests.append(self._authority.append(record,epoch_id=epoch_id,cohort_digest=cohort_digest,run_id=run_id,attempt_id=attempt_id,sequence=record_sequence))
+        return tuple(digests)

--- a/newsroom/tests/test_increment9b1_shadow_epoch.py
+++ b/newsroom/tests/test_increment9b1_shadow_epoch.py
@@ -1,0 +1,521 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import FrozenInstanceError, replace
+from pathlib import Path
+
+import pytest
+
+from newsroom.authority.canonical import canonical_json_bytes
+from newsroom.authority.increment9_shadow_migrations import (
+    INCREMENT9_SHADOW_APPLICATION_ID,
+    INCREMENT9_SHADOW_MIGRATION_CHECKSUM,
+    INCREMENT9_SHADOW_SCHEMA_FINGERPRINT,
+    INCREMENT9_SHADOW_SCHEMA_VERSION,
+    Increment9ShadowMigrationError,
+    install_increment9_shadow_schema,
+    verify_increment9_shadow_schema,
+)
+from newsroom.increment9.epoch import (
+    EFFECTIVE_MANIFEST_IDENTITY_KEYS,
+    ChangeClassification,
+    Checkpoint,
+    CostRecord,
+    EffectIntent,
+    EffectKind,
+    EffectResult,
+    EffectiveManifest,
+    EpochAuthorityError,
+    EvaluationEpoch,
+    ManifestCohort,
+    RecordOutcome,
+    ReplayController,
+    RunAttempt,
+    RunKind,
+    RunOutcome,
+    ShadowEpochAuthority,
+    ShadowRun,
+    classify_manifest_change,
+    initialise_shadow_epoch_authority,
+    qualify_final_cohort,
+    validate_cohort_chain,
+)
+from newsroom.increment9.plan import INCREMENT_9_SHADOW_PLAN_DIGEST
+
+D = lambda character: "sha256:" + character * 64
+T0 = "2042-01-01T00:00:00.000000Z"
+T1 = "2042-01-01T00:01:00.000000Z"
+T2 = "2042-01-01T00:02:00.000000Z"
+T3 = "2042-01-01T00:03:00.000000Z"
+T4 = "2042-01-01T00:04:00.000000Z"
+T9 = "2042-01-29T00:00:00.000000Z"
+
+
+def _epoch() -> EvaluationEpoch:
+    return EvaluationEpoch(
+        epoch_id="epoch-9-fixture",
+        plan_digest=INCREMENT_9_SHADOW_PLAN_DIGEST,
+        shadow_scope_digest=D("1"),
+        source_portfolio_digest=D("2"),
+        prospective_universe_digest=D("3"),
+        slice_rules_digest=D("4"),
+        thresholds_digest=D("5"),
+        comparator_rules_digest=D("6"),
+        reviewer_rules_digest=D("7"),
+        budget_rules_digest=D("8"),
+        rights_rules_digest=D("9"),
+        opened_at=T0,
+        cutoff_at=T0,
+        closes_at=T9,
+    )
+
+
+def _manifest(character: str = "a", *, resolved: bool = True) -> EffectiveManifest:
+    digits = "0123456789abcdef"
+    identities = {
+        key: D(digits[(index + int(character, 16)) % 16])
+        for index, key in enumerate(sorted(EFFECTIVE_MANIFEST_IDENTITY_KEYS))
+    }
+    return EffectiveManifest(
+        manifest_id=f"effective-manifest-{character}",
+        identity_digests=identities,
+        observed_at=T0,
+        identity_resolved=resolved,
+    )
+
+
+def _cohort(
+    epoch: EvaluationEpoch | None = None,
+    manifest: EffectiveManifest | None = None,
+    **changes: object,
+) -> ManifestCohort:
+    epoch = epoch or _epoch()
+    manifest = manifest or _manifest()
+    values: dict[str, object] = {
+        "cohort_id": "cohort-1",
+        "epoch_id": epoch.epoch_id,
+        "epoch_digest": epoch.canonical_digest,
+        "manifest_digest": manifest.canonical_digest,
+        "ordinal": 1,
+        "previous_cohort_digest": None,
+        "exposure_contract_digest": D("b"),
+        "required_slices": ("HONG_KONG", "UK"),
+        "opened_at": T1,
+        "closed_at": T9,
+        "final_at_closeout": True,
+        "decision_bearing": manifest.decision_bearing,
+    }
+    values.update(changes)
+    return ManifestCohort(**values)  # type: ignore[arg-type]
+
+
+def _run(
+    epoch: EvaluationEpoch | None = None,
+    cohort: ManifestCohort | None = None,
+    manifest: EffectiveManifest | None = None,
+) -> ShadowRun:
+    epoch = epoch or _epoch()
+    manifest = manifest or _manifest()
+    cohort = cohort or _cohort(epoch, manifest)
+    return ShadowRun(
+        run_id="run-1",
+        epoch_id=epoch.epoch_id,
+        epoch_digest=epoch.canonical_digest,
+        cohort_id=cohort.cohort_id,
+        cohort_digest=cohort.canonical_digest,
+        manifest_digest=manifest.canonical_digest,
+        production_snapshot_digest=D("c"),
+        production_nonmutation_before_digest=D("d"),
+        run_kind=RunKind.PROSPECTIVE_BASELINE,
+        started_at=T2,
+        prospective=True,
+    )
+
+
+def _attempt(run: ShadowRun | None = None, **changes: object) -> RunAttempt:
+    run = run or _run()
+    values: dict[str, object] = {
+        "attempt_id": "attempt-1",
+        "run_id": run.run_id,
+        "run_digest": run.canonical_digest,
+        "ordinal": 1,
+        "previous_attempt_digest": None,
+        "started_at": T2,
+        "restart_reason": None,
+    }
+    values.update(changes)
+    return RunAttempt(**values)  # type: ignore[arg-type]
+
+
+def _intent(attempt: RunAttempt | None = None) -> EffectIntent:
+    attempt = attempt or _attempt()
+    return EffectIntent(
+        intent_id="intent-1",
+        attempt_id=attempt.attempt_id,
+        attempt_digest=attempt.canonical_digest,
+        sequence=1,
+        effect_kind=EffectKind.SOURCE_REQUEST,
+        request_digest=D("e"),
+        budget_reservation_digest=D("f"),
+        persisted_at=T3,
+    )
+
+
+def _records():
+    epoch = _epoch()
+    manifest = _manifest()
+    cohort = _cohort(epoch, manifest)
+    run = _run(epoch, cohort, manifest)
+    attempt = _attempt(run)
+    intent = _intent(attempt)
+    result = EffectResult(
+        result_id="result-1",
+        intent_id=intent.intent_id,
+        intent_digest=intent.canonical_digest,
+        response_digest=D("1"),
+        usage_digest=D("2"),
+        outcome=RecordOutcome.COMPLETE,
+        observed_valid_at=T3,
+        completed_at=T4,
+        recorded_at=T4,
+    )
+    checkpoint = Checkpoint(
+        checkpoint_id="checkpoint-1",
+        attempt_id=attempt.attempt_id,
+        attempt_digest=attempt.canonical_digest,
+        sequence=1,
+        watermark="source:1",
+        inventory_digest=D("3"),
+        ledger_digest=D("4"),
+        recorded_at=T4,
+    )
+    cost = CostRecord(
+        cost_id="cost-1",
+        attempt_id=attempt.attempt_id,
+        intent_digest=intent.canonical_digest,
+        provider="fixture",
+        input_units=10,
+        output_units=2,
+        monetary_minor_units=1,
+        storage_byte_days=0,
+        recorded_at=T4,
+    )
+    outcome = RunOutcome(
+        outcome_id="outcome-1",
+        run_id=run.run_id,
+        run_digest=run.canonical_digest,
+        attempt_digest=attempt.canonical_digest,
+        cohort_digest=cohort.canonical_digest,
+        outcome=RecordOutcome.COMPLETE,
+        evidence_inventory_digest=D("5"),
+        production_nonmutation_after_digest=D("d"),
+        decision_bearing=True,
+        recorded_at=T4,
+    )
+    return epoch, manifest, cohort, run, attempt, intent, result, checkpoint, cost, outcome
+
+
+def test_all_public_records_round_trip_exact_canonical_bytes() -> None:
+    for record in _records():
+        reconstructed = type(record).from_bytes(record.canonical_bytes)
+        assert reconstructed == record
+        assert reconstructed.canonical_digest == record.canonical_digest
+
+
+@pytest.mark.parametrize("kind", ("unknown", "duplicate", "noncanonical"))
+def test_strict_epoch_parser_rejects_unknown_duplicate_and_noncanonical(kind: str) -> None:
+    raw = _epoch().canonical_bytes
+    if kind == "unknown":
+        value = json.loads(raw)
+        value["unknown"] = True
+        raw = canonical_json_bytes(value)
+    elif kind == "duplicate":
+        raw = raw.replace(b'{"budget_rules_digest":', b'{"budget_rules_digest":null,"budget_rules_digest":', 1)
+    else:
+        raw += b"\n"
+    with pytest.raises(EpochAuthorityError):
+        EvaluationEpoch.from_bytes(raw)
+
+
+def test_epoch_is_prospective_frozen_and_chronological() -> None:
+    epoch = _epoch()
+    with pytest.raises(FrozenInstanceError):
+        epoch.epoch_id = "changed"  # type: ignore[misc]
+    with pytest.raises(EpochAuthorityError, match="prospective"):
+        replace(epoch, hindsight_changes_allowed=True)
+    with pytest.raises(EpochAuthorityError, match="chronology"):
+        replace(epoch, closes_at=epoch.cutoff_at)
+
+
+def test_effective_manifest_requires_every_exact_identity_and_resolution_is_explicit() -> None:
+    manifest = _manifest()
+    assert manifest.decision_bearing is True
+    unresolved = _manifest("b", resolved=False)
+    assert unresolved.decision_bearing is False
+    with pytest.raises(EpochAuthorityError, match="identity fields"):
+        EffectiveManifest(
+            manifest_id="broken",
+            identity_digests={"model": D("1")},
+            observed_at=T0,
+            identity_resolved=True,
+        )
+
+
+def test_change_classifier_opens_cohort_or_requires_new_epoch() -> None:
+    assert classify_manifest_change((), identities_resolved=True) is ChangeClassification.UNCHANGED
+    assert classify_manifest_change(("model",), identities_resolved=True) is ChangeClassification.COMPATIBLE_NEW_COHORT
+    assert classify_manifest_change(("thresholds",), identities_resolved=True) is ChangeClassification.INCOMPATIBLE_NEW_EPOCH
+    assert classify_manifest_change(("model",), identities_resolved=False) is ChangeClassification.UNRESOLVED_NOT_DECISION_BEARING
+    with pytest.raises(EpochAuthorityError, match="not classified"):
+        classify_manifest_change(("mystery",), identities_resolved=True)
+
+
+def test_cohorts_are_isolated_content_addressed_and_only_last_is_final() -> None:
+    epoch = _epoch()
+    first_manifest = _manifest("a")
+    second_manifest = _manifest("b")
+    first = _cohort(epoch, first_manifest, closed_at=T2, final_at_closeout=False)
+    second = _cohort(
+        epoch,
+        second_manifest,
+        cohort_id="cohort-2",
+        ordinal=2,
+        previous_cohort_digest=first.canonical_digest,
+        opened_at=T3,
+    )
+    manifests = {
+        first_manifest.canonical_digest: first_manifest,
+        second_manifest.canonical_digest: second_manifest,
+    }
+    assert validate_cohort_chain(epoch, manifests, (first, second)) == (first, second)
+    first_final = replace(first, final_at_closeout=True)
+    with pytest.raises(EpochAuthorityError, match="only the final"):
+        validate_cohort_chain(
+            epoch,
+            manifests,
+            (
+                first_final,
+                replace(
+                    second,
+                    previous_cohort_digest=first_final.canonical_digest,
+                ),
+            ),
+        )
+
+
+def test_final_cohort_qualifies_only_with_independent_complete_exposure() -> None:
+    cohort = _cohort()
+    assert qualify_final_cohort(
+        cohort,
+        observed_slice_ids=("HONG_KONG", "UK"),
+        exposure_minima_met=True,
+        complete_denominators=True,
+        unresolved_identity_count=0,
+    ) is True
+    assert qualify_final_cohort(
+        cohort,
+        observed_slice_ids=("UK",),
+        exposure_minima_met=True,
+        complete_denominators=True,
+        unresolved_identity_count=0,
+    ) is False
+    assert qualify_final_cohort(
+        cohort,
+        observed_slice_ids=("HONG_KONG", "UK"),
+        exposure_minima_met=True,
+        complete_denominators=True,
+        unresolved_identity_count=1,
+    ) is False
+
+
+def test_partial_stale_blocked_failed_and_early_stopped_cannot_be_decision_bearing() -> None:
+    records = _records()
+    complete = records[-1]
+    for outcome in (
+        RecordOutcome.PARTIAL,
+        RecordOutcome.STALE,
+        RecordOutcome.UNAVAILABLE,
+        RecordOutcome.BLOCKED,
+        RecordOutcome.FAILED,
+        RecordOutcome.EARLY_STOPPED,
+        RecordOutcome.INCONCLUSIVE,
+    ):
+        with pytest.raises(EpochAuthorityError, match="cannot be decision-bearing"):
+            replace(complete, outcome=outcome)
+
+
+def test_lost_response_and_ambiguous_effect_are_retained_explicitly() -> None:
+    intent = _intent()
+    for outcome in (RecordOutcome.LOST_RESPONSE, RecordOutcome.AMBIGUOUS_EFFECT):
+        result = EffectResult(
+            result_id=f"result-{outcome.value.lower()}",
+            intent_id=intent.intent_id,
+            intent_digest=intent.canonical_digest,
+            response_digest=None,
+            usage_digest=D("1"),
+            outcome=outcome,
+            observed_valid_at=T3,
+            completed_at=T4,
+            recorded_at=T4,
+        )
+
+    with pytest.raises(EpochAuthorityError, match="transaction time"):
+        replace(
+            EffectResult(
+                result_id="chronology",
+                intent_id=intent.intent_id,
+                intent_digest=intent.canonical_digest,
+                response_digest=D("1"),
+                usage_digest=D("1"),
+                outcome=RecordOutcome.COMPLETE,
+                observed_valid_at=T3,
+                completed_at=T4,
+                recorded_at=T4,
+            ),
+            recorded_at=T3,
+        )
+        assert result.response_digest is None
+    with pytest.raises(EpochAuthorityError, match="missing response"):
+        EffectResult(
+            result_id="bad",
+            intent_id=intent.intent_id,
+            intent_digest=intent.canonical_digest,
+            response_digest=None,
+            usage_digest=D("1"),
+            outcome=RecordOutcome.COMPLETE,
+            observed_valid_at=T3,
+            completed_at=T4,
+            recorded_at=T4,
+        )
+
+
+def test_restart_requires_exact_predecessor_and_reason() -> None:
+    first = _attempt()
+    second = _attempt(
+        attempt_id="attempt-2",
+        ordinal=2,
+        previous_attempt_digest=first.canonical_digest,
+        restart_reason="LOST_RESPONSE_RECONCILED",
+        started_at=T3,
+    )
+    assert second.previous_attempt_digest == first.canonical_digest
+    with pytest.raises(EpochAuthorityError, match="restart reason"):
+        replace(second, restart_reason=None)
+
+
+def test_standalone_schema_rejects_production_or_contaminated_database() -> None:
+    production = sqlite3.connect(":memory:", isolation_level=None)
+    production.execute("PRAGMA user_version=32")
+    with pytest.raises(Increment9ShadowMigrationError, match="production"):
+        install_increment9_shadow_schema(production)
+    contaminated = sqlite3.connect(":memory:", isolation_level=None)
+    contaminated.execute("CREATE TABLE production_authority(id TEXT)")
+    with pytest.raises(Increment9ShadowMigrationError, match="identity"):
+        install_increment9_shadow_schema(contaminated)
+
+
+def test_isolated_schema_identity_checksum_and_integrity_are_exact() -> None:
+    connection = sqlite3.connect(":memory:", isolation_level=None)
+    install_increment9_shadow_schema(connection)
+    verify_increment9_shadow_schema(connection)
+    assert connection.execute("PRAGMA application_id").fetchone()[0] == INCREMENT9_SHADOW_APPLICATION_ID
+    assert connection.execute("PRAGMA user_version").fetchone()[0] == INCREMENT9_SHADOW_SCHEMA_VERSION
+    assert INCREMENT9_SHADOW_MIGRATION_CHECKSUM.startswith("sha256:")
+    assert INCREMENT9_SHADOW_SCHEMA_FINGERPRINT.startswith("sha256:")
+    connection.execute("DROP TRIGGER immutable_shadow_epoch_records")
+    with pytest.raises(Increment9ShadowMigrationError, match="fingerprint"):
+        verify_increment9_shadow_schema(connection)
+
+
+def test_authority_enforces_persist_before_effect_and_exact_correlations() -> None:
+    connection = sqlite3.connect(":memory:", isolation_level=None)
+    authority = initialise_shadow_epoch_authority(connection)
+    epoch, manifest, cohort, run, attempt, intent, result, checkpoint, cost, outcome = _records()
+    with pytest.raises(EpochAuthorityError, match="predecessor"):
+        authority.append(result, epoch_id=epoch.epoch_id)
+    for record in (epoch, manifest, cohort, run, attempt, intent, result, checkpoint, cost, outcome):
+        authority.append(
+            record,
+            epoch_id=epoch.epoch_id,
+            cohort_digest=cohort.canonical_digest if record is not epoch else None,
+            run_id=run.run_id if record in (run, attempt, intent, result, checkpoint, cost, outcome) else None,
+            attempt_id=attempt.attempt_id if record in (attempt, intent, result, checkpoint, cost, outcome) else None,
+            sequence=getattr(record, "sequence", None),
+        )
+    assert authority.read(result.canonical_digest) == result
+    assert set(authority.inventory(epoch.epoch_id)) == {item.canonical_digest for item in _records()}
+
+
+def test_authority_records_are_immutable_retained_and_idempotency_conflicts_fail() -> None:
+    connection = sqlite3.connect(":memory:", isolation_level=None)
+    authority = initialise_shadow_epoch_authority(connection)
+    epoch = _epoch()
+    authority.append(epoch, epoch_id=epoch.epoch_id)
+    with pytest.raises(EpochAuthorityError, match="append failed"):
+        authority.append(epoch, epoch_id=epoch.epoch_id)
+    with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+        connection.execute("UPDATE shadow_epoch_records SET epoch_id='other'")
+    with pytest.raises(sqlite3.IntegrityError, match="retained"):
+        connection.execute("DELETE FROM shadow_epoch_records")
+
+
+def test_two_authority_connections_serialize_and_reject_duplicate_identity(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "increment9-shadow.sqlite3"
+    first_connection = sqlite3.connect(path, isolation_level=None)
+    first = initialise_shadow_epoch_authority(first_connection)
+    second_connection = sqlite3.connect(path, isolation_level=None)
+    second = ShadowEpochAuthority(second_connection)
+    epoch = _epoch()
+    first.append(epoch, epoch_id=epoch.epoch_id)
+    with pytest.raises(EpochAuthorityError, match="append failed"):
+        second.append(epoch, epoch_id=epoch.epoch_id)
+    assert second.read(epoch.canonical_digest) == epoch
+
+
+def test_authority_rejects_pre_cutoff_valid_time_for_prospective_result() -> None:
+    authority = initialise_shadow_epoch_authority(
+        sqlite3.connect(":memory:", isolation_level=None)
+    )
+    epoch, manifest, cohort, run, attempt, intent, result, *_ = _records()
+    for record in (epoch, manifest, cohort, run, attempt, intent):
+        authority.append(
+            record,
+            epoch_id=epoch.epoch_id,
+            cohort_digest=cohort.canonical_digest,
+            run_id=run.run_id if isinstance(record, (ShadowRun, RunAttempt, EffectIntent)) else None,
+            attempt_id=attempt.attempt_id if isinstance(record, (RunAttempt, EffectIntent)) else None,
+            sequence=getattr(record, "sequence", None),
+        )
+    with pytest.raises(EpochAuthorityError, match="prospective cutoff"):
+        authority.append(
+            replace(result, observed_valid_at="2041-12-31T23:59:59.000000Z"),
+            epoch_id=epoch.epoch_id,
+            cohort_digest=cohort.canonical_digest,
+            run_id=run.run_id,
+            attempt_id=attempt.attempt_id,
+        )
+
+
+def test_replay_controller_replays_complete_ordered_fixture_without_effect() -> None:
+    authority = initialise_shadow_epoch_authority(sqlite3.connect(":memory:", isolation_level=None))
+    records = _records()
+    controller = ReplayController(authority)
+    observed = controller.replay(records, epoch_id=records[0].epoch_id)
+    assert observed == tuple(record.canonical_digest for record in records)
+    assert controller.authorises_live_call is False
+    assert controller.authorises_external_egress is False
+    assert controller.authorises_production_mutation is False
+
+
+def test_every_record_and_authority_seam_has_no_external_effect_authority() -> None:
+    authority = initialise_shadow_epoch_authority(sqlite3.connect(":memory:", isolation_level=None))
+    for record in (*_records(), authority):
+        assert record.authorises_live_call is False
+        assert record.authorises_credentials is False
+        assert record.authorises_external_egress is False
+        assert record.authorises_spend is False
+        assert record.authorises_publication is False
+        assert record.authorises_production_mutation is False

--- a/newsroom/tests/test_increment9b1_shadow_epoch.py
+++ b/newsroom/tests/test_increment9b1_shadow_epoch.py
@@ -21,6 +21,7 @@ from newsroom.increment9.epoch import (
     EFFECTIVE_MANIFEST_IDENTITY_KEYS,
     ChangeClassification,
     Checkpoint,
+    CohortCloseout,
     CostRecord,
     EffectIntent,
     EffectKind,
@@ -39,6 +40,7 @@ from newsroom.increment9.epoch import (
     classify_manifest_change,
     initialise_shadow_epoch_authority,
     qualify_final_cohort,
+    validate_cohort_closeout,
     validate_cohort_chain,
 )
 from newsroom.increment9.plan import INCREMENT_9_SHADOW_PLAN_DIGEST
@@ -102,12 +104,32 @@ def _cohort(
         "exposure_contract_digest": D("b"),
         "required_slices": ("HONG_KONG", "UK"),
         "opened_at": T1,
-        "closed_at": T9,
-        "final_at_closeout": True,
         "decision_bearing": manifest.decision_bearing,
     }
     values.update(changes)
     return ManifestCohort(**values)  # type: ignore[arg-type]
+
+
+def _closeout(
+    epoch: EvaluationEpoch,
+    cohorts: tuple[ManifestCohort, ...],
+    **changes: object,
+) -> CohortCloseout:
+    final = cohorts[-1]
+    values: dict[str, object] = {
+        "closeout_id": "cohort-closeout-1",
+        "epoch_id": epoch.epoch_id,
+        "epoch_digest": epoch.canonical_digest,
+        "final_cohort_digest": final.canonical_digest,
+        "observed_slice_ids": final.required_slices,
+        "exposure_minima_met": True,
+        "complete_denominators": True,
+        "unresolved_identity_count": 0,
+        "qualifies": final.decision_bearing,
+        "closed_at": T9,
+    }
+    values.update(changes)
+    return CohortCloseout(**values)  # type: ignore[arg-type]
 
 
 def _run(
@@ -213,7 +235,8 @@ def _records():
         decision_bearing=True,
         recorded_at=T4,
     )
-    return epoch, manifest, cohort, run, attempt, intent, result, checkpoint, cost, outcome
+    closeout = _closeout(epoch, (cohort,))
+    return epoch, manifest, cohort, run, attempt, intent, result, checkpoint, cost, outcome, closeout
 
 
 def test_all_public_records_round_trip_exact_canonical_bytes() -> None:
@@ -275,7 +298,7 @@ def test_cohorts_are_isolated_content_addressed_and_only_last_is_final() -> None
     epoch = _epoch()
     first_manifest = _manifest("a")
     second_manifest = _manifest("b")
-    first = _cohort(epoch, first_manifest, closed_at=T2, final_at_closeout=False)
+    first = _cohort(epoch, first_manifest)
     second = _cohort(
         epoch,
         second_manifest,
@@ -289,49 +312,51 @@ def test_cohorts_are_isolated_content_addressed_and_only_last_is_final() -> None
         second_manifest.canonical_digest: second_manifest,
     }
     assert validate_cohort_chain(epoch, manifests, (first, second)) == (first, second)
-    first_final = replace(first, final_at_closeout=True)
+    first_closeout = _closeout(
+        epoch,
+        (first,),
+        final_cohort_digest=first.canonical_digest,
+        closed_at=T2,
+    )
     with pytest.raises(EpochAuthorityError, match="only the final"):
-        validate_cohort_chain(
+        validate_cohort_closeout(
             epoch,
-            manifests,
-            (
-                first_final,
-                replace(
-                    second,
-                    previous_cohort_digest=first_final.canonical_digest,
-                ),
-            ),
+            (first, second),
+            first_closeout,
         )
 
 
 def test_final_cohort_qualifies_only_with_independent_complete_exposure() -> None:
+    epoch = _epoch()
     cohort = _cohort()
+    cohorts = (cohort,)
     assert qualify_final_cohort(
-        cohort,
-        observed_slice_ids=("HONG_KONG", "UK"),
-        exposure_minima_met=True,
-        complete_denominators=True,
-        unresolved_identity_count=0,
+        epoch,
+        cohorts,
+        _closeout(epoch, cohorts),
     ) is True
-    assert qualify_final_cohort(
-        cohort,
-        observed_slice_ids=("UK",),
-        exposure_minima_met=True,
-        complete_denominators=True,
-        unresolved_identity_count=0,
-    ) is False
-    assert qualify_final_cohort(
-        cohort,
-        observed_slice_ids=("HONG_KONG", "UK"),
-        exposure_minima_met=True,
-        complete_denominators=True,
-        unresolved_identity_count=1,
-    ) is False
+    for changes in (
+        {"observed_slice_ids": ("UK",), "qualifies": False},
+        {"unresolved_identity_count": 1, "qualifies": False},
+        {"exposure_minima_met": False, "qualifies": False},
+        {"complete_denominators": False, "qualifies": False},
+    ):
+        assert qualify_final_cohort(
+            epoch,
+            cohorts,
+            _closeout(epoch, cohorts, **changes),
+        ) is False
+    with pytest.raises(EpochAuthorityError, match="qualification truth"):
+        validate_cohort_closeout(
+            epoch,
+            cohorts,
+            _closeout(epoch, cohorts, observed_slice_ids=("UK",), qualifies=True),
+        )
 
 
 def test_partial_stale_blocked_failed_and_early_stopped_cannot_be_decision_bearing() -> None:
     records = _records()
-    complete = records[-1]
+    complete = next(record for record in records if isinstance(record, RunOutcome))
     for outcome in (
         RecordOutcome.PARTIAL,
         RecordOutcome.STALE,
@@ -359,6 +384,7 @@ def test_lost_response_and_ambiguous_effect_are_retained_explicitly() -> None:
             completed_at=T4,
             recorded_at=T4,
         )
+        assert result.response_digest is None
 
     with pytest.raises(EpochAuthorityError, match="transaction time"):
         replace(
@@ -375,7 +401,6 @@ def test_lost_response_and_ambiguous_effect_are_retained_explicitly() -> None:
             ),
             recorded_at=T3,
         )
-        assert result.response_digest is None
     with pytest.raises(EpochAuthorityError, match="missing response"):
         EffectResult(
             result_id="bad",
@@ -431,20 +456,92 @@ def test_isolated_schema_identity_checksum_and_integrity_are_exact() -> None:
 def test_authority_enforces_persist_before_effect_and_exact_correlations() -> None:
     connection = sqlite3.connect(":memory:", isolation_level=None)
     authority = initialise_shadow_epoch_authority(connection)
-    epoch, manifest, cohort, run, attempt, intent, result, checkpoint, cost, outcome = _records()
+    epoch, manifest, cohort, run, attempt, intent, result, checkpoint, cost, outcome, closeout = _records()
     with pytest.raises(EpochAuthorityError, match="predecessor"):
         authority.append(result, epoch_id=epoch.epoch_id)
-    for record in (epoch, manifest, cohort, run, attempt, intent, result, checkpoint, cost, outcome):
-        authority.append(
-            record,
-            epoch_id=epoch.epoch_id,
-            cohort_digest=cohort.canonical_digest if record is not epoch else None,
-            run_id=run.run_id if record in (run, attempt, intent, result, checkpoint, cost, outcome) else None,
-            attempt_id=attempt.attempt_id if record in (attempt, intent, result, checkpoint, cost, outcome) else None,
-            sequence=getattr(record, "sequence", None),
-        )
+    for record in (epoch, manifest, cohort, run, attempt, intent, result, checkpoint, cost, outcome, closeout):
+        authority.append(record, epoch_id=epoch.epoch_id)
     assert authority.read(result.canonical_digest) == result
     assert set(authority.inventory(epoch.epoch_id)) == {item.canonical_digest for item in _records()}
+    rows = connection.execute(
+        "SELECT record_schema,cohort_digest,run_id,attempt_id,sequence "
+        "FROM shadow_epoch_records ORDER BY record_schema"
+    ).fetchall()
+    by_schema = {row[0]: row[1:] for row in rows}
+    assert by_schema[EffectIntent.schema_version] == (
+        cohort.canonical_digest,
+        run.run_id,
+        attempt.attempt_id,
+        intent.sequence,
+    )
+    assert by_schema[CohortCloseout.schema_version] == (
+        cohort.canonical_digest,
+        None,
+        None,
+        None,
+    )
+
+
+def test_authority_rejects_orphan_manifest_stale_cohort_run_and_false_decision() -> None:
+    orphan = initialise_shadow_epoch_authority(
+        sqlite3.connect(":memory:", isolation_level=None)
+    )
+    with pytest.raises(EpochAuthorityError, match="predecessor"):
+        orphan.append(_manifest(), epoch_id=_epoch().epoch_id)
+
+    authority = initialise_shadow_epoch_authority(
+        sqlite3.connect(":memory:", isolation_level=None)
+    )
+    epoch = _epoch()
+    first_manifest = _manifest("a")
+    first = _cohort(epoch, first_manifest)
+    second_manifest = _manifest("b", resolved=False)
+    second = _cohort(
+        epoch,
+        second_manifest,
+        cohort_id="cohort-2",
+        ordinal=2,
+        previous_cohort_digest=first.canonical_digest,
+        opened_at=T3,
+    )
+    for record in (epoch, first_manifest, first, second_manifest, second):
+        authority.append(record, epoch_id=epoch.epoch_id)
+    with pytest.raises(EpochAuthorityError, match="not current"):
+        authority.append(_run(epoch, first, first_manifest), epoch_id=epoch.epoch_id)
+
+    run = _run(epoch, second, second_manifest)
+    attempt = _attempt(run)
+    authority.append(run, epoch_id=epoch.epoch_id)
+    authority.append(attempt, epoch_id=epoch.epoch_id)
+    invalid = RunOutcome(
+        outcome_id="false-decision",
+        run_id=run.run_id,
+        run_digest=run.canonical_digest,
+        attempt_digest=attempt.canonical_digest,
+        cohort_digest=second.canonical_digest,
+        outcome=RecordOutcome.COMPLETE,
+        evidence_inventory_digest=D("5"),
+        production_nonmutation_after_digest=D("d"),
+        decision_bearing=True,
+        recorded_at=T4,
+    )
+    with pytest.raises(EpochAuthorityError, match="outcome binding"):
+        authority.append(invalid, epoch_id=epoch.epoch_id)
+
+
+def test_closeout_seals_epoch_and_authority_rechecks_schema_on_every_use() -> None:
+    connection = sqlite3.connect(":memory:", isolation_level=None)
+    authority = initialise_shadow_epoch_authority(connection)
+    records = _records()
+    controller = ReplayController(authority)
+    controller.replay(records, epoch_id=records[0].epoch_id)
+    with pytest.raises(EpochAuthorityError, match="already closed out"):
+        authority.append(_manifest("b"), epoch_id=records[0].epoch_id)
+    connection.execute("DROP TRIGGER immutable_shadow_epoch_records")
+    with pytest.raises(Increment9ShadowMigrationError, match="fingerprint"):
+        authority.read(records[0].canonical_digest)
+    with pytest.raises(Increment9ShadowMigrationError, match="fingerprint"):
+        authority.inventory(records[0].epoch_id)
 
 
 def test_authority_records_are_immutable_retained_and_idempotency_conflicts_fail() -> None:
@@ -481,21 +578,11 @@ def test_authority_rejects_pre_cutoff_valid_time_for_prospective_result() -> Non
     )
     epoch, manifest, cohort, run, attempt, intent, result, *_ = _records()
     for record in (epoch, manifest, cohort, run, attempt, intent):
-        authority.append(
-            record,
-            epoch_id=epoch.epoch_id,
-            cohort_digest=cohort.canonical_digest,
-            run_id=run.run_id if isinstance(record, (ShadowRun, RunAttempt, EffectIntent)) else None,
-            attempt_id=attempt.attempt_id if isinstance(record, (RunAttempt, EffectIntent)) else None,
-            sequence=getattr(record, "sequence", None),
-        )
+        authority.append(record, epoch_id=epoch.epoch_id)
     with pytest.raises(EpochAuthorityError, match="prospective cutoff"):
         authority.append(
             replace(result, observed_valid_at="2041-12-31T23:59:59.000000Z"),
             epoch_id=epoch.epoch_id,
-            cohort_digest=cohort.canonical_digest,
-            run_id=run.run_id,
-            attempt_id=attempt.attempt_id,
         )
 
 


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-9b1-491
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

## What changed

- adds immutable Evaluation Epoch, Effective Manifest, cohort, Run, Attempt, intent/result, checkpoint, cost and outcome contracts;
- implements Effective Manifest Cohorts: compatible implementation changes open a cohort; evaluation-rule changes require a new Epoch;
- records finality only in a separate immutable Cohort Closeout, which selects the last retained cohort and seals the Epoch;
- derives persistence correlation indexes from retained records rather than trusting caller-supplied metadata;
- makes unresolved identities, partial/stale/blocked/failed/early-stopped/inconclusive/lost/ambiguous outcomes non-decision-bearing;
- requires the final cohort to satisfy its own complete slices and exposure;
- enforces prospective valid-time/cutoff and transaction-time chronology;
- enforces persist-before-effect and exact request/response/usage correlation;
- adds a standalone isolated SQLite schema that rejects production or contaminated databases;
- adds immutable/retained triggers, schema fingerprint verification, bounded inventories and checked dependency reconstruction;
- adds deterministic fake/replay authority with no external effect.

## Exact identity after the single authorised rebase

- capacity prerequisite: #508 / PR #509 merged at `701c4a2ff5cac718c45a8080f6e2594e03be8a6d`;
- base: `701c4a2ff5cac718c45a8080f6e2594e03be8a6d`;
- head: `f13d2a6da268b2b016e9e5b1d21f3d0a8d20edee`;
- tree: `bc85da077a5d07fdb3101246bf88386186a426b4`;
- plan: `sha256:92510c8b3989bb25cfce187b3477a71d8909a691ad8f3b88ae4917e456e9216d`.

## Local evidence

- 61 focused dependency/authority/replay tests passed;
- source integrity PASS;
- compileall PASS;
- diff-check PASS;
- projected stable partition for this 3,901-node tree: 18/18 non-empty, exhaustive, 0 assignment movement across shared nodes.

The superseded pre-#508 run `31918289400` remains retained as a failed capacity result and was not rerun unchanged. One new exact-head gate is required.

## Non-effects

No live source/provider/model/embedding call, credential use, egress, spend, shadow campaign, Evidence Intake, publication, canary or production mutation occurred.

Tracks #491.