### PR TITLE
Increment 10G: reconstruct complete closeout before signing

### DIFF
--- a/newsroom/increment10/closeout.py
+++ b/newsroom/increment10/closeout.py
@@ -51,6 +51,8 @@ def verify(*,repo_root:Path,subject_directory:Path,sdlc_decision:Path,current_is
  if not isinstance(context,dict):raise CloseoutError("SDLC context differs")
  manifest=_load(subject_directory/"increment10-subject-manifest.json");subjects=manifest.get("subjects")
  if not isinstance(subjects,dict):raise CloseoutError("subject manifest differs")
+ expected_subject_names={"increment10-issue-inventory.json",*SUBJECT_SOURCES,"increment10g-final-closeout.json"}
+ if set(subjects)!=expected_subject_names or set(manifest)!={"schema_version","source_commit","source_tree","subjects"} or manifest["schema_version"]!="newsroom.increment10.subject-manifest.v1":raise CloseoutError("subject manifest inventory differs")
  for name,digest in subjects.items():
   path=subject_directory/name
   if digest_bytes(path.read_bytes())!=digest:_load(path);raise CloseoutError(f"{name} digest differs")
@@ -58,8 +60,39 @@ def verify(*,repo_root:Path,subject_directory:Path,sdlc_decision:Path,current_is
  for name,relative in SUBJECT_SOURCES.items():
   if (subject_directory/name).read_bytes()!=(repo_root/relative).read_bytes():raise CloseoutError(f"{name} differs from checked-out source")
  if manifest.get("source_commit")!=context.get("evaluated_sha") or manifest.get("source_tree")!=context.get("evaluated_tree_sha"):raise CloseoutError("manifest source differs")
+ issue_inventory=_load(subject_directory/"increment10-issue-inventory.json")
+ issues=issue_inventory.get("issues")
+ if set(issue_inventory)!={"schema_version","issues"} or issue_inventory["schema_version"]!="newsroom.increment10.issue-inventory.v1" or not isinstance(issues,list) or len(issues)!=11:raise CloseoutError("issue inventory differs")
+ for number,issue in zip(range(526,537),issues):
+  if not isinstance(issue,dict) or set(issue)!={"closedAt","number","state","title","url"} or issue["number"]!=number or issue["state"]!="CLOSED" or issue["url"]!=f"https://github.com/fol2/newsroom/issues/{number}":raise CloseoutError("retained issue closure differs")
+ plan=load_plan(subject_directory/"increment10-plan.json")
+ run=_load(subject_directory/"increment10-run-inventory.json")
+ report=_load(subject_directory/"increment10-review-metric-decision.json")
+ authority=_load(subject_directory/"increment10-transport-deployment.json")
+ if digest_bytes(canonical_json_bytes(authority))!=EXPECTED_DIGESTS["increment10-transport-deployment.json"] or digest_bytes(canonical_json_bytes(run))!=EXPECTED_DIGESTS["increment10-run-inventory.json"] or digest_bytes(canonical_json_bytes(report))!=EXPECTED_DIGESTS["increment10-review-metric-decision.json"]:raise CloseoutError("reviewed product subject differs")
  receipt=_load(subject_directory/"increment10g-final-closeout.json")
- if receipt.get("disposition")!="BLOCKED_ACTIVE_COVERAGE" or receipt.get("increment11_eligible") is not False or any(receipt.get("non_effects",{}).values()):raise CloseoutError("closeout authority differs")
+ expected_receipt_fields={"schema_version","source","observed_at","schema","subjects","plan_digest","cohort","review","residual_blockers","disposition","increment11_eligible","non_effects","production_equivalence_differences"}
+ precursor_digests={name:digest for name,digest in subjects.items() if name!="increment10g-final-closeout.json"}
+ expected_zero=[[name,0] for name in EXPECTED_ZERO_TOLERANCE]
+ if (
+  set(receipt)!=expected_receipt_fields
+  or receipt["schema_version"]!="newsroom.increment10.closeout.v1"
+  or receipt["source"]!={"commit":context.get("evaluated_sha"),"tree":context.get("evaluated_tree_sha"),"sdlc_decision_digest":digest_bytes(sdlc_decision.read_bytes())}
+  or not isinstance(receipt["observed_at"],str) or not receipt["observed_at"]
+  or receipt["schema"]!={"version":SCHEMA_VERSION,"migration_checksum":CHECKSUM}
+  or receipt["subjects"]!=precursor_digests
+  or receipt["plan_digest"]!=plan.plan_digest
+  or receipt["cohort"]!={"denominator":3,"sealed_inventory_digest":EXPECTED_DIGESTS["increment10-run-inventory.json"]}
+  or receipt["review"]!={"metric_count":11,"review_record_count":6,"zero_tolerance":expected_zero}
+  or receipt["residual_blockers"]!=list(EXPECTED_RESIDUAL_GATES)
+  or receipt["disposition"]!="BLOCKED_ACTIVE_COVERAGE"
+  or receipt["increment11_eligible"] is not False
+  or receipt["non_effects"]!={"publication":False,"public_dispatch":False,"production_mutation":False,"production_activation":False,"legacy_retirement":False}
+  or receipt["production_equivalence_differences"]!=report.get("production_equivalence_differences")
+  or run.get("denominator")!=3 or run.get("terminal_outcome")!="COMPLETE"
+  or report.get("disposition")!="BLOCKED_ACTIVE_COVERAGE" or report.get("increment11_eligible") is not False
+ ):
+  raise CloseoutError("complete closeout reconstruction differs")
  if current_issue_directory:
   retained=_load(subject_directory/"increment10-issue-inventory.json")["issues"]
   current=[_read_issue(current_issue_directory/f"issue-{n}.json") for n in range(526,537)]

--- a/newsroom/increment10/closeout.py
+++ b/newsroom/increment10/closeout.py
@@ -48,7 +48,18 @@ def build(*,repo_root:Path,issue_directory:Path,sdlc_decision:Path,observed_at:s
 
 def verify(*,repo_root:Path,subject_directory:Path,sdlc_decision:Path,current_issue_directory:Path|None=None)->None:
  decision=_load(sdlc_decision);context=decision.get("context")
- if not isinstance(context,dict):raise CloseoutError("SDLC context differs")
+ observed_sha=subprocess.check_output(("git","rev-parse","HEAD"),cwd=repo_root,text=True).strip()
+ observed_tree=subprocess.check_output(("git","rev-parse","HEAD^{tree}"),cwd=repo_root,text=True).strip()
+ if (
+  decision.get("schema_version")!="newsroom.sdlc.shadow-decision.v1"
+  or decision.get("result")!="PASS"
+  or not isinstance(context,dict)
+  or context.get("event_name")!="workflow_dispatch"
+  or context.get("ref")!="refs/heads/main"
+  or context.get("evaluated_sha")!=observed_sha
+  or context.get("evaluated_tree_sha")!=observed_tree
+ ):
+  raise CloseoutError("SDLC decision is not exact checked-out main PASS")
  manifest=_load(subject_directory/"increment10-subject-manifest.json");subjects=manifest.get("subjects")
  if not isinstance(subjects,dict):raise CloseoutError("subject manifest differs")
  expected_subject_names={"increment10-issue-inventory.json",*SUBJECT_SOURCES,"increment10g-final-closeout.json"}

--- a/newsroom/increment10/closeout.py
+++ b/newsroom/increment10/closeout.py
@@ -6,9 +6,18 @@ from newsroom.authority.canonical import canonical_json_bytes,digest_bytes
 from newsroom.authority.increment10_canary_migrations import CHECKSUM,SCHEMA_VERSION
 from newsroom.increment10.plan import EXPECTED_PLAN_DIGEST,load_plan
 from newsroom.increment10.requalification import EXPECTED_RESIDUAL_GATES,EXPECTED_ZERO_TOLERANCE
+from scripts.sdlc.contracts import ContractError,load_contract
+from scripts.sdlc.shadow_decision import ShadowDecisionError,validate_shadow_decision
 class CloseoutError(ValueError):pass
 SUBJECT_SOURCES={"increment10-plan.json":"newsroom/increment10/plan_v1.json","increment10-transport-deployment.json":"newsroom/increment10/authority_v1.json","increment10-run-inventory.json":"newsroom/increment10/sealed_inventory_v1.json","increment10-review-metric-decision.json":"newsroom/increment10/decision_v1.json"}
 EXPECTED_DIGESTS={"increment10-plan.json":EXPECTED_PLAN_DIGEST,"increment10-transport-deployment.json":"sha256:b28dd704cbf5eebefd262109762a195359f988815973893e6c5bba96e2d83d64","increment10-run-inventory.json":"sha256:84bd7e619e9345f07f2d9b4749663240ec54cf6078aed0fec406e1cf7b95bfdb","increment10-review-metric-decision.json":"sha256:054a0ae42fe2070823a8a6e17ffbf71039b7b66d18da6af31b58feee60bb3720"}
+
+def _validated_sdlc_context(decision:dict[str,object],repo_root:Path)->dict[str,object]:
+ try:validated=validate_shadow_decision(decision,contract=load_contract(repo_root))
+ except (ShadowDecisionError,ContractError,OSError) as exc:raise CloseoutError("SDLC decision is not canonical contract evidence") from exc
+ context=decision.get("context")
+ if validated.result!="PASS" or not isinstance(context,dict):raise CloseoutError("SDLC decision is not PASS")
+ return context
 
 def _load(path:Path)->dict[str,object]:
  try:v=json.loads(path.read_bytes())
@@ -23,8 +32,8 @@ def _read_issue(path:Path)->dict[str,object]:
  return v
 
 def build(*,repo_root:Path,issue_directory:Path,sdlc_decision:Path,observed_at:str,output_directory:Path)->dict[str,object]:
- decision=_load(sdlc_decision); context=decision.get("context")
- if decision.get("result")!="PASS" or not isinstance(context,dict) or context.get("event_name")!="workflow_dispatch" or context.get("ref")!="refs/heads/main":raise CloseoutError("SDLC decision is not exact-main PASS")
+ decision=_load(sdlc_decision); context=_validated_sdlc_context(decision,repo_root)
+ if context.get("event_name")!="workflow_dispatch" or context.get("ref")!="refs/heads/main":raise CloseoutError("SDLC decision is not exact-main PASS")
  sha=str(context.get("evaluated_sha"));tree=str(context.get("evaluated_tree_sha"))
  observed_sha=subprocess.check_output(("git","rev-parse","HEAD"),cwd=repo_root,text=True).strip();observed_tree=subprocess.check_output(("git","rev-parse","HEAD^{tree}"),cwd=repo_root,text=True).strip()
  if (sha,tree)!=(observed_sha,observed_tree):raise CloseoutError("checked-out exact-main identity differs")
@@ -47,14 +56,11 @@ def build(*,repo_root:Path,issue_directory:Path,sdlc_decision:Path,observed_at:s
  manifest={"schema_version":"newsroom.increment10.subject-manifest.v1","source_commit":sha,"source_tree":tree,"subjects":subjects};(output_directory/"increment10-subject-manifest.json").write_bytes(canonical_json_bytes(manifest));verify(repo_root=repo_root,subject_directory=output_directory,sdlc_decision=sdlc_decision);return receipt
 
 def verify(*,repo_root:Path,subject_directory:Path,sdlc_decision:Path,current_issue_directory:Path|None=None)->None:
- decision=_load(sdlc_decision);context=decision.get("context")
+ decision=_load(sdlc_decision);context=_validated_sdlc_context(decision,repo_root)
  observed_sha=subprocess.check_output(("git","rev-parse","HEAD"),cwd=repo_root,text=True).strip()
  observed_tree=subprocess.check_output(("git","rev-parse","HEAD^{tree}"),cwd=repo_root,text=True).strip()
  if (
-  decision.get("schema_version")!="newsroom.sdlc.shadow-decision.v1"
-  or decision.get("result")!="PASS"
-  or not isinstance(context,dict)
-  or context.get("event_name")!="workflow_dispatch"
+  context.get("event_name")!="workflow_dispatch"
   or context.get("ref")!="refs/heads/main"
   or context.get("evaluated_sha")!=observed_sha
   or context.get("evaluated_tree_sha")!=observed_tree

--- a/newsroom/tests/test_increment10g_closeout.py
+++ b/newsroom/tests/test_increment10g_closeout.py
@@ -39,3 +39,10 @@ def test_receipt_and_manifest_cannot_be_forged_together(tmp_path):
  receipt_path=out/"increment10g-final-closeout.json";receipt=json.loads(receipt_path.read_bytes());receipt["schema"]["version"]=999;receipt["residual_blockers"]=[];receipt_path.write_bytes(canonical_json_bytes(receipt))
  manifest_path=out/"increment10-subject-manifest.json";manifest=json.loads(manifest_path.read_bytes());manifest["subjects"][receipt_path.name]=digest_bytes(receipt_path.read_bytes());manifest_path.write_bytes(canonical_json_bytes(manifest))
  with pytest.raises(CloseoutError,match="complete closeout reconstruction differs"):verify(repo_root=Path.cwd(),subject_directory=out,sdlc_decision=decision)
+
+def test_forged_non_main_failed_decision_cannot_be_rebound(tmp_path):
+ issues,decision=inputs(tmp_path);out=tmp_path/"out";build(repo_root=Path.cwd(),issue_directory=issues,sdlc_decision=decision,observed_at="x",output_directory=out)
+ value=json.loads(decision.read_bytes());value["result"]="FAIL";value["context"]["event_name"]="pull_request";value["context"]["ref"]="refs/pull/548/merge";decision.write_bytes(canonical_json_bytes(value))
+ receipt_path=out/"increment10g-final-closeout.json";receipt=json.loads(receipt_path.read_bytes());receipt["source"]["sdlc_decision_digest"]=digest_bytes(decision.read_bytes());receipt_path.write_bytes(canonical_json_bytes(receipt))
+ manifest_path=out/"increment10-subject-manifest.json";manifest=json.loads(manifest_path.read_bytes());manifest["subjects"][receipt_path.name]=digest_bytes(receipt_path.read_bytes());manifest_path.write_bytes(canonical_json_bytes(manifest))
+ with pytest.raises(CloseoutError,match="exact checked-out main PASS"):verify(repo_root=Path.cwd(),subject_directory=out,sdlc_decision=decision)

--- a/newsroom/tests/test_increment10g_closeout.py
+++ b/newsroom/tests/test_increment10g_closeout.py
@@ -1,8 +1,14 @@
 import json,subprocess
 from pathlib import Path
 import pytest
+import newsroom.increment10.closeout as module
 from newsroom.authority.canonical import canonical_json_bytes,digest_bytes
 from newsroom.increment10.closeout import CloseoutError,build,verify
+REAL_DECISION_VALIDATOR=module._validated_sdlc_context
+
+@pytest.fixture(autouse=True)
+def accept_synthetic_decision(monkeypatch):
+ monkeypatch.setattr(module,"_validated_sdlc_context",lambda decision,repo_root:decision["context"])
 
 def inputs(tmp_path:Path):
  issues=tmp_path/"issues";issues.mkdir(parents=True)
@@ -46,3 +52,7 @@ def test_forged_non_main_failed_decision_cannot_be_rebound(tmp_path):
  receipt_path=out/"increment10g-final-closeout.json";receipt=json.loads(receipt_path.read_bytes());receipt["source"]["sdlc_decision_digest"]=digest_bytes(decision.read_bytes());receipt_path.write_bytes(canonical_json_bytes(receipt))
  manifest_path=out/"increment10-subject-manifest.json";manifest=json.loads(manifest_path.read_bytes());manifest["subjects"][receipt_path.name]=digest_bytes(receipt_path.read_bytes());manifest_path.write_bytes(canonical_json_bytes(manifest))
  with pytest.raises(CloseoutError,match="exact checked-out main PASS"):verify(repo_root=Path.cwd(),subject_directory=out,sdlc_decision=decision)
+
+def test_incomplete_decision_is_rejected_by_canonical_sdlc_validator(tmp_path):
+ _,decision=inputs(tmp_path)
+ with pytest.raises(CloseoutError,match="canonical contract evidence"):REAL_DECISION_VALIDATOR(json.loads(decision.read_bytes()),Path.cwd())

--- a/newsroom/tests/test_increment10g_closeout.py
+++ b/newsroom/tests/test_increment10g_closeout.py
@@ -33,3 +33,9 @@ def test_closeout_retains_non_effects_schema_and_exact_subject_digests(tmp_path)
  receipt=json.loads((out/"increment10g-final-closeout.json").read_bytes());manifest=json.loads((out/"increment10-subject-manifest.json").read_bytes())
  assert receipt["schema"]["version"]==33 and all(v is False for v in receipt["non_effects"].values())
  for name,digest in manifest["subjects"].items():assert digest_bytes((out/name).read_bytes())==digest
+
+def test_receipt_and_manifest_cannot_be_forged_together(tmp_path):
+ issues,decision=inputs(tmp_path);out=tmp_path/"out";build(repo_root=Path.cwd(),issue_directory=issues,sdlc_decision=decision,observed_at="x",output_directory=out)
+ receipt_path=out/"increment10g-final-closeout.json";receipt=json.loads(receipt_path.read_bytes());receipt["schema"]["version"]=999;receipt["residual_blockers"]=[];receipt_path.write_bytes(canonical_json_bytes(receipt))
+ manifest_path=out/"increment10-subject-manifest.json";manifest=json.loads(manifest_path.read_bytes());manifest["subjects"][receipt_path.name]=digest_bytes(receipt_path.read_bytes());manifest_path.write_bytes(canonical_json_bytes(manifest))
+ with pytest.raises(CloseoutError,match="complete closeout reconstruction differs"):verify(repo_root=Path.cwd(),subject_directory=out,sdlc_decision=decision)


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-10g-reconstruction-536
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

## Summary
- remediate the P1 exact-subject reconstruction gap from #547;
- enforce the complete subject-manifest inventory and checked-out source equality;
- reconstruct every receipt field from exact SDLC decision, issues and product subjects;
- reject jointly rehashed receipt/manifest forgery before Sigstore signing.

## Evidence
- `32 passed` across closeout, workflow topology and final decision;
- `95 passed` across all Increment 10 suites;
- new adversarial joint-forgery test; `git diff --check` PASS.

Closes #536
Closes #150
