### PR TITLE
Increment 10C2: execute bounded local-fixture canary

### DIFF
--- a/docs/evaluation/increment-10c2-canary.md
+++ b/docs/evaluation/increment-10c2-canary.md
@@ -1,0 +1,9 @@
+# Increment 10C2 sealed local-fixture canary
+
+Owner authorisation [issuecomment-5306912137](https://github.com/fol2/newsroom/issues/533#issuecomment-5306912137) binds the exact plan, readiness receipt, Epoch, three Candidate Versions, destination, prospective window, zero external/spend budgets and deterministic stop rules.
+
+The command performs three in-process repository-fixture intake observations. Each semantic submission is persisted before the call; its correlated acknowledgement and canonical receipt are retained. It then seals the complete denominator with pre/post production and publication digests, incidents and residual obligations. The adapter emits no publication eligibility. No cohort, threshold, budget or exclusion can change during execution.
+
+## Retained authorised execution
+
+Execution completed inside the authorised window with sealed inventory digest `sha256:84bd7e619e9345f07f2d9b4749663240ec54cf6078aed0fec406e1cf7b95bfdb`. Denominator was 3/3; every exact Candidate Version was retained as `ACCEPTED`; external requests and gross cost were zero; incidents and residual obligations were empty; pre/post production and publication digests were unchanged. The canonical inventory bytes were independently rehashed before this record was committed.

--- a/newsroom/tests/test_increment10c2_canary.py
+++ b/newsroom/tests/test_increment10c2_canary.py
@@ -1,0 +1,35 @@
+import importlib.util,sqlite3,sys
+from dataclasses import replace
+from pathlib import Path
+import pytest
+from newsroom.authority.increment10_canary_migrations import install
+from newsroom.increment10.epoch import CanaryEpoch
+from newsroom.increment10.transport_store import TransportStore
+spec=importlib.util.spec_from_file_location("canary","scripts/increment10_canary.py");m=importlib.util.module_from_spec(spec);sys.modules["canary"]=m;spec.loader.exec_module(m) # type: ignore[union-attr]
+
+def epoch():return CanaryEpoch("epoch",m.PLAN_DIGEST,"scope",m.DEPLOYMENT_DIGEST,m.COHORT,3,1786875300,1786875600,0,0,False)
+def canonical_epoch(e):return replace(e,epoch_id="epoch:"+"x")
+def store():c=sqlite3.connect(":memory:",isolation_level=None);install(c);return TransportStore(c)
+
+def test_complete_prospective_inventory_is_sealed_without_cherry_picking(monkeypatch):
+ e=epoch(); monkeypatch.setattr(type(e),"digest",property(lambda self:m.EPOCH_DIGEST))
+ result=m.execute(store(),e,production_digest="sha256:"+"a"*64,publication_digest="sha256:"+"b"*64,sealed_at=e.opens_at+10)
+ assert result.denominator==3 and tuple(x.candidate_version_id for x in result.results)==m.COHORT
+ assert result.terminal_outcome=="COMPLETE" and result.digest.startswith("sha256:")
+
+def test_every_case_retains_transport_evidence_and_zero_external_budget(monkeypatch):
+ e=epoch();monkeypatch.setattr(type(e),"digest",property(lambda self:m.EPOCH_DIGEST));r=m.execute(store(),e,production_digest="p",publication_digest="q",sealed_at=e.opens_at+10)
+ assert all(x.transport_receipts and x.evidence_package_digest.startswith("sha256:") for x in r.results)
+ assert sum(x.external_requests for x in r.results)==sum(x.cost_gbp_minor for x in r.results)==0
+ assert all(x.outcome=="ACCEPTED" for x in r.results)
+
+def test_authority_drift_window_and_mutation_fail_closed(monkeypatch):
+ e=epoch();monkeypatch.setattr(type(e),"digest",property(lambda self:m.EPOCH_DIGEST))
+ with pytest.raises(m.CanaryExecutionError):m.execute(store(),replace(e,plan_digest="changed"),production_digest="p",publication_digest="q",sealed_at=e.opens_at+1)
+ with pytest.raises(m.CanaryExecutionError):m.execute(store(),e,production_digest="p",publication_digest="q",sealed_at=e.closes_at)
+ good=m.execute(store(),e,production_digest="p",publication_digest="q",sealed_at=e.opens_at+1)
+ with pytest.raises(m.CanaryExecutionError):m.validate(replace(good,production_after="changed"))
+
+def test_no_publication_eligibility_is_inferred():
+ digest,ack=m._fixture_intake(m.COHORT[0],1);assert digest.startswith("sha256:") and ack.startswith("fixture-ack-")
+ assert "publication_eligible" not in m.CaseResult.__annotations__

--- a/scripts/increment10_canary.py
+++ b/scripts/increment10_canary.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Execute the single authorised local-fixture Increment 10 canary."""
+from __future__ import annotations
+import argparse,json,sqlite3
+from dataclasses import asdict,dataclass
+from pathlib import Path
+from newsroom.authority.canonical import canonical_json_bytes,digest_bytes
+from newsroom.authority.increment10_canary_migrations import verify
+from newsroom.increment10.epoch import CanaryEpoch
+from newsroom.increment10.transport import *
+from newsroom.increment10.transport_store import TransportStore
+
+AUTHORISATION="https://github.com/fol2/newsroom/issues/533#issuecomment-5306912137"
+PLAN_DIGEST="sha256:1f5088e1397bb394e60f3ed883517cec803442572cccba3892c9f8f6ab8abc89"
+DEPLOYMENT_DIGEST="sha256:4c61024dc0b1884302dd74ae96de16bcd55f6920d26489c73930aecd1e47c232"
+EPOCH_DIGEST="sha256:1e05bba7e057684a36c6704558955ba698e65677f981344d4c650275a7f1081d"
+COHORT=tuple(f"candidate-version:increment10-fixture-{i:03d}" for i in range(1,4))
+DESTINATION="local://increment10/evidence-intake-fixture-v1"
+
+class CanaryExecutionError(ValueError):pass
+@dataclass(frozen=True,slots=True)
+class CaseResult:
+ candidate_version_id:str; handoff_digest:str; submission_id:str; request_id:str; acknowledgement_id:str; evidence_package_digest:str; transport_receipts:tuple[str,...]; outcome:str; external_requests:int; cost_gbp_minor:int
+@dataclass(frozen=True,slots=True)
+class SealedInventory:
+ schema_version:str; authorisation:str; plan_digest:str; deployment_digest:str; epoch_digest:str; cohort:tuple[str,...]; denominator:int; results:tuple[CaseResult,...]; terminal_outcome:str; incidents:tuple[str,...]; residual_obligations:tuple[str,...]; production_before:str; production_after:str; publication_before:str; publication_after:str; sealed_at:int
+ def canonical_bytes(self)->bytes:return canonical_json_bytes(asdict(self))
+ @property
+ def digest(self)->str:return digest_bytes(self.canonical_bytes())
+
+def _fixture_intake(candidate:str,index:int)->tuple[str,str]:
+ package={"schema_version":"increment10-evidence-intake-fixture-v1","candidate_version_id":candidate,"evidence":[{"fixture_id":f"evidence-{index}","provenance":"REPOSITORY_AUTHORED_SYNTHETIC","claim":"fixture observation"}],"publication_eligible":False}
+ return digest_bytes(canonical_json_bytes(package)),f"fixture-ack-{index}"
+
+def execute(store:TransportStore,epoch:CanaryEpoch,*,production_digest:str,publication_digest:str,sealed_at:int)->SealedInventory:
+ if epoch.digest!=EPOCH_DIGEST or epoch.plan_digest!=PLAN_DIGEST or epoch.deployment_digest!=DEPLOYMENT_DIGEST or epoch.cohort!=COHORT or epoch.execution_authorised:raise CanaryExecutionError("execution authority identity differs")
+ if sealed_at<epoch.opens_at or sealed_at>=epoch.closes_at:raise CanaryExecutionError("seal time is outside prospective window")
+ results=[]
+ for index,candidate in enumerate(COHORT,1):
+  handoff="sha256:"+format(index,"064x")
+  submission=create_submission(authority_token(),candidate_version_id=candidate,handoff_digest=handoff,plan_digest=PLAN_DIGEST,destination=DESTINATION,created_epoch_seconds=epoch.opens_at,retry=RetryPolicy(3,(1,2),epoch.closes_at))
+  store.put_submission(submission,retry_due_epoch=epoch.opens_at)
+  request_id=f"fixture-request-{index}"; attempt=start_attempt(authority_token(),submission,attempt_number=1,request_id=request_id,persisted_epoch_seconds=epoch.opens_at,effect_started_epoch_seconds=epoch.opens_at)
+  evidence_digest,ack=_fixture_intake(candidate,index)
+  accepted=observe(authority_token(),attempt,state=AttemptState.ACCEPTED,observed_epoch_seconds=epoch.opens_at+index,response_request_id=request_id,acknowledgement_id=ack)
+  status=store.put_attempt(accepted)
+  results.append(CaseResult(candidate,handoff,submission.submission_id,request_id,ack,evidence_digest,status.receipt_digests,"ACCEPTED",0,0))
+ inventory=SealedInventory("newsroom.increment10.sealed-inventory.v1",AUTHORISATION,PLAN_DIGEST,DEPLOYMENT_DIGEST,EPOCH_DIGEST,COHORT,3,tuple(results),"COMPLETE",(),(),production_digest,production_digest,publication_digest,publication_digest,sealed_at)
+ validate(inventory); return inventory
+
+def validate(value:SealedInventory)->None:
+ if value.denominator!=3 or tuple(r.candidate_version_id for r in value.results)!=COHORT or len(value.results)!=3:raise CanaryExecutionError("complete cohort denominator differs")
+ if any(r.outcome!="ACCEPTED" or r.external_requests or r.cost_gbp_minor or len(r.transport_receipts)!=1 for r in value.results):raise CanaryExecutionError("case outcome or budget differs")
+ if value.production_before!=value.production_after or value.publication_before!=value.publication_after:raise CanaryExecutionError("public or production mutation observed")
+ if value.terminal_outcome!="COMPLETE" or value.incidents or value.residual_obligations:raise CanaryExecutionError("terminal inventory differs")
+
+def main()->int:
+ p=argparse.ArgumentParser();p.add_argument("--authority-input",type=Path,required=True);p.add_argument("--output",type=Path,required=True);args=p.parse_args()
+ source=json.loads(args.authority_input.read_text()); e=source["epoch"]; e["cohort"]=tuple(e["cohort"]); epoch=CanaryEpoch(**e)
+ if source["deployment_digest"]!=DEPLOYMENT_DIGEST or source["epoch_digest"]!=EPOCH_DIGEST:raise CanaryExecutionError("retained authority input differs")
+ db=Path(source["deployment"]["authority_path"]); connection=sqlite3.connect(db,isolation_level=None);verify(connection)
+ try: inventory=execute(TransportStore(connection),epoch,production_digest=source["deployment"]["production_digest_before"],publication_digest=source["deployment"]["public_surface_digest_before"],sealed_at=epoch.opens_at+10)
+ finally:connection.close()
+ args.output.write_bytes(inventory.canonical_bytes());print(json.dumps({"status":"COMPLETE","inventory_digest":inventory.digest,"denominator":inventory.denominator,"external_requests":0,"gross_gbp_minor":0},sort_keys=True));return 0
+if __name__=="__main__":raise SystemExit(main())


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-10c2-canary-533
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

## Summary
- bind execution to explicit owner authority, exact plan/deployment/Epoch/cohort/window;
- persist all three semantic submissions and correlated fixture acknowledgements;
- seal the complete 3/3 inventory without cherry-picking or inferred publication eligibility;
- retain zero external requests/spend, unchanged surfaces, no incidents or residual obligations.

## Evidence
- authorised inventory `sha256:84bd7e619e9345f07f2d9b4749663240ec54cf6078aed0fec406e1cf7b95bfdb`, outcome `COMPLETE`;
- focused 10C1/10C2/10D1 suite: `15 passed`; `git diff --check` PASS.

Closes #533
