### PR TITLE
docs: accept quality-evaluation-and-change-control (#619)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,6 +1,6 @@
 # Newsroom domain language
 
-**Status:** Proposed vocabulary; Increment 9 autonomy terms accepted 2026-08-15; Active Coverage accepted 2026-08-17
+**Status:** Proposed vocabulary; Increment 9 autonomy terms accepted 2026-08-15; Active Coverage accepted 2026-08-17; Evaluation Threshold Schedule accepted 2026-08-17
 
 This glossary proposes the canonical meanings of editorial records that connect evidence, decisions, publication and derived newsroom intelligence. The product owner has not accepted this vocabulary yet.
 
@@ -313,6 +313,10 @@ reviewers, or a valid authorised AI adjudication of their disagreement. For the
 accepted Increment 9 evaluation it is the editorial-quality ground truth; it is
 not a human label and must never be described as human review.
 _Avoid_: Human approval, majority vote with a missing primary, model confidence
+
+**Evaluation Threshold Schedule**:
+An owner-approved, versioned production-policy artefact that names each non-zero-tolerance evaluation metric, its threshold, and the evaluated version and product scope it binds. Missing metric or schedule fails closed. It is not ADR 0006 AI Review Consensus, not a QA-041 zero-tolerance defect, and not the CONT-084 originality overlap threshold.
+_Avoid_: Confidence interval, Increment 9 Evaluation Plan, calibration result, aggregate score, originality threshold
 
 **Hermes Publication Admission**:
 The Hermes Control Plane's terminal decision that one exact Publication Bundle

--- a/docs/specs/editorial-automation/quality-evaluation-and-change-control.md
+++ b/docs/specs/editorial-automation/quality-evaluation-and-change-control.md
@@ -1,8 +1,9 @@
 # Quality evaluation and change-control specification
 
-**Status:** Draft  
+**Status:** Accepted  
 **Owner:** Product owner  
-**Last updated:** 2026-07-15
+**Last updated:** 2026-08-17  
+**Accepted by owner:** 2026-08-17  
 **Canonical language:** English  
 **Related plan:** None  
 **Related reference:** [`product-editorial-charter.zh-HK.md`](../../reference/editorial/product-editorial-charter.zh-HK.md), sections 13 and 14  
@@ -11,6 +12,8 @@
 ## Purpose
 
 Define how models, prompts, validators, policies, source adapters and publication components earn and retain production authority in an autonomous newsroom.
+
+This specification's evaluation is a versioned Evaluation Corpus with reviewable expected outcomes (`QA-023`) plus owner or delegated specialist review of release evidence (`QA-045`). It is not ADR 0006 AI Review Consensus, not OD-008 Active Coverage, and not the Increment 11R live Evidence Intake canary.
 
 ## Scope
 
@@ -123,9 +126,17 @@ This specification covers versioning, evaluation datasets, release evidence, cha
 - fail-open behaviour; and
 - policy or credential escalation from untrusted content.
 
-**QA-042 — Quantitative thresholds.** Numerical thresholds for non-zero-tolerance metrics MUST be defined and owner-approved before production activation. The thresholds MUST be attached to the evaluated version and product scope.
+**QA-042 — Quantitative thresholds.** Numerical thresholds for non-zero-tolerance metrics MUST live in an owner-approved, versioned production-policy artefact named **Evaluation Threshold Schedule**. The schedule MUST bind each metric to the evaluated version and product scope. The schedule MUST be approved before those evaluation results are reviewed; the same discipline as `DEVAL-051` in the accepted discovery-shadow-evaluation specification applies. A run used to choose thresholds MUST NOT also qualify them (`DEVAL-012`). Missing schedule, missing metric or missing binding MUST fail the release gate: that version MUST NOT receive publication authority. Launch MUST NOT require statistical confidence intervals. An evaluation report MUST include count, denominator and required slices; `CI not defined` is not a pass. `QA-041` safety-critical defects remain zero-count and MUST NOT appear in the Evaluation Threshold Schedule as non-zero rates. CONT-084 originality-check overlap thresholds remain owned by the content-generation-and-presentation specification and production policy; this specification MUST NOT restate those numbers.
 
-**QA-043 — Slice evaluation.** Aggregate passing results MUST NOT hide a material failure in a high-risk category, language, jurisdiction, source class or publication path. Required slices MUST be reported separately.
+**QA-043 — Slice evaluation.** Aggregate passing results MUST NOT hide a material failure in a high-risk category, language, jurisdiction, source class or publication path. Required slices MUST be reported separately. Launch blocking required slices are:
+
+- **Jurisdiction:** UK, HK;
+- **Language:** English, Hong Kong Traditional Chinese;
+- **Source class:** official OD-001 Source Definition versus lead-only comparator (`RAD-01`, `RAD-02`);
+- **Publication path:** app article, feed card; and
+- **High-risk categories, only when the Evaluation Corpus has at least one case:** Immigration and status; Education and campuses; Weather and disasters; Safety and crime.
+
+An empty required slice is not evaluated and fail-closed; it MUST NOT be reported as a pass. Other charter categories MAY be reported and MUST NOT be launch-blocking merely by absence. `QA-022` challenge classes remain corpus case types, not extra blocking slices. Generative, stock and map-tile visual cases remain in the corpus as hold or reject expected outcomes; they do not authorise those paths.
 
 **QA-044 — Baseline comparison.** A release report MUST compare the candidate version with the current production baseline and explain material regressions or trade-offs.
 
@@ -133,7 +144,7 @@ This specification covers versioning, evaluation datasets, release evidence, cha
 
 ### Shadow, canary and rollout
 
-**QA-050 — Shadow mode.** The system SHOULD support running a candidate component against live or representative inputs without permitting it to publish.
+**QA-050 — Shadow mode.** Before a new model, prompt, policy or validator version may receive publication authority, including `AUTO_PUBLISH`, the system MUST run that candidate against live or representative inputs without permitting it to publish. That shadow is distinct from the Increment 11R live Evidence Intake canary and from OD-008 Active Coverage; neither satisfies this requirement. Calendar duration alone MUST NOT establish adequate exposure (`DEVAL-013`). An owner-approved change-control Evaluation Plan, immutable before outcomes are reviewed and distinct from the Increment 9 or OD-008 plan, MUST name the window and the minimum live exposure per required slice, plus the `QA-025` stable regression set. Insufficient live exposure on a required slice fails closed unless that Plan pre-declares the slice as corpus-only. Exact counts and window length live in production policy, not this specification. First `AUTO_PUBLISH` enablement timing is not defined here.
 
 **QA-051 — Decision comparison.** Shadow evaluation SHOULD compare candidate and production evidence selection, drafts, validator results, hold/reject reasons and publication decisions.
 
@@ -162,9 +173,9 @@ This specification covers versioning, evaluation datasets, release evidence, cha
 
 **QA-062 — Version segmentation.** Every metric and incident MUST be attributable to the relevant model, prompt, policy, validator and software versions.
 
-**QA-063 — Alert conditions.** Owner-approved alert conditions MUST exist for safety-critical failures and material unexpected shifts in publish, hold, reject, correction or error behaviour.
+**QA-063 — Alert conditions.** Owner-approved alert conditions MUST exist for material unexpected shifts in publish, hold, reject or correction behaviour, reviewer queue age where holds exist, and model, tool or provider errors that already failed closed without publishing. Rate-shift tripwires live in production policy. Missing tripwire means alert only: the system MUST NOT silently auto-pause on a rate shift, and MUST NOT treat a missing tripwire as licence to skip a `QA-041` automatic pause.
 
-**QA-064 — Automatic containment.** A safety-critical runtime signal SHOULD be able to pause the affected scope automatically, subject to a policy that avoids destructive or unaudited actions.
+**QA-064 — Automatic containment.** The system MUST automatically pause the affected scope for any `QA-041` class runtime signal, audit-write failure or publication-controller failure, using only the launch MUST scopes from the autonomy-and-publication-control specification: global pause (`AUTO-060`) and per-publication-target pause. Automatic pause is not the Kill Switch and not a Human Emergency Stop; resume follows `AUTO-063`. `HUMAN_RELEASE_REQUIRED` stays on signed emergency stop. Finer `AUTO-061` scoped pause remains deferred fail-closed per the autonomy-and-publication-control acceptance decision: where a finer scope is needed, use the global pause.
 
 ### Incident and rollback process
 
@@ -200,16 +211,16 @@ This specification covers versioning, evaluation datasets, release evidence, cha
 8. A failed evaluation remains available after a later successful run.
 9. Runtime audit-write failure triggers containment rather than unlogged publication.
 10. A generative agent's attempt to obtain publishing credentials is a release-blocking defect.
+11. Missing Evaluation Threshold Schedule metric cannot grant publication authority.
+12. An aggregate pass with a failed or unevaluated required slice fails.
+13. A calendar-duration shadow that missed a required slice does not qualify.
+14. The Increment 11R live Evidence Intake canary does not qualify a model, prompt, policy or validator version.
+15. A `QA-041` runtime signal, audit-write failure or publication-controller failure without automatic global or per-target pause fails.
+16. A rate shift with no tripwire alerts and MUST NOT auto-pause.
+17. Thresholds chosen on a calibration run cannot be qualified by that same run.
 
 ## Non-goals
 
 This specification does not set the final numerical quality thresholds, choose an observability platform or define a deployment pipeline implementation.
 
 It does not permit agents to optimise directly against engagement at the expense of the charter requirements.
-
-## Open questions
-
-- What numerical thresholds and confidence intervals are appropriate for each non-zero-tolerance metric?
-- Which categories, jurisdictions and source classes require mandatory separate evaluation slices at launch?
-- How much live shadow traffic is necessary before enabling a new model or policy version?
-- Which runtime conditions should trigger an automatic scoped pause versus an operator alert only?


### PR DESCRIPTION
## Summary

- Flip `docs/specs/editorial-automation/quality-evaluation-and-change-control.md` from Draft to Accepted (2026-08-17), per owner decision #611.
- Resolve the four open questions into `QA-042`, `QA-043`, `QA-050`, `QA-063` and `QA-064`: Evaluation Threshold Schedule, launch required slices, mandatory no-publish shadow, and automatic pause versus alert-only behaviour.
- Add seven acceptance criteria covering threshold schedule, slice evaluation, shadow qualification, canary distinction, automatic pause, rate-shift alerts and calibration separation.
- Add **Evaluation Threshold Schedule** to `CONTEXT.md` under Autonomous evaluation and control.

Closes #619

## Test plan

- [x] Spec Status is Accepted with `Accepted by owner: 2026-08-17`
- [x] Open questions section removed; answers reflected in requirements
- [x] Only `quality-evaluation-and-change-control.md` and `CONTEXT.md` changed
- [x] UK English throughout

Made with [Cursor](https://cursor.com)