### PR TITLE
SDLC: preserve cleanliness across generated evidence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.egg-info/
 .venv/
 venv/
+.sdlc-run/
 .env
 .env.*
 !.env.example

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ __pycache__/
 *.egg-info/
 .venv/
 venv/
-.sdlc-run/
+/.sdlc-run/
 .env
 .env.*
 !.env.example

--- a/newsroom/tests/test_increment9g_closeout_receipt.py
+++ b/newsroom/tests/test_increment9g_closeout_receipt.py
@@ -61,6 +61,13 @@ def test_generated_sdlc_evidence_does_not_weaken_exact_source_cleanliness(
         _git(repository)
     unrelated.unlink()
 
+    nested = repository / "newsroom" / ".sdlc-run" / "unexpected.py"
+    nested.parent.mkdir(parents=True)
+    nested.write_text("unexpected = True\n", encoding="utf-8")
+    with pytest.raises(Increment9CloseoutCommandError, match="checkout is not clean"):
+        _git(repository)
+    nested.unlink()
+
     tracked.write_text("changed\n", encoding="utf-8")
     with pytest.raises(Increment9CloseoutCommandError, match="checkout is not clean"):
         _git(repository)

--- a/newsroom/tests/test_increment9g_closeout_receipt.py
+++ b/newsroom/tests/test_increment9g_closeout_receipt.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.sdlc.increment9g_closeout_receipt import (
+    Increment9CloseoutCommandError,
+    _git,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run(repository: Path, *arguments: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repository), *arguments],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def test_generated_sdlc_evidence_does_not_weaken_exact_source_cleanliness(
+    tmp_path: Path,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    _run(repository, "init", "--initial-branch=main")
+    (repository / ".gitignore").write_text(
+        (REPO_ROOT / ".gitignore").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    tracked = repository / "tracked.txt"
+    tracked.write_text("exact\n", encoding="utf-8")
+    _run(repository, "add", ".gitignore", "tracked.txt")
+    _run(
+        repository,
+        "-c",
+        "user.name=Newsroom Tests",
+        "-c",
+        "user.email=newsroom-tests@example.invalid",
+        "commit",
+        "-m",
+        "fixture",
+    )
+
+    artifact = repository / ".sdlc-run" / "increment9-subjects" / "subject.json"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text("{}\n", encoding="utf-8")
+    head, tree = _git(repository)
+    assert head == _run(repository, "rev-parse", "HEAD")
+    assert tree == _run(repository, "rev-parse", "HEAD^{tree}")
+
+    unrelated = repository / "unexpected.txt"
+    unrelated.write_text("unexpected\n", encoding="utf-8")
+    with pytest.raises(Increment9CloseoutCommandError, match="checkout is not clean"):
+        _git(repository)
+    unrelated.unlink()
+
+    tracked.write_text("changed\n", encoding="utf-8")
+    with pytest.raises(Increment9CloseoutCommandError, match="checkout is not clean"):
+        _git(repository)


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-9g-cleanliness-524
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

## Summary

- classify `.sdlc-run/` as the generated local/CI evidence-artifact root;
- preserve strict rejection of every unrelated untracked file and every tracked modification;
- add a repository-level regression test exercising the same `_git()` exact-source gate used by Increment 9G build and reconstruction.

## TDD evidence

Before `.gitignore` correction, the new regression failed with `Increment9CloseoutCommandError: checkout is not clean` after creating only `.sdlc-run/increment9-subjects/subject.json`.

After correction:

- 75 focused SDLC/CI/closeout tests passed;
- `git check-ignore` binds the generated subject to `.gitignore:6:.sdlc-run/`;
- `git diff --check` passed.

## Boundaries

- no product/runtime changes;
- no test deletion, skip, selection, timeout, budget, shard or worker change;
- no live source/provider/model/reviewer call;
- no publication, Evidence Intake, canary or production mutation;
- exact-main run 31927077485 remains retained as the failed precursor and is not rerun unchanged.

Closes #524
Closes #521
