### PR TITLE
feat(pr-lifecycle): delete canonical branches on merge

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,16 +3,16 @@ Delivery-Atom: REPLACE-ME
 Canonical-PR: self
 Checkpoint-Ref: NONE
 Close-When: merged
-Branch-Retention: keep
+Branch-Retention: delete-after-merge
 
 <!--
 Required lifecycle metadata:
 - the six visible metadata lines above must remain the first six body lines
 - hidden comments, fenced examples and later fields are never authoritative
-- canonical: Canonical-PR self, Close-When merged, Branch-Retention keep
-- support: draft, support/ branch, reference canonical #, never merge
-- preflight: draft, preflight/ branch, reference canonical #, never merge
-- Branch-Retention must always be keep; automated branch deletion is unsupported.
+- canonical: Canonical-PR self, Close-When merged, Branch-Retention delete-after-merge
+- support: draft, support/ branch, reference canonical #, never merge, Branch-Retention keep
+- preflight: draft, preflight/ branch, reference canonical #, never merge, Branch-Retention keep
+- GitHub deletes canonical heads on merge; housekeeping never DELETE git refs.
 See docs/operations/pr-lifecycle.md.
 -->
 

--- a/docs/operations/pr-lifecycle.md
+++ b/docs/operations/pr-lifecycle.md
@@ -18,7 +18,7 @@ Delivery-Atom: increment-5b3
 Canonical-PR: self
 Checkpoint-Ref: checkpoint/increment-5b3-final-YYYYMMDD
 Close-When: merged
-Branch-Retention: keep
+Branch-Retention: delete-after-merge
 ```
 
 There may be only one open canonical PR for the same `Delivery-Atom`. A canonical
@@ -92,12 +92,17 @@ Valid close conditions are:
 - `canonical-merged`: disposable PR closes only after its canonical PR is
   independently revalidated as merged.
 
-`Branch-Retention` has exactly one supported value: `keep`. Automated branch
-cleanup is deliberately unsupported. GitHub's ref deletion endpoint has no
-compare-and-delete operation, so a check followed by deletion cannot safely bind
-the mutation to the checked commit. Branch cleanup is therefore a separate manual
-owner action outside this automation; checkpoint refs and disposable branches are
-retained by every automated closure.
+`Branch-Retention` has two supported values:
+
+- `delete-after-merge`: canonical PRs only. GitHub's repository setting
+  `delete_branch_on_merge` deletes the head branch at merge time.
+- `keep`: disposable support/preflight PRs only. Those PRs are never merged, so
+  GitHub does not delete their heads.
+
+`delete-after-checkpoint` is unsupported. Housekeeping never calls GitHub's ref
+deletion endpoint: that API has no compare-and-delete operation, so a check
+followed by deletion cannot safely bind the mutation to the checked commit.
+Checkpoint refs and disposable branches remain until an owner deletes them.
 
 ## Operating limits
 
@@ -108,7 +113,8 @@ retained by every automated closure.
   satisfied.
 - No unexplained open PR may remain older than seven days.
 - Canonical PRs are never closed by automation.
-- Automated housekeeping never deletes a Git ref.
+- Canonical head branches are deleted by GitHub at merge time
+  (`delete_branch_on_merge`). Automated housekeeping never deletes a Git ref.
 
 ## Automation
 
@@ -154,7 +160,9 @@ disposable PR; repository contents remain read-only. It then re-reads the curren
 target PR state, body, labels, head repository, head SHA, checkpoint and canonical
 binding before every effect. The re-read head SHA must equal the exact SHA embedded
 in the reviewed close action; any drift fails closed before a comment or closure.
-It never merges or closes a canonical PR and never deletes a branch.
+It never merges or closes a canonical PR and never deletes a Git ref. GitHub
+itself may delete a merged canonical head when `delete_branch_on_merge` is
+enabled.
 
 ## Recovery
 

--- a/docs/operations/pr-lifecycle.md
+++ b/docs/operations/pr-lifecycle.md
@@ -99,6 +99,10 @@ Valid close conditions are:
 - `keep`: disposable support/preflight PRs only. Those PRs are never merged, so
   GitHub does not delete their heads.
 
+Open canonical PRs must declare `delete-after-merge`. Inventory still accepts
+`keep` on an independently verified merged canonical so historical bodies created
+under the previous template do not abort housekeeping.
+
 `delete-after-checkpoint` is unsupported. Housekeeping never calls GitHub's ref
 deletion endpoint: that API has no compare-and-delete operation, so a check
 followed by deletion cannot safely bind the mutation to the checked commit.

--- a/newsroom/checks/pr_lifecycle.py
+++ b/newsroom/checks/pr_lifecycle.py
@@ -27,6 +27,7 @@ class CloseWhen(StrEnum):
 
 class BranchRetention(StrEnum):
     KEEP = "keep"
+    DELETE_AFTER_MERGE = "delete-after-merge"
     DELETE_AFTER_CHECKPOINT = "delete-after-checkpoint"
 
 
@@ -236,23 +237,25 @@ def validate_pull_request_lifecycle(
     if not isinstance(draft, bool):
         raise PrLifecycleError("pull-request draft state must be boolean")
     _validate_ref(head_ref, field="head_ref")
-    if lifecycle.branch_retention is not BranchRetention.KEEP:
-        raise PrLifecycleError(
-            "automatic branch deletion is unsupported; "
-            "Branch-Retention must be keep"
-        )
 
     if lifecycle.kind is LifecycleKind.CANONICAL:
         if lifecycle.canonical_pr is not None:
             raise PrLifecycleError("canonical PR must declare Canonical-PR: self")
         if lifecycle.close_when is not CloseWhen.MERGED:
             raise PrLifecycleError("canonical PR must close only when merged")
-        if lifecycle.branch_retention is not BranchRetention.KEEP:
-            raise PrLifecycleError("canonical branch retention must be keep")
+        if lifecycle.branch_retention is not BranchRetention.DELETE_AFTER_MERGE:
+            raise PrLifecycleError(
+                "canonical branch retention must be delete-after-merge"
+            )
         if head_ref.startswith(("support/", "preflight/")):
             raise PrLifecycleError("canonical PR cannot use a disposable branch prefix")
         return
 
+    if lifecycle.branch_retention is not BranchRetention.KEEP:
+        raise PrLifecycleError(
+            "disposable Branch-Retention must be keep; "
+            "housekeeping never deletes Git refs"
+        )
     if lifecycle.canonical_pr is None:
         raise PrLifecycleError("disposable PR must reference a canonical PR")
     if lifecycle.canonical_pr == pr_number:
@@ -521,19 +524,21 @@ def _validate_lifecycle_shape(lifecycle: PrLifecycle) -> None:
         raise PrLifecycleError(
             "checkpoint ref must use the dedicated checkpoint/ namespace"
         )
-    if lifecycle.branch_retention is not BranchRetention.KEEP:
-        raise PrLifecycleError(
-            "automatic branch deletion is unsupported; "
-            "Branch-Retention must be keep"
-        )
     if lifecycle.kind is LifecycleKind.CANONICAL:
         if lifecycle.canonical_pr is not None:
             raise PrLifecycleError("canonical lifecycle must reference self")
         if lifecycle.close_when is not CloseWhen.MERGED:
             raise PrLifecycleError("canonical lifecycle must close when merged")
-        if lifecycle.branch_retention is not BranchRetention.KEEP:
-            raise PrLifecycleError("canonical lifecycle must retain its branch")
+        if lifecycle.branch_retention is not BranchRetention.DELETE_AFTER_MERGE:
+            raise PrLifecycleError(
+                "canonical lifecycle must delete its branch after merge"
+            )
         return
+    if lifecycle.branch_retention is not BranchRetention.KEEP:
+        raise PrLifecycleError(
+            "disposable Branch-Retention must be keep; "
+            "housekeeping never deletes Git refs"
+        )
     if lifecycle.canonical_pr is None:
         raise PrLifecycleError("disposable lifecycle requires canonical PR")
     if lifecycle.close_when is CloseWhen.MERGED:

--- a/newsroom/checks/pr_lifecycle.py
+++ b/newsroom/checks/pr_lifecycle.py
@@ -227,6 +227,7 @@ def validate_pull_request_lifecycle(
     pr_number: int,
     draft: bool,
     head_ref: str,
+    merged: bool = False,
 ) -> None:
     """Validate metadata against the actual pull-request surface."""
 
@@ -236,6 +237,8 @@ def validate_pull_request_lifecycle(
         raise PrLifecycleError("pull-request number must be positive")
     if not isinstance(draft, bool):
         raise PrLifecycleError("pull-request draft state must be boolean")
+    if not isinstance(merged, bool):
+        raise PrLifecycleError("pull-request merged state must be boolean")
     _validate_ref(head_ref, field="head_ref")
 
     if lifecycle.kind is LifecycleKind.CANONICAL:
@@ -243,7 +246,10 @@ def validate_pull_request_lifecycle(
             raise PrLifecycleError("canonical PR must declare Canonical-PR: self")
         if lifecycle.close_when is not CloseWhen.MERGED:
             raise PrLifecycleError("canonical PR must close only when merged")
-        if lifecycle.branch_retention is not BranchRetention.DELETE_AFTER_MERGE:
+        allowed_retention = {BranchRetention.DELETE_AFTER_MERGE}
+        if merged:
+            allowed_retention.add(BranchRetention.KEEP)
+        if lifecycle.branch_retention not in allowed_retention:
             raise PrLifecycleError(
                 "canonical branch retention must be delete-after-merge"
             )
@@ -529,9 +535,12 @@ def _validate_lifecycle_shape(lifecycle: PrLifecycle) -> None:
             raise PrLifecycleError("canonical lifecycle must reference self")
         if lifecycle.close_when is not CloseWhen.MERGED:
             raise PrLifecycleError("canonical lifecycle must close when merged")
-        if lifecycle.branch_retention is not BranchRetention.DELETE_AFTER_MERGE:
+        if lifecycle.branch_retention not in {
+            BranchRetention.KEEP,
+            BranchRetention.DELETE_AFTER_MERGE,
+        }:
             raise PrLifecycleError(
-                "canonical lifecycle must delete its branch after merge"
+                "canonical lifecycle must keep or delete-after-merge"
             )
         return
     if lifecycle.branch_retention is not BranchRetention.KEEP:

--- a/newsroom/tests/test_pr_lifecycle.py
+++ b/newsroom/tests/test_pr_lifecycle.py
@@ -740,11 +740,30 @@ def test_plan_rejects_malformed_checkpoint_head_sha() -> None:
 
 
 def test_automatic_branch_deletion_metadata_is_rejected() -> None:
+    legacy = parse_pr_lifecycle(body(retention="keep"))
+    assert legacy.branch_retention is BranchRetention.KEEP
     with pytest.raises(
         PrLifecycleError,
-        match="canonical lifecycle must delete its branch after merge",
+        match="canonical branch retention must be delete-after-merge",
     ):
-        parse_pr_lifecycle(body(retention="keep"))
+        validate_pull_request_lifecycle(
+            legacy,
+            pr_number=10,
+            draft=False,
+            head_ref="agent/increment-5b2",
+        )
+    validate_pull_request_lifecycle(
+        legacy,
+        pr_number=10,
+        draft=False,
+        head_ref="agent/increment-5b2",
+        merged=True,
+    )
+    with pytest.raises(
+        PrLifecycleError,
+        match="canonical lifecycle must keep or delete-after-merge",
+    ):
+        parse_pr_lifecycle(body(retention="delete-after-checkpoint"))
     with pytest.raises(
         PrLifecycleError,
         match="disposable Branch-Retention must be keep",
@@ -769,6 +788,72 @@ def test_automatic_branch_deletion_metadata_is_rejected() -> None:
                 retention="delete-after-checkpoint",
             )
         )
+
+
+def test_plan_rejects_open_canonical_keep_retention() -> None:
+    with pytest.raises(
+        PrLifecycleError,
+        match="canonical branch retention must be delete-after-merge",
+    ):
+        plan_housekeeping(
+            (
+                open_pr(
+                    10,
+                    pr_body=body(retention="keep"),
+                    draft=False,
+                    head_ref="agent/increment-5b2",
+                ),
+            ),
+            now=NOW,
+        )
+
+
+def test_merged_canonical_legacy_keep_does_not_abort_inventory() -> None:
+    module = _load_lifecycle_cli("test_pr_lifecycle_legacy_keep_cli")
+    support = module._open_pr_from_json(
+        {
+            "number": 11,
+            "body": body(
+                lifecycle="support",
+                canonical="#10",
+                close_when="canonical-merged",
+            ),
+            "draft": True,
+            "head": {
+                "ref": "support/increment-5b2",
+                "sha": "a" * 40,
+                "repo": {"full_name": "fol2/newsroom"},
+            },
+            "labels": [{"name": HOUSEKEEPING_LABEL}],
+            "created_at": "2026-08-05T12:00:00Z",
+        }
+    )
+
+    class FakeClient:
+        def get_pull_request(self, number: int):
+            assert number == 10
+            return {
+                "number": 10,
+                "body": body(retention="keep"),
+                "draft": False,
+                "head": {
+                    "ref": "agent/increment-5b2",
+                    "sha": "b" * 40,
+                    "repo": {"full_name": "fol2/newsroom"},
+                },
+                "labels": [],
+                "created_at": "2026-08-01T12:00:00Z",
+                "merged_at": "2026-08-02T12:00:00Z",
+            }
+
+    verified = module._verified_merged_canonical_prs(
+        FakeClient(),
+        open_prs=(support,),
+        lifecycles={support.number: module.parse_pr_lifecycle(support.body)},
+    )
+    assert set(verified) == {10}
+    assert verified[10][1].branch_retention.value == "keep"
+
 
 def test_plan_rejects_unknown_or_mismatched_canonical_reference() -> None:
     support = open_pr(

--- a/newsroom/tests/test_pr_lifecycle.py
+++ b/newsroom/tests/test_pr_lifecycle.py
@@ -36,8 +36,12 @@ def body(
     canonical: str = "self",
     checkpoint: str = "checkpoint/increment-5b2",
     close_when: str = "merged",
-    retention: str = "keep",
+    retention: str | None = None,
 ) -> str:
+    if retention is None:
+        retention = (
+            "keep" if lifecycle != "canonical" else "delete-after-merge"
+        )
     return "\n".join(
         (
             f"Lifecycle: {lifecycle}",
@@ -84,7 +88,7 @@ def test_parse_canonical_lifecycle() -> None:
     assert lifecycle.canonical_pr is None
     assert lifecycle.checkpoint_ref == "checkpoint/increment-5b2"
     assert lifecycle.close_when is CloseWhen.MERGED
-    assert lifecycle.branch_retention is BranchRetention.KEEP
+    assert lifecycle.branch_retention is BranchRetention.DELETE_AFTER_MERGE
 
 
 def test_parser_rejects_reserved_delivery_atom_placeholder() -> None:
@@ -738,7 +742,24 @@ def test_plan_rejects_malformed_checkpoint_head_sha() -> None:
 def test_automatic_branch_deletion_metadata_is_rejected() -> None:
     with pytest.raises(
         PrLifecycleError,
-        match="automatic branch deletion is unsupported",
+        match="canonical lifecycle must delete its branch after merge",
+    ):
+        parse_pr_lifecycle(body(retention="keep"))
+    with pytest.raises(
+        PrLifecycleError,
+        match="disposable Branch-Retention must be keep",
+    ):
+        parse_pr_lifecycle(
+            body(
+                lifecycle="support",
+                canonical="#10",
+                close_when="canonical-merged",
+                retention="delete-after-merge",
+            )
+        )
+    with pytest.raises(
+        PrLifecycleError,
+        match="disposable Branch-Retention must be keep",
     ):
         parse_pr_lifecycle(
             body(

--- a/scripts/sdlc/pr_lifecycle.py
+++ b/scripts/sdlc/pr_lifecycle.py
@@ -687,14 +687,14 @@ def _apply_plan(
             raise GithubApiError(
                 f"pull request #{action.pr_number} lifecycle changed after planning"
             )
-        if lifecycle.branch_retention.value != "keep":
-            raise GithubApiError(
-                f"pull request #{action.pr_number} requests unsupported "
-                "automatic branch deletion"
-            )
         if not lifecycle.is_disposable:
             raise GithubApiError(
                 f"pull request #{action.pr_number} is no longer disposable"
+            )
+        if lifecycle.branch_retention.value != "keep":
+            raise GithubApiError(
+                f"pull request #{action.pr_number} requests housekeeping "
+                "Git-ref deletion"
             )
         if HOUSEKEEPING_LABEL not in current.labels:
             raise GithubApiError(

--- a/scripts/sdlc/pr_lifecycle.py
+++ b/scripts/sdlc/pr_lifecycle.py
@@ -239,6 +239,7 @@ def _verified_merged_canonical_prs(
             pr_number=canonical_pr.number,
             draft=canonical_pr.draft,
             head_ref=canonical_pr.head_ref,
+            merged=True,
         )
         if not canonical_lifecycle.canonical_is_self:
             raise GithubApiError(
@@ -632,6 +633,7 @@ def _validated_current_canonical(
         pr_number=canonical_pr.number,
         draft=canonical_pr.draft,
         head_ref=canonical_pr.head_ref,
+        merged=raw_canonical.get("merged_at") is not None,
     )
     if (
         not canonical_lifecycle.canonical_is_self


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: pr-lifecycle-delete-after-merge
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: keep

## Scope

Change the default so merged canonical heads are not retained.

- Canonical PRs require `Branch-Retention: delete-after-merge`.
- Disposable support/preflight PRs stay `keep` (never merged).
- GitHub `delete_branch_on_merge` is the merge-time deletion mechanism.
- Housekeeping still never DELETE git refs (no compare-and-delete).

This PR still declares `keep` so current `main` lifecycle validate accepts it. After merge, later canonical PRs must declare `delete-after-merge`.

## Exact state

```text
base: origin/main
head: jamesto/pr-lifecycle-delete-after-merge
```

## Verification

- `uv run pytest newsroom/tests/test_pr_lifecycle.py -q` — 42 passed

## Non-effects

Does not add housekeeping Git-ref deletion. Does not change Increment 9P, hub, or Increment 11. Does not close #550 (already closed after #552).


Made with [Cursor](https://cursor.com)