### PR TITLE
Restore Evidence core-shard-17: drop duplicative hatchling force-include

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ venv/
 !.env.example
 newsroom/rss_feeds.yaml
 secrets/
-data/
+/data/
 logs/
 workspace/jobs/
 *.sqlite3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,5 @@ dev = [
 [tool.hatch.build.targets.wheel]
 packages = ["newsroom", "scripts"]
 
-[tool.hatch.build.force-include]
-"newsroom/increment5/data" = "newsroom/increment5/data"
-"newsroom/increment9/fixtures" = "newsroom/increment9/fixtures"
-
 [tool.pytest.ini_options]
 testpaths = ["newsroom/tests"]


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: hatchling-duplicate-wheel-paths
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: delete-after-merge

## Scope

CI unblock for [Evidence workflow core-shard-17 fails repo-wide: hatchling rejects force-include duplicate wheel paths](https://github.com/fol2/newsroom/issues/602). Hatchling now errors on duplicate wheel paths. The broad gitignore `data/` pattern hid Increment 5A contract files, so `force-include` both supplied them and collided with auto-included Increment 9 fixtures. Narrow gitignore to the repo-root runtime store and drop the duplicative `force-include` table.

Fixes #602

## Exact state

```text
base: e7eaa39a3746341e1eba0bbbe1f86c203199768b
head: e46fbe4305de214150f17f19663f5bc9207b25f5
tree: 83513a35c6e5c740b81137607610fce4017684d2
commits over base: 1
changed files: 2
```

## Verification

Local `uv build` succeeds. Wheel contains `newsroom/increment5/data/increment5a_retrieval_contract_v1.json` and `newsroom/increment9/fixtures/increment9q1_nonmutation/CANARY`. `uv run pytest newsroom/tests/test_increment6r_readiness.py::test_built_wheel_contains_and_loads_all_readiness_resources -v` passed. Canonical complete deterministic evidence remains the decision-validated exact-head SDLC core receipt after CI.

## Non-effects

This PR does not pin hatchling, does not authorise Increment 9Q, 11B, 11R or production activation, and does not change First I/O Gate Records, live coverage, or the Hermes Control Plane.


Made with [Cursor](https://cursor.com)