### PR TITLE
Increment 9B2: qualify production-equivalent shadow controller

### DIFF
--- a/docs/operations/increment-9b2-shadow-controller.md
+++ b/docs/operations/increment-9b2-shadow-controller.md
@@ -1,0 +1,161 @@
+# Increment 9B2 production-equivalent integration controller
+
+- **Status:** controller and dry-run qualification contract implemented; 9B3 remains blocked
+- **Issue:** [#492](https://github.com/fol2/newsroom/issues/492)
+- **Dependencies:** #488, #489, #490, #491 and #500
+- **Module:** `newsroom.increment9.controller`
+
+## Boundary
+
+9B2 assembles the exact integrated path using content-addressed fixtures and
+replay records inside an explicitly supplied isolated SQLite journal. It makes
+no source, provider, model or embedding request, obtains no credential, creates
+no spend and exposes no publication, Evidence Intake, canary or production
+writer adapter. A successful receipt means only
+`READY_FOR_9B3_AUTHORISATION_GATE`; the separate prospective runtime gate in
+#493 remains mandatory.
+
+The plan consumes and revalidates all predecessor authorities:
+
+- the owner-approved #488 plan and exact 9A1 Shadow Scope;
+- the 9A2 Deployment Plan, isolated deployment receipt and
+  `READY_FOR_9B2_CONTROLLER_QUALIFICATION` readiness receipt;
+- the 9B1 Evaluation Epoch, resolved Effective Manifest and current
+  decision-bearing Manifest Cohort; and
+- one non-prospective `REPLAY_QUALIFICATION` Run and first Attempt.
+
+Cross-scope, stale, unresolved, not-ready, wrong-Run, wrong-cohort, wrong
+snapshot or invalid chronology inputs fail before controller construction.
+
+## Exact integrated path
+
+The controller permits exactly this ordered stage inventory:
+
+1. `SOURCE`
+2. `DISCOVERY`
+3. `EXTRACTION`
+4. `GRAPHITI_PROPOSAL`
+5. `DETERMINISTIC_ADMISSION`
+6. `NEO4J_PROJECTION`
+7. `HYBRID_RETRIEVAL`
+8. `TRIAGE`
+9. `CANDIDATE`
+10. `HANDOFF`
+11. `EVALUATION_SINK`
+
+Every stage interface digest must equal the appropriate identity in the
+resolved Effective Manifest. Source, code, ontology, projector, retrieval,
+triage, Candidate, Handoff and Operational Profile identities therefore cannot
+be independently substituted after the plan is sealed. Adjacent stages are a
+content-addressed chain: the next request digest must equal the preceding
+response digest.
+
+Graphiti has one proposal record and no deterministic decision record. Only
+admission, triage, Candidate, Handoff and the evaluation sink carry decision
+records. The resulting evidence requires zero Graphiti/proposal authority
+commits and exactly five deterministic authority commits.
+
+## Persist-before-downstream journal
+
+Each stage supplies exact rights, purpose, credential-scope, egress, budget,
+freshness, request, response, proposal/decision, checkpoint, usage and cost
+digests. Before the stage response can be recorded, the controller appends:
+
+1. the control envelope;
+2. the budget reservation; and
+3. the request.
+
+Before the next stage starts it appends the response, any proposal or decision,
+the checkpoint, usage and cost records. Every entry carries a contiguous
+ordinal and the exact predecessor digest.
+
+`ControllerEvidenceJournal` is a dedicated, separately supplied SQLite
+authority with its own application ID and schema version. It accepts only a
+pristine database, uses `BEGIN IMMEDIATE`, stores exact canonical bytes and has
+triggers rejecting update and delete. Reopening reconstructs and verifies every
+byte, digest, ordinal and predecessor. A non-empty journal cannot be reused as
+a fresh qualification attempt. It must live in the isolated protected evidence
+area; it is not installed into or aliased with the production or 9B1 Epoch
+schema.
+
+## Controls and missing evidence
+
+Qualification requires explicit retained evidence digests for the complete
+closed control inventory:
+
+- rights, purpose, credential separation and default-deny egress;
+- budget/cost, freshness, contiguous watermark, visible gap and dead letter;
+- exact source representation, ontology/relation policy, index generation and
+  Operational Profile;
+- Graphiti proposal-only and deterministic-committer boundaries;
+- unreachable publication, dispatch, Evidence Intake and production writer
+  paths;
+- production non-mutation, kill/containment propagation, restart/replay and
+  teardown/rebuild; and
+- every predeclared production-equivalence difference and inference limit.
+
+The runner does not manufacture missing proof digests. Missing, additional or
+renamed scenario, control or production-equivalence evidence fails closed.
+The evidence bundle binds every supplied digest into canonical bytes.
+
+## Restart, duplicate, ambiguity, kill and rebuild
+
+The exact recovery inventory is:
+
+- `RESTART_REPLAY` → `RECONCILED`;
+- `DUPLICATE_REQUEST` → `DEDUPLICATED`;
+- `LOST_RESPONSE` → `BLOCKED_RECONCILED`;
+- `PARTIAL_RESPONSE` → `BLOCKED_RECONCILED`;
+- `AMBIGUOUS_EFFECT` → `BLOCKED_RECONCILED`;
+- `KILL_SWITCH_PROPAGATION` → `EARLY_STOPPED`; and
+- `TEARDOWN_REBUILD` → `REBUILT`.
+
+Lost, partial, ambiguous and early-stopped evidence retains the original
+failure. Recovery evidence is never decision-bearing and cannot convert the
+failed attempt into a pass. Every scenario requires zero public effect,
+production mutation and orphan resources.
+
+## Qualification receipt
+
+`qualify_controller` passes only when all of the following remain true:
+
+- the exact plan, stage/interface inventory and stage content chain match;
+- the durable ledger has exact kinds, payloads, timestamps, ordinals and
+  predecessor digests;
+- every required scenario and control passes with complete evidence;
+- all OD-013 differences and inference limits are retained;
+- the production before/after digest is byte-identical;
+- Graphiti has no commit authority and only the five deterministic stages
+  commit decisions;
+- source/provider requests, credentials, gross money, decision-bearing cases,
+  public effects, production mutations and Evidence Intake all remain zero;
+- teardown/rebuild completes with no orphan; and
+- the bundle is sealed inside the plan window.
+
+Missing or prohibited evidence yields `NOT_READY` with
+`CONTROLLER_EVIDENCE_INCOMPLETE_OR_FAILED`; it never becomes an optimistic
+pass. Even a ready receipt records `runtime_campaign_authority_still_required`
+and `campaign_started=false`.
+
+## Production-equivalence and actual-service proof
+
+The plan retains every material and non-material OD-013 difference and its
+inference limit. Qualification is component-scoped: it makes no traffic-scale,
+high-availability, production-identity or untested credential inference.
+
+#490's exact-main readiness receipt is a required predecessor. The final #492
+gate also re-runs the dedicated Neo4j 5.26.2 workflow on the exact controller
+head using workflow dispatch, so the retained actual-service proof cannot be
+silently inherited from an older tree. This is still an isolated readiness
+probe, not prospective campaign evidence.
+
+## Handoff
+
+A merged #492 closes only controller qualification. #493 may begin only after:
+
+- the exact #488–#492 dependencies remain current on one `main`;
+- the Effective Manifest identities, source rights/licences and budgets remain
+  current;
+- the frozen Epoch/Run authority admits a prospective baseline Run;
+- the phase gate records the conditional owner execution authority; and
+- no human emergency stop or deterministic veto is active.

--- a/docs/operations/increment-9b2-shadow-controller.md
+++ b/docs/operations/increment-9b2-shadow-controller.md
@@ -71,12 +71,13 @@ ordinal and the exact predecessor digest.
 
 `ControllerEvidenceJournal` is a dedicated, separately supplied SQLite
 authority with its own application ID and schema version. It accepts only a
-pristine database, uses `BEGIN IMMEDIATE`, stores exact canonical bytes and has
-triggers rejecting update and delete. Reopening reconstructs and verifies every
-byte, digest, ordinal and predecessor. A non-empty journal cannot be reused as
-a fresh qualification attempt. It must live in the isolated protected evidence
-area; it is not installed into or aliased with the production or 9B1 Epoch
-schema.
+pristine database, verifies the exact table/constraint/trigger definitions,
+uses `BEGIN IMMEDIATE`, stores exact canonical bytes and has triggers rejecting
+update and delete. Reopening reconstructs and verifies every byte, digest,
+ordinal and predecessor. A same-name lookalike schema fails closed. A non-empty
+journal cannot be reused as a fresh qualification attempt. It must live in the
+isolated protected evidence area; it is not installed into or aliased with the
+production or 9B1 Epoch schema.
 
 ## Controls and missing evidence
 

--- a/newsroom/increment9/controller.py
+++ b/newsroom/increment9/controller.py
@@ -1,0 +1,1394 @@
+"""Bounded Increment 9B2 integration-controller qualification.
+
+The controller in this module executes canonical fixture/replay records only.  It
+has no credential, network, provider, publication, Evidence Intake or production
+writer capability and cannot start the 9B3 prospective campaign.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from types import MappingProxyType
+from typing import ClassVar, Mapping, Self
+
+from newsroom.authority.canonical import (
+    CanonicalizationError,
+    canonical_json_bytes,
+    digest_bytes,
+    validate_sha256_digest,
+)
+from newsroom.increment9.deployment import (
+    DeploymentPlan,
+    DeploymentReadinessReceipt,
+    IsolatedDeploymentReceipt,
+    ReadinessDisposition,
+)
+from newsroom.increment9.epoch import (
+    EFFECTIVE_MANIFEST_IDENTITY_KEYS,
+    EffectiveManifest,
+    EvaluationEpoch,
+    ManifestCohort,
+    RunAttempt,
+    RunKind,
+    ShadowRun,
+)
+from newsroom.increment9.plan import INCREMENT_9_SHADOW_PLAN_DIGEST
+from newsroom.increment9.shadow_contracts import ShadowScope
+
+MAX_RECORD_BYTES = 4_194_304
+CONTROLLER_JOURNAL_APPLICATION_ID = 0x49394232
+CONTROLLER_JOURNAL_SCHEMA_VERSION = 1
+_TOKEN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:/\-]{0,255}\Z")
+_UTC = re.compile(
+    r"[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T"
+    r"(?:[01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]\.[0-9]{6}Z\Z"
+)
+
+
+class ControllerError(ValueError):
+    """Controller qualification input or evidence differs from authority."""
+
+
+class ControllerStage(StrEnum):
+    SOURCE = "SOURCE"
+    DISCOVERY = "DISCOVERY"
+    EXTRACTION = "EXTRACTION"
+    GRAPHITI_PROPOSAL = "GRAPHITI_PROPOSAL"
+    DETERMINISTIC_ADMISSION = "DETERMINISTIC_ADMISSION"
+    NEO4J_PROJECTION = "NEO4J_PROJECTION"
+    HYBRID_RETRIEVAL = "HYBRID_RETRIEVAL"
+    TRIAGE = "TRIAGE"
+    CANDIDATE = "CANDIDATE"
+    HANDOFF = "HANDOFF"
+    EVALUATION_SINK = "EVALUATION_SINK"
+
+
+CONTROLLER_STAGES = tuple(ControllerStage)
+STAGE_MANIFEST_DIMENSIONS: Mapping[ControllerStage, str] = MappingProxyType(
+    {
+        ControllerStage.SOURCE: "source",
+        ControllerStage.DISCOVERY: "code",
+        ControllerStage.EXTRACTION: "code",
+        ControllerStage.GRAPHITI_PROPOSAL: "code",
+        ControllerStage.DETERMINISTIC_ADMISSION: "ontology",
+        ControllerStage.NEO4J_PROJECTION: "projector",
+        ControllerStage.HYBRID_RETRIEVAL: "retrieval",
+        ControllerStage.TRIAGE: "triage",
+        ControllerStage.CANDIDATE: "candidate",
+        ControllerStage.HANDOFF: "handoff",
+        ControllerStage.EVALUATION_SINK: "operational_profile",
+    }
+)
+_PROPOSAL_STAGES = frozenset({ControllerStage.GRAPHITI_PROPOSAL})
+_DECISION_STAGES = frozenset(
+    {
+        ControllerStage.DETERMINISTIC_ADMISSION,
+        ControllerStage.TRIAGE,
+        ControllerStage.CANDIDATE,
+        ControllerStage.HANDOFF,
+        ControllerStage.EVALUATION_SINK,
+    }
+)
+
+
+class LedgerKind(StrEnum):
+    CONTROL_ENVELOPE = "CONTROL_ENVELOPE"
+    BUDGET_RESERVATION = "BUDGET_RESERVATION"
+    REQUEST = "REQUEST"
+    RESPONSE = "RESPONSE"
+    PROPOSAL = "PROPOSAL"
+    DECISION = "DECISION"
+    CHECKPOINT = "CHECKPOINT"
+    USAGE = "USAGE"
+    COST = "COST"
+
+
+class RecoveryScenario(StrEnum):
+    RESTART_REPLAY = "RESTART_REPLAY"
+    DUPLICATE_REQUEST = "DUPLICATE_REQUEST"
+    LOST_RESPONSE = "LOST_RESPONSE"
+    PARTIAL_RESPONSE = "PARTIAL_RESPONSE"
+    AMBIGUOUS_EFFECT = "AMBIGUOUS_EFFECT"
+    KILL_SWITCH_PROPAGATION = "KILL_SWITCH_PROPAGATION"
+    TEARDOWN_REBUILD = "TEARDOWN_REBUILD"
+
+
+RECOVERY_SCENARIOS = tuple(RecoveryScenario)
+
+
+class ScenarioOutcome(StrEnum):
+    RECONCILED = "RECONCILED"
+    DEDUPLICATED = "DEDUPLICATED"
+    BLOCKED_RECONCILED = "BLOCKED_RECONCILED"
+    EARLY_STOPPED = "EARLY_STOPPED"
+    REBUILT = "REBUILT"
+
+
+_SCENARIO_OUTCOMES: Mapping[RecoveryScenario, ScenarioOutcome] = MappingProxyType(
+    {
+        RecoveryScenario.RESTART_REPLAY: ScenarioOutcome.RECONCILED,
+        RecoveryScenario.DUPLICATE_REQUEST: ScenarioOutcome.DEDUPLICATED,
+        RecoveryScenario.LOST_RESPONSE: ScenarioOutcome.BLOCKED_RECONCILED,
+        RecoveryScenario.PARTIAL_RESPONSE: ScenarioOutcome.BLOCKED_RECONCILED,
+        RecoveryScenario.AMBIGUOUS_EFFECT: ScenarioOutcome.BLOCKED_RECONCILED,
+        RecoveryScenario.KILL_SWITCH_PROPAGATION: ScenarioOutcome.EARLY_STOPPED,
+        RecoveryScenario.TEARDOWN_REBUILD: ScenarioOutcome.REBUILT,
+    }
+)
+
+
+class CheckOutcome(StrEnum):
+    PASS = "PASS"
+    FAIL = "FAIL"
+
+
+CHECK_IDS = (
+    "RIGHTS_CURRENT",
+    "PURPOSE_BOUND",
+    "CREDENTIAL_SEPARATION",
+    "EGRESS_DEFAULT_DENY",
+    "BUDGET_AND_COST_LEDGER",
+    "FRESHNESS_BOUND",
+    "WATERMARK_CONTIGUOUS",
+    "GAP_VISIBLE",
+    "DEAD_LETTER_VISIBLE",
+    "SOURCE_REPRESENTATION_EXACT",
+    "ONTOLOGY_RELATION_POLICY_EXACT",
+    "INDEX_GENERATION_EXACT",
+    "OPERATIONAL_PROFILE_EXACT",
+    "GRAPHITI_PROPOSAL_ONLY",
+    "DETERMINISTIC_AUTHORITIES_SOLE_COMMITTERS",
+    "PROHIBITED_PATHS_UNREACHABLE",
+    "PRODUCTION_NONMUTATION",
+    "KILL_AND_CONTAINMENT_PROPAGATED",
+    "RESTART_REPLAY_RECONCILED",
+    "TEARDOWN_REBUILD_FROM_AUTHORITY",
+    "PRODUCTION_EQUIVALENCE_DIFFERENCES_RETAINED",
+)
+
+
+class ControllerQualificationDisposition(StrEnum):
+    READY_FOR_9B3_AUTHORISATION_GATE = "READY_FOR_9B3_AUTHORISATION_GATE"
+    NOT_READY = "NOT_READY"
+
+
+class _NoRuntimeAuthority:
+    authorises_live_call = False
+    authorises_credentials = False
+    authorises_external_egress = False
+    authorises_spend = False
+    authorises_publication = False
+    authorises_evidence_intake = False
+    authorises_canary = False
+    authorises_production_mutation = False
+    authorises_production_activation = False
+    authorises_decision_bearing_campaign = False
+
+
+def _pairs(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if type(key) is not str or key in result:
+            raise ControllerError("controller JSON names are invalid or duplicated")
+        result[key] = value
+    return result
+
+
+def _text(value: object, field: str, maximum: int = 2048) -> str:
+    if (
+        type(value) is not str
+        or not value
+        or len(value) > maximum
+        or any(ord(character) < 0x20 for character in value)
+    ):
+        raise ControllerError(f"{field} text differs")
+    return value
+
+
+def _token(value: object, field: str) -> str:
+    value = _text(value, field, 256)
+    if not _TOKEN.fullmatch(value):
+        raise ControllerError(f"{field} token differs")
+    return value
+
+
+def _digest(value: object, field: str) -> str:
+    if type(value) is not str:
+        raise ControllerError(f"{field} digest differs")
+    try:
+        validate_sha256_digest(value)
+    except (TypeError, ValueError) as exc:
+        raise ControllerError(f"{field} digest differs") from exc
+    return value
+
+
+def _timestamp(value: object, field: str) -> str:
+    value = _text(value, field, 64)
+    if not _UTC.fullmatch(value):
+        raise ControllerError(f"{field} timestamp differs")
+    try:
+        datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=UTC)
+    except ValueError as exc:
+        raise ControllerError(f"{field} timestamp differs") from exc
+    return value
+
+
+def _instant(value: str) -> datetime:
+    return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=UTC)
+
+
+def _integer(value: object, field: str, *, minimum: int = 0) -> int:
+    if type(value) is not int or value < minimum:
+        raise ControllerError(f"{field} integer differs")
+    return value
+
+
+def _boolean(value: object, field: str) -> bool:
+    if type(value) is not bool:
+        raise ControllerError(f"{field} boolean differs")
+    return value
+
+
+def _enum[T: StrEnum](kind: type[T], value: object, field: str) -> T:
+    if isinstance(value, kind):
+        return value
+    if type(value) is not str:
+        raise ControllerError(f"{field} enum differs")
+    try:
+        return kind(value)
+    except ValueError as exc:
+        raise ControllerError(f"{field} enum differs") from exc
+
+
+def _mapping(value: object, fields: frozenset[str], field: str) -> dict[str, object]:
+    if type(value) is not dict or set(value) != fields:
+        raise ControllerError(f"{field} fields differ")
+    return dict(value)
+
+
+def _digest_mapping(
+    value: object, expected_keys: tuple[str, ...], field: str
+) -> Mapping[str, str]:
+    if not isinstance(value, Mapping) or set(value) != set(expected_keys):
+        raise ControllerError(f"{field} fields differ")
+    return MappingProxyType(
+        {key: _digest(value[key], f"{field}.{key}") for key in expected_keys}
+    )
+
+
+def _document(raw: bytes, schema: str, fields: frozenset[str]) -> dict[str, object]:
+    if type(raw) is not bytes or not raw or len(raw) > MAX_RECORD_BYTES:
+        raise ControllerError("controller record bytes are not bounded")
+    try:
+        value = json.loads(raw.decode("utf-8"), object_pairs_hook=_pairs)
+        canonical = canonical_json_bytes(value)
+    except ControllerError:
+        raise
+    except (UnicodeError, json.JSONDecodeError, CanonicalizationError, RecursionError) as exc:
+        raise ControllerError("controller record bytes are invalid") from exc
+    if canonical != raw:
+        raise ControllerError("controller record bytes must be exact canonical JSON")
+    value = _mapping(value, fields | {"schema_version"}, "controller record")
+    if value.pop("schema_version") != schema:
+        raise ControllerError("controller record schema differs")
+    return value
+
+
+class _Record(_NoRuntimeAuthority):
+    schema_version: ClassVar[str]
+
+    def primitive(self) -> dict[str, object]:
+        raise NotImplementedError
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return canonical_json_bytes(self.primitive())
+
+    @property
+    def canonical_digest(self) -> str:
+        return digest_bytes(self.canonical_bytes)
+
+
+@dataclass(frozen=True, slots=True)
+class ControllerQualificationPlan(_Record):
+    schema_version: ClassVar[str] = "newsroom.increment9.controller-qualification-plan.v1"
+    qualification_id: str
+    owner_plan_digest: str
+    scope_digest: str
+    shadow_manifest_digest: str
+    deployment_plan_digest: str
+    deployment_readiness_receipt_digest: str
+    isolated_deployment_receipt_digest: str
+    epoch_digest: str
+    effective_manifest_digest: str
+    cohort_digest: str
+    run_digest: str
+    attempt_digest: str
+    production_snapshot_digest: str
+    production_nonmutation_before_digest: str
+    stage_interface_digests: Mapping[str, str]
+    effective_identity_digests: Mapping[str, str]
+    production_difference_ids: tuple[str, ...]
+    inference_limits: Mapping[str, str]
+    run_kind: RunKind
+    created_at: str
+    expires_at: str
+    fixture_replay_only: bool = True
+    campaign_started: bool = False
+
+    def __post_init__(self) -> None:
+        _token(self.qualification_id, "qualification_id")
+        for field in (
+            "owner_plan_digest",
+            "scope_digest",
+            "shadow_manifest_digest",
+            "deployment_plan_digest",
+            "deployment_readiness_receipt_digest",
+            "isolated_deployment_receipt_digest",
+            "epoch_digest",
+            "effective_manifest_digest",
+            "cohort_digest",
+            "run_digest",
+            "attempt_digest",
+            "production_snapshot_digest",
+            "production_nonmutation_before_digest",
+        ):
+            _digest(getattr(self, field), field)
+        if self.owner_plan_digest != INCREMENT_9_SHADOW_PLAN_DIGEST:
+            raise ControllerError("owner plan digest differs")
+        stage_keys = tuple(str(stage) for stage in CONTROLLER_STAGES)
+        object.__setattr__(
+            self,
+            "stage_interface_digests",
+            _digest_mapping(self.stage_interface_digests, stage_keys, "stage_interface_digests"),
+        )
+        identity_keys = tuple(sorted(EFFECTIVE_MANIFEST_IDENTITY_KEYS))
+        if set(self.effective_identity_digests) != set(identity_keys):
+            raise ControllerError("effective identity fields differ")
+        object.__setattr__(
+            self,
+            "effective_identity_digests",
+            _digest_mapping(self.effective_identity_digests, identity_keys, "effective_identity_digests"),
+        )
+        if any(
+            self.stage_interface_digests[str(stage)]
+            != self.effective_identity_digests[STAGE_MANIFEST_DIMENSIONS[stage]]
+            for stage in CONTROLLER_STAGES
+        ):
+            raise ControllerError("stage interface does not bind the Effective Manifest")
+        if (
+            type(self.production_difference_ids) is not tuple
+            or not self.production_difference_ids
+            or len(set(self.production_difference_ids)) != len(self.production_difference_ids)
+        ):
+            raise ControllerError("production difference inventory differs")
+        differences = tuple(_token(item, "production_difference_id") for item in self.production_difference_ids)
+        if tuple(sorted(differences)) != differences:
+            raise ControllerError("production difference inventory differs")
+        object.__setattr__(self, "production_difference_ids", differences)
+        if not isinstance(self.inference_limits, Mapping) or tuple(self.inference_limits) != differences:
+            raise ControllerError("inference limit inventory differs")
+        object.__setattr__(
+            self,
+            "inference_limits",
+            MappingProxyType({key: _token(self.inference_limits[key], f"inference_limits.{key}") for key in differences}),
+        )
+        object.__setattr__(self, "run_kind", _enum(RunKind, self.run_kind, "run_kind"))
+        if self.run_kind is not RunKind.REPLAY_QUALIFICATION:
+            raise ControllerError("9B2 requires a replay qualification Run")
+        _timestamp(self.created_at, "created_at")
+        _timestamp(self.expires_at, "expires_at")
+        if _instant(self.created_at) >= _instant(self.expires_at):
+            raise ControllerError("controller plan chronology differs")
+        if self.fixture_replay_only is not True or self.campaign_started is not False:
+            raise ControllerError("controller plan runtime boundary differs")
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        qualification_id: str,
+        scope: ShadowScope,
+        deployment_plan: DeploymentPlan,
+        readiness_receipt: DeploymentReadinessReceipt,
+        isolated_deployment_receipt: IsolatedDeploymentReceipt,
+        epoch: EvaluationEpoch,
+        effective_manifest: EffectiveManifest,
+        cohort: ManifestCohort,
+        run: ShadowRun,
+        attempt: RunAttempt,
+        stage_interface_digests: Mapping[ControllerStage | str, str],
+        created_at: str,
+        expires_at: str,
+    ) -> Self:
+        if type(scope) is not ShadowScope or type(deployment_plan) is not DeploymentPlan:
+            raise ControllerError("controller predecessor type differs")
+        if deployment_plan.scope_digest != scope.canonical_digest:
+            raise ControllerError("controller scope binding differs")
+        if (
+            type(readiness_receipt) is not DeploymentReadinessReceipt
+            or readiness_receipt.disposition
+            is not ReadinessDisposition.READY_FOR_9B2_CONTROLLER_QUALIFICATION
+            or readiness_receipt.deployment_plan_digest != deployment_plan.canonical_digest
+            or not readiness_receipt.production_nonmutation_proved
+            or not readiness_receipt.teardown_complete
+        ):
+            raise ControllerError("deployment readiness binding differs")
+        if (
+            type(isolated_deployment_receipt) is not IsolatedDeploymentReceipt
+            or isolated_deployment_receipt.deployment_plan_digest
+            != deployment_plan.canonical_digest
+            or isolated_deployment_receipt.production_snapshot_digest
+            != deployment_plan.production_snapshot_digest
+        ):
+            raise ControllerError("isolated deployment receipt binding differs")
+        if (
+            type(epoch) is not EvaluationEpoch
+            or epoch.plan_digest != deployment_plan.owner_plan_digest
+            or epoch.shadow_scope_digest != scope.canonical_digest
+        ):
+            raise ControllerError("Epoch binding differs")
+        if type(effective_manifest) is not EffectiveManifest or not effective_manifest.identity_resolved:
+            raise ControllerError("Effective Manifest identities are not resolved")
+        if (
+            type(cohort) is not ManifestCohort
+            or cohort.epoch_digest != epoch.canonical_digest
+            or cohort.manifest_digest != effective_manifest.canonical_digest
+            or not cohort.decision_bearing
+        ):
+            raise ControllerError("Manifest Cohort binding differs")
+        if (
+            type(run) is not ShadowRun
+            or run.run_kind is not RunKind.REPLAY_QUALIFICATION
+            or run.prospective
+            or run.epoch_digest != epoch.canonical_digest
+            or run.cohort_digest != cohort.canonical_digest
+            or run.manifest_digest != effective_manifest.canonical_digest
+            or run.production_snapshot_digest != deployment_plan.production_snapshot_digest
+        ):
+            raise ControllerError("9B2 replay Run binding differs")
+        if (
+            type(attempt) is not RunAttempt
+            or attempt.run_digest != run.canonical_digest
+            or attempt.run_id != run.run_id
+            or attempt.ordinal != 1
+        ):
+            raise ControllerError("9B2 Attempt binding differs")
+        created = _instant(_timestamp(created_at, "created_at"))
+        expiry = _instant(_timestamp(expires_at, "expires_at"))
+        if (
+            created < _instant(readiness_receipt.completed_at)
+            or created < _instant(isolated_deployment_receipt.created_at)
+            or created != _instant(run.started_at)
+            or created != _instant(attempt.started_at)
+            or expiry > _instant(deployment_plan.expires_at)
+            or expiry > _instant(epoch.closes_at)
+        ):
+            raise ControllerError("controller predecessor chronology differs")
+        stage_values = {str(key): value for key, value in stage_interface_digests.items()}
+        expected_stage_values = {
+            str(stage): effective_manifest.identity_digests[
+                STAGE_MANIFEST_DIMENSIONS[stage]
+            ]
+            for stage in CONTROLLER_STAGES
+        }
+        if stage_values != expected_stage_values:
+            raise ControllerError("stage interface does not bind the Effective Manifest")
+        differences = tuple(sorted(scope.production_differences, key=lambda item: item.difference_id))
+        return cls(
+            qualification_id=qualification_id,
+            owner_plan_digest=deployment_plan.owner_plan_digest,
+            scope_digest=scope.canonical_digest,
+            shadow_manifest_digest=deployment_plan.manifest_digest,
+            deployment_plan_digest=deployment_plan.canonical_digest,
+            deployment_readiness_receipt_digest=readiness_receipt.canonical_digest,
+            isolated_deployment_receipt_digest=isolated_deployment_receipt.canonical_digest,
+            epoch_digest=epoch.canonical_digest,
+            effective_manifest_digest=effective_manifest.canonical_digest,
+            cohort_digest=cohort.canonical_digest,
+            run_digest=run.canonical_digest,
+            attempt_digest=attempt.canonical_digest,
+            production_snapshot_digest=deployment_plan.production_snapshot_digest,
+            production_nonmutation_before_digest=run.production_nonmutation_before_digest,
+            stage_interface_digests=stage_values,
+            effective_identity_digests=effective_manifest.identity_digests,
+            production_difference_ids=tuple(item.difference_id for item in differences),
+            inference_limits={item.difference_id: item.inference_limit for item in differences},
+            run_kind=run.run_kind,
+            created_at=created_at,
+            expires_at=expires_at,
+        )
+
+    def primitive(self) -> dict[str, object]:
+        return {
+            "attempt_digest": self.attempt_digest,
+            "campaign_started": self.campaign_started,
+            "cohort_digest": self.cohort_digest,
+            "created_at": self.created_at,
+            "deployment_plan_digest": self.deployment_plan_digest,
+            "deployment_readiness_receipt_digest": self.deployment_readiness_receipt_digest,
+            "effective_identity_digests": dict(self.effective_identity_digests),
+            "effective_manifest_digest": self.effective_manifest_digest,
+            "epoch_digest": self.epoch_digest,
+            "expires_at": self.expires_at,
+            "fixture_replay_only": self.fixture_replay_only,
+            "inference_limits": dict(self.inference_limits),
+            "isolated_deployment_receipt_digest": self.isolated_deployment_receipt_digest,
+            "owner_plan_digest": self.owner_plan_digest,
+            "production_difference_ids": list(self.production_difference_ids),
+            "production_nonmutation_before_digest": self.production_nonmutation_before_digest,
+            "production_snapshot_digest": self.production_snapshot_digest,
+            "qualification_id": self.qualification_id,
+            "run_digest": self.run_digest,
+            "run_kind": str(self.run_kind),
+            "schema_version": self.schema_version,
+            "scope_digest": self.scope_digest,
+            "shadow_manifest_digest": self.shadow_manifest_digest,
+            "stage_interface_digests": dict(self.stage_interface_digests),
+        }
+
+    @classmethod
+    def from_bytes(cls, raw: bytes) -> Self:
+        fields = frozenset(name for name in cls.__dataclass_fields__ if name != "schema_version")
+        value = _document(raw, cls.schema_version, fields)
+        value["production_difference_ids"] = tuple(value["production_difference_ids"])
+        value["run_kind"] = _enum(RunKind, value["run_kind"], "run_kind")
+        return cls(**value)  # type: ignore[arg-type]
+
+
+@dataclass(frozen=True, slots=True)
+class StageFixture(_NoRuntimeAuthority):
+    stage: ControllerStage
+    target_interface_digest: str
+    rights_receipt_digest: str
+    purpose_digest: str
+    credential_scope_digest: str
+    egress_receipt_digest: str
+    budget_reservation_digest: str
+    freshness_digest: str
+    request_digest: str
+    response_digest: str
+    proposal_digest: str | None
+    decision_digest: str | None
+    checkpoint_digest: str
+    usage_digest: str
+    cost_digest: str
+    watermark: str
+    started_at: str
+    completed_at: str
+    deterministic_replay: bool = True
+    outcome: str = "COMPLETE"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "stage", _enum(ControllerStage, self.stage, "stage"))
+        for field in (
+            "target_interface_digest",
+            "rights_receipt_digest",
+            "purpose_digest",
+            "credential_scope_digest",
+            "egress_receipt_digest",
+            "budget_reservation_digest",
+            "freshness_digest",
+            "request_digest",
+            "response_digest",
+            "checkpoint_digest",
+            "usage_digest",
+            "cost_digest",
+        ):
+            _digest(getattr(self, field), field)
+        if (self.proposal_digest is not None) != (self.stage in _PROPOSAL_STAGES):
+            raise ControllerError("proposal authority boundary differs")
+        if self.proposal_digest is not None:
+            _digest(self.proposal_digest, "proposal_digest")
+        if (self.decision_digest is not None) != (self.stage in _DECISION_STAGES):
+            raise ControllerError("deterministic decision boundary differs")
+        if self.decision_digest is not None:
+            _digest(self.decision_digest, "decision_digest")
+        _token(self.watermark, "watermark")
+        _timestamp(self.started_at, "started_at")
+        _timestamp(self.completed_at, "completed_at")
+        if _instant(self.started_at) > _instant(self.completed_at):
+            raise ControllerError("stage chronology differs")
+        if self.deterministic_replay is not True or self.outcome != "COMPLETE":
+            raise ControllerError("stage fixture outcome differs")
+
+    def primitive(self) -> dict[str, object]:
+        return {
+            "budget_reservation_digest": self.budget_reservation_digest,
+            "checkpoint_digest": self.checkpoint_digest,
+            "completed_at": self.completed_at,
+            "cost_digest": self.cost_digest,
+            "credential_scope_digest": self.credential_scope_digest,
+            "decision_digest": self.decision_digest,
+            "deterministic_replay": self.deterministic_replay,
+            "egress_receipt_digest": self.egress_receipt_digest,
+            "freshness_digest": self.freshness_digest,
+            "outcome": self.outcome,
+            "proposal_digest": self.proposal_digest,
+            "purpose_digest": self.purpose_digest,
+            "request_digest": self.request_digest,
+            "response_digest": self.response_digest,
+            "rights_receipt_digest": self.rights_receipt_digest,
+            "stage": str(self.stage),
+            "started_at": self.started_at,
+            "target_interface_digest": self.target_interface_digest,
+            "usage_digest": self.usage_digest,
+            "watermark": self.watermark,
+        }
+
+    @classmethod
+    def from_primitive(cls, value: object) -> Self:
+        raw = _mapping(value, frozenset(cls.__dataclass_fields__), "stage fixture")
+        raw["stage"] = _enum(ControllerStage, raw["stage"], "stage")
+        return cls(**raw)  # type: ignore[arg-type]
+
+    @property
+    def control_envelope_digest(self) -> str:
+        return digest_bytes(
+            canonical_json_bytes(
+                {
+                    "budget_reservation_digest": self.budget_reservation_digest,
+                    "credential_scope_digest": self.credential_scope_digest,
+                    "egress_receipt_digest": self.egress_receipt_digest,
+                    "freshness_digest": self.freshness_digest,
+                    "purpose_digest": self.purpose_digest,
+                    "request_digest": self.request_digest,
+                    "rights_receipt_digest": self.rights_receipt_digest,
+                    "stage": str(self.stage),
+                }
+            )
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ControllerLedgerEntry(_NoRuntimeAuthority):
+    ordinal: int
+    stage: ControllerStage
+    kind: LedgerKind
+    payload_digest: str
+    previous_entry_digest: str | None
+    persisted_at: str
+
+    def __post_init__(self) -> None:
+        _integer(self.ordinal, "ordinal", minimum=1)
+        object.__setattr__(self, "stage", _enum(ControllerStage, self.stage, "stage"))
+        object.__setattr__(self, "kind", _enum(LedgerKind, self.kind, "kind"))
+        _digest(self.payload_digest, "payload_digest")
+        if (self.ordinal == 1) != (self.previous_entry_digest is None):
+            raise ControllerError("ledger predecessor shape differs")
+        if self.previous_entry_digest is not None:
+            _digest(self.previous_entry_digest, "previous_entry_digest")
+        _timestamp(self.persisted_at, "persisted_at")
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return canonical_json_bytes(self.primitive())
+
+    @property
+    def canonical_digest(self) -> str:
+        return digest_bytes(self.canonical_bytes)
+
+    def primitive(self) -> dict[str, object]:
+        return {
+            "kind": str(self.kind),
+            "ordinal": self.ordinal,
+            "payload_digest": self.payload_digest,
+            "persisted_at": self.persisted_at,
+            "previous_entry_digest": self.previous_entry_digest,
+            "stage": str(self.stage),
+        }
+
+    @classmethod
+    def from_primitive(cls, value: object) -> Self:
+        raw = _mapping(value, frozenset(cls.__dataclass_fields__), "ledger entry")
+        raw["stage"] = _enum(ControllerStage, raw["stage"], "stage")
+        raw["kind"] = _enum(LedgerKind, raw["kind"], "kind")
+        return cls(**raw)  # type: ignore[arg-type]
+
+
+_JOURNAL_SCHEMA = """
+CREATE TABLE controller_ledger (
+    ordinal INTEGER PRIMARY KEY CHECK (ordinal > 0),
+    entry_digest TEXT NOT NULL UNIQUE,
+    entry_bytes BLOB NOT NULL
+);
+CREATE TRIGGER controller_ledger_no_update
+BEFORE UPDATE ON controller_ledger BEGIN SELECT RAISE(ABORT, 'immutable'); END;
+CREATE TRIGGER controller_ledger_no_delete
+BEFORE DELETE ON controller_ledger BEGIN SELECT RAISE(ABORT, 'immutable'); END;
+"""
+
+
+def _verify_journal_schema(connection: sqlite3.Connection) -> None:
+    application_id = int(connection.execute("PRAGMA application_id").fetchone()[0])
+    version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+    names = tuple(
+        row[0]
+        for row in connection.execute(
+            "SELECT name FROM sqlite_schema "
+            "WHERE name NOT LIKE 'sqlite_%' ORDER BY name"
+        )
+    )
+    if (
+        application_id != CONTROLLER_JOURNAL_APPLICATION_ID
+        or version != CONTROLLER_JOURNAL_SCHEMA_VERSION
+        or names
+        != (
+            "controller_ledger",
+            "controller_ledger_no_delete",
+            "controller_ledger_no_update",
+        )
+    ):
+        raise ControllerError("controller journal schema differs")
+
+
+class ControllerEvidenceJournal(_NoRuntimeAuthority):
+    """Append-only isolated SQLite journal used before each downstream stage."""
+
+    def __init__(self, connection: sqlite3.Connection) -> None:
+        if type(connection) is not sqlite3.Connection:
+            raise ControllerError("controller journal connection differs")
+        _verify_journal_schema(connection)
+        self.__connection = connection
+
+    def append(self, entry: ControllerLedgerEntry) -> str:
+        if type(entry) is not ControllerLedgerEntry:
+            raise ControllerError("controller journal entry type differs")
+        try:
+            self.__connection.execute("BEGIN IMMEDIATE")
+            row = self.__connection.execute(
+                "SELECT ordinal, entry_digest FROM controller_ledger "
+                "ORDER BY ordinal DESC LIMIT 1"
+            ).fetchone()
+            expected_ordinal = 1 if row is None else int(row[0]) + 1
+            expected_predecessor = None if row is None else str(row[1])
+            if (
+                entry.ordinal != expected_ordinal
+                or entry.previous_entry_digest != expected_predecessor
+            ):
+                raise ControllerError("controller journal predecessor differs")
+            self.__connection.execute(
+                "INSERT INTO controller_ledger(ordinal,entry_digest,entry_bytes) "
+                "VALUES(?,?,?)",
+                (entry.ordinal, entry.canonical_digest, entry.canonical_bytes),
+            )
+            self.__connection.commit()
+        except Exception:
+            self.__connection.rollback()
+            raise
+        return entry.canonical_digest
+
+    def inventory(self) -> tuple[ControllerLedgerEntry, ...]:
+        _verify_journal_schema(self.__connection)
+        result: list[ControllerLedgerEntry] = []
+        for ordinal, stored_digest, raw in self.__connection.execute(
+            "SELECT ordinal,entry_digest,entry_bytes "
+            "FROM controller_ledger ORDER BY ordinal"
+        ):
+            try:
+                value = json.loads(bytes(raw).decode("utf-8"), object_pairs_hook=_pairs)
+                if canonical_json_bytes(value) != bytes(raw):
+                    raise ControllerError("controller journal bytes are not canonical")
+                entry = ControllerLedgerEntry.from_primitive(value)
+            except ControllerError:
+                raise
+            except (UnicodeError, json.JSONDecodeError, CanonicalizationError) as exc:
+                raise ControllerError("controller journal bytes are invalid") from exc
+            if (
+                entry.ordinal != ordinal
+                or entry.canonical_digest != stored_digest
+                or entry.previous_entry_digest
+                != (None if not result else result[-1].canonical_digest)
+            ):
+                raise ControllerError("controller journal inventory differs")
+            result.append(entry)
+        return tuple(result)
+
+
+def initialise_controller_journal(
+    connection: sqlite3.Connection,
+) -> ControllerEvidenceJournal:
+    if type(connection) is not sqlite3.Connection:
+        raise ControllerError("controller journal connection differs")
+    existing = tuple(
+        row[0]
+        for row in connection.execute(
+            "SELECT name FROM sqlite_schema WHERE name NOT LIKE 'sqlite_%'"
+        )
+    )
+    application_id = int(connection.execute("PRAGMA application_id").fetchone()[0])
+    version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+    if existing or application_id != 0 or version != 0:
+        raise ControllerError("controller journal is not pristine")
+    connection.executescript(_JOURNAL_SCHEMA)
+    connection.execute(f"PRAGMA application_id={CONTROLLER_JOURNAL_APPLICATION_ID}")
+    connection.execute(f"PRAGMA user_version={CONTROLLER_JOURNAL_SCHEMA_VERSION}")
+    connection.commit()
+    return ControllerEvidenceJournal(connection)
+
+
+@dataclass(frozen=True, slots=True)
+class ScenarioEvidence(_NoRuntimeAuthority):
+    scenario: RecoveryScenario
+    outcome: ScenarioOutcome
+    checkpoint_digest: str
+    evidence_digest: str
+    original_failure_retained: bool
+    resumed_decision_bearing: bool = False
+    public_effect_count: int = 0
+    production_mutation_count: int = 0
+    orphan_resource_count: int = 0
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "scenario", _enum(RecoveryScenario, self.scenario, "scenario"))
+        object.__setattr__(self, "outcome", _enum(ScenarioOutcome, self.outcome, "outcome"))
+        _digest(self.checkpoint_digest, "checkpoint_digest")
+        _digest(self.evidence_digest, "evidence_digest")
+        _boolean(self.original_failure_retained, "original_failure_retained")
+        _boolean(self.resumed_decision_bearing, "resumed_decision_bearing")
+        for field in ("public_effect_count", "production_mutation_count", "orphan_resource_count"):
+            _integer(getattr(self, field), field)
+
+    def primitive(self) -> dict[str, object]:
+        return {
+            "checkpoint_digest": self.checkpoint_digest,
+            "evidence_digest": self.evidence_digest,
+            "original_failure_retained": self.original_failure_retained,
+            "orphan_resource_count": self.orphan_resource_count,
+            "outcome": str(self.outcome),
+            "production_mutation_count": self.production_mutation_count,
+            "public_effect_count": self.public_effect_count,
+            "resumed_decision_bearing": self.resumed_decision_bearing,
+            "scenario": str(self.scenario),
+        }
+
+    @classmethod
+    def from_primitive(cls, value: object) -> Self:
+        raw = _mapping(value, frozenset(cls.__dataclass_fields__), "scenario evidence")
+        raw["scenario"] = _enum(RecoveryScenario, raw["scenario"], "scenario")
+        raw["outcome"] = _enum(ScenarioOutcome, raw["outcome"], "outcome")
+        return cls(**raw)  # type: ignore[arg-type]
+
+
+@dataclass(frozen=True, slots=True)
+class ControllerCheck(_NoRuntimeAuthority):
+    check_id: str
+    outcome: CheckOutcome
+    evidence_digest: str
+
+    def __post_init__(self) -> None:
+        _token(self.check_id, "check_id")
+        if self.check_id not in CHECK_IDS:
+            raise ControllerError("controller check identity differs")
+        object.__setattr__(self, "outcome", _enum(CheckOutcome, self.outcome, "outcome"))
+        _digest(self.evidence_digest, "evidence_digest")
+
+    def primitive(self) -> dict[str, object]:
+        return {"check_id": self.check_id, "evidence_digest": self.evidence_digest, "outcome": str(self.outcome)}
+
+    @classmethod
+    def from_primitive(cls, value: object) -> Self:
+        raw = _mapping(value, frozenset(cls.__dataclass_fields__), "controller check")
+        raw["outcome"] = _enum(CheckOutcome, raw["outcome"], "outcome")
+        return cls(**raw)  # type: ignore[arg-type]
+
+
+@dataclass(frozen=True, slots=True)
+class EquivalenceObservation(_NoRuntimeAuthority):
+    difference_id: str
+    inference_limit: str
+    evidence_digest: str
+
+    def __post_init__(self) -> None:
+        _token(self.difference_id, "difference_id")
+        _token(self.inference_limit, "inference_limit")
+        _digest(self.evidence_digest, "evidence_digest")
+
+    def primitive(self) -> dict[str, object]:
+        return {
+            "difference_id": self.difference_id,
+            "evidence_digest": self.evidence_digest,
+            "inference_limit": self.inference_limit,
+        }
+
+    @classmethod
+    def from_primitive(cls, value: object) -> Self:
+        return cls(**_mapping(value, frozenset(cls.__dataclass_fields__), "equivalence observation"))  # type: ignore[arg-type]
+
+
+@dataclass(frozen=True, slots=True)
+class ControllerEvidenceBundle(_Record):
+    schema_version: ClassVar[str] = "newsroom.increment9.controller-evidence-bundle.v1"
+    evidence_id: str
+    controller_plan_digest: str
+    stages: tuple[StageFixture, ...]
+    ledger: tuple[ControllerLedgerEntry, ...]
+    scenarios: tuple[ScenarioEvidence, ...]
+    checks: tuple[ControllerCheck, ...]
+    equivalence_observations: tuple[EquivalenceObservation, ...]
+    production_nonmutation_before_digest: str
+    production_nonmutation_after_digest: str
+    sealed_at: str
+    proposal_authority_commit_count: int = 0
+    deterministic_authority_commit_count: int = 5
+    external_request_count: int = 0
+    provider_call_count: int = 0
+    credential_use_count: int = 0
+    gross_monetary_minor_units: int = 0
+    decision_bearing_case_count: int = 0
+    public_effect_count: int = 0
+    production_mutation_count: int = 0
+    evidence_intake_count: int = 0
+
+    def __post_init__(self) -> None:
+        _token(self.evidence_id, "evidence_id")
+        _digest(self.controller_plan_digest, "controller_plan_digest")
+        if type(self.stages) is not tuple or any(type(item) is not StageFixture for item in self.stages):
+            raise ControllerError("controller stage evidence type differs")
+        if tuple(item.stage for item in self.stages) != CONTROLLER_STAGES:
+            raise ControllerError("controller stage inventory differs")
+        if type(self.ledger) is not tuple or not self.ledger or any(type(item) is not ControllerLedgerEntry for item in self.ledger):
+            raise ControllerError("controller ledger type differs")
+        if type(self.scenarios) is not tuple or tuple(item.scenario for item in self.scenarios) != RECOVERY_SCENARIOS:
+            raise ControllerError("recovery scenario inventory differs")
+        if type(self.checks) is not tuple or tuple(item.check_id for item in self.checks) != CHECK_IDS:
+            raise ControllerError("controller check inventory differs")
+        if type(self.equivalence_observations) is not tuple or not self.equivalence_observations:
+            raise ControllerError("production equivalence inventory differs")
+        _digest(self.production_nonmutation_before_digest, "production_nonmutation_before_digest")
+        _digest(self.production_nonmutation_after_digest, "production_nonmutation_after_digest")
+        _timestamp(self.sealed_at, "sealed_at")
+        if any(_instant(item.completed_at) > _instant(self.sealed_at) for item in self.stages):
+            raise ControllerError("controller evidence predates a stage")
+        for field in (
+            "proposal_authority_commit_count",
+            "deterministic_authority_commit_count",
+            "external_request_count",
+            "provider_call_count",
+            "credential_use_count",
+            "gross_monetary_minor_units",
+            "decision_bearing_case_count",
+            "public_effect_count",
+            "production_mutation_count",
+            "evidence_intake_count",
+        ):
+            _integer(getattr(self, field), field)
+
+    def primitive(self) -> dict[str, object]:
+        return {
+            "checks": [item.primitive() for item in self.checks],
+            "controller_plan_digest": self.controller_plan_digest,
+            "credential_use_count": self.credential_use_count,
+            "decision_bearing_case_count": self.decision_bearing_case_count,
+            "deterministic_authority_commit_count": self.deterministic_authority_commit_count,
+            "equivalence_observations": [item.primitive() for item in self.equivalence_observations],
+            "evidence_id": self.evidence_id,
+            "evidence_intake_count": self.evidence_intake_count,
+            "external_request_count": self.external_request_count,
+            "gross_monetary_minor_units": self.gross_monetary_minor_units,
+            "ledger": [item.primitive() for item in self.ledger],
+            "production_mutation_count": self.production_mutation_count,
+            "production_nonmutation_after_digest": self.production_nonmutation_after_digest,
+            "production_nonmutation_before_digest": self.production_nonmutation_before_digest,
+            "proposal_authority_commit_count": self.proposal_authority_commit_count,
+            "provider_call_count": self.provider_call_count,
+            "public_effect_count": self.public_effect_count,
+            "scenarios": [item.primitive() for item in self.scenarios],
+            "schema_version": self.schema_version,
+            "sealed_at": self.sealed_at,
+            "stages": [item.primitive() for item in self.stages],
+        }
+
+    @classmethod
+    def from_bytes(cls, raw: bytes) -> Self:
+        fields = frozenset(name for name in cls.__dataclass_fields__ if name != "schema_version")
+        value = _document(raw, cls.schema_version, fields)
+        for field, kind in (
+            ("stages", StageFixture),
+            ("ledger", ControllerLedgerEntry),
+            ("scenarios", ScenarioEvidence),
+            ("checks", ControllerCheck),
+            ("equivalence_observations", EquivalenceObservation),
+        ):
+            items = value[field]
+            if type(items) is not list:
+                raise ControllerError(f"{field} must be an array")
+            value[field] = tuple(kind.from_primitive(item) for item in items)
+        return cls(**value)  # type: ignore[arg-type]
+
+
+@dataclass(frozen=True, slots=True)
+class ControllerQualificationReceipt(_Record):
+    schema_version: ClassVar[str] = "newsroom.increment9.controller-qualification-receipt.v1"
+    receipt_id: str
+    controller_plan_digest: str
+    controller_evidence_digest: str
+    disposition: ControllerQualificationDisposition
+    reason: str
+    production_nonmutation_proved: bool
+    full_teardown_rebuild_proved: bool
+    completed_at: str
+    runtime_campaign_authority_still_required: bool = True
+    campaign_started: bool = False
+
+    def __post_init__(self) -> None:
+        _token(self.receipt_id, "receipt_id")
+        _digest(self.controller_plan_digest, "controller_plan_digest")
+        _digest(self.controller_evidence_digest, "controller_evidence_digest")
+        object.__setattr__(self, "disposition", _enum(ControllerQualificationDisposition, self.disposition, "disposition"))
+        _token(self.reason, "reason")
+        _boolean(self.production_nonmutation_proved, "production_nonmutation_proved")
+        _boolean(self.full_teardown_rebuild_proved, "full_teardown_rebuild_proved")
+        _timestamp(self.completed_at, "completed_at")
+        if self.runtime_campaign_authority_still_required is not True or self.campaign_started is not False:
+            raise ControllerError("9B2 receipt cannot grant or claim campaign authority")
+        if self.disposition is ControllerQualificationDisposition.READY_FOR_9B3_AUTHORISATION_GATE:
+            if (
+                self.reason != "CONTROLLER_QUALIFICATION_COMPLETE"
+                or not self.production_nonmutation_proved
+                or not self.full_teardown_rebuild_proved
+            ):
+                raise ControllerError("ready controller receipt differs")
+        elif self.reason != "CONTROLLER_EVIDENCE_INCOMPLETE_OR_FAILED":
+            raise ControllerError("not-ready controller receipt differs")
+
+    def primitive(self) -> dict[str, object]:
+        return {
+            "campaign_started": self.campaign_started,
+            "completed_at": self.completed_at,
+            "controller_evidence_digest": self.controller_evidence_digest,
+            "controller_plan_digest": self.controller_plan_digest,
+            "disposition": str(self.disposition),
+            "full_teardown_rebuild_proved": self.full_teardown_rebuild_proved,
+            "production_nonmutation_proved": self.production_nonmutation_proved,
+            "reason": self.reason,
+            "receipt_id": self.receipt_id,
+            "runtime_campaign_authority_still_required": self.runtime_campaign_authority_still_required,
+            "schema_version": self.schema_version,
+        }
+
+    @classmethod
+    def from_bytes(cls, raw: bytes) -> Self:
+        fields = frozenset(name for name in cls.__dataclass_fields__ if name != "schema_version")
+        value = _document(raw, cls.schema_version, fields)
+        value["disposition"] = _enum(ControllerQualificationDisposition, value["disposition"], "disposition")
+        return cls(**value)  # type: ignore[arg-type]
+
+
+class ReplayIntegrationController(_NoRuntimeAuthority):
+    """Execute the exact integrated path with content-addressed replay fixtures."""
+
+    def __init__(
+        self,
+        plan: ControllerQualificationPlan,
+        journal: ControllerEvidenceJournal,
+    ) -> None:
+        if type(plan) is not ControllerQualificationPlan:
+            raise ControllerError("controller plan type differs")
+        if type(journal) is not ControllerEvidenceJournal:
+            raise ControllerError("controller journal type differs")
+        if journal.inventory():
+            raise ControllerError("controller qualification requires an empty journal")
+        self.__plan = plan
+        self.__journal = journal
+
+    def qualify(
+        self,
+        *,
+        fixtures: tuple[StageFixture, ...],
+        scenario_evidence_digests: Mapping[RecoveryScenario | str, str],
+        check_evidence_digests: Mapping[str, str],
+        equivalence_evidence_digests: Mapping[str, str],
+        sealed_at: str,
+        production_nonmutation_after_digest: str,
+    ) -> ControllerEvidenceBundle:
+        if type(fixtures) is not tuple or tuple(item.stage for item in fixtures) != CONTROLLER_STAGES:
+            raise ControllerError("controller stage inventory differs")
+        scenario_digests = {str(key): value for key, value in scenario_evidence_digests.items()}
+        if set(scenario_digests) != {str(item) for item in RECOVERY_SCENARIOS}:
+            raise ControllerError("recovery scenario evidence inventory differs")
+        check_digests = dict(check_evidence_digests)
+        if set(check_digests) != set(CHECK_IDS):
+            raise ControllerError("controller check evidence inventory differs")
+        equivalence_digests = dict(equivalence_evidence_digests)
+        if set(equivalence_digests) != set(self.__plan.production_difference_ids):
+            raise ControllerError("production equivalence evidence inventory differs")
+        previous_response: str | None = None
+        previous_completed_at: str | None = None
+        ledger: list[ControllerLedgerEntry] = []
+        for fixture in fixtures:
+            if type(fixture) is not StageFixture:
+                raise ControllerError("controller stage fixture type differs")
+            if fixture.target_interface_digest != self.__plan.stage_interface_digests[str(fixture.stage)]:
+                raise ControllerError("controller target interface differs")
+            if previous_response is not None and fixture.request_digest != previous_response:
+                raise ControllerError("controller stage chain differs")
+            if previous_completed_at is not None and _instant(fixture.started_at) < _instant(previous_completed_at):
+                raise ControllerError("controller downstream stage predates persisted evidence")
+            if _instant(fixture.started_at) < _instant(self.__plan.created_at):
+                raise ControllerError("controller stage predates plan")
+            payloads: list[tuple[LedgerKind, str]] = [
+                (LedgerKind.CONTROL_ENVELOPE, fixture.control_envelope_digest),
+                (LedgerKind.BUDGET_RESERVATION, fixture.budget_reservation_digest),
+                (LedgerKind.REQUEST, fixture.request_digest),
+                (LedgerKind.RESPONSE, fixture.response_digest),
+            ]
+            if fixture.proposal_digest is not None:
+                payloads.append((LedgerKind.PROPOSAL, fixture.proposal_digest))
+            if fixture.decision_digest is not None:
+                payloads.append((LedgerKind.DECISION, fixture.decision_digest))
+            payloads.extend(
+                (
+                    (LedgerKind.CHECKPOINT, fixture.checkpoint_digest),
+                    (LedgerKind.USAGE, fixture.usage_digest),
+                    (LedgerKind.COST, fixture.cost_digest),
+                )
+            )
+            for kind, payload in payloads:
+                entry = ControllerLedgerEntry(
+                    ordinal=len(ledger) + 1,
+                    stage=fixture.stage,
+                    kind=kind,
+                    payload_digest=payload,
+                    previous_entry_digest=None
+                    if not ledger
+                    else ledger[-1].canonical_digest,
+                    persisted_at=fixture.completed_at
+                    if kind
+                    not in {
+                        LedgerKind.CONTROL_ENVELOPE,
+                        LedgerKind.BUDGET_RESERVATION,
+                        LedgerKind.REQUEST,
+                    }
+                    else fixture.started_at,
+                )
+                self.__journal.append(entry)
+                ledger.append(entry)
+            previous_response = fixture.response_digest
+            previous_completed_at = fixture.completed_at
+        if self.__journal.inventory() != tuple(ledger):
+            raise ControllerError("controller journal replay differs")
+        terminal = ledger[-1].canonical_digest
+        scenarios = tuple(
+            ScenarioEvidence(
+                scenario=scenario,
+                outcome=_SCENARIO_OUTCOMES[scenario],
+                checkpoint_digest=terminal,
+                evidence_digest=_digest(
+                    scenario_digests[str(scenario)],
+                    f"scenario_evidence_digests.{scenario}",
+                ),
+                original_failure_retained=_SCENARIO_OUTCOMES[scenario]
+                in {ScenarioOutcome.BLOCKED_RECONCILED, ScenarioOutcome.EARLY_STOPPED},
+            )
+            for scenario in RECOVERY_SCENARIOS
+        )
+        checks = tuple(
+            ControllerCheck(
+                check_id=check_id,
+                outcome=CheckOutcome.PASS,
+                evidence_digest=_digest(
+                    check_digests[check_id], f"check_evidence_digests.{check_id}"
+                ),
+            )
+            for check_id in CHECK_IDS
+        )
+        differences = tuple(
+            EquivalenceObservation(
+                difference_id=difference_id,
+                inference_limit=self.__plan.inference_limits[difference_id],
+                evidence_digest=_digest(
+                    equivalence_digests[difference_id],
+                    f"equivalence_evidence_digests.{difference_id}",
+                ),
+            )
+            for difference_id in self.__plan.production_difference_ids
+        )
+        return ControllerEvidenceBundle(
+            evidence_id=f"{self.__plan.qualification_id}-evidence",
+            controller_plan_digest=self.__plan.canonical_digest,
+            stages=fixtures,
+            ledger=tuple(ledger),
+            scenarios=scenarios,
+            checks=checks,
+            equivalence_observations=differences,
+            production_nonmutation_before_digest=self.__plan.production_nonmutation_before_digest,
+            production_nonmutation_after_digest=production_nonmutation_after_digest,
+            sealed_at=sealed_at,
+        )
+
+
+def _ledger_is_exact(bundle: ControllerEvidenceBundle) -> bool:
+    position = 0
+    previous: ControllerLedgerEntry | None = None
+    for fixture in bundle.stages:
+        expected = [
+            (
+                LedgerKind.CONTROL_ENVELOPE,
+                fixture.control_envelope_digest,
+                fixture.started_at,
+            ),
+            (
+                LedgerKind.BUDGET_RESERVATION,
+                fixture.budget_reservation_digest,
+                fixture.started_at,
+            ),
+            (LedgerKind.REQUEST, fixture.request_digest, fixture.started_at),
+            (LedgerKind.RESPONSE, fixture.response_digest, fixture.completed_at),
+        ]
+        if fixture.proposal_digest is not None:
+            expected.append(
+                (LedgerKind.PROPOSAL, fixture.proposal_digest, fixture.completed_at)
+            )
+        if fixture.decision_digest is not None:
+            expected.append(
+                (LedgerKind.DECISION, fixture.decision_digest, fixture.completed_at)
+            )
+        expected.extend(
+            (
+                (LedgerKind.CHECKPOINT, fixture.checkpoint_digest, fixture.completed_at),
+                (LedgerKind.USAGE, fixture.usage_digest, fixture.completed_at),
+                (LedgerKind.COST, fixture.cost_digest, fixture.completed_at),
+            )
+        )
+        entries = bundle.ledger[position : position + len(expected)]
+        if len(entries) != len(expected) or any(
+            entry.stage is not fixture.stage
+            or entry.kind is not kind
+            or entry.payload_digest != payload
+            or entry.persisted_at != persisted_at
+            for entry, (kind, payload, persisted_at) in zip(
+                entries, expected, strict=True
+            )
+        ):
+            return False
+        for entry in entries:
+            if entry.ordinal != position + 1:
+                return False
+            if entry.previous_entry_digest != (None if previous is None else previous.canonical_digest):
+                return False
+            previous = entry
+            position += 1
+    return position == len(bundle.ledger)
+
+
+def _stage_chain_is_exact(stages: tuple[StageFixture, ...]) -> bool:
+    for previous, current in zip(stages, stages[1:], strict=False):
+        if (
+            current.request_digest != previous.response_digest
+            or _instant(current.started_at) < _instant(previous.completed_at)
+        ):
+            return False
+    return True
+
+
+def qualify_controller(
+    plan: ControllerQualificationPlan,
+    evidence: ControllerEvidenceBundle,
+    *,
+    receipt_id: str,
+) -> ControllerQualificationReceipt:
+    """Create a non-activating 9B2 receipt from one closed evidence bundle."""
+
+    if type(plan) is not ControllerQualificationPlan or type(evidence) is not ControllerEvidenceBundle:
+        raise ControllerError("controller qualification types differ")
+    scenario_exact = all(
+        item.outcome is _SCENARIO_OUTCOMES[item.scenario]
+        and not item.resumed_decision_bearing
+        and item.public_effect_count == 0
+        and item.production_mutation_count == 0
+        and item.orphan_resource_count == 0
+        and (
+            item.original_failure_retained
+            if item.outcome in {ScenarioOutcome.BLOCKED_RECONCILED, ScenarioOutcome.EARLY_STOPPED}
+            else True
+        )
+        for item in evidence.scenarios
+    )
+    equivalence_exact = tuple(item.difference_id for item in evidence.equivalence_observations) == plan.production_difference_ids and all(
+        item.inference_limit == plan.inference_limits[item.difference_id]
+        for item in evidence.equivalence_observations
+    )
+    exact = (
+        evidence.controller_plan_digest == plan.canonical_digest,
+        tuple(item.stage for item in evidence.stages) == CONTROLLER_STAGES,
+        all(item.target_interface_digest == plan.stage_interface_digests[str(item.stage)] for item in evidence.stages),
+        all(item.outcome == "COMPLETE" and item.deterministic_replay for item in evidence.stages),
+        _stage_chain_is_exact(evidence.stages),
+        _ledger_is_exact(evidence),
+        scenario_exact,
+        all(item.outcome is CheckOutcome.PASS for item in evidence.checks),
+        equivalence_exact,
+        evidence.production_nonmutation_before_digest == plan.production_nonmutation_before_digest,
+        evidence.production_nonmutation_after_digest == evidence.production_nonmutation_before_digest,
+        _instant(evidence.sealed_at) <= _instant(plan.expires_at),
+        evidence.proposal_authority_commit_count == 0,
+        evidence.deterministic_authority_commit_count == len(_DECISION_STAGES),
+        evidence.external_request_count == 0,
+        evidence.provider_call_count == 0,
+        evidence.credential_use_count == 0,
+        evidence.gross_monetary_minor_units == 0,
+        evidence.decision_bearing_case_count == 0,
+        evidence.public_effect_count == 0,
+        evidence.production_mutation_count == 0,
+        evidence.evidence_intake_count == 0,
+    )
+    passed = all(exact)
+    teardown = next(item for item in evidence.scenarios if item.scenario is RecoveryScenario.TEARDOWN_REBUILD)
+    return ControllerQualificationReceipt(
+        receipt_id=receipt_id,
+        controller_plan_digest=plan.canonical_digest,
+        controller_evidence_digest=evidence.canonical_digest,
+        disposition=(
+            ControllerQualificationDisposition.READY_FOR_9B3_AUTHORISATION_GATE
+            if passed
+            else ControllerQualificationDisposition.NOT_READY
+        ),
+        reason=(
+            "CONTROLLER_QUALIFICATION_COMPLETE"
+            if passed
+            else "CONTROLLER_EVIDENCE_INCOMPLETE_OR_FAILED"
+        ),
+        production_nonmutation_proved=(
+            evidence.production_nonmutation_before_digest
+            == evidence.production_nonmutation_after_digest
+            and evidence.production_mutation_count == 0
+        ),
+        full_teardown_rebuild_proved=(
+            teardown.outcome is ScenarioOutcome.REBUILT
+            and teardown.orphan_resource_count == 0
+        ),
+        completed_at=evidence.sealed_at,
+    )
+
+
+__all__ = [
+    "CHECK_IDS",
+    "CONTROLLER_STAGES",
+    "RECOVERY_SCENARIOS",
+    "STAGE_MANIFEST_DIMENSIONS",
+    "CheckOutcome",
+    "ControllerCheck",
+    "ControllerError",
+    "ControllerEvidenceBundle",
+    "ControllerEvidenceJournal",
+    "ControllerLedgerEntry",
+    "ControllerQualificationDisposition",
+    "ControllerQualificationPlan",
+    "ControllerQualificationReceipt",
+    "ControllerStage",
+    "EquivalenceObservation",
+    "LedgerKind",
+    "RecoveryScenario",
+    "ReplayIntegrationController",
+    "ScenarioEvidence",
+    "ScenarioOutcome",
+    "StageFixture",
+    "qualify_controller",
+    "initialise_controller_journal",
+]

--- a/newsroom/increment9/controller.py
+++ b/newsroom/increment9/controller.py
@@ -722,18 +722,48 @@ BEFORE UPDATE ON controller_ledger BEGIN SELECT RAISE(ABORT, 'immutable'); END;
 CREATE TRIGGER controller_ledger_no_delete
 BEFORE DELETE ON controller_ledger BEGIN SELECT RAISE(ABORT, 'immutable'); END;
 """
+_EXPECTED_JOURNAL_SCHEMA = (
+    (
+        "table",
+        "controller_ledger",
+        "controller_ledger",
+        "CREATE TABLE controller_ledger ( ordinal INTEGER PRIMARY KEY CHECK "
+        "(ordinal > 0), entry_digest TEXT NOT NULL UNIQUE, entry_bytes BLOB NOT NULL )",
+    ),
+    (
+        "trigger",
+        "controller_ledger_no_delete",
+        "controller_ledger",
+        "CREATE TRIGGER controller_ledger_no_delete BEFORE DELETE ON "
+        "controller_ledger BEGIN SELECT RAISE(ABORT, 'immutable'); END",
+    ),
+    (
+        "trigger",
+        "controller_ledger_no_update",
+        "controller_ledger",
+        "CREATE TRIGGER controller_ledger_no_update BEFORE UPDATE ON "
+        "controller_ledger BEGIN SELECT RAISE(ABORT, 'immutable'); END",
+    ),
+)
+
+
+def _normalise_schema_sql(value: object) -> str:
+    if type(value) is not str:
+        raise ControllerError("controller journal schema differs")
+    return " ".join(value.split())
 
 
 def _verify_journal_schema(connection: sqlite3.Connection) -> None:
     application_id = int(connection.execute("PRAGMA application_id").fetchone()[0])
     version = int(connection.execute("PRAGMA user_version").fetchone()[0])
-    names = tuple(
-        row[0]
-        for row in connection.execute(
-            "SELECT name FROM sqlite_schema "
+    schema = tuple(
+        (str(kind), str(name), str(table), _normalise_schema_sql(sql))
+        for kind, name, table, sql in connection.execute(
+            "SELECT type,name,tbl_name,sql FROM sqlite_schema "
             "WHERE name NOT LIKE 'sqlite_%' ORDER BY name"
         )
     )
+    names = tuple(row[1] for row in schema)
     if (
         application_id != CONTROLLER_JOURNAL_APPLICATION_ID
         or version != CONTROLLER_JOURNAL_SCHEMA_VERSION
@@ -743,6 +773,7 @@ def _verify_journal_schema(connection: sqlite3.Connection) -> None:
             "controller_ledger_no_delete",
             "controller_ledger_no_update",
         )
+        or schema != _EXPECTED_JOURNAL_SCHEMA
     ):
         raise ControllerError("controller journal schema differs")
 
@@ -1370,6 +1401,8 @@ def qualify_controller(
 __all__ = [
     "CHECK_IDS",
     "CONTROLLER_STAGES",
+    "CONTROLLER_JOURNAL_APPLICATION_ID",
+    "CONTROLLER_JOURNAL_SCHEMA_VERSION",
     "RECOVERY_SCENARIOS",
     "STAGE_MANIFEST_DIMENSIONS",
     "CheckOutcome",

--- a/newsroom/tests/test_increment9b2_shadow_controller.py
+++ b/newsroom/tests/test_increment9b2_shadow_controller.py
@@ -1,0 +1,460 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import replace
+
+import pytest
+
+from newsroom.authority.canonical import digest_bytes
+from newsroom.increment9.controller import (
+    CHECK_IDS,
+    CONTROLLER_STAGES,
+    RECOVERY_SCENARIOS,
+    STAGE_MANIFEST_DIMENSIONS,
+    ControllerError,
+    ControllerEvidenceJournal,
+    ControllerQualificationDisposition,
+    ControllerQualificationPlan,
+    ControllerQualificationReceipt,
+    ControllerEvidenceBundle,
+    LedgerKind,
+    ReplayIntegrationController,
+    ScenarioOutcome,
+    StageFixture,
+    qualify_controller,
+    initialise_controller_journal,
+)
+from newsroom.increment9.deployment import (
+    INCREMENT9_SHADOW_SCHEMA_FINGERPRINT,
+    INCREMENT9_SHADOW_SCHEMA_VERSION,
+    ISOLATED_DIRECTORY_INVENTORY,
+    ISOLATED_FILE_INVENTORY,
+    PRODUCTION_MIGRATION_HISTORY_DIGEST,
+    PRODUCTION_SCHEMA_FINGERPRINT,
+    PRODUCTION_SCHEMA_VERSION,
+    IsolatedDeploymentReceipt,
+    qualify_deployment,
+)
+from newsroom.increment9.epoch import RunKind, RunAttempt, ShadowRun
+
+from .test_increment9a2_shadow_deployment import D, _bundle, _plan, _scope
+from .test_increment9b1_shadow_epoch import _cohort, _epoch, _manifest
+
+
+T6 = "2042-01-01T00:06:00.000000Z"
+T7 = "2042-01-01T00:07:00.000000Z"
+T8 = "2042-01-01T00:08:00.000000Z"
+
+
+def _isolated(plan):
+    return IsolatedDeploymentReceipt(
+        receipt_id="isolated-9b2",
+        deployment_plan_digest=plan.canonical_digest,
+        root_identity_digest=D("a"),
+        directory_inventory=ISOLATED_DIRECTORY_INVENTORY,
+        protected_file_digests={path: D("b") for path in ISOLATED_FILE_INVENTORY},
+        epoch_schema_version=INCREMENT9_SHADOW_SCHEMA_VERSION,
+        epoch_schema_fingerprint=INCREMENT9_SHADOW_SCHEMA_FINGERPRINT,
+        epoch_backup_restore_digest=D("c"),
+        production_snapshot_digest=plan.production_snapshot_digest,
+        production_snapshot_schema_version=PRODUCTION_SCHEMA_VERSION,
+        production_snapshot_schema_fingerprint=PRODUCTION_SCHEMA_FINGERPRINT,
+        production_snapshot_migration_history_digest=PRODUCTION_MIGRATION_HISTORY_DIGEST,
+        production_snapshot_backup_restore_digest=D("d"),
+        graphiti_workspace=plan.graphiti_workspace,
+        neo4j_database=plan.neo4j_database,
+        neo4j_namespace=plan.neo4j_namespace,
+        created_at="2042-01-01T00:02:30.000000Z",
+    )
+
+
+def _records():
+    scope = _scope()
+    deployment = _plan()
+    readiness = qualify_deployment(deployment, _bundle(deployment), receipt_id="ready-9b2")
+    epoch = replace(
+        _epoch(),
+        shadow_scope_digest=deployment.scope_digest,
+        opened_at="2042-01-01T00:00:00.000000Z",
+        cutoff_at="2042-01-01T00:00:00.000000Z",
+    )
+    manifest = _manifest("a", resolved=True)
+    cohort = _cohort(epoch, manifest, opened_at="2042-01-01T00:01:00.000000Z")
+    run = ShadowRun(
+        run_id="run-9b2-replay",
+        epoch_id=epoch.epoch_id,
+        epoch_digest=epoch.canonical_digest,
+        cohort_id=cohort.cohort_id,
+        cohort_digest=cohort.canonical_digest,
+        manifest_digest=manifest.canonical_digest,
+        production_snapshot_digest=deployment.production_snapshot_digest,
+        production_nonmutation_before_digest=D("e"),
+        run_kind=RunKind.REPLAY_QUALIFICATION,
+        started_at=T6,
+        prospective=False,
+    )
+    attempt = RunAttempt(
+        attempt_id="attempt-9b2-replay",
+        run_id=run.run_id,
+        run_digest=run.canonical_digest,
+        ordinal=1,
+        previous_attempt_digest=None,
+        started_at=T6,
+        restart_reason=None,
+    )
+    return scope, deployment, readiness, _isolated(deployment), epoch, manifest, cohort, run, attempt
+
+
+def _controller_plan() -> ControllerQualificationPlan:
+    scope, deployment, readiness, isolated, epoch, manifest, cohort, run, attempt = _records()
+    return ControllerQualificationPlan.build(
+        qualification_id="controller-qualification-9b2",
+        scope=scope,
+        deployment_plan=deployment,
+        readiness_receipt=readiness,
+        isolated_deployment_receipt=isolated,
+        epoch=epoch,
+        effective_manifest=manifest,
+        cohort=cohort,
+        run=run,
+        attempt=attempt,
+        stage_interface_digests={
+            stage: manifest.identity_digests[STAGE_MANIFEST_DIMENSIONS[stage]]
+            for stage in CONTROLLER_STAGES
+        },
+        created_at=T6,
+        expires_at="2042-01-02T00:00:00.000000Z",
+    )
+
+
+def _fixtures(plan: ControllerQualificationPlan) -> tuple[StageFixture, ...]:
+    fixtures = []
+    request = D("1")
+    for index, stage in enumerate(CONTROLLER_STAGES):
+        response = D(format((index + 2) % 16, "x"))
+        fixtures.append(
+            StageFixture(
+                stage=stage,
+                target_interface_digest=plan.stage_interface_digests[str(stage)],
+                rights_receipt_digest=D("2"),
+                purpose_digest=D("3"),
+                credential_scope_digest=D("4"),
+                egress_receipt_digest=D("5"),
+                budget_reservation_digest=D("6"),
+                freshness_digest=D("7"),
+                request_digest=request,
+                response_digest=response,
+                proposal_digest=D("a") if str(stage) == "GRAPHITI_PROPOSAL" else None,
+                decision_digest=D("b") if str(stage) in {
+                    "DETERMINISTIC_ADMISSION", "TRIAGE", "CANDIDATE", "HANDOFF", "EVALUATION_SINK"
+                } else None,
+                checkpoint_digest=D("c"),
+                usage_digest=D("d"),
+                cost_digest=D("e"),
+                watermark=f"watermark-{index:02d}",
+                started_at=T7,
+                completed_at=T7,
+            )
+        )
+        request = response
+    return tuple(fixtures)
+
+
+def _evidence(plan: ControllerQualificationPlan):
+    return _controller(plan).qualify(
+        fixtures=_fixtures(plan),
+        scenario_evidence_digests={item: D("7") for item in RECOVERY_SCENARIOS},
+        check_evidence_digests={item: D("8") for item in CHECK_IDS},
+        equivalence_evidence_digests={
+            item: D("9") for item in plan.production_difference_ids
+        },
+        sealed_at=T8,
+        production_nonmutation_after_digest=plan.production_nonmutation_before_digest,
+    )
+
+
+def _controller(plan: ControllerQualificationPlan) -> ReplayIntegrationController:
+    return ReplayIntegrationController(
+        plan, initialise_controller_journal(sqlite3.connect(":memory:"))
+    )
+
+
+def test_plan_binds_all_predecessor_authorities_and_no_effects() -> None:
+    plan = _controller_plan()
+    assert plan.owner_plan_digest
+    assert plan.run_kind is RunKind.REPLAY_QUALIFICATION
+    assert tuple(plan.stage_interface_digests) == tuple(str(stage) for stage in CONTROLLER_STAGES)
+    assert plan.authorises_live_call is False
+    assert plan.authorises_credentials is False
+    assert plan.authorises_external_egress is False
+    assert plan.authorises_spend is False
+    assert plan.authorises_publication is False
+    assert plan.authorises_evidence_intake is False
+    assert plan.authorises_production_mutation is False
+    assert plan.authorises_decision_bearing_campaign is False
+
+
+def test_plan_strict_canonical_round_trip_and_tamper_rejection() -> None:
+    plan = _controller_plan()
+    assert ControllerQualificationPlan.from_bytes(plan.canonical_bytes) == plan
+    with pytest.raises(ControllerError, match="canonical"):
+        ControllerQualificationPlan.from_bytes(json.dumps(plan.primitive()).encode())
+    duplicate = plan.canonical_bytes.replace(b'{"attempt_digest"', b'{"attempt_digest":"' + "0".encode() * 64 + b'","attempt_digest"', 1)
+    with pytest.raises(ControllerError):
+        ControllerQualificationPlan.from_bytes(duplicate)
+
+
+def test_plan_rejects_not_ready_unresolved_wrong_run_and_cross_binding() -> None:
+    scope, deployment, readiness, isolated, epoch, manifest, cohort, run, attempt = _records()
+    kwargs = dict(
+        qualification_id="controller-qualification-9b2",
+        scope=scope,
+        deployment_plan=deployment,
+        readiness_receipt=readiness,
+        isolated_deployment_receipt=isolated,
+        epoch=epoch,
+        effective_manifest=manifest,
+        cohort=cohort,
+        run=run,
+        attempt=attempt,
+        stage_interface_digests={
+            stage: manifest.identity_digests[STAGE_MANIFEST_DIMENSIONS[stage]]
+            for stage in CONTROLLER_STAGES
+        },
+        created_at=T6,
+        expires_at="2042-01-02T00:00:00.000000Z",
+    )
+    with pytest.raises(ControllerError, match="readiness"):
+        ControllerQualificationPlan.build(**{**kwargs, "readiness_receipt": replace(readiness, disposition="NOT_READY", reason="READINESS_EVIDENCE_INCOMPLETE_OR_FAILED", actual_service_probe_ids=(), actual_host_probe_ids=(), production_nonmutation_proved=False, teardown_complete=False)})
+    unresolved = _manifest("a", resolved=False)
+    with pytest.raises(ControllerError, match="resolved"):
+        ControllerQualificationPlan.build(**{**kwargs, "effective_manifest": unresolved})
+    wrong_run = replace(run, run_kind=RunKind.READINESS_PROBE)
+    with pytest.raises(ControllerError, match="replay"):
+        ControllerQualificationPlan.build(**{**kwargs, "run": wrong_run, "attempt": replace(attempt, run_digest=wrong_run.canonical_digest)})
+    with pytest.raises(ControllerError, match="scope"):
+        ControllerQualificationPlan.build(**{**kwargs, "scope": replace(scope, scope_id="other-scope")})
+
+
+def test_replay_executes_exact_stage_path_and_persists_before_downstream() -> None:
+    plan = _controller_plan()
+    evidence = _evidence(plan)
+    assert tuple(item.stage for item in evidence.stages) == CONTROLLER_STAGES
+    assert tuple(item.scenario for item in evidence.scenarios) == RECOVERY_SCENARIOS
+    assert tuple(item.check_id for item in evidence.checks) == CHECK_IDS
+    assert [entry.ordinal for entry in evidence.ledger] == list(range(1, len(evidence.ledger) + 1))
+    for previous, current in zip(evidence.ledger, evidence.ledger[1:], strict=False):
+        assert current.previous_entry_digest == previous.canonical_digest
+    first_by_stage = {stage: next(entry for entry in evidence.ledger if entry.stage is stage) for stage in CONTROLLER_STAGES}
+    last_by_stage = {stage: [entry for entry in evidence.ledger if entry.stage is stage][-1] for stage in CONTROLLER_STAGES}
+    for previous, current in zip(CONTROLLER_STAGES, CONTROLLER_STAGES[1:], strict=False):
+        assert first_by_stage[current].ordinal == last_by_stage[previous].ordinal + 1
+        assert first_by_stage[current].kind is LedgerKind.CONTROL_ENVELOPE
+    assert evidence.external_request_count == 0
+    assert evidence.provider_call_count == 0
+    assert evidence.credential_use_count == 0
+    assert evidence.gross_monetary_minor_units == 0
+    assert evidence.decision_bearing_case_count == 0
+
+
+def test_graphiti_is_proposal_only_and_deterministic_stages_are_sole_committers() -> None:
+    evidence = _evidence(_controller_plan())
+    proposal = next(item for item in evidence.stages if str(item.stage) == "GRAPHITI_PROPOSAL")
+    admission = next(item for item in evidence.stages if str(item.stage) == "DETERMINISTIC_ADMISSION")
+    assert proposal.proposal_digest is not None and proposal.decision_digest is None
+    assert admission.proposal_digest is None and admission.decision_digest is not None
+    assert evidence.proposal_authority_commit_count == 0
+    assert evidence.deterministic_authority_commit_count == 5
+
+
+def test_recovery_inventory_blocks_lost_partial_ambiguous_and_kill_evidence() -> None:
+    evidence = _evidence(_controller_plan())
+    outcomes = {str(item.scenario): item.outcome for item in evidence.scenarios}
+    assert outcomes["RESTART_REPLAY"] is ScenarioOutcome.RECONCILED
+    assert outcomes["DUPLICATE_REQUEST"] is ScenarioOutcome.DEDUPLICATED
+    assert outcomes["LOST_RESPONSE"] is ScenarioOutcome.BLOCKED_RECONCILED
+    assert outcomes["PARTIAL_RESPONSE"] is ScenarioOutcome.BLOCKED_RECONCILED
+    assert outcomes["AMBIGUOUS_EFFECT"] is ScenarioOutcome.BLOCKED_RECONCILED
+    assert outcomes["KILL_SWITCH_PROPAGATION"] is ScenarioOutcome.EARLY_STOPPED
+    assert outcomes["TEARDOWN_REBUILD"] is ScenarioOutcome.REBUILT
+    assert all(item.resumed_decision_bearing is False for item in evidence.scenarios)
+    assert all(item.original_failure_retained for item in evidence.scenarios if item.outcome in {ScenarioOutcome.BLOCKED_RECONCILED, ScenarioOutcome.EARLY_STOPPED})
+
+
+def test_qualification_receipt_is_non_activating_and_exact() -> None:
+    plan = _controller_plan()
+    evidence = _evidence(plan)
+    receipt = qualify_controller(plan, evidence, receipt_id="qualified-9b2")
+    assert receipt.disposition is ControllerQualificationDisposition.READY_FOR_9B3_AUTHORISATION_GATE
+    assert receipt.production_nonmutation_proved is True
+    assert receipt.full_teardown_rebuild_proved is True
+    assert receipt.runtime_campaign_authority_still_required is True
+    assert receipt.campaign_started is False
+    assert receipt.canonical_digest
+
+
+@pytest.mark.parametrize(
+    "change",
+    (
+        {"production_nonmutation_after_digest": D("f")},
+        {"public_effect_count": 1},
+        {"production_mutation_count": 1},
+        {"evidence_intake_count": 1},
+        {"decision_bearing_case_count": 1},
+        {"external_request_count": 1},
+        {"credential_use_count": 1},
+        {"gross_monetary_minor_units": 1},
+    ),
+)
+def test_missing_or_prohibited_evidence_never_passes(change: dict[str, object]) -> None:
+    plan = _controller_plan()
+    evidence = replace(_evidence(plan), **change)
+    receipt = qualify_controller(plan, evidence, receipt_id="blocked-9b2")
+    assert receipt.disposition is ControllerQualificationDisposition.NOT_READY
+    assert receipt.reason == "CONTROLLER_EVIDENCE_INCOMPLETE_OR_FAILED"
+
+
+def test_stage_reordering_interface_drift_and_chain_break_fail_closed() -> None:
+    plan = _controller_plan()
+    evidence_inputs = {
+        "scenario_evidence_digests": {item: D("7") for item in RECOVERY_SCENARIOS},
+        "check_evidence_digests": {item: D("8") for item in CHECK_IDS},
+        "equivalence_evidence_digests": {
+            item: D("9") for item in plan.production_difference_ids
+        },
+        "sealed_at": T8,
+        "production_nonmutation_after_digest": plan.production_nonmutation_before_digest,
+    }
+    fixtures = list(_fixtures(plan))
+    fixtures[0], fixtures[1] = fixtures[1], fixtures[0]
+    with pytest.raises(ControllerError, match="stage"):
+        _controller(plan).qualify(fixtures=tuple(fixtures), **evidence_inputs)
+    fixtures = list(_fixtures(plan))
+    fixtures[0] = replace(fixtures[0], target_interface_digest=D("f"))
+    with pytest.raises(ControllerError, match="interface"):
+        _controller(plan).qualify(fixtures=tuple(fixtures), **evidence_inputs)
+    fixtures = list(_fixtures(plan))
+    fixtures[1] = replace(fixtures[1], request_digest=D("f"))
+    with pytest.raises(ControllerError, match="chain"):
+        _controller(plan).qualify(fixtures=tuple(fixtures), **evidence_inputs)
+
+
+def test_all_records_reject_type_confusion_and_unbounded_or_unknown_input() -> None:
+    plan = _controller_plan()
+    value = plan.primitive()
+    value["unknown"] = False
+    raw = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+    with pytest.raises(ControllerError, match="fields"):
+        ControllerQualificationPlan.from_bytes(raw)
+    with pytest.raises(ControllerError):
+        ControllerQualificationPlan.from_bytes(b"[]")
+    with pytest.raises(ControllerError):
+        ControllerQualificationPlan.from_bytes(b"{" + b" " * 4_194_304 + b"}")
+
+
+def test_receipt_digest_changes_with_any_evidence_byte() -> None:
+    plan = _controller_plan()
+    evidence = _evidence(plan)
+    original = qualify_controller(plan, evidence, receipt_id="qualified-9b2")
+    changed = replace(evidence, sealed_at="2042-01-01T00:08:01.000000Z")
+    revised = qualify_controller(plan, changed, receipt_id="qualified-9b2")
+    assert original.controller_evidence_digest != revised.controller_evidence_digest
+    assert original.canonical_digest != revised.canonical_digest
+
+
+def test_bundle_and_receipt_strict_canonical_round_trip() -> None:
+    plan = _controller_plan()
+    evidence = _evidence(plan)
+    receipt = qualify_controller(plan, evidence, receipt_id="qualified-9b2")
+    assert ControllerEvidenceBundle.from_bytes(evidence.canonical_bytes) == evidence
+    assert ControllerQualificationReceipt.from_bytes(receipt.canonical_bytes) == receipt
+
+
+def test_missing_recovery_check_or_equivalence_evidence_fails_closed() -> None:
+    plan = _controller_plan()
+    controller = _controller(plan)
+    common = {
+        "fixtures": _fixtures(plan),
+        "scenario_evidence_digests": {item: D("7") for item in RECOVERY_SCENARIOS},
+        "check_evidence_digests": {item: D("8") for item in CHECK_IDS},
+        "equivalence_evidence_digests": {
+            item: D("9") for item in plan.production_difference_ids
+        },
+        "sealed_at": T8,
+        "production_nonmutation_after_digest": plan.production_nonmutation_before_digest,
+    }
+    for field in (
+        "scenario_evidence_digests",
+        "check_evidence_digests",
+        "equivalence_evidence_digests",
+    ):
+        changed = {**common, field: dict(common[field])}
+        changed[field].pop(next(iter(changed[field])))
+        with pytest.raises(ControllerError, match="evidence inventory"):
+            controller.qualify(**changed)
+
+
+def test_forged_ledger_payload_and_stage_chronology_do_not_qualify() -> None:
+    plan = _controller_plan()
+    evidence = _evidence(plan)
+    ledger = list(evidence.ledger)
+    ledger[1] = replace(ledger[1], payload_digest=D("f"))
+    forged = replace(evidence, ledger=tuple(ledger))
+    assert qualify_controller(plan, forged, receipt_id="forged").disposition is ControllerQualificationDisposition.NOT_READY
+
+    fixtures = list(_fixtures(plan))
+    fixtures[1] = replace(
+        fixtures[1],
+        started_at="2042-01-01T00:06:59.000000Z",
+        completed_at="2042-01-01T00:07:00.000000Z",
+    )
+    with pytest.raises(ControllerError, match="downstream"):
+        _controller(plan).qualify(
+            fixtures=tuple(fixtures),
+            scenario_evidence_digests={item: D("7") for item in RECOVERY_SCENARIOS},
+            check_evidence_digests={item: D("8") for item in CHECK_IDS},
+            equivalence_evidence_digests={item: D("9") for item in plan.production_difference_ids},
+            sealed_at=T8,
+            production_nonmutation_after_digest=plan.production_nonmutation_before_digest,
+        )
+
+
+def test_plan_rejects_stage_interface_not_bound_to_effective_manifest() -> None:
+    plan = _controller_plan()
+    interfaces = dict(plan.stage_interface_digests)
+    interfaces["SOURCE"] = D("f")
+    with pytest.raises(ControllerError, match="Effective Manifest"):
+        replace(plan, stage_interface_digests=interfaces)
+
+
+def test_append_only_journal_survives_restart_and_rejects_mutation(tmp_path) -> None:
+    path = tmp_path / "controller-journal.sqlite3"
+    connection = sqlite3.connect(path)
+    plan = _controller_plan()
+    controller = ReplayIntegrationController(
+        plan, initialise_controller_journal(connection)
+    )
+    evidence = controller.qualify(
+        fixtures=_fixtures(plan),
+        scenario_evidence_digests={item: D("7") for item in RECOVERY_SCENARIOS},
+        check_evidence_digests={item: D("8") for item in CHECK_IDS},
+        equivalence_evidence_digests={
+            item: D("9") for item in plan.production_difference_ids
+        },
+        sealed_at=T8,
+        production_nonmutation_after_digest=plan.production_nonmutation_before_digest,
+    )
+    connection.close()
+
+    reopened = sqlite3.connect(path)
+    journal = ControllerEvidenceJournal(reopened)
+    assert journal.inventory() == evidence.ledger
+    with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+        reopened.execute("UPDATE controller_ledger SET entry_bytes=entry_bytes")
+    reopened.rollback()
+    with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+        reopened.execute("DELETE FROM controller_ledger")
+    reopened.rollback()
+    with pytest.raises(ControllerError, match="empty journal"):
+        ReplayIntegrationController(plan, journal)

--- a/newsroom/tests/test_increment9b2_shadow_controller.py
+++ b/newsroom/tests/test_increment9b2_shadow_controller.py
@@ -14,6 +14,8 @@ from newsroom.increment9.controller import (
     STAGE_MANIFEST_DIMENSIONS,
     ControllerError,
     ControllerEvidenceJournal,
+    CONTROLLER_JOURNAL_APPLICATION_ID,
+    CONTROLLER_JOURNAL_SCHEMA_VERSION,
     ControllerQualificationDisposition,
     ControllerQualificationPlan,
     ControllerQualificationReceipt,
@@ -458,3 +460,24 @@ def test_append_only_journal_survives_restart_and_rejects_mutation(tmp_path) -> 
     reopened.rollback()
     with pytest.raises(ControllerError, match="empty journal"):
         ReplayIntegrationController(plan, journal)
+
+
+def test_lookalike_journal_schema_is_rejected() -> None:
+    connection = sqlite3.connect(":memory:")
+    connection.executescript(
+        """
+        CREATE TABLE controller_ledger (
+            ordinal INTEGER,
+            entry_digest TEXT,
+            entry_bytes BLOB
+        );
+        CREATE TRIGGER controller_ledger_no_update
+        BEFORE UPDATE ON controller_ledger BEGIN SELECT 1; END;
+        CREATE TRIGGER controller_ledger_no_delete
+        BEFORE DELETE ON controller_ledger BEGIN SELECT 1; END;
+        """
+    )
+    connection.execute(f"PRAGMA application_id={CONTROLLER_JOURNAL_APPLICATION_ID}")
+    connection.execute(f"PRAGMA user_version={CONTROLLER_JOURNAL_SCHEMA_VERSION}")
+    with pytest.raises(ControllerError, match="schema"):
+        ControllerEvidenceJournal(connection)


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-9b2-492
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

## Summary

- bind the exact #488/#489 scope, #490 deployment/readiness receipts, #491 Epoch, resolved Effective Manifest, current Cohort, replay Run and Attempt into one strict canonical controller plan;
- assemble the exact Source → discovery → extraction → Graphiti proposal → deterministic admission → Neo4j projection → hybrid retrieval → triage → Candidate → Handoff → evaluation-sink path;
- bind every stage interface to its resolved Effective Manifest identity and require a content-addressed response-to-request chain;
- add a dedicated append-only isolated SQLite journal that persists control envelope, budget reservation, request, response, proposal/decision, checkpoint, usage and cost before downstream execution;
- retain exact restart/replay, duplicate, lost-response, partial-response, ambiguous-effect, kill propagation and teardown/rebuild evidence;
- require complete rights, purpose, credential, egress, budget, freshness, watermark, gap, dead-letter, compatibility, non-effect, non-mutation and production-equivalence evidence;
- produce only a non-activating `READY_FOR_9B3_AUTHORISATION_GATE` or `NOT_READY` receipt.

## Runtime boundary

Fixture/replay qualification and approved isolated readiness probes only. No live source/provider/model/embedding request, credentials, egress, spend, decision-bearing campaign, Evidence Intake, publication, canary or production mutation/activation. #493 remains blocked until this atom closes and its separate execution gate passes.

## Dependencies

- #488, #489, #490, #491 and #500 are closed completed on current main `4429323296bc037e8d5eb702c5777b2fc20d89b1`;
- #490 exact-head readiness run `31923002243` and SDLC run `31923002263` passed before merge;
- this PR changes only the three owner-assigned #492 files.

## Local evidence

- TDD red: the new test module initially failed collection because the controller module was absent;
- 24 controller tests passed, including durable-journal restart, immutability and lookalike-schema rejection;
- 176 Increment 9 planning/contract/deployment/Epoch/controller/comparator/review tests passed;
- compileall and `git diff --check` passed;
- no external call, credential lookup, spend or runtime campaign occurred.

## Exact-head gate

- head `cff1dce3a0257c83b079955960d6e3091f969cb3`, tree `dd60145c1ee7213d13c2381d2555052fd76738f0`;
- SDLC run `31924037015` PASS: 4,024 outcomes, 0 failures/errors/required skips and source integrity PASS; decision `sha256:af5d9c26088bb17ca7d7c416670d0c09e4aaa885c5c92d005e464143a92a14f5`;
- manually dispatched exact-head readiness run `31924038314` PASS: Neo4j 5.26.2 Community, isolated database/namespace, FULLTEXT/VECTOR online, round trip, actual restart/re-authentication, zero residual nodes/indexes and zero secrets.
- final substantive review `4945304552`: P1=0, material P2=0, unresolved threads=0.

Closes #492
