### PR TITLE
SDLC: sign exact Increment 9 closeout subjects

### DIFF
--- a/.github/workflows/evidence.yml
+++ b/.github/workflows/evidence.yml
@@ -569,6 +569,7 @@ jobs:
     permissions:
       actions: read
       contents: read
+      issues: read
       pull-requests: read
     steps:
       - name: Checkout evaluated head
@@ -714,6 +715,58 @@ jobs:
             --operational-admission-decision .sdlc-run/increment8-operational-admission-decision.json \
             --output .sdlc-run/increment8f-final-closeout.json
 
+      - name: Collect exact Increment 9G closeout inputs
+        if: >-
+          github.event_name == 'workflow_dispatch' &&
+          github.ref == 'refs/heads/main' &&
+          needs.route.outputs.service_required == 'true'
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          issue_root=".sdlc-run/increment9-issues"
+          deployment_root=".sdlc-run/increment9-deployment"
+          mkdir -p "${issue_root}" "${deployment_root}"
+          chmod 700 "${issue_root}" "${deployment_root}"
+          for number in {488..497} 500 521; do
+            gh issue view "${number}" \
+              --repo "${{ github.repository }}" \
+              --json number,state,title,closedAt,url \
+              > "${issue_root}/issue-${number}.json"
+            chmod 600 "${issue_root}/issue-${number}.json"
+          done
+          gh run download 31923002243 \
+            --repo "${{ github.repository }}" \
+            --name increment9-neo4j-5262-readiness-31923002243-1-390237b9183f5ee77da363669de3ddef964d0c32 \
+            --dir "${deployment_root}"
+          chmod 600 "${deployment_root}"/*.json
+
+      - name: Build and verify exact Increment 9G subjects
+        if: >-
+          github.event_name == 'workflow_dispatch' &&
+          github.ref == 'refs/heads/main' &&
+          needs.route.outputs.service_required == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          subject_root=".sdlc-run/increment9-subjects"
+          observed_at="$(date -u +'%Y-%m-%dT%H:%M:%S.%6NZ')"
+          mkdir -p "${subject_root}"
+          chmod 700 "${subject_root}"
+          uv run --no-sync python -m scripts.sdlc.increment9g_closeout_receipt build \
+            --repo-root . \
+            --issue-directory .sdlc-run/increment9-issues \
+            --sdlc-decision .sdlc-run/decision.json \
+            --deployment-readiness .sdlc-run/increment9-deployment/increment9-neo4j-readiness.json \
+            --deployment-restart .sdlc-run/increment9-deployment/increment9-neo4j-restart.json \
+            --observed-at "${observed_at}" \
+            --output-directory "${subject_root}"
+          uv run --no-sync python -m scripts.sdlc.increment9g_closeout_receipt verify \
+            --repo-root . \
+            --subject-directory "${subject_root}" \
+            --sdlc-decision .sdlc-run/decision.json
+
       - name: Upload final decision evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -730,6 +783,16 @@ jobs:
             .sdlc-run/increment8-qualification-packet.json
             .sdlc-run/increment8-operational-admission-decision.json
             .sdlc-run/increment8-substantive-review.json
+            .sdlc-run/increment9-subjects/increment9-campaign-bundle.json
+            .sdlc-run/increment9-subjects/increment9-deployment-receipt.json
+            .sdlc-run/increment9-subjects/increment9-fault-bundle.json
+            .sdlc-run/increment9-subjects/increment9-issue-inventory.json
+            .sdlc-run/increment9-subjects/increment9-review-metric-report.json
+            .sdlc-run/increment9-subjects/increment9-run-inventory.json
+            .sdlc-run/increment9-subjects/increment9-shadow-decision.json
+            .sdlc-run/increment9-subjects/increment9-shadow-plan.json
+            .sdlc-run/increment9-subjects/increment9-subject-manifest.json
+            .sdlc-run/increment9-subjects/increment9g-final-closeout.json
           if-no-files-found: error
           retention-days: 30
           compression-level: 0
@@ -1370,6 +1433,15 @@ jobs:
               raise SystemExit('signed decision context differs')
           PY
 
+      - name: Reconstruct exact Increment 9G subjects
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run --no-sync python -m scripts.sdlc.increment9g_closeout_receipt verify \
+            --repo-root . \
+            --subject-directory .sdlc-run/signed-closeout-input/increment9-subjects \
+            --sdlc-decision .sdlc-run/signed-closeout-input/decision.json
+
       - name: Attest final decision and closeout receipt
         id: attest
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
@@ -1383,6 +1455,16 @@ jobs:
             .sdlc-run/signed-closeout-input/increment8-qualification-packet.json
             .sdlc-run/signed-closeout-input/increment8-operational-admission-decision.json
             .sdlc-run/signed-closeout-input/increment8-substantive-review.json
+            .sdlc-run/signed-closeout-input/increment9-subjects/increment9-campaign-bundle.json
+            .sdlc-run/signed-closeout-input/increment9-subjects/increment9-deployment-receipt.json
+            .sdlc-run/signed-closeout-input/increment9-subjects/increment9-fault-bundle.json
+            .sdlc-run/signed-closeout-input/increment9-subjects/increment9-issue-inventory.json
+            .sdlc-run/signed-closeout-input/increment9-subjects/increment9-review-metric-report.json
+            .sdlc-run/signed-closeout-input/increment9-subjects/increment9-run-inventory.json
+            .sdlc-run/signed-closeout-input/increment9-subjects/increment9-shadow-decision.json
+            .sdlc-run/signed-closeout-input/increment9-subjects/increment9-shadow-plan.json
+            .sdlc-run/signed-closeout-input/increment9-subjects/increment9-subject-manifest.json
+            .sdlc-run/signed-closeout-input/increment9-subjects/increment9g-final-closeout.json
 
       - name: Retain attestation bundle
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/newsroom/tests/test_sdlc_evidence_workflow.py
+++ b/newsroom/tests/test_sdlc_evidence_workflow.py
@@ -169,6 +169,7 @@ def test_job_graph_is_exact_and_decision_always_reports() -> None:
     assert jobs["decision"]["permissions"] == {
         "actions": "read",
         "contents": "read",
+        "issues": "read",
         "pull-requests": "read",
     }
     assert jobs["signed-closeout"]["if"] == (
@@ -369,6 +370,16 @@ def test_lane_and_decision_artifacts_are_compact_immutable_and_attempt_scoped() 
                 ".sdlc-run/increment8-qualification-packet.json",
                 ".sdlc-run/increment8-operational-admission-decision.json",
                 ".sdlc-run/increment8-substantive-review.json",
+                ".sdlc-run/increment9-subjects/increment9-campaign-bundle.json",
+                ".sdlc-run/increment9-subjects/increment9-deployment-receipt.json",
+                ".sdlc-run/increment9-subjects/increment9-fault-bundle.json",
+                ".sdlc-run/increment9-subjects/increment9-issue-inventory.json",
+                ".sdlc-run/increment9-subjects/increment9-review-metric-report.json",
+                ".sdlc-run/increment9-subjects/increment9-run-inventory.json",
+                ".sdlc-run/increment9-subjects/increment9-shadow-decision.json",
+                ".sdlc-run/increment9-subjects/increment9-shadow-plan.json",
+                ".sdlc-run/increment9-subjects/increment9-subject-manifest.json",
+                ".sdlc-run/increment9-subjects/increment9g-final-closeout.json",
             ]
 
 
@@ -467,6 +478,16 @@ def test_signed_closeout_attests_only_the_validated_exact_main_receipt() -> None
         ".sdlc-run/signed-closeout-input/increment8-qualification-packet.json",
         ".sdlc-run/signed-closeout-input/increment8-operational-admission-decision.json",
         ".sdlc-run/signed-closeout-input/increment8-substantive-review.json",
+        ".sdlc-run/signed-closeout-input/increment9-subjects/increment9-campaign-bundle.json",
+        ".sdlc-run/signed-closeout-input/increment9-subjects/increment9-deployment-receipt.json",
+        ".sdlc-run/signed-closeout-input/increment9-subjects/increment9-fault-bundle.json",
+        ".sdlc-run/signed-closeout-input/increment9-subjects/increment9-issue-inventory.json",
+        ".sdlc-run/signed-closeout-input/increment9-subjects/increment9-review-metric-report.json",
+        ".sdlc-run/signed-closeout-input/increment9-subjects/increment9-run-inventory.json",
+        ".sdlc-run/signed-closeout-input/increment9-subjects/increment9-shadow-decision.json",
+        ".sdlc-run/signed-closeout-input/increment9-subjects/increment9-shadow-plan.json",
+        ".sdlc-run/signed-closeout-input/increment9-subjects/increment9-subject-manifest.json",
+        ".sdlc-run/signed-closeout-input/increment9-subjects/increment9g-final-closeout.json",
     ]
     upload = _step("signed-closeout", "Retain attestation bundle")
     assert upload["uses"] == UPLOAD
@@ -484,6 +505,41 @@ def test_signed_closeout_attests_only_the_validated_exact_main_receipt() -> None
         "archive": "true",
     }
     assert job["steps"][-1] == upload
+
+
+def test_increment9g_subjects_are_built_only_for_exact_main_tier_m() -> None:
+    condition = (
+        "github.event_name == 'workflow_dispatch' && "
+        "github.ref == 'refs/heads/main' && "
+        "needs.route.outputs.service_required == 'true'"
+    )
+    collect = _step("decision", "Collect exact Increment 9G closeout inputs")
+    assert collect["if"] == condition
+    assert collect["env"] == {"GITHUB_TOKEN": "${{ github.token }}"}
+    for expected in (
+        "for number in {488..497} 500 521",
+        'gh issue view "${number}"',
+        "gh run download 31923002243",
+        "increment9-neo4j-5262-readiness-31923002243-1-390237b9183f5ee77da363669de3ddef964d0c32",
+    ):
+        assert expected in collect["run"]
+
+    build = _step("decision", "Build and verify exact Increment 9G subjects")
+    assert build["if"] == condition
+    for expected in (
+        "scripts.sdlc.increment9g_closeout_receipt build",
+        "--sdlc-decision .sdlc-run/decision.json",
+        "--deployment-readiness .sdlc-run/increment9-deployment/increment9-neo4j-readiness.json",
+        "scripts.sdlc.increment9g_closeout_receipt verify",
+    ):
+        assert expected in build["run"]
+
+    reconstruct = _step("signed-closeout", "Reconstruct exact Increment 9G subjects")
+    assert "scripts.sdlc.increment9g_closeout_receipt verify" in reconstruct["run"]
+    assert (
+        "--subject-directory .sdlc-run/signed-closeout-input/increment9-subjects"
+        in reconstruct["run"]
+    )
 
 
 def test_only_signed_closeout_receives_oidc_and_attestation_permissions() -> None:
@@ -716,6 +772,7 @@ def test_github_token_exists_only_on_exact_collection_step() -> None:
     assert locations == [
         ("decision", "Collect exact lane evidence"),
         ("decision", "Retain exact Increment 8 substantive review"),
+        ("decision", "Collect exact Increment 9G closeout inputs"),
         ("signed-closeout", "Reconstruct exact Increment 8 admission subjects"),
     ]
 


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-9g-signing-521
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

## Summary

- collect the immutable closed-issue inventory and retained isolated Neo4j deployment evidence only on manual exact-main Tier-M runs;
- build and independently verify the complete Increment 9G subject inventory in the decision job;
- carry all ten Increment 9 subjects into the retained decision artifact and the existing OIDC/Sigstore attestation;
- reconstruct the subjects again in the signing job before attestation.

## Boundaries

- no product/runtime changes;
- no source, provider, model, embedding or reviewer calls;
- no publication, Evidence Intake, canary or production mutation;
- no timeout, budget, shard, worker, selection or skip changes;
- retained outcome remains `BLOCKED_ACTIVE_COVERAGE`; Increment 10 remains blocked.

## Local evidence

- `74 passed in 3.30s` across the evidence workflow, CI workflow and SDLC contract suites;
- YAML parse PASS;
- `git diff --check` PASS.

## Exact-main boundary

This PR supplies the missing signing capability. Merge closes #521 and permits one manual exact-main Tier-M run. Issue #498 and parent #149 remain open until that run is fully green and every Increment 9 subject verifies against its retained Sigstore bundle.

Closes #521
