### PR TITLE
ci: protect Increment 9A2 readiness evidence parent

### DIFF
--- a/.github/workflows/increment9-shadow-readiness.yml
+++ b/.github/workflows/increment9-shadow-readiness.yml
@@ -22,7 +22,7 @@ jobs:
       NEO4J_INCREMENT9_IMAGE_DIGEST: neo4j@sha256:099b9f74968c123209972835417985ed2a1cc19c0422c0753a313e26a736c365
       NEWSROOM_INCREMENT9_NEO4J_URI: bolt://localhost:7687
       NEWSROOM_INCREMENT9_NEO4J_USERNAME: neo4j
-      NEWSROOM_INCREMENT9_EVIDENCE_DIR: ${{ runner.temp }}/increment9-protected-evidence
+      NEWSROOM_INCREMENT9_EVIDENCE_DIR: /tmp/increment9-protected-evidence-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/increment9-shadow-readiness.yml
+++ b/.github/workflows/increment9-shadow-readiness.yml
@@ -22,6 +22,7 @@ jobs:
       NEO4J_INCREMENT9_IMAGE_DIGEST: neo4j@sha256:099b9f74968c123209972835417985ed2a1cc19c0422c0753a313e26a736c365
       NEWSROOM_INCREMENT9_NEO4J_URI: bolt://localhost:7687
       NEWSROOM_INCREMENT9_NEO4J_USERNAME: neo4j
+      NEWSROOM_INCREMENT9_EVIDENCE_DIR: ${{ runner.temp }}/increment9-protected-evidence
 
     steps:
       - uses: actions/checkout@v4
@@ -55,6 +56,8 @@ jobs:
           umask 077
           printf 'NEWSROOM_INCREMENT9_NEO4J_PASSWORD=%s\n' "${password}" > "${credential_file}"
           chmod 600 "${credential_file}"
+          install -d -m 0700 "${NEWSROOM_INCREMENT9_EVIDENCE_DIR}"
+          test "$(stat -c '%a' "${NEWSROOM_INCREMENT9_EVIDENCE_DIR}")" = 700
           docker pull "${NEO4J_INCREMENT9_IMAGE}"
           docker image inspect "${NEO4J_INCREMENT9_IMAGE}" \
             --format '{{json .RepoDigests}}' > "${RUNNER_TEMP}/increment9-image-digests.json"
@@ -111,7 +114,7 @@ jobs:
           set -a
           source "${credential_file}"
           set +a
-          evidence="${RUNNER_TEMP}/increment9-neo4j-readiness.json"
+          evidence="${NEWSROOM_INCREMENT9_EVIDENCE_DIR}/increment9-neo4j-readiness.json"
           if test -f scripts/increment9_shadow_deployment.py; then
             uv run python scripts/increment9_shadow_deployment.py \
               neo4j --output "${evidence}"
@@ -206,7 +209,7 @@ jobs:
           observed["evidence_digest"] = "sha256:" + hashlib.sha256(
               json.dumps(observed, sort_keys=True, separators=(",", ":")).encode()
           ).hexdigest()
-          output = Path(os.environ["RUNNER_TEMP"]) / "increment9-neo4j-readiness.json"
+          output = Path(os.environ["NEWSROOM_INCREMENT9_EVIDENCE_DIR"]) / "increment9-neo4j-readiness.json"
           output.write_text(json.dumps(observed, sort_keys=True, separators=(",", ":")))
           output.chmod(0o600)
           PY
@@ -217,7 +220,8 @@ jobs:
         run: |
           set -euo pipefail
           credential_file="${RUNNER_TEMP}/increment9-neo4j.env"
-          evidence="${RUNNER_TEMP}/increment9-neo4j-readiness.json"
+          evidence="${NEWSROOM_INCREMENT9_EVIDENCE_DIR}/increment9-neo4j-readiness.json"
+          test "$(stat -c '%a' "${NEWSROOM_INCREMENT9_EVIDENCE_DIR}")" = 700
           test "$(stat -c '%a' "${credential_file}")" = 600
           test "$(stat -c '%a' "${evidence}")" = 600
           set -a
@@ -229,7 +233,7 @@ jobs:
           from pathlib import Path
           from neo4j import GraphDatabase
 
-          evidence = Path(os.environ["RUNNER_TEMP"]) / "increment9-neo4j-readiness.json"
+          evidence = Path(os.environ["NEWSROOM_INCREMENT9_EVIDENCE_DIR"]) / "increment9-neo4j-readiness.json"
           raw = evidence.read_bytes()
           value = json.loads(raw)
           assert raw == json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
@@ -277,6 +281,12 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: increment9-neo4j-5262-readiness-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.event.pull_request.head.sha || github.sha }}
-          path: ${{ runner.temp }}/increment9-neo4j-readiness.json
+          path: ${{ env.NEWSROOM_INCREMENT9_EVIDENCE_DIR }}/increment9-neo4j-readiness.json
           if-no-files-found: error
           retention-days: 30
+
+      - name: Purge protected readiness workspace
+        if: always()
+        run: |
+          rm -f "${NEWSROOM_INCREMENT9_EVIDENCE_DIR}/increment9-neo4j-readiness.json"
+          rmdir "${NEWSROOM_INCREMENT9_EVIDENCE_DIR}"

--- a/newsroom/tests/test_increment9a2_workflow_contract.py
+++ b/newsroom/tests/test_increment9a2_workflow_contract.py
@@ -36,7 +36,7 @@ def test_workflow_uses_ephemeral_masked_credentials_and_loopback_only() -> None:
         "bolt://localhost:7687",
         'rm -f "${credential_file}"',
         "test ! -e \"${RUNNER_TEMP}/increment9-neo4j.env\"",
-        'NEWSROOM_INCREMENT9_EVIDENCE_DIR: ${{ runner.temp }}/increment9-protected-evidence',
+        "NEWSROOM_INCREMENT9_EVIDENCE_DIR: /tmp/increment9-protected-evidence-${{ github.run_id }}-${{ github.run_attempt }}",
         'install -d -m 0700 "${NEWSROOM_INCREMENT9_EVIDENCE_DIR}"',
         'stat -c \'%a\' "${NEWSROOM_INCREMENT9_EVIDENCE_DIR}"',
     )

--- a/newsroom/tests/test_increment9a2_workflow_contract.py
+++ b/newsroom/tests/test_increment9a2_workflow_contract.py
@@ -36,6 +36,9 @@ def test_workflow_uses_ephemeral_masked_credentials_and_loopback_only() -> None:
         "bolt://localhost:7687",
         'rm -f "${credential_file}"',
         "test ! -e \"${RUNNER_TEMP}/increment9-neo4j.env\"",
+        'NEWSROOM_INCREMENT9_EVIDENCE_DIR: ${{ runner.temp }}/increment9-protected-evidence',
+        'install -d -m 0700 "${NEWSROOM_INCREMENT9_EVIDENCE_DIR}"',
+        'stat -c \'%a\' "${NEWSROOM_INCREMENT9_EVIDENCE_DIR}"',
     )
     for statement in required:
         assert statement in text
@@ -83,6 +86,8 @@ def test_workflow_retains_canonical_secret_free_component_evidence() -> None:
         "if: success() && steps.probe.outcome == 'success'",
         "sort_keys=True",
         "not in raw.decode()",
+        "Purge protected readiness workspace",
+        'rmdir "${NEWSROOM_INCREMENT9_EVIDENCE_DIR}"',
     )
     for statement in required:
         assert statement in text


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-9a2-native-512-protected-output
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

## Root cause

The first repository-owned #490 probe run `31921673573` failed closed because `${RUNNER_TEMP}` permits group/public traversal while the protected writer requires a private parent. The #512 bootstrap probe had written mode-0600 output directly and therefore did not exercise this parent-directory control.

## Correction

- create one dedicated mode-0700 readiness evidence directory;
- route repository and bootstrap probe outputs, verification and artifact upload through it;
- verify the directory mode before probe and verification;
- purge the protected workspace after artifact upload on every path;
- retain the unchanged mode-0600 file rule and add workflow-contract assertions.

No credential leaked, no readiness artifact was uploaded by the failed run, and the disposable Neo4j service was removed. This changes storage isolation rather than weakening it. No product/runtime, SDLC limit, campaign, provider/model, public or production authority change.

## Local evidence

- 59 workflow/SDLC contract tests passed;
- workflow YAML parsed;
- `git diff --check` passed.

Closes #512
