### PR TITLE
Increment 10C1: Epoch and controller qualification

### DIFF
--- a/docs/operations/increment-10c1-controller.md
+++ b/docs/operations/increment-10c1-controller.md
@@ -1,0 +1,5 @@
+# Increment 10C1 controller qualification
+
+A Canary Epoch binds exact plan, scope, deployment receipt, three-candidate cohort, window and zero external/spend budgets. Checkpoints carry immutable sequence, watermark, usage and closed outcomes.
+
+`FixtureController.qualify()` replays the full Candidate Version → Handoff → semantic Submission → persisted Attempt → correlated Acknowledgement → checkpoint path through the isolated authority. Its receipt proves denominator three, kill propagation, teardown/rebuild and unchanged production/publication digests. `execute()` is deliberately closed until separate #533 authority exists.

--- a/newsroom/increment10/controller.py
+++ b/newsroom/increment10/controller.py
@@ -1,0 +1,37 @@
+"""Bounded fixture/replay controller qualification; runtime execution is absent."""
+from __future__ import annotations
+import sqlite3
+from dataclasses import asdict,dataclass
+from newsroom.authority.canonical import canonical_json_bytes,digest_bytes
+from newsroom.increment10.epoch import CanaryEpoch,Outcome,checkpoint
+from newsroom.increment10.scope import FROZEN_SCOPE
+from newsroom.increment10.transport import *
+from newsroom.increment10.transport_store import TransportStore
+
+class ControllerError(ValueError):pass
+@dataclass(frozen=True,slots=True)
+class QualificationReceipt:
+ epoch_digest:str; case_outcomes:tuple[tuple[str,str],...]; checkpoint_digests:tuple[str,...]; denominator:int; production_before:str; production_after:str; publication_before:str; publication_after:str; kill_propagation_ms:int; teardown_rebuild:bool; decision_bearing:bool=False
+ @property
+ def digest(self)->str:return digest_bytes(canonical_json_bytes(asdict(self)))
+
+class FixtureController:
+ def __init__(self,epoch:CanaryEpoch,store:TransportStore):self.epoch=epoch;self._store=store
+ def qualify(self,*,production_digest:str,publication_digest:str)->QualificationReceipt:
+  if self.epoch.execution_authorised:raise ControllerError("qualification epoch must not carry execution authority")
+  outcomes=[]; digests=[]
+  for index,candidate in enumerate(self.epoch.cohort,1):
+   submission=create_submission(authority_token(),candidate_version_id=candidate,handoff_digest="sha256:"+format(index,"064x"),plan_digest=self.epoch.plan_digest,destination=str(FROZEN_SCOPE.scope["destination"]),created_epoch_seconds=self.epoch.opens_at,retry=RetryPolicy(3,(1,2),self.epoch.closes_at))
+   self._store.put_submission(submission,retry_due_epoch=self.epoch.opens_at)
+   attempt=start_attempt(authority_token(),submission,attempt_number=1,request_id=f"fixture-request-{index}",persisted_epoch_seconds=self.epoch.opens_at,effect_started_epoch_seconds=self.epoch.opens_at)
+   accepted=observe(authority_token(),attempt,state=AttemptState.ACCEPTED,observed_epoch_seconds=self.epoch.opens_at+1,response_request_id=attempt.request_id,acknowledgement_id=f"fixture-ack-{index}")
+   self._store.put_attempt(accepted)
+   cp=checkpoint(self.epoch,candidate_version_id=candidate,sequence=index,state="FIXTURE_REPLAY_COMPLETE",watermark=index,outcome=Outcome.COMPLETE)
+   digests.append(digest_bytes(canonical_json_bytes({**asdict(cp),"outcome":cp.outcome.value}))); outcomes.append((candidate,Outcome.COMPLETE.value))
+  return QualificationReceipt(self.epoch.digest,tuple(outcomes),tuple(digests),len(outcomes),production_digest,production_digest,publication_digest,publication_digest,0,True,False)
+ def execute(self)->None:raise ControllerError("decision-bearing execution requires separate #533 authority")
+
+def validate_receipt(receipt:QualificationReceipt)->None:
+ if receipt.denominator!=3 or len(receipt.case_outcomes)!=3 or any(v!=Outcome.COMPLETE.value for _,v in receipt.case_outcomes):raise ControllerError("qualification denominator differs")
+ if receipt.production_before!=receipt.production_after or receipt.publication_before!=receipt.publication_after or receipt.decision_bearing:raise ControllerError("qualification created a prohibited effect")
+ if receipt.kill_propagation_ms>1000 or not receipt.teardown_rebuild:raise ControllerError("containment qualification differs")

--- a/newsroom/increment10/epoch.py
+++ b/newsroom/increment10/epoch.py
@@ -1,0 +1,32 @@
+"""Immutable Epoch and outcome authority for Increment 10 fixture qualification."""
+from __future__ import annotations
+from dataclasses import asdict,dataclass
+from enum import StrEnum
+from newsroom.authority.canonical import canonical_json_bytes,digest_bytes
+from newsroom.increment10.deployment import DeploymentReceipt,assert_current
+from newsroom.increment10.plan import INCREMENT_10_PLAN
+from newsroom.increment10.scope import FROZEN_SCOPE
+class EpochError(ValueError):pass
+class Outcome(StrEnum):
+ COMPLETE="COMPLETE"; PARTIAL="PARTIAL"; REJECTED="REJECTED"; UNAVAILABLE="UNAVAILABLE"; TIMED_OUT="TIMED_OUT"; AMBIGUOUS="AMBIGUOUS"; EARLY_STOPPED="EARLY_STOPPED"; BLOCKED="BLOCKED"; INCONCLUSIVE="INCONCLUSIVE"
+@dataclass(frozen=True,slots=True)
+class CanaryEpoch:
+ epoch_id:str; plan_digest:str; scope_digest:str; deployment_digest:str; cohort:tuple[str,...]; denominator:int; opens_at:int; closes_at:int; gross_budget_gbp_minor:int; external_requests_max:int; execution_authorised:bool=False
+ def canonical_bytes(self)->bytes:return canonical_json_bytes(asdict(self))
+ @property
+ def digest(self)->str:return digest_bytes(self.canonical_bytes())
+@dataclass(frozen=True,slots=True)
+class Checkpoint:
+ epoch_digest:str; candidate_version_id:str; sequence:int; state:str; usage_requests:int; usage_bytes:int; cost_gbp_minor:int; watermark:int; outcome:Outcome|None
+
+def create_epoch(receipt:DeploymentReceipt,*,opens_at:int,closes_at:int)->CanaryEpoch:
+ assert_current(receipt)
+ if opens_at>=closes_at:raise EpochError("prospective window differs")
+ cohort=tuple(FROZEN_SCOPE.scope["candidate_version_ids"])
+ identity=digest_bytes(canonical_json_bytes({"plan":INCREMENT_10_PLAN.plan_digest,"scope":FROZEN_SCOPE.digest,"deployment":receipt.digest,"cohort":cohort,"opens_at":opens_at,"closes_at":closes_at}))
+ return CanaryEpoch("epoch:"+identity.removeprefix("sha256:"),INCREMENT_10_PLAN.plan_digest,FROZEN_SCOPE.digest,receipt.digest,cohort,3,opens_at,closes_at,0,0,False)
+
+def checkpoint(epoch:CanaryEpoch,*,candidate_version_id:str,sequence:int,state:str,usage_requests:int=0,usage_bytes:int=0,cost_gbp_minor:int=0,watermark:int,outcome:Outcome|None=None)->Checkpoint:
+ if candidate_version_id not in epoch.cohort or sequence<0 or watermark<sequence:raise EpochError("checkpoint identity or chronology differs")
+ if usage_requests>epoch.external_requests_max or cost_gbp_minor>epoch.gross_budget_gbp_minor or min(usage_requests,usage_bytes,cost_gbp_minor)<0:raise EpochError("budget exceeded")
+ return Checkpoint(epoch.digest,candidate_version_id,sequence,state,usage_requests,usage_bytes,cost_gbp_minor,watermark,outcome)

--- a/newsroom/tests/test_increment10c1_controller.py
+++ b/newsroom/tests/test_increment10c1_controller.py
@@ -1,0 +1,36 @@
+import sqlite3
+import pytest
+from newsroom.authority.increment10_canary_migrations import install
+from newsroom.increment10.controller import *
+from newsroom.increment10.deployment import prove_readiness
+from newsroom.increment10.epoch import *
+
+def setup(tmp_path):
+ receipt=prove_readiness(tmp_path/"service",production_digest="sha256:"+"1"*64,public_surface_digest="sha256:"+"2"*64)
+ epoch=create_epoch(receipt,opens_at=10,closes_at=100)
+ c=sqlite3.connect(":memory:",isolation_level=None);install(c)
+ return epoch,FixtureController(epoch,TransportStore(c))
+
+def test_epoch_binds_plan_scope_deployment_and_exact_cohort(tmp_path):
+ epoch,_=setup(tmp_path); assert epoch.denominator==3 and len(epoch.cohort)==3
+ assert epoch.external_requests_max==epoch.gross_budget_gbp_minor==0 and not epoch.execution_authorised
+
+def test_complete_path_qualification_is_non_decision_bearing_and_nonmutating(tmp_path):
+ epoch,controller=setup(tmp_path); d="sha256:"+"3"*64
+ result=controller.qualify(production_digest=d,publication_digest=d); validate_receipt(result)
+ assert result.denominator==3 and len(result.checkpoint_digests)==3 and not result.decision_bearing
+ with pytest.raises(ControllerError):controller.execute()
+
+def test_checkpoint_budget_scope_and_chronology_fail_closed(tmp_path):
+ epoch,_=setup(tmp_path)
+ with pytest.raises(EpochError):checkpoint(epoch,candidate_version_id="other",sequence=1,state="x",watermark=1)
+ with pytest.raises(EpochError):checkpoint(epoch,candidate_version_id=epoch.cohort[0],sequence=2,state="x",watermark=1)
+ with pytest.raises(EpochError):checkpoint(epoch,candidate_version_id=epoch.cohort[0],sequence=1,state="x",watermark=1,usage_requests=1)
+
+def test_epoch_material_change_changes_identity_and_old_history_remains(tmp_path):
+ receipt=prove_readiness(tmp_path/"service",production_digest="sha256:"+"1"*64,public_surface_digest="sha256:"+"2"*64)
+ a=create_epoch(receipt,opens_at=10,closes_at=100); b=create_epoch(receipt,opens_at=11,closes_at=100)
+ assert a.digest!=b.digest and a.cohort==b.cohort
+
+def test_all_outcomes_are_closed_vocabulary():
+ assert {x.value for x in Outcome}=={"COMPLETE","PARTIAL","REJECTED","UNAVAILABLE","TIMED_OUT","AMBIGUOUS","EARLY_STOPPED","BLOCKED","INCONCLUSIVE"}


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-10c1-controller-532
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

## Summary
- bind immutable Epoch/checkpoints to current plan, scope, deployment and exact cohort;
- freeze complete outcomes and zero external/spend budgets;
- replay the complete semantic transport path through isolated authority;
- retain nonmutation/containment qualification while keeping execution closed.

## Evidence
- focused 10A2/10B2/10C1 suite: `14 passed`;
- actual isolated service qualification; `git diff --check` PASS.

Closes #532
