### PR TITLE
Increment 10A1: semantic transport contracts

### DIFF
--- a/docs/operations/increment-10a1-transport.md
+++ b/docs/operations/increment-10a1-transport.md
@@ -1,0 +1,5 @@
+# Increment 10A1 transport contracts
+
+`newsroom.increment10.transport` defines immutable semantic submission and attempt observations for the exact local-fixture destination. Submission identity is derived from Candidate Version, Handoff digest, accepted plan digest and destination, independently of transient request IDs.
+
+Intent must be persisted before any later adapter effect. Responses must correlate to the exact request. Uncertain states reconcile only through the dedicated late-acknowledgement transition. Terminal records are immutable. The module exposes no I/O adapter: acknowledgement grants no evidence, editorial, publication or production authority.

--- a/newsroom/increment10/transport.py
+++ b/newsroom/increment10/transport.py
@@ -1,0 +1,191 @@
+"""Pure contracts for the Increment 10 semantic Handoff transport.
+
+The module models durable intent and observations. It contains no I/O adapter;
+acknowledgement never implies evidence, editorial, publication or runtime authority.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, replace
+from enum import StrEnum
+from hashlib import sha256
+from typing import Any
+
+from newsroom.authority.canonical import canonical_json_bytes
+
+
+class TransportContractError(ValueError):
+    pass
+
+
+class AttemptState(StrEnum):
+    NOT_STARTED = "NOT_STARTED"
+    PENDING = "PENDING"
+    ACCEPTED = "ACCEPTED"
+    REJECTED = "REJECTED"
+    PARTIAL = "PARTIAL"
+    UNAVAILABLE = "UNAVAILABLE"
+    TIMED_OUT = "TIMED_OUT"
+    AMBIGUOUS = "AMBIGUOUS"
+    RECONCILED = "RECONCILED"
+
+
+TERMINAL_STATES = frozenset({AttemptState.ACCEPTED, AttemptState.REJECTED, AttemptState.RECONCILED})
+
+
+@dataclass(frozen=True, slots=True)
+class RetryPolicy:
+    attempts_max: int
+    backoff_seconds: tuple[int, ...]
+    expiry_epoch_seconds: int
+
+    def __post_init__(self) -> None:
+        if self.attempts_max < 1 or self.attempts_max > 3:
+            raise TransportContractError("attempt ceiling must be within 1..3")
+        if len(self.backoff_seconds) != self.attempts_max - 1 or any(v < 0 or v > 30 for v in self.backoff_seconds):
+            raise TransportContractError("backoff coordinates differ")
+        if self.expiry_epoch_seconds <= 0:
+            raise TransportContractError("expiry must be positive")
+
+
+@dataclass(frozen=True, slots=True)
+class Submission:
+    schema_version: str
+    submission_id: str
+    candidate_version_id: str
+    handoff_digest: str
+    plan_digest: str
+    destination: str
+    created_epoch_seconds: int
+    retry: RetryPolicy
+
+    @property
+    def semantic_idempotency_key(self) -> str:
+        return _identity(self.candidate_version_id, self.handoff_digest, self.plan_digest, self.destination)
+
+    def canonical_bytes(self) -> bytes:
+        return canonical_json_bytes(asdict(self))
+
+    @property
+    def digest(self) -> str:
+        return "sha256:" + sha256(self.canonical_bytes()).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class Attempt:
+    schema_version: str
+    submission_id: str
+    attempt_number: int
+    request_id: str
+    state: AttemptState
+    persisted_epoch_seconds: int
+    effect_started_epoch_seconds: int | None
+    observed_epoch_seconds: int | None
+    response_request_id: str | None
+    acknowledgement_id: str | None
+    reason: str | None
+
+    @property
+    def terminal(self) -> bool:
+        return self.state in TERMINAL_STATES
+
+    def canonical_bytes(self) -> bytes:
+        value = asdict(self)
+        value["state"] = self.state.value
+        return canonical_json_bytes(value)
+
+
+class _Authority:
+    pass
+
+
+_AUTHORITY = _Authority()
+
+
+def authority_token() -> object:
+    """Return the process-private construction capability for governed callers."""
+    return _AUTHORITY
+
+
+def _require(token: object) -> None:
+    if token is not _AUTHORITY:
+        raise TransportContractError("transport authority token differs")
+
+
+def _identity(*parts: str) -> str:
+    if any(type(part) is not str or not part for part in parts):
+        raise TransportContractError("identity components must be non-empty strings")
+    return "sha256:" + sha256(canonical_json_bytes(list(parts))).hexdigest()
+
+
+def create_submission(token: object, *, candidate_version_id: str, handoff_digest: str, plan_digest: str, destination: str, created_epoch_seconds: int, retry: RetryPolicy) -> Submission:
+    _require(token)
+    if not candidate_version_id.startswith("candidate-version:") or not handoff_digest.startswith("sha256:") or not plan_digest.startswith("sha256:"):
+        raise TransportContractError("governing identities differ")
+    if destination != "local://increment10/evidence-intake-fixture-v1":
+        raise TransportContractError("destination is outside the frozen plan")
+    semantic = _identity(candidate_version_id, handoff_digest, plan_digest, destination)
+    return Submission("newsroom.increment10.submission.v1", semantic, candidate_version_id, handoff_digest, plan_digest, destination, created_epoch_seconds, retry)
+
+
+def start_attempt(token: object, submission: Submission, *, attempt_number: int, request_id: str, persisted_epoch_seconds: int, effect_started_epoch_seconds: int | None = None) -> Attempt:
+    _require(token)
+    if attempt_number < 1 or attempt_number > submission.retry.attempts_max:
+        raise TransportContractError("attempt is outside retry coordinates")
+    if persisted_epoch_seconds >= submission.retry.expiry_epoch_seconds:
+        raise TransportContractError("submission expired before attempt")
+    if effect_started_epoch_seconds is not None and effect_started_epoch_seconds < persisted_epoch_seconds:
+        raise TransportContractError("persist-before-effect violated")
+    return Attempt("newsroom.increment10.attempt.v1", submission.submission_id, attempt_number, request_id, AttemptState.PENDING, persisted_epoch_seconds, effect_started_epoch_seconds, None, None, None, None)
+
+
+def observe(token: object, attempt: Attempt, *, state: AttemptState, observed_epoch_seconds: int, response_request_id: str | None = None, acknowledgement_id: str | None = None, reason: str | None = None) -> Attempt:
+    _require(token)
+    if attempt.terminal:
+        raise TransportContractError("terminal attempt is immutable")
+    if observed_epoch_seconds < attempt.persisted_epoch_seconds:
+        raise TransportContractError("observation precedes persisted intent")
+    if response_request_id is not None and response_request_id != attempt.request_id:
+        raise TransportContractError("request/response correlation differs")
+    if state is AttemptState.ACCEPTED and (not acknowledgement_id or response_request_id is None):
+        raise TransportContractError("accepted observation requires correlated acknowledgement")
+    if state is AttemptState.RECONCILED:
+        raise TransportContractError("reconciliation requires the dedicated transition")
+    return replace(attempt, state=state, observed_epoch_seconds=observed_epoch_seconds, response_request_id=response_request_id, acknowledgement_id=acknowledgement_id, reason=reason)
+
+
+def reconcile(token: object, attempt: Attempt, *, acknowledgement_id: str, observed_epoch_seconds: int, authoritative_request_id: str) -> Attempt:
+    _require(token)
+    if attempt.state not in {AttemptState.AMBIGUOUS, AttemptState.TIMED_OUT, AttemptState.PARTIAL, AttemptState.UNAVAILABLE}:
+        raise TransportContractError("only uncertain attempts may reconcile")
+    if authoritative_request_id != attempt.request_id or observed_epoch_seconds < (attempt.observed_epoch_seconds or attempt.persisted_epoch_seconds):
+        raise TransportContractError("late acknowledgement chronology or correlation differs")
+    return replace(attempt, state=AttemptState.RECONCILED, observed_epoch_seconds=observed_epoch_seconds, response_request_id=authoritative_request_id, acknowledgement_id=acknowledgement_id)
+
+
+def parse_submission(raw: bytes) -> Submission:
+    try:
+        pairs: list[tuple[str, Any]] = json.loads(raw, object_pairs_hook=lambda values: values)
+        if not isinstance(pairs, list) or any(not isinstance(item, tuple) for item in pairs):
+            raise TransportContractError("submission must be an object")
+        value: dict[str, Any] = {}
+        for key, item in pairs:
+            if key in value:
+                raise TransportContractError("duplicate submission field")
+            value[key] = item
+        if set(value) != {"schema_version", "submission_id", "candidate_version_id", "handoff_digest", "plan_digest", "destination", "created_epoch_seconds", "retry"}:
+            raise TransportContractError("submission fields differ")
+        retry = value.pop("retry")
+        if not isinstance(retry, list):
+            raise TransportContractError("retry must be an object")
+        retry_dict = dict(retry)
+        if len(retry_dict) != len(retry) or set(retry_dict) != {"attempts_max", "backoff_seconds", "expiry_epoch_seconds"}:
+            raise TransportContractError("retry fields differ")
+        result = Submission(retry=RetryPolicy(retry_dict["attempts_max"], tuple(retry_dict["backoff_seconds"]), retry_dict["expiry_epoch_seconds"]), **value)
+        if raw != result.canonical_bytes() or result.submission_id != result.semantic_idempotency_key:
+            raise TransportContractError("submission is non-canonical or identity differs")
+        return result
+    except TransportContractError:
+        raise
+    except (TypeError, ValueError, KeyError, UnicodeError, json.JSONDecodeError, RecursionError) as exc:
+        raise TransportContractError("submission is malformed") from exc

--- a/newsroom/tests/test_increment10a1_transport.py
+++ b/newsroom/tests/test_increment10a1_transport.py
@@ -1,0 +1,56 @@
+from dataclasses import replace
+import pytest
+from newsroom.increment10.transport import *
+
+
+def submission():
+    return create_submission(authority_token(), candidate_version_id="candidate-version:increment10-fixture-001", handoff_digest="sha256:"+"1"*64, plan_digest="sha256:"+"2"*64, destination="local://increment10/evidence-intake-fixture-v1", created_epoch_seconds=10, retry=RetryPolicy(3,(1,2),100))
+
+
+def test_semantic_idempotency_and_canonical_replay():
+    first=submission(); second=submission()
+    assert first.submission_id == second.submission_id
+    assert parse_submission(first.canonical_bytes()) == first
+    assert first.digest.startswith("sha256:")
+
+
+def test_authority_destination_and_retry_fail_closed():
+    with pytest.raises(TransportContractError):
+        create_submission(object(), candidate_version_id="candidate-version:x", handoff_digest="sha256:"+"1"*64, plan_digest="sha256:"+"2"*64, destination="local://increment10/evidence-intake-fixture-v1", created_epoch_seconds=1, retry=RetryPolicy(1,(),2))
+    with pytest.raises(TransportContractError):
+        RetryPolicy(4,(1,2,3),100)
+
+
+def test_persist_before_effect_and_exact_correlation():
+    with pytest.raises(TransportContractError, match="persist-before-effect"):
+        start_attempt(authority_token(), submission(), attempt_number=1, request_id="r1", persisted_epoch_seconds=20, effect_started_epoch_seconds=19)
+    attempt=start_attempt(authority_token(), submission(), attempt_number=1, request_id="r1", persisted_epoch_seconds=20, effect_started_epoch_seconds=21)
+    with pytest.raises(TransportContractError, match="correlation"):
+        observe(authority_token(), attempt, state=AttemptState.ACCEPTED, observed_epoch_seconds=22, response_request_id="other", acknowledgement_id="ack")
+    accepted=observe(authority_token(), attempt, state=AttemptState.ACCEPTED, observed_epoch_seconds=22, response_request_id="r1", acknowledgement_id="ack")
+    assert accepted.terminal
+    with pytest.raises(TransportContractError, match="immutable"):
+        observe(authority_token(), accepted, state=AttemptState.REJECTED, observed_epoch_seconds=23)
+
+
+def test_lost_response_reconciles_once_and_conflict_is_rejected():
+    attempt=start_attempt(authority_token(), submission(), attempt_number=1, request_id="r1", persisted_epoch_seconds=20)
+    timed=observe(authority_token(), attempt, state=AttemptState.TIMED_OUT, observed_epoch_seconds=30, reason="lost response")
+    reconciled=reconcile(authority_token(), timed, acknowledgement_id="ack", observed_epoch_seconds=40, authoritative_request_id="r1")
+    assert reconciled.state is AttemptState.RECONCILED
+    with pytest.raises(TransportContractError):
+        reconcile(authority_token(), reconciled, acknowledgement_id="conflict", observed_epoch_seconds=41, authoritative_request_id="r1")
+
+
+def test_duplicate_unknown_tampered_or_noncanonical_fields_rejected():
+    raw=submission().canonical_bytes()
+    for changed in (raw.replace(b'"schema_version"',b'"unknown"',1), b'{"x":1,"x":2}', b'{ "x":1}'):
+        with pytest.raises(TransportContractError): parse_submission(changed)
+    changed=replace(submission(), submission_id="sha256:"+"0"*64)
+    with pytest.raises(TransportContractError, match="identity differs"): parse_submission(changed.canonical_bytes())
+
+
+def test_acknowledgement_has_no_evidence_or_publication_authority():
+    attempt=start_attempt(authority_token(), submission(), attempt_number=1, request_id="r1", persisted_epoch_seconds=20)
+    accepted=observe(authority_token(), attempt, state=AttemptState.ACCEPTED, observed_epoch_seconds=21, response_request_id="r1", acknowledgement_id="ack")
+    assert not hasattr(accepted,"evidence") and not hasattr(accepted,"publication_authority")


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-10a1-transport-528
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

## Summary
- add immutable semantic Submission and Attempt contracts;
- enforce semantic idempotency, persist-before-effect, correlation, bounded retry and reconciliation chronology;
- reject unknown, duplicate, tampered and non-canonical records;
- expose no transport adapter or evidence/publication authority.

## Evidence
- focused 10A1 and frozen-plan suite: `20 passed`;
- `git diff --check` PASS.

Closes #528
