### PR TITLE
docs: refresh Matt Pocock agent skill conventions

### DIFF
--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,22 +1,35 @@
-# Domain docs
+# Domain Docs
 
-This is a single-context repository.
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
 
-## Before exploring
+This is a single-context repository: one `CONTEXT.md` at the repo root, and system-wide ADRs under `docs/adr/`.
 
-Read these when they exist:
+## Before exploring, read these
 
-- `CONTEXT.md` at the repository root
-- Relevant ADRs under `docs/adr/`
+- **`CONTEXT.md`** at the repo root
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in
 
-Their absence is not an error. Continue silently. The domain-modelling flow creates them lazily after terminology or an architectural decision has genuinely been resolved.
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
 
-## Domain language
+## File structure
 
-Use canonical terms from `CONTEXT.md` in plans, issues, code, tests, and documentation. Avoid synonyms that the glossary marks as discouraged.
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+└── newsroom/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
 
 `CONTEXT.md` is a glossary only. It must not contain implementation details, plans, or architectural decisions.
 
-## Architectural decisions
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
 
-If proposed work conflicts with an existing ADR, identify the conflict explicitly. Do not silently override the recorded decision.
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,26 +1,45 @@
 # Issue tracker: GitHub
 
-Engineering plans, tickets, and PRDs for this repository live as GitHub issues. Use the `gh` CLI for issue operations and infer the repository from `git remote -v`.
+Issues and specs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
 
 ## Conventions
 
-- Create: `gh issue create --title "..." --body "..."`
-- Read: `gh issue view <number> --comments`
-- List: `gh issue list --state open --json number,title,body,labels,comments`
-- Comment: `gh issue comment <number> --body "..."`
-- Label: `gh issue edit <number> --add-label "..."` or `--remove-label "..."`
-- Close: `gh issue close <number> --comment "..."`
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
 
-When a skill says to publish work to the issue tracker, create a GitHub issue. When it says to fetch a ticket, read the issue and its comments.
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
 
 ## Pull requests as a triage surface
 
-External pull requests are not a request surface and must not enter the issue-triage state machine. Existing maintainer and collaborator pull requests continue through the normal review workflow.
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
 
-GitHub issues and pull requests share one number space. Resolve an ambiguous reference with `gh pr view <number>` and fall back to `gh issue view <number>`.
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
 
-## Dependencies
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
 
-Use GitHub sub-issues and native issue dependencies where available. Otherwise, record `Part of #<number>` and `Blocked by: #<number>` explicitly in issue bodies.
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
 
-A ticket is ready only when all blocking issues are closed.
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,11 +1,15 @@
-# Triage labels
+# Triage Labels
 
-| Canonical role    | GitHub label       | Meaning                                      |
-| ----------------- | ------------------ | -------------------------------------------- |
-| `needs-triage`    | `needs-triage`     | Maintainer evaluation is required            |
-| `needs-info`      | `needs-info`       | Waiting for information from the reporter    |
-| `ready-for-agent` | `ready-for-agent`  | Fully specified and ready for an AFK agent   |
-| `ready-for-human` | `ready-for-human`  | Human implementation or judgement is needed |
-| `wontfix`         | `wontfix`          | The issue will not be actioned               |
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
 
-When an engineering skill names a canonical role, apply the corresponding GitHub label from this table.
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: agent-skills-docs
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: delete-after-merge

## Scope

Refresh the per-repo Matt Pocock engineering-skill configuration so `to-tickets`, `triage`, `to-spec`, `wayfinder`, and `domain-modeling` read current GitHub Issues conventions, the five canonical triage labels, and single-context domain-doc consumer rules.

## Exact state

```text
base: 45e931a33d4a45f5253c3a2373704636c551d08d
head: ab6f54c7e46f8b0406de13afc5109f7e0443f352
tree: 6f1ad4d266714b9867532a4e0e05afefbe064b29
commits over base: 1
changed files:
docs/agents/domain.md
docs/agents/issue-tracker.md
docs/agents/triage-labels.md
```

## Verification

Docs-only change. No runtime code, tests, or SDLC core receipt. Fast CI on this head is a compatibility signal only. Feature-complete stop: three agent docs files match the confirmed setup drafts; review state is draft pending human review.

## Non-effects

Does not change the issue tracker (GitHub Issues), triage label names, `CLAUDE.md`, planner/runner runtime, or CONTEXT/ADR contents. Does not treat external PRs as a triage request surface. Does not create wayfinder maps, GitHub issues, or labels.

Made with [Cursor](https://cursor.com)