### PR TITLE
Implement Increment 9Q-5 BASELINE_CREDENTIAL_SCOPES qualification evidence

### DIFF
--- a/newsroom/increment9/baseline_credential_scopes.py
+++ b/newsroom/increment9/baseline_credential_scopes.py
@@ -1,0 +1,428 @@
+"""Increment 9Q-5 BASELINE_CREDENTIAL_SCOPES qualification evidence.
+
+CI fixture digests only. Does not mint First I/O Gate Records. Loading this
+module performs no network I/O and no production writes.
+
+Qualification proves inventory bind, principal bind, isolation and
+least-privilege resolution on the real contracts, fail-closed.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from newsroom.authority.canonical import canonical_json_bytes, digest_bytes
+from newsroom.increment9.credential_scopes import (
+    BOUNDARY_ONLY_CLASSES,
+    CREDENTIAL_SCOPE,
+    DETERMINISTIC_BOUNDARY,
+    FIXTURE_PRINCIPAL_DIGEST,
+    FIXTURE_PRODUCTION_NAMES,
+    MODEL_FAMILY_LOGIN,
+    NAMESAKE_CAMPAIGN_CLASSES,
+    CredentialScopeError,
+    bind_campaign_credential_classes,
+    bind_inventory,
+    bound_resolver,
+    credential_ref_from_primitive,
+    inventory_digest,
+    resolve,
+)
+from newsroom.increment9.deployment import (
+    EXPECTED_CREDENTIAL_CLASSES,
+    EXPECTED_PROBES,
+    PROHIBITED_CREDENTIAL_CLASSES,
+)
+from newsroom.increment9.shadow_contracts import ShadowAccessBoundary, ShadowContractError
+
+SCHEMA_VERSION = "newsroom.increment9.qualification-evidence.v1"
+GATE_ID = "BASELINE_CREDENTIAL_SCOPES"
+
+REFUSAL_CLASSES = (
+    "UNKNOWN_CREDENTIAL_CLASS",
+    "PUBLICATION_TARGET_ADAPTER_REFUSED",
+    "CROSS_FAMILY_LOGIN_REFUSED",
+    "MODEL_FAMILY_AUTHORITY_CLASS_REFUSED",
+    "PRODUCTION_STORE_NAME_REFUSED",
+    "PRINCIPAL_DIGEST_MISMATCH",
+    "INVENTORY_DRIFT",
+    "SECRET_BYTES_IN_RESOLUTION",
+    "MALFORMED_REQUEST",
+    "ANTI_NAMESAKE",
+)
+PACKAGE_FIXTURES = Path(__file__).parent / "fixtures" / "increment9q5_baseline_credential_scopes"
+_A2_PROBES = ("CREDENTIAL_VALUES_ABSENT", "PRODUCTION_CREDENTIAL_DENIED")
+_MARKERS = {
+    "UNKNOWN_CREDENTIAL_CLASS": b"unknown_credential_class",
+    "PUBLICATION_TARGET_ADAPTER_REFUSED": b"publication_target_adapter_refused",
+    "CROSS_FAMILY_LOGIN_REFUSED": b"cross_family_login_refused",
+    "MODEL_FAMILY_AUTHORITY_CLASS_REFUSED": b"model_family_authority_class_refused",
+    "PRODUCTION_STORE_NAME_REFUSED": b"production_store_name_refused",
+    "PRINCIPAL_DIGEST_MISMATCH": b"principal_digest_mismatch",
+    "INVENTORY_DRIFT": b"inventory_drift",
+    "SECRET_BYTES_IN_RESOLUTION": b"secret_bytes_in_resolution",
+    "MALFORMED_REQUEST": b"malformed_request",
+    "ANTI_NAMESAKE": b"anti_namesake",
+}
+
+Probe = Callable[[str, Path], bool]
+
+
+class QualificationError(ValueError):
+    """Qualification inventory, probe or digest check failed closed."""
+
+
+@dataclass(frozen=True, slots=True)
+class RefusalDigest:
+    refusal_class: str
+    before_digest: str
+    after_digest: str
+    engaged: bool
+    count: int
+
+
+@dataclass(frozen=True, slots=True)
+class QualificationEvidence:
+    gate_id: str
+    status: str
+    refusals_engaged: int
+    refusals: tuple[RefusalDigest, ...]
+    principal_digest: str
+    inventory_digest: str
+    evidence_digest: str
+
+
+def _reject_forbidden(inventory: Path) -> None:
+    lowered = str(inventory).lower()
+    if "news_pool" in lowered:
+        raise QualificationError("inventory must not alias news_pool")
+
+
+def _refusal_surfaces(inventory: Path) -> tuple[tuple[str, Path], ...]:
+    if not inventory.is_dir():
+        raise QualificationError("inventory is required")
+    missing = [rc for rc in REFUSAL_CLASSES if not (inventory / rc).is_file()]
+    if missing:
+        raise QualificationError(f"missing refusal class: {missing[0]}")
+    extras = sorted(
+        path.name for path in inventory.iterdir() if path.name not in REFUSAL_CLASSES
+    )
+    if extras:
+        raise QualificationError(f"unexpected refusal class: {extras[0]}")
+    return tuple((rc, inventory / rc) for rc in REFUSAL_CLASSES)
+
+
+def _digest_file(path: Path) -> str:
+    return digest_bytes(path.read_bytes())
+
+
+def _refused(action: Callable[[], object]) -> bool:
+    try:
+        action()
+    except (CredentialScopeError, ShadowContractError):
+        return True
+    return False
+
+
+def default_probe(refusal_class: str, path: Path) -> bool:
+    """Verify that a credential-scope refusal class engages on the real contracts.
+
+    Returns True if the refusal engaged (fail-closed). Returns False if it
+    did not engage (unexpected success).
+    """
+    if refusal_class not in REFUSAL_CLASSES:
+        raise QualificationError(f"unknown refusal class: {refusal_class}")
+    if not path.is_file():
+        raise QualificationError(f"missing refusal class: {refusal_class}")
+    if _MARKERS[refusal_class] not in path.read_bytes():
+        return False
+    probes = {
+        "UNKNOWN_CREDENTIAL_CLASS": _should_engage_unknown_credential_class,
+        "PUBLICATION_TARGET_ADAPTER_REFUSED": _should_engage_publication_target,
+        "CROSS_FAMILY_LOGIN_REFUSED": _should_engage_cross_family_login,
+        "MODEL_FAMILY_AUTHORITY_CLASS_REFUSED": _should_engage_model_family_authority,
+        "PRODUCTION_STORE_NAME_REFUSED": _should_engage_production_store_name,
+        "PRINCIPAL_DIGEST_MISMATCH": _should_engage_principal_digest_mismatch,
+        "INVENTORY_DRIFT": _should_engage_inventory_drift,
+        "SECRET_BYTES_IN_RESOLUTION": _should_engage_secret_bytes,
+        "MALFORMED_REQUEST": _should_engage_malformed_request,
+        "ANTI_NAMESAKE": _should_engage_anti_namesake,
+    }
+    return bool(probes[refusal_class]())
+
+
+def _should_engage_unknown_credential_class() -> bool:
+    return _refused(
+        lambda: resolve(
+            FIXTURE_PRINCIPAL_DIGEST,
+            DETERMINISTIC_BOUNDARY,
+            "NOT_A_CREDENTIAL_CLASS",
+        )
+    )
+
+
+def _should_engage_publication_target() -> bool:
+    handles = (DETERMINISTIC_BOUNDARY, *MODEL_FAMILY_LOGIN)
+    return all(
+        _refused(
+            lambda h=handle: resolve(
+                FIXTURE_PRINCIPAL_DIGEST, h, "PUBLICATION_TARGET_ADAPTER"
+            )
+        )
+        for handle in handles
+    )
+
+
+def _should_engage_cross_family_login() -> bool:
+    pairs = [
+        (handle, other)
+        for handle, own in MODEL_FAMILY_LOGIN.items()
+        for other in MODEL_FAMILY_LOGIN.values()
+        if other != own
+    ]
+    return all(
+        _refused(
+            lambda h=handle, c=other: resolve(FIXTURE_PRINCIPAL_DIGEST, h, c)
+        )
+        for handle, other in pairs
+    )
+
+
+def _should_engage_model_family_authority() -> bool:
+    return all(
+        _refused(
+            lambda h=handle, c=cls: resolve(FIXTURE_PRINCIPAL_DIGEST, h, c)
+        )
+        for handle in MODEL_FAMILY_LOGIN
+        for cls in BOUNDARY_ONLY_CLASSES
+    )
+
+
+def _should_engage_production_store_name() -> bool:
+    handles = (DETERMINISTIC_BOUNDARY, *MODEL_FAMILY_LOGIN)
+    return all(
+        _refused(
+            lambda h=handle, c=name: resolve(FIXTURE_PRINCIPAL_DIGEST, h, c)
+        )
+        for handle in handles
+        for name in FIXTURE_PRODUCTION_NAMES
+    )
+
+
+def _should_engage_principal_digest_mismatch() -> bool:
+    other = "sha256:" + "0" * 64
+    return other != FIXTURE_PRINCIPAL_DIGEST and _refused(
+        lambda: resolve(other, DETERMINISTIC_BOUNDARY, "OPENAI_CODEX_LOGIN")
+    )
+
+
+def _should_engage_inventory_drift() -> bool:
+    missing = EXPECTED_CREDENTIAL_CLASSES[:-1]
+    extra = tuple(sorted((*EXPECTED_CREDENTIAL_CLASSES, "EXTRA_CREDENTIAL_CLASS")))
+    unsorted = (
+        EXPECTED_CREDENTIAL_CLASSES[1],
+        EXPECTED_CREDENTIAL_CLASSES[0],
+        *EXPECTED_CREDENTIAL_CLASSES[2:],
+    )
+    duplicate = (EXPECTED_CREDENTIAL_CLASSES[0], *EXPECTED_CREDENTIAL_CLASSES)
+    overlap_prohibited = ("NEO4J_SHADOW_WRITER",)
+    drifted = (
+        (missing, PROHIBITED_CREDENTIAL_CLASSES),
+        (extra, PROHIBITED_CREDENTIAL_CLASSES),
+        (unsorted, PROHIBITED_CREDENTIAL_CLASSES),
+        (duplicate, PROHIBITED_CREDENTIAL_CLASSES),
+        (EXPECTED_CREDENTIAL_CLASSES, overlap_prohibited),
+        (("ANTHROPIC_AGENT_SDK",), ("ANTHROPIC_AGENT_SDK",)),
+    )
+    bind_closed = all(
+        _refused(lambda p=permitted, q=prohibited: bind_inventory(p, q))
+        for permitted, prohibited in drifted
+    )
+    boundary_overlap = _refused(
+        lambda: ShadowAccessBoundary(
+            purpose_identity="increment9-evaluation-only",
+            principal_identity_digest=FIXTURE_PRINCIPAL_DIGEST,
+            permitted_credential_classes=("ANTHROPIC_AGENT_SDK",),
+            prohibited_credential_classes=("ANTHROPIC_AGENT_SDK",),
+            egress_policy_digest=FIXTURE_PRINCIPAL_DIGEST,
+            artefact_policy_digest=FIXTURE_PRINCIPAL_DIGEST,
+        )
+    )
+    boundary_unsorted = _refused(
+        lambda: ShadowAccessBoundary(
+            purpose_identity="increment9-evaluation-only",
+            principal_identity_digest=FIXTURE_PRINCIPAL_DIGEST,
+            permitted_credential_classes=(
+                "OPENAI_CODEX_LOGIN",
+                "ANTHROPIC_AGENT_SDK",
+            ),
+            prohibited_credential_classes=PROHIBITED_CREDENTIAL_CLASSES,
+            egress_policy_digest=FIXTURE_PRINCIPAL_DIGEST,
+            artefact_policy_digest=FIXTURE_PRINCIPAL_DIGEST,
+        )
+    )
+    deployment_closed = (
+        extra != EXPECTED_CREDENTIAL_CLASSES
+        and overlap_prohibited != PROHIBITED_CREDENTIAL_CLASSES
+    )
+    return bind_closed and boundary_overlap and boundary_unsorted and deployment_closed
+
+
+def _should_engage_secret_bytes() -> bool:
+    digest = digest_bytes(
+        canonical_json_bytes(
+            {"credential_class": "OPENAI_CODEX_LOGIN", "scope": CREDENTIAL_SCOPE}
+        )
+    )
+    secret_record = {
+        "credential_class": "OPENAI_CODEX_LOGIN",
+        "digest": digest,
+        "scope": CREDENTIAL_SCOPE,
+        "secret": "sk-fixture-not-a-real-secret",
+    }
+    load_closed = _refused(lambda: credential_ref_from_primitive(secret_record))
+    ref = resolve(
+        FIXTURE_PRINCIPAL_DIGEST, DETERMINISTIC_BOUNDARY, "OPENAI_CODEX_LOGIN"
+    )
+    primitive = ref.primitive()
+    evidence = json.loads(canonical_json_bytes(primitive).decode("utf-8"))
+    clean = set(primitive) == {"credential_class", "digest", "scope"} and not (
+        {"secret", "secret_bytes"} & set(evidence)
+    )
+    return load_closed and clean
+
+
+def _should_engage_malformed_request() -> bool:
+    over_long = "H" * 257
+    return all(
+        (
+            _refused(
+                lambda: resolve(
+                    FIXTURE_PRINCIPAL_DIGEST, "", "OPENAI_CODEX_LOGIN"
+                )
+            ),
+            _refused(
+                lambda: resolve(
+                    FIXTURE_PRINCIPAL_DIGEST, over_long, "OPENAI_CODEX_LOGIN"
+                )
+            ),
+            _refused(
+                lambda: resolve(
+                    FIXTURE_PRINCIPAL_DIGEST,
+                    "not a token",
+                    "OPENAI_CODEX_LOGIN",
+                )
+            ),
+            _refused(
+                lambda: resolve(
+                    FIXTURE_PRINCIPAL_DIGEST,
+                    "WEIRD_HANDLE",
+                    "OPENAI_CODEX_LOGIN",
+                )
+            ),
+        )
+    )
+
+
+def _should_engage_anti_namesake() -> bool:
+    namesake_closed = _refused(
+        lambda: bind_campaign_credential_classes(NAMESAKE_CAMPAIGN_CLASSES)
+    )
+    a2_as_classes = _refused(lambda: bind_campaign_credential_classes(_A2_PROBES))
+    a2_not_this_gate = all(name not in REFUSAL_CLASSES for name in _A2_PROBES)
+    a2_remain_readiness = all(name in EXPECTED_PROBES for name in _A2_PROBES)
+    authorised = not _refused(
+        lambda: bind_campaign_credential_classes(EXPECTED_CREDENTIAL_CLASSES)
+    )
+    return (
+        namesake_closed
+        and a2_as_classes
+        and a2_not_this_gate
+        and a2_remain_readiness
+        and authorised
+    )
+
+
+def _refusal_payload(
+    records: tuple[RefusalDigest, ...],
+) -> list[dict[str, str | bool | int]]:
+    return [
+        {
+            "after_digest": item.after_digest,
+            "before_digest": item.before_digest,
+            "count": item.count,
+            "engaged": item.engaged,
+            "refusal_class": item.refusal_class,
+        }
+        for item in records
+    ]
+
+
+def assess(inventory: Path, *, probe: Probe | None = None) -> QualificationEvidence:
+    """Assess that all ten credential-scope refusal classes engage deterministically.
+
+    Fails closed if:
+    - Inventory missing or inaccessible
+    - Any refusal class surface missing or unexpected
+    - Any digest changes without claimed engagement
+    - Probe mutates any surface (fail-closed invariant)
+    - Any refusal fails to engage
+    """
+    _reject_forbidden(inventory)
+    surfaces = _refusal_surfaces(inventory)
+    writer = default_probe if probe is None else probe
+    bound_resolver()
+    bind_inventory(EXPECTED_CREDENTIAL_CLASSES, PROHIBITED_CREDENTIAL_CLASSES)
+    before = {rc: _digest_file(path) for rc, path in surfaces}
+    engaged_count = 0
+    for rc, path in surfaces:
+        if writer(rc, path):
+            engaged_count += 1
+    after = {rc: _digest_file(path) for rc, path in surfaces}
+    if any(before[rc] != after[rc] for rc in REFUSAL_CLASSES):
+        raise QualificationError("refusal surface digest mutated")
+    if engaged_count != len(REFUSAL_CLASSES):
+        raise QualificationError(
+            f"not all refusals engaged: {engaged_count}/{len(REFUSAL_CLASSES)}"
+        )
+    records = tuple(
+        RefusalDigest(rc, before[rc], after[rc], True, 1) for rc in REFUSAL_CLASSES
+    )
+    principal = FIXTURE_PRINCIPAL_DIGEST
+    inventory_id = inventory_digest()
+    payload = {
+        "gate_id": GATE_ID,
+        "inventory_digest": inventory_id,
+        "principal_digest": principal,
+        "refusals": _refusal_payload(records),
+        "refusals_engaged": engaged_count,
+        "schema_version": SCHEMA_VERSION,
+        "status": "PASS",
+    }
+    return QualificationEvidence(
+        gate_id=GATE_ID,
+        status="PASS",
+        refusals_engaged=engaged_count,
+        refusals=records,
+        principal_digest=principal,
+        inventory_digest=inventory_id,
+        evidence_digest=digest_bytes(canonical_json_bytes(payload)),
+    )
+
+
+def evidence_json(evidence: QualificationEvidence) -> bytes:
+    """Serialise qualification evidence to canonical JSON."""
+    payload = {
+        "evidence_digest": evidence.evidence_digest,
+        "gate_id": evidence.gate_id,
+        "inventory_digest": evidence.inventory_digest,
+        "principal_digest": evidence.principal_digest,
+        "refusals": _refusal_payload(evidence.refusals),
+        "refusals_engaged": evidence.refusals_engaged,
+        "schema_version": SCHEMA_VERSION,
+        "status": evidence.status,
+    }
+    return canonical_json_bytes(payload)

--- a/newsroom/increment9/credential_scopes.py
+++ b/newsroom/increment9/credential_scopes.py
@@ -1,0 +1,282 @@
+"""Least-privilege CredentialRef resolver for Increment 9Q-5.
+
+Injected fixture store only. No Keychain, daemon or network. Resolution
+returns class, scope and digest — never secret bytes.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Mapping
+
+from newsroom.authority.canonical import (
+    CanonicalizationError,
+    canonical_json_bytes,
+    digest_bytes,
+    validate_sha256_digest,
+)
+from newsroom.increment9.deployment import (
+    EXPECTED_CREDENTIAL_CLASSES,
+    PROHIBITED_CREDENTIAL_CLASSES,
+)
+from newsroom.increment9.plan import INCREMENT_9_SHADOW_PLAN
+
+DETERMINISTIC_BOUNDARY = "DETERMINISTIC_BOUNDARY"
+CREDENTIAL_SCOPE = "INCREMENT9_SHADOW"
+FIXTURE_PRINCIPAL_DIGEST = "sha256:" + "e" * 64
+FIXTURE_PRODUCTION_NAMES = ("PRODUCTION_NEO4J", "PRODUCTION_SQLITE")
+NAMESAKE_CAMPAIGN_CLASSES = (
+    "NEO4J_SHADOW_WRITER",
+    "OPENAI_CODEX_LOGIN",
+    "OPENAI_EMBEDDINGS_API",
+)
+MODEL_FAMILY_LOGIN = {
+    "ANTHROPIC_AGENT_SDK": "ANTHROPIC_AGENT_SDK",
+    "GOOGLE_GEMINI_API": "GOOGLE_GEMINI_API",
+    "OPENAI_CODEX_LOGIN": "OPENAI_CODEX_LOGIN",
+    "XAI_GROK_BUILD_LOGIN": "XAI_GROK_BUILD_LOGIN",
+}
+BOUNDARY_ONLY_CLASSES = frozenset(
+    {
+        "NEO4J_SHADOW_WRITER",
+        "OPENAI_EMBEDDINGS_API",
+        "SOURCE_OWNER_PROVISIONED",
+    }
+)
+ADMITTED_HANDLES = frozenset({DETERMINISTIC_BOUNDARY, *MODEL_FAMILY_LOGIN})
+_SECRET_KEYS = frozenset(
+    {"api_key", "credential_value", "password", "secret", "secret_bytes"}
+)
+_TOKEN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:/\-]{0,255}\Z")
+_REF_FIELDS = frozenset({"credential_class", "digest", "scope"})
+
+
+class CredentialScopeError(ValueError):
+    """Credential resolution or inventory bind failed closed."""
+
+
+@dataclass(frozen=True, slots=True)
+class CredentialRef:
+    """Metadata-only credential handle: class, scope and digest. Never secret bytes."""
+
+    credential_class: str
+    scope: str
+    digest: str
+
+    def __post_init__(self) -> None:
+        _token(self.credential_class, "credential_class")
+        _token(self.scope, "scope")
+        try:
+            object.__setattr__(
+                self, "digest", validate_sha256_digest(self.digest, field="digest")
+            )
+        except (CanonicalizationError, TypeError, ValueError) as exc:
+            raise CredentialScopeError("credential digest differs") from exc
+
+    def primitive(self) -> dict[str, str]:
+        return {
+            "credential_class": self.credential_class,
+            "digest": self.digest,
+            "scope": self.scope,
+        }
+
+
+def _token(value: object, field: str) -> str:
+    if type(value) is not str or not value or value != value.strip():
+        raise CredentialScopeError(f"{field} token is malformed")
+    encoded = value.encode("utf-8", errors="strict")
+    if len(encoded) > 256 or _TOKEN.fullmatch(value) is None:
+        raise CredentialScopeError(f"{field} token is malformed")
+    return value
+
+
+def _od012_classes() -> set[str]:
+    decisions = {
+        item.decision_id: item.selection
+        for item in INCREMENT_9_SHADOW_PLAN.owner_decisions
+    }
+    classes = decisions["OD-012"]["credential_classes_and_secret_locations"]["classes"]
+    return set(classes)
+
+
+def inventory_digest() -> str:
+    """Canonical digest of the OD-012 seven-permitted-plus-one-prohibited split."""
+
+    return digest_bytes(
+        canonical_json_bytes(
+            {
+                "permitted_credential_classes": list(EXPECTED_CREDENTIAL_CLASSES),
+                "prohibited_credential_classes": list(PROHIBITED_CREDENTIAL_CLASSES),
+            }
+        )
+    )
+
+
+def bind_inventory(
+    permitted: tuple[str, ...], prohibited: tuple[str, ...]
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Refuse inventory drift against the OD-012 split and the deployment contract."""
+
+    if type(permitted) is not tuple or type(prohibited) is not tuple:
+        raise CredentialScopeError("credential class inventory type differs")
+    if permitted != tuple(sorted(set(permitted))) or not permitted:
+        raise CredentialScopeError("permitted credential classes are not unique and sorted")
+    if prohibited != tuple(sorted(set(prohibited))) or not prohibited:
+        raise CredentialScopeError("prohibited credential classes are not unique and sorted")
+    if set(permitted) & set(prohibited):
+        raise CredentialScopeError("credential class boundaries overlap")
+    expected = _od012_classes()
+    if set(permitted) | set(prohibited) != expected:
+        raise CredentialScopeError("credential classes differ from OD-012")
+    if permitted != EXPECTED_CREDENTIAL_CLASSES:
+        raise CredentialScopeError("permitted credential classes differ from OD-012")
+    if prohibited != PROHIBITED_CREDENTIAL_CLASSES:
+        raise CredentialScopeError("prohibited credential classes differ from OD-012")
+    return permitted, prohibited
+
+
+def bind_campaign_credential_classes(classes: tuple[str, ...]) -> tuple[str, ...]:
+    """Campaign BASELINE_CREDENTIAL_SCOPES inventory: OD-012 permitted classes only.
+
+    The historical three-class namesake list cannot PASS.
+    """
+
+    if type(classes) is not tuple or classes != EXPECTED_CREDENTIAL_CLASSES:
+        raise CredentialScopeError("campaign credential classes differ from OD-012")
+    bind_inventory(EXPECTED_CREDENTIAL_CLASSES, PROHIBITED_CREDENTIAL_CLASSES)
+    return classes
+
+
+def credential_ref_from_primitive(value: object) -> CredentialRef:
+    """Load a CredentialRef, refusing secret bytes or extra fields."""
+
+    if type(value) is not dict:
+        raise CredentialScopeError("credential ref is not an object")
+    if _SECRET_KEYS & set(value):
+        raise CredentialScopeError("secret bytes are prohibited in a credential ref")
+    if set(value) != _REF_FIELDS:
+        raise CredentialScopeError("credential ref fields differ")
+    ref = CredentialRef(
+        credential_class=_token(value["credential_class"], "credential_class"),
+        scope=_token(value["scope"], "scope"),
+        digest=value["digest"],  # type: ignore[arg-type]
+    )
+    if set(ref.primitive()) != _REF_FIELDS:
+        raise CredentialScopeError("secret bytes are prohibited in a credential ref")
+    return ref
+
+
+def fixture_credential_refs() -> tuple[CredentialRef, ...]:
+    """Synthetic metadata-only store for the seven permitted classes."""
+
+    return tuple(
+        CredentialRef(
+            credential_class=cls,
+            scope=CREDENTIAL_SCOPE,
+            digest=digest_bytes(
+                canonical_json_bytes(
+                    {"credential_class": cls, "scope": CREDENTIAL_SCOPE}
+                )
+            ),
+        )
+        for cls in EXPECTED_CREDENTIAL_CLASSES
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class CredentialResolver:
+    """Injected-store resolver bound to one principal digest."""
+
+    bound_principal_digest: str
+    store: tuple[CredentialRef, ...]
+
+    def __post_init__(self) -> None:
+        try:
+            object.__setattr__(
+                self,
+                "bound_principal_digest",
+                validate_sha256_digest(
+                    self.bound_principal_digest, field="principal_identity_digest"
+                ),
+            )
+        except (CanonicalizationError, TypeError, ValueError) as exc:
+            raise CredentialScopeError("principal digest differs") from exc
+        bind_inventory(EXPECTED_CREDENTIAL_CLASSES, PROHIBITED_CREDENTIAL_CLASSES)
+        if type(self.store) is not tuple or not self.store:
+            raise CredentialScopeError("credential store differs")
+        by_class = {}
+        for item in self.store:
+            if type(item) is not CredentialRef:
+                raise CredentialScopeError("store entry is not a CredentialRef")
+            if set(item.primitive()) != _REF_FIELDS:
+                raise CredentialScopeError("secret bytes are prohibited in a credential ref")
+            if item.credential_class in by_class:
+                raise CredentialScopeError("store contains a duplicate class")
+            by_class[item.credential_class] = item
+        if tuple(sorted(by_class)) != EXPECTED_CREDENTIAL_CLASSES:
+            raise CredentialScopeError("store inventory differs from OD-012")
+        object.__setattr__(self, "store", tuple(by_class[cls] for cls in EXPECTED_CREDENTIAL_CLASSES))
+
+    def _lookup(self) -> Mapping[str, CredentialRef]:
+        return {item.credential_class: item for item in self.store}
+
+    def resolve(
+        self, principal: str, handle: str, credential_class: str
+    ) -> CredentialRef:
+        """Return a metadata CredentialRef or refuse fail-closed."""
+
+        _token(principal, "principal")
+        try:
+            principal = validate_sha256_digest(principal, field="principal")
+        except (CanonicalizationError, TypeError, ValueError) as exc:
+            raise CredentialScopeError("principal token is malformed") from exc
+        _token(handle, "handle")
+        _token(credential_class, "credential_class")
+        if handle not in ADMITTED_HANDLES:
+            raise CredentialScopeError("handle token is malformed")
+        if principal != self.bound_principal_digest:
+            raise CredentialScopeError("principal digest differs")
+        if credential_class in FIXTURE_PRODUCTION_NAMES:
+            raise CredentialScopeError("production store name is refused")
+        if credential_class == "PUBLICATION_TARGET_ADAPTER":
+            raise CredentialScopeError("publication credential is refused")
+        if credential_class not in EXPECTED_CREDENTIAL_CLASSES:
+            raise CredentialScopeError("unknown credential class")
+        if handle != DETERMINISTIC_BOUNDARY:
+            if credential_class in BOUNDARY_ONLY_CLASSES:
+                raise CredentialScopeError(
+                    "model-family handle cannot resolve a boundary-only class"
+                )
+            if credential_class != MODEL_FAMILY_LOGIN[handle]:
+                raise CredentialScopeError(
+                    "model-family handle may resolve only its own login class"
+                )
+        ref = self._lookup()[credential_class]
+        if set(ref.primitive()) != _REF_FIELDS:
+            raise CredentialScopeError("secret bytes are prohibited in a credential ref")
+        return ref
+
+
+def bound_resolver(
+    *,
+    principal_digest: str = FIXTURE_PRINCIPAL_DIGEST,
+    store: tuple[CredentialRef, ...] | None = None,
+) -> CredentialResolver:
+    return CredentialResolver(
+        bound_principal_digest=principal_digest,
+        store=store if store is not None else fixture_credential_refs(),
+    )
+
+
+def resolve(
+    principal: str,
+    handle: str,
+    credential_class: str,
+    *,
+    resolver: CredentialResolver | None = None,
+) -> CredentialRef:
+    """Resolve against the injected fixture store. Never returns secret bytes."""
+
+    active = resolver if resolver is not None else bound_resolver()
+    return active.resolve(principal, handle, credential_class)

--- a/newsroom/increment9/fixtures/increment9q5_baseline_credential_scopes/ANTI_NAMESAKE
+++ b/newsroom/increment9/fixtures/increment9q5_baseline_credential_scopes/ANTI_NAMESAKE
@@ -1,0 +1,1 @@
+anti_namesake

--- a/newsroom/increment9/fixtures/increment9q5_baseline_credential_scopes/CROSS_FAMILY_LOGIN_REFUSED
+++ b/newsroom/increment9/fixtures/increment9q5_baseline_credential_scopes/CROSS_FAMILY_LOGIN_REFUSED
@@ -1,0 +1,1 @@
+cross_family_login_refused

--- a/newsroom/increment9/fixtures/increment9q5_baseline_credential_scopes/INVENTORY_DRIFT
+++ b/newsroom/increment9/fixtures/increment9q5_baseline_credential_scopes/INVENTORY_DRIFT
@@ -1,0 +1,1 @@
+inventory_drift

--- a/newsroom/increment9/fixtures/increment9q5_baseline_credential_scopes/MALFORMED_REQUEST
+++ b/newsroom/increment9/fixtures/increment9q5_baseline_credential_scopes/MALFORMED_REQUEST
@@ -1,0 +1,1 @@
+malformed_request

--- a/newsroom/increment9/fixtures/increment9q5_baseline_credential_scopes/MODEL_FAMILY_AUTHORITY_CLASS_REFUSED
+++ b/newsroom/increment9/fixtures/increment9q5_baseline_credential_scopes/MODEL_FAMILY_AUTHORITY_CLASS_REFUSED
@@ -1,0 +1,1 @@
+model_family_authority_class_refused

--- a/newsroom/increment9/fixtures/increment9q5_baseline_credential_scopes/PRINCIPAL_DIGEST_MISMATCH
+++ b/newsroom/increment9/fixtures/increment9q5_baseline_credential_scopes/PRINCIPAL_DIGEST_MISMATCH
@@ -1,0 +1,1 @@
+principal_digest_mismatch

--- a/newsroom/increment9/fixtures/increment9q5_baseline_credential_scopes/PRODUCTION_STORE_NAME_REFUSED
+++ b/newsroom/increment9/fixtures/increment9q5_baseline_credential_scopes/PRODUCTION_STORE_NAME_REFUSED
@@ -1,0 +1,1 @@
+production_store_name_refused

--- a/newsroom/increment9/fixtures/increment9q5_baseline_credential_scopes/PUBLICATION_TARGET_ADAPTER_REFUSED
+++ b/newsroom/increment9/fixtures/increment9q5_baseline_credential_scopes/PUBLICATION_TARGET_ADAPTER_REFUSED
@@ -1,0 +1,1 @@
+publication_target_adapter_refused

--- a/newsroom/increment9/fixtures/increment9q5_baseline_credential_scopes/SECRET_BYTES_IN_RESOLUTION
+++ b/newsroom/increment9/fixtures/increment9q5_baseline_credential_scopes/SECRET_BYTES_IN_RESOLUTION
@@ -1,0 +1,1 @@
+secret_bytes_in_resolution

--- a/newsroom/increment9/fixtures/increment9q5_baseline_credential_scopes/UNKNOWN_CREDENTIAL_CLASS
+++ b/newsroom/increment9/fixtures/increment9q5_baseline_credential_scopes/UNKNOWN_CREDENTIAL_CLASS
@@ -1,0 +1,1 @@
+unknown_credential_class

--- a/newsroom/tests/test_increment9q5_baseline_credential_scopes.py
+++ b/newsroom/tests/test_increment9q5_baseline_credential_scopes.py
@@ -1,0 +1,413 @@
+import subprocess
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+import pytest
+
+from newsroom.increment9.baseline_credential_scopes import (
+    GATE_ID,
+    PACKAGE_FIXTURES,
+    REFUSAL_CLASSES,
+    SCHEMA_VERSION,
+    QualificationError,
+    assess,
+    default_probe,
+    evidence_json,
+)
+from newsroom.increment9.credential_scopes import (
+    BOUNDARY_ONLY_CLASSES,
+    CREDENTIAL_SCOPE,
+    DETERMINISTIC_BOUNDARY,
+    FIXTURE_PRINCIPAL_DIGEST,
+    FIXTURE_PRODUCTION_NAMES,
+    MODEL_FAMILY_LOGIN,
+    NAMESAKE_CAMPAIGN_CLASSES,
+    CredentialRef,
+    CredentialScopeError,
+    bind_campaign_credential_classes,
+    bind_inventory,
+    bound_resolver,
+    credential_ref_from_primitive,
+    fixture_credential_refs,
+    inventory_digest,
+    resolve,
+)
+from newsroom.increment9.deployment import (
+    EXPECTED_CREDENTIAL_CLASSES,
+    EXPECTED_PROBES,
+    PROHIBITED_CREDENTIAL_CLASSES,
+)
+
+_SPEC = spec_from_file_location(
+    "increment9q5_baseline_credential_scopes",
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "increment9q5_baseline_credential_scopes.py",
+)
+assert _SPEC is not None and _SPEC.loader is not None
+_CLI = module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_CLI)
+
+from scripts.increment9_shadow_campaign import (
+    GateRecord,
+    GateStatus,
+    _gate_findings,
+    main as campaign_main,
+)
+
+
+def _inventory(tmp_path: Path) -> Path:
+    root = tmp_path / "fixtures"
+    root.mkdir()
+    for rc in REFUSAL_CLASSES:
+        (root / rc).write_bytes(f"refusal:{rc}\n".encode())
+    return root
+
+
+def _authorised_inventory(tmp_path: Path) -> Path:
+    root = tmp_path / "fixtures"
+    root.mkdir()
+    for rc in REFUSAL_CLASSES:
+        (root / rc).write_bytes(PACKAGE_FIXTURES.joinpath(rc).read_bytes())
+    return root
+
+
+def test_assess_fails_closed_without_inventory(tmp_path: Path) -> None:
+    with pytest.raises(QualificationError, match="inventory"):
+        assess(tmp_path / "missing")
+
+
+def test_assess_fails_closed_when_a_refusal_class_is_missing(tmp_path: Path) -> None:
+    root = _inventory(tmp_path)
+    (root / REFUSAL_CLASSES[0]).unlink()
+    with pytest.raises(QualificationError, match="refusal"):
+        assess(root)
+
+
+def test_assess_fails_closed_when_an_extra_refusal_class_is_present(
+    tmp_path: Path,
+) -> None:
+    root = _inventory(tmp_path)
+    (root / "EXTRA").write_bytes(b"extra")
+    with pytest.raises(QualificationError, match="refusal"):
+        assess(root)
+
+
+def test_news_pool_paths_are_rejected(tmp_path: Path) -> None:
+    with pytest.raises(QualificationError, match="news_pool"):
+        assess(tmp_path / "news_pool.sqlite3")
+
+
+def test_assess_emits_qualification_evidence_not_a_gate_record(tmp_path: Path) -> None:
+    evidence = assess(_authorised_inventory(tmp_path))
+    assert evidence.gate_id == GATE_ID
+    assert evidence.status == "PASS"
+    assert evidence.refusals_engaged == len(REFUSAL_CLASSES)
+    assert tuple(item.refusal_class for item in evidence.refusals) == REFUSAL_CLASSES
+    assert all(item.before_digest == item.after_digest for item in evidence.refusals)
+    assert all(item.count == 1 and item.engaged for item in evidence.refusals)
+    assert evidence.principal_digest == FIXTURE_PRINCIPAL_DIGEST
+    assert evidence.inventory_digest == inventory_digest()
+    payload = evidence_json(evidence)
+    assert SCHEMA_VERSION.encode() in payload
+    assert b'"refusals_engaged":10' in payload
+    assert b'"gate_id":"BASELINE_CREDENTIAL_SCOPES"' in payload
+    assert evidence.principal_digest.encode() in payload
+    assert evidence.inventory_digest.encode() in payload
+    assert b"exact_main_sha" not in payload
+    assert b"campaign-gate" not in payload
+    assert b"qualification-evidence" in payload
+    assert b"sk-fixture-not-a-real-secret" not in payload
+
+
+def test_assess_fails_closed_when_a_probe_mutates(tmp_path: Path) -> None:
+    root = _inventory(tmp_path)
+
+    def mutate(rc: str, path: Path) -> bool:
+        path.write_bytes(path.read_bytes() + b"mutated")
+        return True
+
+    with pytest.raises(QualificationError, match="mutated"):
+        assess(root, probe=mutate)
+
+
+def test_assess_fails_closed_when_digest_changes_without_engagement(
+    tmp_path: Path,
+) -> None:
+    root = _inventory(tmp_path)
+
+    def silent_mutate(rc: str, path: Path) -> bool:
+        if rc == "UNKNOWN_CREDENTIAL_CLASS":
+            path.write_bytes(b"changed")
+        return False
+
+    with pytest.raises(QualificationError, match="mutated"):
+        assess(root, probe=silent_mutate)
+
+
+def test_assess_fails_closed_when_not_all_refusals_engage(tmp_path: Path) -> None:
+    root = _inventory(tmp_path)
+
+    def partial_engage(rc: str, path: Path) -> bool:
+        return rc in REFUSAL_CLASSES[:4]
+
+    with pytest.raises(QualificationError, match="not all refusals"):
+        assess(root, probe=partial_engage)
+
+
+def test_authorised_package_fixtures_assess_without_mutating() -> None:
+    evidence = assess(PACKAGE_FIXTURES)
+    assert evidence.status == "PASS"
+    assert evidence.refusals_engaged == len(REFUSAL_CLASSES)
+    assert all(item.before_digest == item.after_digest for item in evidence.refusals)
+    for rc in REFUSAL_CLASSES:
+        assert default_probe(rc, PACKAGE_FIXTURES / rc) is True
+
+
+def test_cli_assess_is_fail_closed_without_inventory_and_writes_evidence(
+    tmp_path: Path,
+) -> None:
+    assert _CLI.main(["assess", "--inventory", str(tmp_path / "missing")]) == 2
+    output = tmp_path / "evidence.json"
+    assert _CLI.main(["assess", "--output", str(output)]) == 0
+    raw = output.read_bytes()
+    assert b'"status":"PASS"' in raw
+    assert b"exact_main_sha" not in raw
+    assert b'"gate_id":"BASELINE_CREDENTIAL_SCOPES"' in raw
+
+
+def test_deterministic_boundary_resolves_seven_permitted_classes() -> None:
+    for cls in EXPECTED_CREDENTIAL_CLASSES:
+        ref = resolve(FIXTURE_PRINCIPAL_DIGEST, DETERMINISTIC_BOUNDARY, cls)
+        assert isinstance(ref, CredentialRef)
+        assert ref.credential_class == cls
+        assert ref.scope == CREDENTIAL_SCOPE
+        assert set(ref.primitive()) == {"credential_class", "digest", "scope"}
+
+
+def test_model_family_handles_resolve_only_own_login_class() -> None:
+    for handle, own in MODEL_FAMILY_LOGIN.items():
+        ref = resolve(FIXTURE_PRINCIPAL_DIGEST, handle, own)
+        assert ref.credential_class == own
+        for other in MODEL_FAMILY_LOGIN.values():
+            if other == own:
+                continue
+            with pytest.raises(CredentialScopeError):
+                resolve(FIXTURE_PRINCIPAL_DIGEST, handle, other)
+        for cls in BOUNDARY_ONLY_CLASSES:
+            with pytest.raises(CredentialScopeError):
+                resolve(FIXTURE_PRINCIPAL_DIGEST, handle, cls)
+
+
+def test_publication_and_production_names_are_refused_for_every_handle() -> None:
+    handles = (DETERMINISTIC_BOUNDARY, *MODEL_FAMILY_LOGIN)
+    for handle in handles:
+        with pytest.raises(CredentialScopeError, match="publication"):
+            resolve(FIXTURE_PRINCIPAL_DIGEST, handle, "PUBLICATION_TARGET_ADAPTER")
+        for name in FIXTURE_PRODUCTION_NAMES:
+            with pytest.raises(CredentialScopeError, match="production"):
+                resolve(FIXTURE_PRINCIPAL_DIGEST, handle, name)
+
+
+def test_unknown_class_and_malformed_requests_are_refused() -> None:
+    with pytest.raises(CredentialScopeError, match="unknown"):
+        resolve(FIXTURE_PRINCIPAL_DIGEST, DETERMINISTIC_BOUNDARY, "NOT_A_CREDENTIAL_CLASS")
+    with pytest.raises(CredentialScopeError, match="malformed"):
+        resolve(FIXTURE_PRINCIPAL_DIGEST, "", "OPENAI_CODEX_LOGIN")
+    with pytest.raises(CredentialScopeError, match="malformed"):
+        resolve(FIXTURE_PRINCIPAL_DIGEST, "H" * 257, "OPENAI_CODEX_LOGIN")
+    with pytest.raises(CredentialScopeError, match="malformed"):
+        resolve(FIXTURE_PRINCIPAL_DIGEST, "not a token", "OPENAI_CODEX_LOGIN")
+
+
+def test_principal_mismatch_is_refused() -> None:
+    with pytest.raises(CredentialScopeError, match="principal"):
+        resolve("sha256:" + "0" * 64, DETERMINISTIC_BOUNDARY, "OPENAI_CODEX_LOGIN")
+
+
+def test_secret_bytes_cannot_enter_a_credential_ref() -> None:
+    digest = fixture_credential_refs()[0].digest
+    with pytest.raises(CredentialScopeError, match="secret"):
+        credential_ref_from_primitive(
+            {
+                "credential_class": "OPENAI_CODEX_LOGIN",
+                "digest": digest,
+                "scope": CREDENTIAL_SCOPE,
+                "secret": "sk-fixture-not-a-real-secret",
+            }
+        )
+    ref = resolve(
+        FIXTURE_PRINCIPAL_DIGEST, DETERMINISTIC_BOUNDARY, "OPENAI_CODEX_LOGIN"
+    )
+    assert "secret" not in ref.primitive()
+
+
+def test_inventory_bind_matches_od012_and_deployment_contracts() -> None:
+    bind_inventory(EXPECTED_CREDENTIAL_CLASSES, PROHIBITED_CREDENTIAL_CLASSES)
+    with pytest.raises(CredentialScopeError):
+        bind_inventory(EXPECTED_CREDENTIAL_CLASSES[:-1], PROHIBITED_CREDENTIAL_CLASSES)
+    with pytest.raises(CredentialScopeError):
+        bind_inventory(
+            tuple(sorted((*EXPECTED_CREDENTIAL_CLASSES, "EXTRA_CREDENTIAL_CLASS"))),
+            PROHIBITED_CREDENTIAL_CLASSES,
+        )
+    with pytest.raises(CredentialScopeError):
+        bind_inventory(
+            (
+                EXPECTED_CREDENTIAL_CLASSES[1],
+                EXPECTED_CREDENTIAL_CLASSES[0],
+                *EXPECTED_CREDENTIAL_CLASSES[2:],
+            ),
+            PROHIBITED_CREDENTIAL_CLASSES,
+        )
+    with pytest.raises(CredentialScopeError):
+        bind_inventory(
+            (EXPECTED_CREDENTIAL_CLASSES[0], *EXPECTED_CREDENTIAL_CLASSES),
+            PROHIBITED_CREDENTIAL_CLASSES,
+        )
+    with pytest.raises(CredentialScopeError):
+        bind_inventory(EXPECTED_CREDENTIAL_CLASSES, ("NEO4J_SHADOW_WRITER",))
+    with pytest.raises(CredentialScopeError):
+        bind_inventory(("ANTHROPIC_AGENT_SDK",), ("ANTHROPIC_AGENT_SDK",))
+
+
+def test_campaign_namesake_three_class_list_cannot_pass() -> None:
+    with pytest.raises(CredentialScopeError):
+        bind_campaign_credential_classes(NAMESAKE_CAMPAIGN_CLASSES)
+    bind_campaign_credential_classes(EXPECTED_CREDENTIAL_CLASSES)
+    import scripts.increment9_shadow_campaign as campaign_mod
+
+    assert not hasattr(campaign_mod, "BASELINE_CREDENTIAL_CLASSES")
+    assert "PRODUCTION_CREDENTIAL_DENIED" in EXPECTED_PROBES
+    assert "CREDENTIAL_VALUES_ABSENT" in EXPECTED_PROBES
+    assert "PRODUCTION_CREDENTIAL_DENIED" not in REFUSAL_CLASSES
+    assert "CREDENTIAL_VALUES_ABSENT" not in REFUSAL_CLASSES
+
+
+def _gate_record(classes: tuple[str, ...]) -> GateRecord:
+    return GateRecord(
+        gate_id="BASELINE_CREDENTIAL_SCOPES",
+        observed_at="2026-08-16T00:00:00.000000Z",
+        expires_at="2026-08-17T00:00:00.000000Z",
+        exact_main_sha="a" * 40,
+        exact_main_tree="b" * 40,
+        subject_digest="sha256:" + "c" * 64,
+        evidence_digest="sha256:" + "d" * 64,
+        issuer_id="fixture",
+        status=GateStatus.PASS,
+        credential_classes=classes,
+    )
+
+
+def test_campaign_gate_check_uses_od012_inventory_not_three_class_list() -> None:
+    findings_ok = _gate_findings(
+        {"BASELINE_CREDENTIAL_SCOPES": _gate_record(EXPECTED_CREDENTIAL_CLASSES)},
+        head="a" * 40,
+        tree="b" * 40,
+        observed_at="2026-08-16T12:00:00.000000Z",
+    )
+    assert "BASELINE_CREDENTIAL_CLASSES_DIFFER" not in findings_ok
+    findings_namesake = _gate_findings(
+        {"BASELINE_CREDENTIAL_SCOPES": _gate_record(NAMESAKE_CAMPAIGN_CLASSES)},
+        head="a" * 40,
+        tree="b" * 40,
+        observed_at="2026-08-16T12:00:00.000000Z",
+    )
+    assert "BASELINE_CREDENTIAL_CLASSES_DIFFER" in findings_namesake
+
+
+def test_campaign_assess_lands_at_requested_output_and_reruns(
+    tmp_path: Path,
+) -> None:
+    from newsroom.increment9.protected_storage import (
+        list_audit_entries,
+        write_protected_artefact,
+    )
+
+    root = tmp_path / "storage"
+    root.mkdir(mode=0o700)
+    output = tmp_path / "exact" / "bundle.json"
+    payload = {"gate_id": GATE_ID, "status": "PASS"}
+    write_protected_artefact(
+        root,
+        artefact_class="CAMPAIGN_EVIDENCE",
+        artefact_id="bundle.json",
+        payload=payload,
+        target_path=output,
+    )
+    assert output.is_file()
+    write_protected_artefact(
+        root,
+        artefact_class="CAMPAIGN_EVIDENCE",
+        artefact_id="bundle.json",
+        payload={"gate_id": GATE_ID, "status": "PASS", "attempt": 2},
+        target_path=output,
+    )
+    assert b'"attempt":2' in output.read_bytes()
+    writes = [e for e in list_audit_entries(root) if e.operation == "WRITE"]
+    assert len(writes) == 2
+
+
+def test_campaign_cli_writes_requested_output_and_reruns(tmp_path: Path) -> None:
+    repo = tmp_path / "repository"
+    repo.mkdir()
+    subprocess.run(
+        ["git", "init", "--initial-branch=main", str(repo)],
+        check=True,
+        capture_output=True,
+    )
+    (repo / "tracked.txt").write_text("exact\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "-C", str(repo), "add", "tracked.txt"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "-c",
+            "user.name=Newsroom Tests",
+            "-c",
+            "user.email=newsroom-tests@example.invalid",
+            "commit",
+            "-m",
+            "fixture",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    gates = tmp_path / "gates"
+    gates.mkdir(mode=0o700)
+    output_dir = tmp_path / "out"
+    output_dir.mkdir(mode=0o700)
+    output = output_dir / "bundle.json"
+    argv = [
+        "assess",
+        "--repo",
+        str(repo),
+        "--gate-directory",
+        str(gates),
+        "--campaign-id",
+        "FIXTURE_CAMPAIGN",
+        "--observed-at",
+        "2026-08-16T12:00:00.000000Z",
+        "--output",
+        str(output),
+        "--accept-blocked",
+    ]
+    assert campaign_main(argv) == 0
+    assert output.is_file()
+    first = output.read_bytes()
+    assert b"BASELINE_CREDENTIAL_SCOPES" in first
+    assert campaign_main(argv) == 0
+    assert output.read_bytes() == first
+
+
+def test_bound_resolver_store_is_metadata_only() -> None:
+    resolver = bound_resolver()
+    assert resolver.bound_principal_digest == FIXTURE_PRINCIPAL_DIGEST
+    assert tuple(item.credential_class for item in resolver.store) == EXPECTED_CREDENTIAL_CLASSES
+    for item in resolver.store:
+        assert set(item.primitive()) == {"credential_class", "digest", "scope"}

--- a/scripts/increment9_shadow_campaign.py
+++ b/scripts/increment9_shadow_campaign.py
@@ -29,6 +29,10 @@ from newsroom.authority.canonical import (
     digest_bytes,
     validate_sha256_digest,
 )
+from newsroom.increment9.credential_scopes import (
+    CredentialScopeError,
+    bind_campaign_credential_classes,
+)
 from newsroom.increment9.plan import (
     INCREMENT_9_SHADOW_PLAN,
     INCREMENT_9_SHADOW_PLAN_DIGEST,
@@ -64,11 +68,6 @@ RUNTIME_GATES = (
     "KILL_SWITCH_READY",
     "NO_ACTIVE_HUMAN_EMERGENCY_STOP",
     "PRODUCTION_NONMUTATION_BASELINE",
-)
-BASELINE_CREDENTIAL_CLASSES = (
-    "NEO4J_SHADOW_WRITER",
-    "OPENAI_CODEX_LOGIN",
-    "OPENAI_EMBEDDINGS_API",
 )
 
 
@@ -347,11 +346,11 @@ def _gate_findings(
                 findings.append(f"RIGHTS_SUBJECT_MISMATCH:{source_id}")
             if len(record.reviewer_families) != 3:
                 findings.append(f"RIGHTS_REVIEW_INDEPENDENCE_MISSING:{source_id}")
-        if (
-            gate_id == "BASELINE_CREDENTIAL_SCOPES"
-            and record.credential_classes != BASELINE_CREDENTIAL_CLASSES
-        ):
-            findings.append("BASELINE_CREDENTIAL_CLASSES_DIFFER")
+        if gate_id == "BASELINE_CREDENTIAL_SCOPES":
+            try:
+                bind_campaign_credential_classes(record.credential_classes)
+            except CredentialScopeError:
+                findings.append("BASELINE_CREDENTIAL_CLASSES_DIFFER")
     return sorted(set(findings))
 
 

--- a/scripts/increment9q5_baseline_credential_scopes.py
+++ b/scripts/increment9q5_baseline_credential_scopes.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Increment 9Q-5 Baseline Credential Scopes assess CLI. No network I/O."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from newsroom.increment9.baseline_credential_scopes import (
+    PACKAGE_FIXTURES,
+    QualificationError,
+    assess,
+    evidence_json,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="BASELINE_CREDENTIAL_SCOPES qualification evidence."
+    )
+    parser.add_argument("command", choices=("assess",))
+    parser.add_argument("--inventory", default=str(PACKAGE_FIXTURES))
+    parser.add_argument("--output")
+    args = parser.parse_args(argv)
+    if not args.inventory:
+        print("inventory is required", file=sys.stderr)
+        return 2
+    try:
+        evidence = assess(Path(args.inventory))
+    except QualificationError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    payload = evidence_json(evidence)
+    sys.stdout.buffer.write(payload)
+    sys.stdout.write("\n")
+    if args.output:
+        Path(args.output).write_bytes(payload + b"\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-9q5
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: delete-after-merge

## Summary
- Build the least-privilege `CredentialRef` resolver (`credential_scopes.py`) with principal bind, OD-012 seven-permitted-plus-one-prohibited inventory bind, and metadata-only resolution (class, scope, digest — never secret bytes).
- Switch `scripts/increment9_shadow_campaign.py` off its private three-class `BASELINE_CREDENTIAL_CLASSES` namesake onto `bind_campaign_credential_classes`; `--output` still lands at the caller path and reruns remain idempotent.
- Emit `newsroom.increment9.qualification-evidence.v1` for `gate_id=BASELINE_CREDENTIAL_SCOPES` with all ten refusal classes fail-closed, echoed principal/inventory digests, `status: PASS`, and a canonical `evidence_digest`.

Closes #643

## Exact state

```text
base: e2bb0a5e734a1cd7bb0ef1eeaf650891c907e523
head: a61a590443198a4b92bc7bc473ae879f29415280
tree: 07e01bbe71cc2b350a5fa32d4241457e84ac7162
commits over base: 1
changed files: 15
```

## Test plan
- [x] `uv run pytest newsroom/tests/test_increment9q5_baseline_credential_scopes.py -v` (22 passed)
- [x] CLI `assess` without a valid fixture inventory is fail-closed (exit 2)
- [x] CLI `assess` on authorised fixtures emits PASS qualification evidence (not a Gate Record)
- [x] Full suite `uv run pytest newsroom/tests/ -q`: 3766 passed, 42 skipped, 22 failed — all 22 are the known pre-existing main failures (increment5a ×16, increment6r ×1, sdlc_github_transport ×3, sdlc_watchdog ×1, increment6f2 flaky ×1); no new failures
- [x] Campaign sealer no longer defines `BASELINE_CREDENTIAL_CLASSES`; three-class list cannot PASS; seven OD-012 permitted classes bind; output path and rerun preserved

## Non-effects
Does not mint a First I/O Gate Record, does not launch the shadow campaign, does not touch production, Keychain, Hermes, CONTEXT.md, or OD-012 live classes. Fixture production names remain probes only.

Made with [Cursor](https://cursor.com)