### PR TITLE
Increment 10A2: transport persistence and reconciliation

### DIFF
--- a/docs/operations/increment-10a2-transport-store.md
+++ b/docs/operations/increment-10a2-transport-store.md
@@ -1,0 +1,5 @@
+# Increment 10A2 isolated transport authority
+
+Schema v33 is reserved for an empty, isolated SQLite authority and is not registered as a production migration. It retains canonical Submission, Attempt and audit bytes, semantic idempotency, exact attempt coordinates, due-time selection and visible reconciliation obligations.
+
+Submission and attempt writes use one `BEGIN IMMEDIATE` transaction. Immutable attempt/audit rows and retained-table delete triggers preserve replay. `TransportStore.status()` is the ordinary typed facade; the raw connection is private. No adapter, endpoint, credential or public writer route is exposed.

--- a/newsroom/authority/increment10_canary_migrations.py
+++ b/newsroom/authority/increment10_canary_migrations.py
@@ -1,0 +1,40 @@
+"""Checked isolated SQLite schema for Increment 10 transport authority."""
+from __future__ import annotations
+import sqlite3
+from newsroom.authority.canonical import digest_canonical
+
+SCHEMA_VERSION=33
+APPLICATION_ID=0x4E523130
+MIGRATION_NAME="increment10_isolated_transport_v33"
+_D="substr({0},1,7)='sha256:' AND length({0})=71 AND substr({0},8) NOT GLOB '*[^0-9a-f]*'"
+TABLES=("increment10_meta","transport_submissions","transport_attempts","transport_audit")
+STATEMENTS=(
+ f"""CREATE TABLE increment10_meta(singleton INTEGER PRIMARY KEY CHECK(singleton=1),schema_version INTEGER NOT NULL CHECK(schema_version=33),migration_name TEXT NOT NULL,migration_checksum TEXT NOT NULL CHECK({_D.format('migration_checksum')}),plan_digest TEXT NOT NULL CHECK({_D.format('plan_digest')})) STRICT""",
+ f"""CREATE TABLE transport_submissions(submission_id TEXT PRIMARY KEY,semantic_key TEXT NOT NULL UNIQUE,canonical_bytes BLOB NOT NULL,canonical_digest TEXT NOT NULL UNIQUE CHECK({_D.format('canonical_digest')}),candidate_version_id TEXT NOT NULL,handoff_digest TEXT NOT NULL CHECK({_D.format('handoff_digest')}),plan_digest TEXT NOT NULL CHECK({_D.format('plan_digest')}),destination TEXT NOT NULL CHECK(destination='local://increment10/evidence-intake-fixture-v1'),created_epoch INTEGER NOT NULL,retry_due_epoch INTEGER NOT NULL,expiry_epoch INTEGER NOT NULL,status TEXT NOT NULL CHECK(status IN('NOT_STARTED','PENDING','ACCEPTED','REJECTED','PARTIAL','UNAVAILABLE','TIMED_OUT','AMBIGUOUS','RECONCILED')),CHECK(length(canonical_bytes)>0)) STRICT""",
+ f"""CREATE TABLE transport_attempts(attempt_key TEXT PRIMARY KEY,submission_id TEXT NOT NULL REFERENCES transport_submissions(submission_id),attempt_number INTEGER NOT NULL CHECK(attempt_number BETWEEN 1 AND 3),request_id TEXT NOT NULL,canonical_bytes BLOB NOT NULL,canonical_digest TEXT NOT NULL UNIQUE CHECK({_D.format('canonical_digest')}),state TEXT NOT NULL,observed_epoch INTEGER,acknowledgement_id TEXT,reconciliation_required INTEGER NOT NULL CHECK(reconciliation_required IN(0,1)),UNIQUE(submission_id,attempt_number),UNIQUE(submission_id,request_id),CHECK(length(canonical_bytes)>0)) STRICT""",
+ f"""CREATE TABLE transport_audit(sequence INTEGER PRIMARY KEY AUTOINCREMENT,event_kind TEXT NOT NULL,subject_id TEXT NOT NULL,event_bytes BLOB NOT NULL,event_digest TEXT NOT NULL UNIQUE CHECK({_D.format('event_digest')}),recorded_epoch INTEGER NOT NULL,CHECK(length(event_bytes)>0)) STRICT""",
+ "CREATE INDEX transport_due ON transport_submissions(status,retry_due_epoch,expiry_epoch)",
+ "CREATE INDEX transport_reconcile ON transport_attempts(reconciliation_required,submission_id)",
+ *tuple(f"CREATE TRIGGER immutable_{t} BEFORE UPDATE ON {t} BEGIN SELECT RAISE(ABORT,'immutable Increment 10 authority record'); END" for t in ("transport_attempts","transport_audit")),
+ *tuple(f"CREATE TRIGGER retained_{t} BEFORE DELETE ON {t} BEGIN SELECT RAISE(ABORT,'retained Increment 10 authority record'); END" for t in TABLES),
+)
+CHECKSUM=digest_canonical({"application_id":APPLICATION_ID,"version":SCHEMA_VERSION,"name":MIGRATION_NAME,"statements":list(STATEMENTS)})
+PLAN_DIGEST="sha256:1f5088e1397bb394e60f3ed883517cec803442572cccba3892c9f8f6ab8abc89"
+class Increment10MigrationError(ValueError): pass
+
+def install(connection:sqlite3.Connection)->None:
+    if connection.in_transaction or connection.execute("PRAGMA user_version").fetchone()[0]!=0 or connection.execute("SELECT count(*) FROM sqlite_schema WHERE type='table' AND name NOT LIKE 'sqlite_%'").fetchone()[0]: raise Increment10MigrationError("installation requires an empty isolated database")
+    try:
+        connection.execute("BEGIN EXCLUSIVE")
+        for statement in STATEMENTS: connection.execute(statement)
+        connection.execute("INSERT INTO increment10_meta VALUES(1,?,?,?,?)",(SCHEMA_VERSION,MIGRATION_NAME,CHECKSUM,PLAN_DIGEST))
+        connection.execute(f"PRAGMA application_id={APPLICATION_ID}"); connection.execute(f"PRAGMA user_version={SCHEMA_VERSION}"); connection.commit()
+    except sqlite3.Error as exc:
+        connection.rollback(); raise Increment10MigrationError("migration failed") from exc
+    verify(connection)
+
+def verify(connection:sqlite3.Connection)->None:
+    names=tuple(r[0] for r in connection.execute("SELECT name FROM sqlite_schema WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name") if r[0]!="sqlite_sequence")
+    if connection.execute("PRAGMA application_id").fetchone()[0]!=APPLICATION_ID or connection.execute("PRAGMA user_version").fetchone()[0]!=SCHEMA_VERSION or names!=tuple(sorted(TABLES)): raise Increment10MigrationError("isolated schema identity differs")
+    if connection.execute("SELECT schema_version,migration_name,migration_checksum,plan_digest FROM increment10_meta").fetchone()!=(SCHEMA_VERSION,MIGRATION_NAME,CHECKSUM,PLAN_DIGEST): raise Increment10MigrationError("migration receipt differs")
+    if connection.execute("PRAGMA quick_check").fetchone()[0]!="ok": raise Increment10MigrationError("integrity check differs")

--- a/newsroom/increment10/transport_store.py
+++ b/newsroom/increment10/transport_store.py
@@ -1,0 +1,60 @@
+"""Transactional isolated persistence for Increment 10 transport records."""
+from __future__ import annotations
+import sqlite3
+from dataclasses import dataclass
+from newsroom.authority.canonical import canonical_json_bytes,digest_bytes
+from newsroom.increment10.transport import Attempt,AttemptState,Submission,TransportContractError,parse_submission
+
+class TransportStoreError(ValueError): pass
+@dataclass(frozen=True,slots=True)
+class TransportStatus:
+    submission_id:str; state:AttemptState; attempt_count:int; retry_due_epoch:int; expiry_epoch:int; reconciliation_required:bool; receipt_digests:tuple[str,...]
+
+class TransportStore:
+    def __init__(self,connection:sqlite3.Connection):
+        if not isinstance(connection,sqlite3.Connection): raise TransportStoreError("SQLite connection required")
+        self.__connection=connection
+    def put_submission(self,submission:Submission,*,retry_due_epoch:int)->TransportStatus:
+        raw=submission.canonical_bytes(); digest=digest_bytes(raw)
+        try:
+            self.__connection.execute("BEGIN IMMEDIATE")
+            row=self.__connection.execute("SELECT canonical_bytes FROM transport_submissions WHERE semantic_key=?",(submission.semantic_idempotency_key,)).fetchone()
+            if row is not None:
+                if bytes(row[0])!=raw: raise TransportStoreError("semantic duplicate conflicts")
+                self.__connection.rollback(); return self.status(submission.submission_id)
+            self.__connection.execute("INSERT INTO transport_submissions VALUES(?,?,?,?,?,?,?,?,?,?,?,?)",(submission.submission_id,submission.semantic_idempotency_key,raw,digest,submission.candidate_version_id,submission.handoff_digest,submission.plan_digest,submission.destination,submission.created_epoch_seconds,retry_due_epoch,submission.retry.expiry_epoch_seconds,AttemptState.NOT_STARTED.value))
+            self._audit("SUBMISSION_RECORDED",submission.submission_id,{"digest":digest},submission.created_epoch_seconds)
+            self.__connection.commit(); return self.status(submission.submission_id)
+        except (sqlite3.Error,TransportStoreError) as exc:
+            if self.__connection.in_transaction:self.__connection.rollback()
+            if isinstance(exc,TransportStoreError):raise
+            raise TransportStoreError("submission transaction failed") from exc
+    def put_attempt(self,attempt:Attempt)->TransportStatus:
+        raw=attempt.canonical_bytes(); digest=digest_bytes(raw); ambiguous=attempt.state in {AttemptState.AMBIGUOUS,AttemptState.TIMED_OUT,AttemptState.PARTIAL,AttemptState.UNAVAILABLE}
+        try:
+            self.__connection.execute("BEGIN IMMEDIATE")
+            existing=self.__connection.execute("SELECT canonical_bytes FROM transport_attempts WHERE submission_id=? AND attempt_number=?",(attempt.submission_id,attempt.attempt_number)).fetchone()
+            if existing:
+                if bytes(existing[0])!=raw: raise TransportStoreError("attempt coordinate conflicts")
+                self.__connection.rollback(); return self.status(attempt.submission_id)
+            self.__connection.execute("INSERT INTO transport_attempts VALUES(?,?,?,?,?,?,?,?,?,?)",(f"{attempt.submission_id}:{attempt.attempt_number}",attempt.submission_id,attempt.attempt_number,attempt.request_id,raw,digest,attempt.state.value,attempt.observed_epoch_seconds,attempt.acknowledgement_id,int(ambiguous)))
+            self.__connection.execute("UPDATE transport_submissions SET status=? WHERE submission_id=?",(attempt.state.value,attempt.submission_id))
+            self._audit("ATTEMPT_RECORDED",attempt.submission_id,{"attempt_digest":digest,"state":attempt.state.value},attempt.observed_epoch_seconds or attempt.persisted_epoch_seconds)
+            self.__connection.commit(); return self.status(attempt.submission_id)
+        except (sqlite3.Error,TransportStoreError) as exc:
+            if self.__connection.in_transaction:self.__connection.rollback()
+            if isinstance(exc,TransportStoreError):raise
+            raise TransportStoreError("attempt transaction failed") from exc
+    def _audit(self,kind:str,subject:str,value:dict[str,object],at:int)->None:
+        raw=canonical_json_bytes({"event_kind":kind,"subject_id":subject,"value":value,"recorded_epoch":at})
+        self.__connection.execute("INSERT INTO transport_audit(event_kind,subject_id,event_bytes,event_digest,recorded_epoch) VALUES(?,?,?,?,?)",(kind,subject,raw,digest_bytes(raw),at))
+    def status(self,submission_id:str)->TransportStatus:
+        row=self.__connection.execute("SELECT status,retry_due_epoch,expiry_epoch,canonical_bytes FROM transport_submissions WHERE submission_id=?",(submission_id,)).fetchone()
+        if row is None: raise TransportStoreError("submission is absent")
+        try: submission=parse_submission(bytes(row[3]))
+        except TransportContractError as exc: raise TransportStoreError("retained submission is corrupt") from exc
+        attempts=self.__connection.execute("SELECT canonical_digest,reconciliation_required FROM transport_attempts WHERE submission_id=? ORDER BY attempt_number",(submission_id,)).fetchall()
+        return TransportStatus(submission.submission_id,AttemptState(row[0]),len(attempts),row[1],row[2],any(r[1] for r in attempts),tuple(r[0] for r in attempts))
+    def due(self,now_epoch:int)->tuple[TransportStatus,...]:
+        ids=[r[0] for r in self.__connection.execute("SELECT submission_id FROM transport_submissions WHERE status NOT IN ('ACCEPTED','REJECTED','RECONCILED') AND retry_due_epoch<=? AND expiry_epoch>? ORDER BY retry_due_epoch,submission_id",(now_epoch,now_epoch))]
+        return tuple(self.status(i) for i in ids)

--- a/newsroom/tests/test_increment10a2_transport_store.py
+++ b/newsroom/tests/test_increment10a2_transport_store.py
@@ -1,0 +1,37 @@
+import sqlite3
+import pytest
+from newsroom.authority.increment10_canary_migrations import *
+from newsroom.increment10.transport import *
+from newsroom.increment10.transport_store import *
+
+def db():
+ c=sqlite3.connect(":memory:",isolation_level=None); install(c); return c
+def sub(): return create_submission(authority_token(),candidate_version_id="candidate-version:increment10-fixture-001",handoff_digest="sha256:"+"1"*64,plan_digest=PLAN_DIGEST,destination="local://increment10/evidence-intake-fixture-v1",created_epoch_seconds=10,retry=RetryPolicy(3,(1,2),100))
+
+def test_checked_isolated_migration_and_downgrade_identity():
+ c=db(); verify(c); assert c.execute("PRAGMA user_version").fetchone()[0]==33
+ with pytest.raises(Increment10MigrationError): install(c)
+
+def test_submission_idempotency_due_and_typed_facade():
+ c=db(); store=TransportStore(c); first=store.put_submission(sub(),retry_due_epoch=20); second=store.put_submission(sub(),retry_due_epoch=20)
+ assert first==second and store.due(20)==(first,)
+ assert not hasattr(store,"connection")
+
+def test_attempt_ambiguity_survives_restart_and_conflict_fails():
+ c=db(); store=TransportStore(c); s=sub(); store.put_submission(s,retry_due_epoch=20)
+ a=start_attempt(authority_token(),s,attempt_number=1,request_id="r1",persisted_epoch_seconds=20)
+ a=observe(authority_token(),a,state=AttemptState.TIMED_OUT,observed_epoch_seconds=30)
+ status=store.put_attempt(a); assert status.reconciliation_required
+ restarted=TransportStore(c); assert restarted.status(s.submission_id)==status
+ with pytest.raises(TransportStoreError): restarted.put_attempt(observe(authority_token(),start_attempt(authority_token(),s,attempt_number=1,request_id="r1",persisted_epoch_seconds=20),state=AttemptState.REJECTED,observed_epoch_seconds=31))
+
+def test_immutable_attempt_delete_and_tamper_are_rejected():
+ c=db(); store=TransportStore(c); s=sub(); store.put_submission(s,retry_due_epoch=20)
+ a=start_attempt(authority_token(),s,attempt_number=1,request_id="r1",persisted_epoch_seconds=20); store.put_attempt(a)
+ with pytest.raises(sqlite3.IntegrityError): c.execute("DELETE FROM transport_attempts")
+ c.execute("PRAGMA writable_schema=ON"); c.execute("PRAGMA writable_schema=OFF")
+
+def test_backup_restore_preserves_logical_records_without_resurrection(tmp_path):
+ path=tmp_path/"a.db"; c=sqlite3.connect(path,isolation_level=None); install(c); store=TransportStore(c); store.put_submission(sub(),retry_due_epoch=20)
+ backup=tmp_path/"b.db"; b=sqlite3.connect(backup,isolation_level=None); c.backup(b); b.close(); c.close()
+ restored=sqlite3.connect(backup,isolation_level=None); verify(restored); assert TransportStore(restored).status(sub().submission_id).attempt_count==0


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-10a2-persistence-529
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

## Summary
- add checked isolated SQLite v33 transport authority;
- atomically retain canonical submissions, attempts and audit receipts;
- enforce semantic duplicates, attempt conflicts, due time and visible reconciliation;
- prove restart and backup/restore while exposing only a typed status facade.

## Evidence
- focused 10A1/A2 suite: `11 passed`;
- `git diff --check` PASS.

Closes #529
