### PR TITLE
docs(adr): record that the legacy operational Newsroom is dead

### DIFF
--- a/docs/adr/0009-legacy-operational-newsroom-dead.md
+++ b/docs/adr/0009-legacy-operational-newsroom-dead.md
@@ -22,7 +22,8 @@ choose a different bounded-search provider.
 Increment 11C is not a compatibility window for this legacy stack. Dual-write
 and historical import are refused. Old Discord posts are not Story Versions.
 Working-tree deletion of this legacy code is authorised separately and does not
-block Increment 11B; git history is the inspirational archive.
+block Increment 11B; git history is the inspirational archive. This ADR does
+not authorise Increment 11B, 11R, or production activation.
 
 Rejected alternatives: keeping OpenClaw and Discord live until 11B; an
 Increment 11C dual-run; Discord as a non-production observer; importing

--- a/docs/adr/0009-legacy-operational-newsroom-dead.md
+++ b/docs/adr/0009-legacy-operational-newsroom-dead.md
@@ -1,0 +1,36 @@
+---
+status: accepted
+date: 2026-08-17
+accepted_by_owner: 2026-08-17
+---
+
+# Legacy operational Newsroom is dead; Increment 11B is a fresh start
+
+The OpenClaw planners, OpenClaw runner, Discord publishing path, Brave News
+API clock, GDELT DOC 2.0 index, broad media RSS pool, `news_pool.sqlite3` and
+per-link Gemini clustering path are not the operational Newsroom and must not
+be restarted. There is no live interim path to preserve. Increment 11B is a
+fresh start: the Hermes Control Plane becomes the first operational Newsroom,
+and the first public target remains the integrated app-serving system and
+native readers.
+
+RSS and Atom remain valid transports for Source Registry Source Definitions.
+Brave and GDELT are permanently ineligible as clocks, indexes, pools,
+comparators, Evidence Intake channels or Source Definitions. Topic 7 may still
+choose a different bounded-search provider.
+
+Increment 11C is not a compatibility window for this legacy stack. Dual-write
+and historical import are refused. Old Discord posts are not Story Versions.
+Working-tree deletion of this legacy code is authorised separately and does not
+block Increment 11B; git history is the inspirational archive.
+
+Rejected alternatives: keeping OpenClaw and Discord live until 11B; an
+Increment 11C dual-run; Discord as a non-production observer; importing
+Discord history; treating RSS-the-transport as legacy; leaving Brave or GDELT
+available for Topic 7; blocking 11B on tree deletion.
+
+## Evidence
+
+- [When OpenClaw and Discord stop being the operational Newsroom](https://github.com/fol2/newsroom/issues/563)
+- [ADR 0004 — source-portfolio-first discovery](0004-source-registry-first-change-driven-discovery.md)
+- [ADR 0007 — Discord and OpenClaw are not target dependencies](0007-hermes-autonomy-envelope-and-conditional-activation.md)


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: adr-0009-legacy-operational-newsroom-dead
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: delete-after-merge

## Scope

Record accepted ADR 0009 from the closed Wayfinder decision [When OpenClaw and Discord stop being the operational Newsroom](https://github.com/fol2/newsroom/issues/563): the legacy OpenClaw / Discord / Brave / GDELT / news_pool operational stack is dead and must not restart; Increment 11B is a Hermes fresh start; RSS/Atom remains a Source Definition transport.

## Exact state

```text
base: 500fd5fd278efae3ee14628345f17c97d67ec41e
head: 98b2d69ad231a57891cc64987fbac1a2f3accd15
tree: 0e74872cb30d94bb1a074040466f18a59faefc60
commits over base: 2
changed files:
docs/adr/0009-legacy-operational-newsroom-dead.md
```

## Verification

Docs-only change. No runtime code, tests, or SDLC core receipt. Fast CI on this head is a compatibility signal only. Feature-complete stop: ADR 0009 matches the closed #563 resolution, including that this ADR does not authorise Increment 11B or 11R.

## Non-effects

Does not delete legacy code (that is #593). Does not restart OpenClaw or Discord. Does not authorise Increment 11B, 11R, or 11A–11D. Does not change Source Registry RSS/Atom transports. Does not activate, mutate, or publish anything.