### PR TITLE
SDLC: stabilise 18-shard capacity partition

### DIFF
--- a/.sdlc/gates.toml
+++ b/.sdlc/gates.toml
@@ -194,7 +194,8 @@ clustering = [
 [lanes.core]
 bootstrap_once = true
 shard_count = 18
-partition = "sha256_node_id_balanced"
+partition = "sha256_node_id_stable_v1"
+max_node_count_skew_percent = 15
 workers_per_shard = 2
 distribution = "worksteal"
 max_worker_restart = 0

--- a/newsroom/tests/test_sdlc_contract.py
+++ b/newsroom/tests/test_sdlc_contract.py
@@ -79,7 +79,8 @@ def test_every_gate_lane_resolves_and_core_budget_is_below_six_minutes() -> None
     assert lanes["core"] == {
         "bootstrap_once": True,
         "shard_count": 18,
-        "partition": "sha256_node_id_balanced",
+        "partition": "sha256_node_id_stable_v1",
+        "max_node_count_skew_percent": 15,
         "workers_per_shard": 2,
         "distribution": "worksteal",
         "max_worker_restart": 0,

--- a/newsroom/tests/test_sdlc_core_worker_capacity.py
+++ b/newsroom/tests/test_sdlc_core_worker_capacity.py
@@ -666,7 +666,7 @@ assert reloaded._CORE_TESTS == ('newsroom/tests',)
     assert completed.returncode == 0, completed.stderr
 
 
-def test_core_node_partition_is_deterministic_complete_unique_and_balanced() -> None:
+def test_core_node_partition_is_deterministic_complete_unique_and_bounded() -> None:
     nodes = tuple(
         f"newsroom/tests/test_{index}.py::test_{index}" for index in range(19)
     )
@@ -681,6 +681,56 @@ def test_core_node_partition_is_deterministic_complete_unique_and_balanced() -> 
     assert tuple(sorted(flattened)) == tuple(sorted(nodes))
     assert len(flattened) == len(set(flattened))
     assert max(map(len, first)) - min(map(len, first)) == 1
+
+
+def test_core_node_partition_is_stable_when_unrelated_nodes_are_added() -> None:
+    nodes = tuple(
+        f"newsroom/tests/test_{index}.py::test_{index}" for index in range(3_600)
+    )
+    before = lane_module._core_node_shards(nodes)
+    added = "newsroom/tests/test_new.py::test_new"
+    after = lane_module._core_node_shards((*nodes, added))
+    before_assignment = {
+        node_id: index for index, shard in enumerate(before) for node_id in shard
+    }
+    after_assignment = {
+        node_id: index for index, shard in enumerate(after) for node_id in shard
+    }
+
+    assert all(
+        after_assignment[node_id] == index
+        for node_id, index in before_assignment.items()
+    )
+    assert added in after_assignment
+    removed = nodes[-1]
+    after_removal = lane_module._core_node_shards(nodes[:-1])
+    removal_assignment = {
+        node_id: index
+        for index, shard in enumerate(after_removal)
+        for node_id in shard
+    }
+    assert all(
+        removal_assignment[node_id] == index
+        for node_id, index in before_assignment.items()
+        if node_id != removed
+    )
+
+
+def test_core_node_partition_fails_closed_on_adversarial_load_skew(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class ConcentratedDigest:
+        def digest(self) -> bytes:
+            return bytes(32)
+
+    monkeypatch.setattr(
+        lane_module.hashlib, "sha256", lambda _value: ConcentratedDigest()
+    )
+    nodes = tuple(
+        f"newsroom/tests/test_{index}.py::test_{index}" for index in range(360)
+    )
+    with pytest.raises(WorkflowLaneError, match="core_node_coverage"):
+        lane_module._core_node_shards(nodes)
 
 
 def test_core_reducer_merges_exact_shard_reports_and_preserves_node_identities(

--- a/scripts/sdlc/contracts.py
+++ b/scripts/sdlc/contracts.py
@@ -223,7 +223,8 @@ def validate_contract_data(
     core = _mapping(lanes.get("core"), "lanes.core")
     if (
         core.get("shard_count") != 18
-        or core.get("partition") != "sha256_node_id_balanced"
+        or core.get("partition") != "sha256_node_id_stable_v1"
+        or core.get("max_node_count_skew_percent") != 15
         or core.get("workers_per_shard") != 2
         or core.get("distribution") != "worksteal"
         or core.get("max_worker_restart") != 0

--- a/scripts/sdlc/workflow_lane.py
+++ b/scripts/sdlc/workflow_lane.py
@@ -135,6 +135,8 @@ _CORE_NODE_INVENTORY_FILE = "node-inventory.json"
 _CORE_NODE_INVENTORY_PATH_ENV = "NEWSROOM_SDLC_CORE_NODE_INVENTORY_PATH"
 _CORE_NODE_INVENTORY_DIGEST_ENV = "NEWSROOM_SDLC_CORE_NODE_INVENTORY_DIGEST"
 _CORE_DISTRIBUTION = "worksteal"
+_CORE_PARTITION_SALT = b"newsroom-18-shard-v1\0"
+_CORE_MAX_NODE_LOAD_SKEW_PERCENT = 15
 _CORE_FRAGMENT_SCHEMA = "newsroom.sdlc.core-shard-fragment.v1"
 _CORE_SHARD_LIFECYCLE_SCHEMA = "newsroom.sdlc.core-shard-lifecycle.v1"
 _SOURCE_FRAGMENT_SCHEMA = "newsroom.sdlc.source-fragment.v1"
@@ -1087,20 +1089,54 @@ def _core_node_shards(node_ids: Sequence[str]) -> tuple[tuple[str, ...], ...]:
     inventory = tuple(sorted(node_ids))
     if not inventory or len(inventory) != len(set(inventory)):
         raise WorkflowLaneError("core_node_inventory")
-    ordered = sorted(
-        inventory,
-        key=lambda value: (hashlib.sha256(value.encode("utf-8")).digest(), value),
-    )
-    shards = tuple(
-        tuple(sorted(ordered[index::_CORE_SHARD_COUNT]))
-        for index in range(_CORE_SHARD_COUNT)
-    )
+    mutable_shards: list[list[str]] = [[] for _ in range(_CORE_SHARD_COUNT)]
+    for node_id in inventory:
+        digest = hashlib.sha256(
+            _CORE_PARTITION_SALT + node_id.encode("utf-8")
+        ).digest()
+        shard_index = int.from_bytes(digest[:8], "big") % _CORE_SHARD_COUNT
+        mutable_shards[shard_index].append(node_id)
+
+    # The complete repository inventory should populate every shard naturally.
+    # Deterministic repair keeps small synthetic inventories usable and is a
+    # no-op for the real suite, so additions do not move existing real nodes.
+    for empty_index in (
+        index for index, values in enumerate(mutable_shards) if not values
+    ):
+        donor_index = max(
+            range(_CORE_SHARD_COUNT),
+            key=lambda index: (len(mutable_shards[index]), -index),
+        )
+        if len(mutable_shards[donor_index]) <= 1:
+            raise WorkflowLaneError("core_node_coverage")
+        moved = max(
+            mutable_shards[donor_index],
+            key=lambda value: (
+                hashlib.sha256(
+                    b"empty-shard-repair\0" + value.encode("utf-8")
+                ).digest(),
+                value,
+            ),
+        )
+        mutable_shards[donor_index].remove(moved)
+        mutable_shards[empty_index].append(moved)
+
+    shards = tuple(tuple(sorted(values)) for values in mutable_shards)
     flattened = tuple(item for shard in shards for item in shard)
+    denominator = 100 * _CORE_SHARD_COUNT
+    maximum_numerator = len(inventory) * (
+        100 + _CORE_MAX_NODE_LOAD_SKEW_PERCENT
+    )
+    maximum = (maximum_numerator + denominator - 1) // denominator
+    minimum = (
+        len(inventory) * (100 - _CORE_MAX_NODE_LOAD_SKEW_PERCENT) // denominator
+    )
     if (
         any(not shard for shard in shards)
         or len(flattened) != len(set(flattened))
         or tuple(sorted(flattened)) != inventory
-        or max(map(len, shards)) - min(map(len, shards)) > 1
+        or max(map(len, shards)) > maximum
+        or min(map(len, shards)) < minimum
     ):
         raise WorkflowLaneError("core_node_coverage")
     return shards


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: sdlc-capacity-508
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

## What changed

- preserves the accepted 18 producer shards and two persistent work-stealing workers per shard;
- replaces globally shifting digest-sort/round-robin placement with `sha256_node_id_stable_v1`;
- freezes the semantic salt `newsroom-18-shard-v1`;
- keeps existing node assignments unchanged when unrelated tests are added or removed;
- enforces complete, unique, non-empty coverage and a 15% per-shard node-count skew bound;
- retains all testcase, shard and critical-path warning/hard limits unchanged;
- changes no product code, test selection, skip policy or runtime authority.

## Root cause and proof

PR #507 run `31918289400` failed shard 15 at 322.119s test execution / 329.752s lifecycle because adding nodes shifted much of the existing round-robin assignment.

On the current 3,901-node #491 inventory, the stable partition produces 18 non-empty shards sized:

`201, 197, 234, 232, 217, 222, 241, 204, 236, 217, 214, 213, 208, 190, 238, 207, 207, 223`

Across the 3,878 nodes shared with the pre-#491 inventory, assignment movement is exactly `0`.

## Exact identity

- base: `257f25c1da2c02e59db47ce2547518def8bd09e7`
- head: `459d079b7bf0bc2bb94f0a8fc7af2fc902d0eb50`
- tree: `4927a9ddc0b1cd99d6c9aa50c1f09a19f762df54`

## Local evidence

- 211 focused topology, contract, workflow, reducer and telemetry tests passed;
- complete base inventory: 3,881 unique nodes, 18/18 non-empty, exhaustive;
- #491 inventory projection: 3,901 unique nodes, 18/18 non-empty, exhaustive;
- shared-node movement after addition/removal: 0;
- source integrity PASS;
- compileall PASS;
- diff-check PASS.

## Fixed boundaries

- testcase warning/hard: 75/90s;
- shard warning/hard: 300/330s;
- critical-path warning/hard: 300/330s;
- required skips/failures/errors: 0.

No live calls, credentials, egress, spend, deployment, shadow or production effect.

Closes #508.