### PR TITLE
Increment 9G: build exact-main blocked closeout subjects

### DIFF
--- a/docs/traceability/increment-9g-final-closeout.md
+++ b/docs/traceability/increment-9g-final-closeout.md
@@ -1,0 +1,106 @@
+# Increment 9G exact-main integrated shadow closeout
+
+- **Issue:** [#498](https://github.com/fol2/newsroom/issues/498)
+- **Signing prerequisite:** [#521](https://github.com/fol2/newsroom/issues/521)
+- **Module:** `newsroom.increment9.closeout`
+- **Builder/verifier:** `scripts/sdlc/increment9g_closeout_receipt.py`
+
+## Outcome preserved
+
+Increment 9 completed its evidence process with the explicit shadow disposition
+`BLOCKED_ACTIVE_COVERAGE`:
+
+- 9B3 stopped before first I/O because twenty material runtime gates remained;
+- the Run/Attempt/checkpoint inventory is empty and reconciled;
+- 9C2 retained all eight comparator and eighteen fault phases as not run under
+  the higher-precedence stop;
+- 9D2 retained every metric, slice, ablation, reviewer, zero-tolerance and
+  operational result as `NOT_EVALUATED`; and
+- source/provider/model/embedding/reviewer usage, spend, public effects and
+  production mutations are zero.
+
+Closeout completion does not turn this result into a technical PASS. Increment
+10 eligibility, Evidence Intake, publication, canary, production mutation and
+production activation remain false.
+
+## Exact closed world
+
+The builder requires live-retained CLOSED evidence for #488–#497, #500 and the
+narrow signing prerequisite #521. It refuses an open/missing dependency. #498
+itself remains open during the final signed run and closes only after the bundle
+verifies.
+
+At one exact clean main SHA/tree, the builder independently reconstructs:
+
+1. the owner-approved plan and digest;
+2. the final 9B3 blocked campaign bundle from closed dependency gates;
+3. the final 9C2 complete not-run phase inventory;
+4. the final 9D2 `BLOCKED_ACTIVE_COVERAGE` decision;
+5. the #490 actual Neo4j 5.26.2 readiness/restart receipt;
+6. the reconciled Run inventory;
+7. the complete review/metric report;
+8. the accepted 18-shard topology and unchanged 75/90 and 300/330 limits;
+9. the exact-main Tier-M SDLC decision with both core and actual-service lanes;
+   and
+10. the final closeout receipt and signed-subject manifest.
+
+The historical #490 evidence is fixed to run `31923002243`, head
+`390237b9183f5ee77da363669de3ddef964d0c32`, Community Neo4j 5.26.2,
+`increment9` / `increment9_shadow`, actual restart/re-authentication and zero
+residual nodes, indexes or secrets.
+
+## Required signed subjects
+
+The final GitHub Actions OIDC/Sigstore attestation contains at minimum:
+
+- exact SDLC decision;
+- `increment9-shadow-plan.json`;
+- `increment9-deployment-receipt.json`;
+- `increment9-run-inventory.json`;
+- `increment9-review-metric-report.json`;
+- `increment9-shadow-decision.json`; and
+- `increment9g-final-closeout.json`.
+
+The campaign, fault, issue-inventory and subject-manifest files are retained and
+attested as additional subjects. File digests, canonical identities, exact
+SHA/tree and cross-subject bindings are reconstructed before signing and again
+from the downloaded bundle.
+
+## Topology and gates
+
+The closeout refuses any topology other than:
+
+- 18 core shards;
+- two persistent work-stealing workers per shard;
+- testcase warning/hard 75/90 seconds;
+- shard/critical-path warning/hard 300/330 seconds; and
+- zero required failures, errors or skips.
+
+The final manual Tier-M run must report all complete deterministic outcomes,
+source integrity and the actual Neo4j service lane on exact `main`. P1,
+material-P2 and unresolved review-thread counts must all remain zero.
+
+## Commands
+
+```bash
+python -m scripts.sdlc.increment9g_closeout_receipt build \
+  --repo-root . \
+  --issue-directory /protected/increment9/issues \
+  --sdlc-decision /protected/increment9/decision.json \
+  --deployment-readiness /protected/increment9/increment9-neo4j-readiness.json \
+  --deployment-restart /protected/increment9/increment9-neo4j-restart.json \
+  --observed-at 2026-08-16T00:00:00.000000Z \
+  --output-directory /protected/increment9/subjects
+
+python -m scripts.sdlc.increment9g_closeout_receipt verify \
+  --repo-root . \
+  --subject-directory /protected/increment9/subjects \
+  --sdlc-decision /protected/increment9/decision.json
+```
+
+## Final downstream record
+
+The closeout status is `INCREMENT9_EVIDENCE_PROCESS_CLOSED`, while its shadow
+outcome stays `BLOCKED_ACTIVE_COVERAGE`. Parent #149 may close with that explicit
+result. Parent #150 remains blocked: no suitable canary scope, no accepted
+Evidence Intake authority and no separate Increment 10 owner plan exist.

--- a/newsroom/increment9/closeout.py
+++ b/newsroom/increment9/closeout.py
@@ -174,6 +174,25 @@ def build_deployment_receipt(
     return {**body, "receipt_digest": digest_bytes(canonical_json_bytes(body))}
 
 
+def verify_deployment_receipt(raw: bytes) -> dict[str, object]:
+    value = exact_json(raw)
+    body = dict(value)
+    claimed = _digest(body.pop("receipt_digest", None), "deployment receipt")
+    if digest_bytes(canonical_json_bytes(body)) != claimed:
+        raise Increment9CloseoutError("deployment receipt digest differs")
+    if (
+        value.get("schema_version") != DEPLOYMENT_RECEIPT_SCHEMA
+        or value.get("deployment_run_id") != EXPECTED_DEPLOYMENT_RUN
+        or value.get("deployment_head") != EXPECTED_DEPLOYMENT_HEAD
+        or value.get("actual_service_ready") is not True
+        or value.get("production_nonmutation") is not True
+        or value.get("secret_value_count") != 0
+        or value.get("teardown_residual_count") != 0
+    ):
+        raise Increment9CloseoutError("deployment receipt outcome differs")
+    return value
+
+
 def build_run_inventory(
     *, campaign: Mapping[str, object], fault: Mapping[str, object]
 ) -> dict[str, object]:
@@ -213,6 +232,30 @@ def build_run_inventory(
     return {**body, "inventory_digest": digest_bytes(canonical_json_bytes(body))}
 
 
+def verify_run_inventory(raw: bytes) -> dict[str, object]:
+    value = exact_json(raw)
+    body = dict(value)
+    claimed = _digest(body.pop("inventory_digest", None), "run inventory")
+    if digest_bytes(canonical_json_bytes(body)) != claimed:
+        raise Increment9CloseoutError("run inventory digest differs")
+    if (
+        value.get("schema_version") != RUN_INVENTORY_SCHEMA
+        or value.get("campaign_outcome") != "BLOCKED"
+        or value.get("runs") != []
+        or value.get("attempts") != []
+        or value.get("checkpoints") != []
+        or value.get("decision_bearing_case_count") != 0
+        or value.get("fault_executed_count") != 0
+        or value.get("fault_not_run_count") != 26
+        or value.get("gross_gbp_minor_units") != 0
+        or value.get("source_http_attempts") != 0
+        or value.get("inventory_reconciled") is not True
+        or value.get("original_stop_retained") is not True
+    ):
+        raise Increment9CloseoutError("run inventory outcome differs")
+    return value
+
+
 def build_review_report(decision: BlockedShadowDecision) -> dict[str, object]:
     if decision.disposition is not ShadowDisposition.BLOCKED_ACTIVE_COVERAGE:
         raise Increment9CloseoutError("review disposition differs")
@@ -232,6 +275,32 @@ def build_review_report(decision: BlockedShadowDecision) -> dict[str, object]:
         "zero_tolerance_pass_claimed": False,
     }
     return {**body, "report_digest": digest_bytes(canonical_json_bytes(body))}
+
+
+def verify_review_report(raw: bytes) -> dict[str, object]:
+    value = exact_json(raw)
+    body = dict(value)
+    claimed = _digest(body.pop("report_digest", None), "review report")
+    if digest_bytes(canonical_json_bytes(body)) != claimed:
+        raise Increment9CloseoutError("review report digest differs")
+    costs = value.get("cost_and_capacity")
+    if (
+        value.get("schema_version") != REVIEW_REPORT_SCHEMA
+        or value.get("disposition") != "BLOCKED_ACTIVE_COVERAGE"
+        or value.get("metric_count") != 12
+        or value.get("slice_count") != 14
+        or value.get("ablation_count") != 16
+        or value.get("reviewer_count") != 3
+        or value.get("reviewer_invocation_count") != 0
+        or value.get("zero_tolerance_count") != 12
+        or value.get("zero_tolerance_pass_claimed") is not False
+        or value.get("all_values_not_evaluated") is not True
+        or value.get("production_equivalence_claim_permitted") is not False
+        or not isinstance(costs, Mapping)
+        or any(item != 0 for item in costs.values())
+    ):
+        raise Increment9CloseoutError("review report outcome differs")
+    return value
 
 
 @dataclass(frozen=True, slots=True)

--- a/newsroom/increment9/closeout.py
+++ b/newsroom/increment9/closeout.py
@@ -1,0 +1,334 @@
+"""Closed-world Increment 9G receipt and subject validators.
+
+The closeout preserves the blocked runtime result.  It can establish completion
+of the evidence process, but it cannot turn missing active coverage into
+operational, canary, Increment 10 or production eligibility.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Mapping
+
+from newsroom.authority.canonical import (
+    CanonicalizationError,
+    canonical_json_bytes,
+    digest_bytes,
+    validate_sha256_digest,
+)
+from newsroom.increment9.decision import BlockedShadowDecision, ShadowDisposition
+from newsroom.increment9.plan import INCREMENT_9_SHADOW_PLAN_DIGEST
+
+DEPLOYMENT_RECEIPT_SCHEMA = "newsroom.increment9.closeout-deployment-receipt.v1"
+RUN_INVENTORY_SCHEMA = "newsroom.increment9.closeout-run-inventory.v1"
+REVIEW_REPORT_SCHEMA = "newsroom.increment9.closeout-review-metric-report.v1"
+CLOSEOUT_SCHEMA = "newsroom.increment9.final-closeout.v1"
+MAX_SUBJECT_BYTES = 8_388_608
+EXPECTED_ISSUES = (*range(488, 498), 500, 521)
+EXPECTED_DEPLOYMENT_RUN = 31_923_002_243
+EXPECTED_DEPLOYMENT_HEAD = "390237b9183f5ee77da363669de3ddef964d0c32"
+EXPECTED_TOPOLOGY = {
+    "core_shards": 18,
+    "persistent_workers_per_shard": 2,
+    "required_error_count": 0,
+    "required_failure_count": 0,
+    "required_skip_count": 0,
+    "shard_hard_seconds": 330,
+    "shard_warning_seconds": 300,
+    "testcase_hard_seconds": 90,
+    "testcase_warning_seconds": 75,
+}
+_HEX40 = re.compile(r"[0-9a-f]{40}\Z")
+_UTC = re.compile(
+    r"[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T"
+    r"(?:[01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]\.[0-9]{6}Z\Z"
+)
+
+
+class Increment9CloseoutError(ValueError):
+    """A retained subject or final closeout binding differs."""
+
+
+def _pairs(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    value: dict[str, object] = {}
+    for name, item in pairs:
+        if type(name) is not str or name in value:
+            raise Increment9CloseoutError("closeout JSON names differ")
+        value[name] = item
+    return value
+
+
+def exact_json(raw: bytes, *, maximum: int = MAX_SUBJECT_BYTES) -> dict[str, object]:
+    if type(raw) is not bytes or not raw or len(raw) > maximum:
+        raise Increment9CloseoutError("closeout subject is absent or unbounded")
+    try:
+        value = json.loads(raw.decode("utf-8"), object_pairs_hook=_pairs)
+        canonical = canonical_json_bytes(value)
+    except Increment9CloseoutError:
+        raise
+    except (
+        UnicodeError,
+        json.JSONDecodeError,
+        CanonicalizationError,
+        RecursionError,
+    ) as exc:
+        raise Increment9CloseoutError("closeout subject is not canonical JSON") from exc
+    if canonical != raw or type(value) is not dict:
+        raise Increment9CloseoutError("closeout subject bytes differ")
+    return value
+
+
+def _digest(value: object, field: str) -> str:
+    if type(value) is not str:
+        raise Increment9CloseoutError(f"{field} digest differs")
+    try:
+        return validate_sha256_digest(value, field=field)
+    except (CanonicalizationError, TypeError, ValueError) as exc:
+        raise Increment9CloseoutError(f"{field} digest differs") from exc
+
+
+def _sha(value: object, field: str) -> str:
+    if type(value) is not str or not _HEX40.fullmatch(value):
+        raise Increment9CloseoutError(f"{field} SHA differs")
+    return value
+
+
+def _timestamp(value: object, field: str) -> str:
+    if type(value) is not str or not _UTC.fullmatch(value):
+        raise Increment9CloseoutError(f"{field} timestamp differs")
+    return value
+
+
+def _component(value: Mapping[str, object]) -> dict[str, object]:
+    raw = canonical_json_bytes(dict(value))
+    return {"canonical_digest": digest_bytes(raw), "file_sha256": digest_bytes(raw)}
+
+
+def validate_sdlc_decision(
+    value: Mapping[str, object], *, head: str, tree: str
+) -> str:
+    if value.get("schema_version") != "newsroom.sdlc.shadow-decision.v1" or value.get("result") != "PASS":
+        raise Increment9CloseoutError("SDLC decision is not PASS")
+    context = value.get("context")
+    totals = value.get("totals")
+    lanes = value.get("lanes")
+    if not isinstance(context, Mapping) or not isinstance(totals, Mapping) or not isinstance(lanes, list):
+        raise Increment9CloseoutError("SDLC decision structure differs")
+    if (
+        context.get("evaluated_sha") != head
+        or context.get("evaluated_tree_sha") != tree
+        or context.get("event_name") != "workflow_dispatch"
+        or context.get("ref") != "refs/heads/main"
+    ):
+        raise Increment9CloseoutError("SDLC decision is not exact main")
+    if (
+        totals.get("failure_count") != 0
+        or totals.get("error_count") != 0
+        or totals.get("required_skip_count") != 0
+        or not isinstance(totals.get("test_count"), int)
+        or totals["test_count"] < 4_024
+    ):
+        raise Increment9CloseoutError("SDLC totals differ")
+    if {item.get("lane_id") for item in lanes if isinstance(item, Mapping)} != {"core", "service"}:
+        raise Increment9CloseoutError("exact-main actual-service lane is absent")
+    return _digest(value.get("decision_identity"), "SDLC decision identity")
+
+
+def build_deployment_receipt(
+    *, readiness: Mapping[str, object], restart: Mapping[str, object]
+) -> dict[str, object]:
+    if (
+        readiness.get("server_name") != "Neo4j Kernel"
+        or readiness.get("server_version") != "5.26.2"
+        or readiness.get("edition") != "community"
+        or readiness.get("database") != "increment9"
+        or readiness.get("namespace") != "increment9_shadow"
+        or readiness.get("remaining_probe_indexes") != 0
+        or readiness.get("remaining_probe_nodes") != 0
+        or readiness.get("secret_value_count") != 0
+        or restart.get("server_version") != "5.26.2"
+        or restart.get("restart_count") != 1
+        or restart.get("remaining_probe_indexes") != 0
+        or restart.get("remaining_probe_nodes") != 0
+        or restart.get("secret_value_count") != 0
+    ):
+        raise Increment9CloseoutError("deployment readiness subject differs")
+    readiness_digest = _digest(readiness.get("evidence_digest"), "readiness evidence")
+    restart_digest = _digest(restart.get("evidence_digest"), "restart evidence")
+    body = {
+        "actual_service_ready": True,
+        "deployment_head": EXPECTED_DEPLOYMENT_HEAD,
+        "deployment_run_id": EXPECTED_DEPLOYMENT_RUN,
+        "issue_number": 490,
+        "production_nonmutation": True,
+        "readiness_evidence_digest": readiness_digest,
+        "readiness_file_digest": digest_bytes(canonical_json_bytes(dict(readiness))),
+        "restart_evidence_digest": restart_digest,
+        "restart_file_digest": digest_bytes(canonical_json_bytes(dict(restart))),
+        "schema_version": DEPLOYMENT_RECEIPT_SCHEMA,
+        "secret_value_count": 0,
+        "teardown_residual_count": 0,
+    }
+    return {**body, "receipt_digest": digest_bytes(canonical_json_bytes(body))}
+
+
+def build_run_inventory(
+    *, campaign: Mapping[str, object], fault: Mapping[str, object]
+) -> dict[str, object]:
+    launch = campaign.get("launch_receipt")
+    campaign_outcome = campaign.get("outcome")
+    fault_outcome = fault.get("outcome")
+    phases = fault.get("phase_inventory")
+    if not all(isinstance(item, Mapping) for item in (launch, campaign_outcome, fault_outcome)) or not isinstance(phases, list):
+        raise Increment9CloseoutError("runtime inventory structure differs")
+    if (
+        launch.get("disposition") != "BLOCKED_BEFORE_FIRST_IO"
+        or campaign_outcome.get("outcome") != "BLOCKED"
+        or campaign_outcome.get("run_attempt_inventory") != []
+        or fault_outcome.get("campaign_outcome") != "BLOCKED"
+        or fault_outcome.get("executed_phase_count") != 0
+        or fault_outcome.get("not_run_phase_count") != 26
+        or len(phases) != 26
+    ):
+        raise Increment9CloseoutError("runtime stop inventory differs")
+    body = {
+        "attempts": [],
+        "campaign_bundle_digest": _digest(campaign.get("bundle_digest"), "campaign bundle"),
+        "campaign_outcome": "BLOCKED",
+        "checkpoints": [],
+        "complete_denominators": True,
+        "decision_bearing_case_count": 0,
+        "fault_bundle_digest": _digest(fault.get("bundle_digest"), "fault bundle"),
+        "fault_executed_count": 0,
+        "fault_not_run_count": 26,
+        "gross_gbp_minor_units": 0,
+        "inventory_reconciled": True,
+        "original_stop_retained": True,
+        "runs": [],
+        "schema_version": RUN_INVENTORY_SCHEMA,
+        "source_http_attempts": 0,
+    }
+    return {**body, "inventory_digest": digest_bytes(canonical_json_bytes(body))}
+
+
+def build_review_report(decision: BlockedShadowDecision) -> dict[str, object]:
+    if decision.disposition is not ShadowDisposition.BLOCKED_ACTIVE_COVERAGE:
+        raise Increment9CloseoutError("review disposition differs")
+    body = {
+        "ablation_count": len(decision.ablations),
+        "all_values_not_evaluated": True,
+        "cost_and_capacity": dict(decision.cost_and_capacity),
+        "decision_digest": decision.canonical_digest,
+        "disposition": decision.disposition.value,
+        "metric_count": len(decision.metrics),
+        "production_equivalence_claim_permitted": False,
+        "reviewer_count": len(decision.reviewers),
+        "reviewer_invocation_count": sum(item.invocation_count for item in decision.reviewers),
+        "schema_version": REVIEW_REPORT_SCHEMA,
+        "slice_count": len(decision.slices),
+        "zero_tolerance_count": len(decision.zero_tolerance),
+        "zero_tolerance_pass_claimed": False,
+    }
+    return {**body, "report_digest": digest_bytes(canonical_json_bytes(body))}
+
+
+@dataclass(frozen=True, slots=True)
+class CloseoutInputs:
+    exact_main_sha: str
+    exact_main_tree: str
+    closed_at: str
+    issue_evidence_digest: str
+    sdlc_decision_identity: str
+    plan_file_digest: str
+    deployment_receipt_digest: str
+    run_inventory_digest: str
+    review_report_digest: str
+    shadow_decision_digest: str
+    topology: Mapping[str, object]
+    production_nonmutation: bool
+    public_effect_count: int
+    residual_blockers: tuple[str, ...]
+
+
+def build_closeout_receipt(inputs: CloseoutInputs) -> dict[str, object]:
+    _sha(inputs.exact_main_sha, "closeout main")
+    _sha(inputs.exact_main_tree, "closeout tree")
+    _timestamp(inputs.closed_at, "closeout time")
+    for field in (
+        "issue_evidence_digest",
+        "sdlc_decision_identity",
+        "plan_file_digest",
+        "deployment_receipt_digest",
+        "run_inventory_digest",
+        "review_report_digest",
+        "shadow_decision_digest",
+    ):
+        _digest(getattr(inputs, field), field)
+    if dict(inputs.topology) != EXPECTED_TOPOLOGY:
+        raise Increment9CloseoutError("accepted topology differs")
+    if (
+        inputs.production_nonmutation is not True
+        or inputs.public_effect_count != 0
+        or not inputs.residual_blockers
+        or inputs.residual_blockers != tuple(sorted(set(inputs.residual_blockers)))
+    ):
+        raise Increment9CloseoutError("blocked closeout boundary differs")
+    body = {
+        "closed_at": inputs.closed_at,
+        "completion_status": "INCREMENT9_EVIDENCE_PROCESS_CLOSED",
+        "deployment_receipt_digest": inputs.deployment_receipt_digest,
+        "downstream": {
+            "increment10_eligible": False,
+            "reason": "BLOCKED_ACTIVE_COVERAGE",
+            "separate_increment10_plan_authorised": False,
+        },
+        "exact_main_sha": inputs.exact_main_sha,
+        "exact_main_tree": inputs.exact_main_tree,
+        "issue_evidence_digest": inputs.issue_evidence_digest,
+        "non_effects": {
+            "canary": False,
+            "evidence_intake": False,
+            "production_activation": False,
+            "production_mutation": False,
+            "publication": False,
+            "public_effect_count": inputs.public_effect_count,
+        },
+        "owner_plan_digest": INCREMENT_9_SHADOW_PLAN_DIGEST,
+        "plan_file_digest": inputs.plan_file_digest,
+        "production_nonmutation": inputs.production_nonmutation,
+        "residual_blockers": list(inputs.residual_blockers),
+        "review_report_digest": inputs.review_report_digest,
+        "run_inventory_digest": inputs.run_inventory_digest,
+        "schema_version": CLOSEOUT_SCHEMA,
+        "sdlc_decision_identity": inputs.sdlc_decision_identity,
+        "shadow_decision_digest": inputs.shadow_decision_digest,
+        "shadow_disposition": "BLOCKED_ACTIVE_COVERAGE",
+        "signed_subjects_required": True,
+        "topology": dict(inputs.topology),
+    }
+    return {**body, "closeout_digest": digest_bytes(canonical_json_bytes(body))}
+
+
+def verify_closeout_receipt(raw: bytes) -> dict[str, object]:
+    value = exact_json(raw)
+    if value.get("schema_version") != CLOSEOUT_SCHEMA:
+        raise Increment9CloseoutError("closeout schema differs")
+    body = dict(value)
+    claimed = _digest(body.pop("closeout_digest", None), "closeout digest")
+    if digest_bytes(canonical_json_bytes(body)) != claimed:
+        raise Increment9CloseoutError("closeout digest differs")
+    if (
+        value.get("shadow_disposition") != "BLOCKED_ACTIVE_COVERAGE"
+        or value.get("production_nonmutation") is not True
+        or value.get("signed_subjects_required") is not True
+        or value.get("downstream")
+        != {
+            "increment10_eligible": False,
+            "reason": "BLOCKED_ACTIVE_COVERAGE",
+            "separate_increment10_plan_authorised": False,
+        }
+    ):
+        raise Increment9CloseoutError("closeout outcome differs")
+    return value

--- a/scripts/sdlc/increment9g_closeout_receipt.py
+++ b/scripts/sdlc/increment9g_closeout_receipt.py
@@ -1,0 +1,485 @@
+#!/usr/bin/env python3
+"""Build and independently verify exact-main Increment 9G subjects."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import stat
+import subprocess
+import tempfile
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Mapping, Sequence
+
+from newsroom.authority.canonical import canonical_json_bytes, digest_bytes
+from newsroom.increment9.closeout import (
+    EXPECTED_ISSUES,
+    EXPECTED_TOPOLOGY,
+    CloseoutInputs,
+    Increment9CloseoutError,
+    build_closeout_receipt,
+    build_deployment_receipt,
+    build_review_report,
+    build_run_inventory,
+    exact_json,
+    validate_sdlc_decision,
+    verify_closeout_receipt,
+)
+from newsroom.increment9.decision import BlockedShadowDecision
+from newsroom.increment9.plan import (
+    INCREMENT_9_SHADOW_PLAN_DIGEST,
+    SHADOW_PLAN_PATH,
+)
+from scripts.increment9_fault_campaign import (
+    DEPENDENCY_SCHEMA as FAULT_DEPENDENCY_SCHEMA,
+    build_stopped_bundle,
+    verify_fault_bundle,
+)
+from scripts.increment9_shadow_campaign import (
+    GateRecord,
+    GateStatus,
+    build_bundle as build_campaign_bundle,
+    verify_bundle as verify_campaign_bundle,
+)
+from scripts.increment9_shadow_decision import (
+    DEPENDENCY_SCHEMA as REVIEW_DEPENDENCY_SCHEMA,
+    build_decision,
+)
+from scripts.sdlc.contracts import load_contract
+
+ISSUE_INVENTORY_SCHEMA = "newsroom.increment9.closeout-issue-inventory.v1"
+SUBJECT_MANIFEST_SCHEMA = "newsroom.increment9.closeout-subject-manifest.v1"
+SUBJECT_FILES = (
+    "increment9-campaign-bundle.json",
+    "increment9-deployment-receipt.json",
+    "increment9-fault-bundle.json",
+    "increment9-issue-inventory.json",
+    "increment9-review-metric-report.json",
+    "increment9-run-inventory.json",
+    "increment9-shadow-decision.json",
+    "increment9-shadow-plan.json",
+    "increment9g-final-closeout.json",
+)
+_DEPENDENCY_GATE_NAMES = {
+    488: "ISSUE_488_OWNER_PLAN",
+    489: "ISSUE_489_SHADOW_CONTRACT",
+    490: "ISSUE_490_ISOLATED_DEPLOYMENT",
+    491: "ISSUE_491_FROZEN_EPOCH",
+    492: "ISSUE_492_CONTROLLER_QUALIFICATION",
+}
+_HEX40 = re.compile(r"[0-9a-f]{40}\Z")
+
+
+class Increment9CloseoutCommandError(ValueError):
+    """Closeout command inputs or retained subjects differ."""
+
+
+def _git(repo: Path) -> tuple[str, str]:
+    def run(*arguments: str) -> str:
+        result = subprocess.run(
+            ["git", "-C", str(repo), *arguments],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip()
+
+    head, tree = run("rev-parse", "HEAD"), run("rev-parse", "HEAD^{tree}")
+    if not _HEX40.fullmatch(head) or not _HEX40.fullmatch(tree):
+        raise Increment9CloseoutCommandError("checkout identity differs")
+    if run("status", "--porcelain"):
+        raise Increment9CloseoutCommandError("checkout is not clean")
+    return head, tree
+
+
+def _write(path: Path, value: Mapping[str, object] | bytes) -> None:
+    path = path.resolve()
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    if stat.S_IMODE(path.parent.stat().st_mode) & 0o077:
+        raise Increment9CloseoutCommandError("subject output parent is too permissive")
+    raw = value if type(value) is bytes else canonical_json_bytes(dict(value))
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(raw)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    finally:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+
+
+def _load_issue(path: Path) -> dict[str, object]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise Increment9CloseoutCommandError(f"invalid issue snapshot: {path.name}") from exc
+    if type(value) is not dict or set(value) != {
+        "closedAt",
+        "number",
+        "state",
+        "title",
+        "url",
+    }:
+        raise Increment9CloseoutCommandError("issue snapshot fields differ")
+    return value
+
+
+def _timestamp(value: str) -> str:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    return parsed.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def _issue_inventory(issue_directory: Path) -> tuple[dict[str, object], dict[int, dict[str, object]]]:
+    issues: dict[int, dict[str, object]] = {}
+    entries: list[dict[str, object]] = []
+    for number in EXPECTED_ISSUES:
+        raw_path = issue_directory / f"issue-{number}.json"
+        value = _load_issue(raw_path)
+        if value["number"] != number or value["state"] != "CLOSED" or not value["closedAt"]:
+            raise Increment9CloseoutCommandError(f"issue #{number} is not closed")
+        issues[number] = value
+        entries.append(
+            {
+                "closed_at": _timestamp(value["closedAt"]),
+                "evidence_digest": digest_bytes(canonical_json_bytes(value)),
+                "number": number,
+                "state": "CLOSED",
+                "url": value["url"],
+            }
+        )
+    body = {
+        "issues": entries,
+        "schema_version": ISSUE_INVENTORY_SCHEMA,
+    }
+    return {**body, "inventory_digest": digest_bytes(canonical_json_bytes(body))}, issues
+
+
+def _dependency_evidence(
+    *,
+    schema: str,
+    numbers: tuple[int, ...],
+    issues: Mapping[int, Mapping[str, object]],
+    head: str,
+    tree: str,
+    observed_at: str,
+) -> bytes:
+    entries = [
+        {
+            "closed_at": _timestamp(str(issues[number]["closedAt"])),
+            "evidence_digest": digest_bytes(canonical_json_bytes(dict(issues[number]))),
+            "number": number,
+            "state": "CLOSED",
+        }
+        for number in numbers
+    ]
+    body = {
+        "exact_main_sha": head,
+        "exact_main_tree": tree,
+        "issues": entries,
+        "observed_at": observed_at,
+        "schema_version": schema,
+    }
+    return canonical_json_bytes(
+        {**body, "evidence_digest": digest_bytes(canonical_json_bytes(body))}
+    )
+
+
+def _campaign_gates(
+    *,
+    root: Path,
+    issues: Mapping[int, Mapping[str, object]],
+    head: str,
+    tree: str,
+    observed_at: str,
+) -> Path:
+    gates = root / "campaign-gates"
+    gates.mkdir(mode=0o700)
+    observed = datetime.strptime(observed_at, "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=UTC)
+    expires = (observed + timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    for number, gate_id in _DEPENDENCY_GATE_NAMES.items():
+        evidence = digest_bytes(canonical_json_bytes(dict(issues[number])))
+        subject = INCREMENT_9_SHADOW_PLAN_DIGEST if number == 488 else evidence
+        record = GateRecord(
+            gate_id=gate_id,
+            observed_at=observed_at,
+            expires_at=expires,
+            exact_main_sha=head,
+            exact_main_tree=tree,
+            subject_digest=subject,
+            evidence_digest=evidence,
+            issuer_id="github-fol2-exact-main-closeout",
+            status=GateStatus.PASS,
+        )
+        _write(gates / f"{gate_id}.json", record.primitive())
+    return gates
+
+
+def _topology(repo: Path) -> dict[str, object]:
+    contract = load_contract(repo)
+    data = contract.data
+    strategy = data["test_strategy"]
+    core = data["lanes"]["core"]
+    gate = data["gate"]["core-deterministic"]
+    observed = {
+        "core_shards": core["shard_count"],
+        "persistent_workers_per_shard": core["workers_per_shard"],
+        "required_error_count": 0,
+        "required_failure_count": 0,
+        "required_skip_count": 0,
+        "shard_hard_seconds": gate["hard_timeout_seconds"],
+        "shard_warning_seconds": core["per_shard_warning_seconds"],
+        "testcase_hard_seconds": strategy["individual_testcase_hard_timeout_seconds"],
+        "testcase_warning_seconds": strategy["individual_testcase_warning_seconds"],
+    }
+    if observed != EXPECTED_TOPOLOGY:
+        raise Increment9CloseoutCommandError("topology differs")
+    return observed
+
+
+def build_subjects(
+    *,
+    repo: Path,
+    issue_directory: Path,
+    sdlc_decision_path: Path,
+    readiness_path: Path,
+    restart_path: Path,
+    observed_at: str,
+    output_directory: Path,
+) -> dict[str, object]:
+    head, tree = _git(repo)
+    output_directory = output_directory.resolve()
+    output_directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+    if stat.S_IMODE(output_directory.stat().st_mode) & 0o077:
+        raise Increment9CloseoutCommandError("output directory is too permissive")
+    issue_inventory, issues = _issue_inventory(issue_directory)
+    sdlc_raw = sdlc_decision_path.read_bytes()
+    sdlc = json.loads(sdlc_raw)
+    sdlc_identity = validate_sdlc_decision(sdlc, head=head, tree=tree)
+    readiness = exact_json(readiness_path.read_bytes())
+    restart = exact_json(restart_path.read_bytes())
+    deployment = build_deployment_receipt(readiness=readiness, restart=restart)
+    with tempfile.TemporaryDirectory(prefix="increment9g-") as temporary:
+        temporary_path = Path(temporary)
+        os.chmod(temporary_path, 0o700)
+        gates = _campaign_gates(
+            root=temporary_path,
+            issues=issues,
+            head=head,
+            tree=tree,
+            observed_at=observed_at,
+        )
+        campaign = build_campaign_bundle(
+            repo=repo,
+            gate_directory=gates,
+            campaign_id="increment9-final-blocked-epoch",
+            observed_at=observed_at,
+        )
+        if len(campaign["launch_receipt"]["finding_ids"]) != 20:
+            raise Increment9CloseoutCommandError("final campaign blocker inventory differs")
+        fault_dependencies = _dependency_evidence(
+            schema=FAULT_DEPENDENCY_SCHEMA,
+            numbers=(490, 491, 492, 493, 494),
+            issues=issues,
+            head=head,
+            tree=tree,
+            observed_at=observed_at,
+        )
+        fault = build_stopped_bundle(
+            repo=repo,
+            campaign_bundle_raw=canonical_json_bytes(campaign),
+            dependency_evidence_raw=fault_dependencies,
+            observed_at=observed_at,
+        )
+        review_dependencies = _dependency_evidence(
+            schema=REVIEW_DEPENDENCY_SCHEMA,
+            numbers=(493, 495, 496),
+            issues=issues,
+            head=head,
+            tree=tree,
+            observed_at=observed_at,
+        )
+        decision = build_decision(
+            repo=repo,
+            campaign_raw=canonical_json_bytes(campaign),
+            fault_raw=canonical_json_bytes(fault),
+            dependency_raw=review_dependencies,
+            decision_id="increment9-final-blocked-shadow-decision",
+            decided_at=observed_at,
+        )
+    run_inventory = build_run_inventory(campaign=campaign, fault=fault)
+    review_report = build_review_report(decision)
+    plan_raw = (repo / SHADOW_PLAN_PATH).read_bytes()
+    if digest_bytes(plan_raw) != INCREMENT_9_SHADOW_PLAN_DIGEST:
+        raise Increment9CloseoutCommandError("owner plan file differs")
+    closeout = build_closeout_receipt(
+        CloseoutInputs(
+            exact_main_sha=head,
+            exact_main_tree=tree,
+            closed_at=observed_at,
+            issue_evidence_digest=issue_inventory["inventory_digest"],
+            sdlc_decision_identity=sdlc_identity,
+            plan_file_digest=digest_bytes(plan_raw),
+            deployment_receipt_digest=deployment["receipt_digest"],
+            run_inventory_digest=run_inventory["inventory_digest"],
+            review_report_digest=review_report["report_digest"],
+            shadow_decision_digest=decision.canonical_digest,
+            topology=_topology(repo),
+            production_nonmutation=True,
+            public_effect_count=0,
+            residual_blockers=decision.residual_blockers,
+        )
+    )
+    subjects: dict[str, bytes] = {
+        "increment9-campaign-bundle.json": canonical_json_bytes(campaign),
+        "increment9-deployment-receipt.json": canonical_json_bytes(deployment),
+        "increment9-fault-bundle.json": canonical_json_bytes(fault),
+        "increment9-issue-inventory.json": canonical_json_bytes(issue_inventory),
+        "increment9-review-metric-report.json": canonical_json_bytes(review_report),
+        "increment9-run-inventory.json": canonical_json_bytes(run_inventory),
+        "increment9-shadow-decision.json": decision.canonical_bytes,
+        "increment9-shadow-plan.json": plan_raw,
+        "increment9g-final-closeout.json": canonical_json_bytes(closeout),
+    }
+    for name, raw in subjects.items():
+        _write(output_directory / name, raw)
+    manifest_body = {
+        "exact_main_sha": head,
+        "exact_main_tree": tree,
+        "schema_version": SUBJECT_MANIFEST_SCHEMA,
+        "subjects": [
+            {"file": name, "sha256": digest_bytes(subjects[name])}
+            for name in SUBJECT_FILES
+        ],
+    }
+    manifest = {
+        **manifest_body,
+        "manifest_digest": digest_bytes(canonical_json_bytes(manifest_body)),
+    }
+    _write(output_directory / "increment9-subject-manifest.json", manifest)
+    verify_subjects(
+        repo=repo,
+        subject_directory=output_directory,
+        sdlc_decision_path=sdlc_decision_path,
+    )
+    return manifest
+
+
+def verify_subjects(
+    *, repo: Path, subject_directory: Path, sdlc_decision_path: Path
+) -> dict[str, object]:
+    head, tree = _git(repo)
+    manifest = exact_json((subject_directory / "increment9-subject-manifest.json").read_bytes())
+    if manifest.get("schema_version") != SUBJECT_MANIFEST_SCHEMA or manifest.get("exact_main_sha") != head or manifest.get("exact_main_tree") != tree:
+        raise Increment9CloseoutCommandError("subject manifest checkout differs")
+    entries = manifest.get("subjects")
+    if not isinstance(entries, list) or tuple(item.get("file") for item in entries) != SUBJECT_FILES:
+        raise Increment9CloseoutCommandError("subject manifest inventory differs")
+    for item in entries:
+        raw = (subject_directory / item["file"]).read_bytes()
+        if digest_bytes(raw) != item["sha256"]:
+            raise Increment9CloseoutCommandError("signed subject file digest differs")
+    manifest_body = dict(manifest)
+    claimed = manifest_body.pop("manifest_digest")
+    if digest_bytes(canonical_json_bytes(manifest_body)) != claimed:
+        raise Increment9CloseoutCommandError("subject manifest digest differs")
+    plan_raw = (subject_directory / "increment9-shadow-plan.json").read_bytes()
+    if plan_raw != (repo / SHADOW_PLAN_PATH).read_bytes() or digest_bytes(plan_raw) != INCREMENT_9_SHADOW_PLAN_DIGEST:
+        raise Increment9CloseoutCommandError("signed plan differs")
+    campaign = verify_campaign_bundle((subject_directory / "increment9-campaign-bundle.json").read_bytes())
+    fault = verify_fault_bundle((subject_directory / "increment9-fault-bundle.json").read_bytes())
+    decision = BlockedShadowDecision.from_bytes((subject_directory / "increment9-shadow-decision.json").read_bytes())
+    closeout = verify_closeout_receipt((subject_directory / "increment9g-final-closeout.json").read_bytes())
+    sdlc = json.loads(sdlc_decision_path.read_bytes())
+    sdlc_identity = validate_sdlc_decision(sdlc, head=head, tree=tree)
+    if (
+        closeout["sdlc_decision_identity"] != sdlc_identity
+        or closeout["shadow_decision_digest"] != decision.canonical_digest
+        or closeout["run_inventory_digest"]
+        != exact_json((subject_directory / "increment9-run-inventory.json").read_bytes())["inventory_digest"]
+        or closeout["review_report_digest"]
+        != exact_json((subject_directory / "increment9-review-metric-report.json").read_bytes())["report_digest"]
+        or closeout["deployment_receipt_digest"]
+        != exact_json((subject_directory / "increment9-deployment-receipt.json").read_bytes())["receipt_digest"]
+        or closeout["shadow_disposition"] != decision.disposition.value
+        or campaign["outcome"]["outcome"] != "BLOCKED"
+        or fault["outcome"]["campaign_outcome"] != "BLOCKED"
+    ):
+        raise Increment9CloseoutCommandError("closeout subject binding differs")
+    return manifest
+
+
+def _self_test() -> None:
+    assert len(SUBJECT_FILES) == 9
+    assert EXPECTED_ISSUES == (*range(488, 498), 500, 521)
+    assert EXPECTED_TOPOLOGY["core_shards"] == 18
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    build = subparsers.add_parser("build")
+    build.add_argument("--repo-root", type=Path, required=True)
+    build.add_argument("--issue-directory", type=Path, required=True)
+    build.add_argument("--sdlc-decision", type=Path, required=True)
+    build.add_argument("--deployment-readiness", type=Path, required=True)
+    build.add_argument("--deployment-restart", type=Path, required=True)
+    build.add_argument("--observed-at", required=True)
+    build.add_argument("--output-directory", type=Path, required=True)
+    verify = subparsers.add_parser("verify")
+    verify.add_argument("--repo-root", type=Path, required=True)
+    verify.add_argument("--subject-directory", type=Path, required=True)
+    verify.add_argument("--sdlc-decision", type=Path, required=True)
+    subparsers.add_parser("self-test")
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "self-test":
+            _self_test()
+            print("SELF_TEST_PASS")
+            return 0
+        if args.command == "verify":
+            value = verify_subjects(
+                repo=args.repo_root,
+                subject_directory=args.subject_directory,
+                sdlc_decision_path=args.sdlc_decision,
+            )
+        else:
+            value = build_subjects(
+                repo=args.repo_root,
+                issue_directory=args.issue_directory,
+                sdlc_decision_path=args.sdlc_decision,
+                readiness_path=args.deployment_readiness,
+                restart_path=args.deployment_restart,
+                observed_at=args.observed_at,
+                output_directory=args.output_directory,
+            )
+        print(
+            json.dumps(
+                {
+                    "manifest_digest": value["manifest_digest"],
+                    "status": "VERIFIED",
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
+    except (
+        Increment9CloseoutCommandError,
+        Increment9CloseoutError,
+        OSError,
+        subprocess.CalledProcessError,
+        ValueError,
+    ) as exc:
+        print(f"increment9g_closeout_receipt: {exc}", file=os.sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sdlc/increment9g_closeout_receipt.py
+++ b/scripts/sdlc/increment9g_closeout_receipt.py
@@ -27,6 +27,9 @@ from newsroom.increment9.closeout import (
     exact_json,
     validate_sdlc_decision,
     verify_closeout_receipt,
+    verify_deployment_receipt,
+    verify_review_report,
+    verify_run_inventory,
 )
 from newsroom.increment9.decision import BlockedShadowDecision
 from newsroom.increment9.plan import (
@@ -145,6 +148,8 @@ def _issue_inventory(issue_directory: Path) -> tuple[dict[str, object], dict[int
         value = _load_issue(raw_path)
         if value["number"] != number or value["state"] != "CLOSED" or not value["closedAt"]:
             raise Increment9CloseoutCommandError(f"issue #{number} is not closed")
+        if value["url"] != f"https://github.com/fol2/newsroom/issues/{number}":
+            raise Increment9CloseoutCommandError(f"issue #{number} URL differs")
         issues[number] = value
         entries.append(
             {
@@ -399,15 +404,35 @@ def verify_subjects(
     closeout = verify_closeout_receipt((subject_directory / "increment9g-final-closeout.json").read_bytes())
     sdlc = json.loads(sdlc_decision_path.read_bytes())
     sdlc_identity = validate_sdlc_decision(sdlc, head=head, tree=tree)
+    run_inventory = verify_run_inventory(
+        (subject_directory / "increment9-run-inventory.json").read_bytes()
+    )
+    review_report = verify_review_report(
+        (subject_directory / "increment9-review-metric-report.json").read_bytes()
+    )
+    deployment = verify_deployment_receipt(
+        (subject_directory / "increment9-deployment-receipt.json").read_bytes()
+    )
+    issue_inventory = exact_json(
+        (subject_directory / "increment9-issue-inventory.json").read_bytes()
+    )
+    issue_body = dict(issue_inventory)
+    issue_claimed = issue_body.pop("inventory_digest", None)
+    issue_entries = issue_inventory.get("issues")
+    if (
+        issue_inventory.get("schema_version") != ISSUE_INVENTORY_SCHEMA
+        or not isinstance(issue_entries, list)
+        or tuple(item.get("number") for item in issue_entries) != EXPECTED_ISSUES
+        or digest_bytes(canonical_json_bytes(issue_body)) != issue_claimed
+    ):
+        raise Increment9CloseoutCommandError("signed issue inventory differs")
     if (
         closeout["sdlc_decision_identity"] != sdlc_identity
         or closeout["shadow_decision_digest"] != decision.canonical_digest
-        or closeout["run_inventory_digest"]
-        != exact_json((subject_directory / "increment9-run-inventory.json").read_bytes())["inventory_digest"]
-        or closeout["review_report_digest"]
-        != exact_json((subject_directory / "increment9-review-metric-report.json").read_bytes())["report_digest"]
-        or closeout["deployment_receipt_digest"]
-        != exact_json((subject_directory / "increment9-deployment-receipt.json").read_bytes())["receipt_digest"]
+        or closeout["run_inventory_digest"] != run_inventory["inventory_digest"]
+        or closeout["review_report_digest"] != review_report["report_digest"]
+        or closeout["deployment_receipt_digest"] != deployment["receipt_digest"]
+        or closeout["issue_evidence_digest"] != issue_inventory["inventory_digest"]
         or closeout["shadow_disposition"] != decision.disposition.value
         or campaign["outcome"]["outcome"] != "BLOCKED"
         or fault["outcome"]["campaign_outcome"] != "BLOCKED"


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-9g-498
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

## Summary

- reconstruct the final blocked 9B3/9C2/9D2 chain from exact-main closed issue evidence
- bind the actual #490 Neo4j readiness/restart subjects, empty Run inventory, complete review/metric report and accepted 18-shard topology
- build and independently verify the complete Increment 9G subject manifest and closeout receipt
- preserve `BLOCKED_ACTIVE_COVERAGE` and explicitly block Increment 10/canary/production eligibility

## Signing lifecycle

This PR intentionally does **not** auto-close #498. After this source merges, #521 will add the narrow GitHub Actions OIDC/Sigstore subject integration. #498 closes only after the manual Tier-M exact-main run and downloaded attestation independently verify.

## Non-effects

No source/provider/model/embedding/reviewer call, publication, Evidence Intake, canary or production mutation/activation is performed or authorised.

## Local evidence

- `SELF_TEST_PASS`
- compileall PASS
- `git diff --check` PASS

Final exact-main closeout generation remains gated on #521 CLOSED and a full manual Tier-M run.

