### PR TITLE
Add Increment 9Q-7 PREFUNDED_WALLET_AVAILABLE qualification evidence

### DIFF
--- a/newsroom/increment9/fixtures/increment9q7_prefunded_wallet_available/ANTI_NAMESAKE
+++ b/newsroom/increment9/fixtures/increment9q7_prefunded_wallet_available/ANTI_NAMESAKE
@@ -1,0 +1,1 @@
+anti_namesake

--- a/newsroom/increment9/fixtures/increment9q7_prefunded_wallet_available/BUDGET_RULES_DIGEST_DRIFT
+++ b/newsroom/increment9/fixtures/increment9q7_prefunded_wallet_available/BUDGET_RULES_DIGEST_DRIFT
@@ -1,0 +1,1 @@
+budget_rules_digest_drift

--- a/newsroom/increment9/fixtures/increment9q7_prefunded_wallet_available/CAPACITY_MISMATCH
+++ b/newsroom/increment9/fixtures/increment9q7_prefunded_wallet_available/CAPACITY_MISMATCH
@@ -1,0 +1,1 @@
+capacity_mismatch

--- a/newsroom/increment9/fixtures/increment9q7_prefunded_wallet_available/CURRENCY_OR_UNITS_MISMATCH
+++ b/newsroom/increment9/fixtures/increment9q7_prefunded_wallet_available/CURRENCY_OR_UNITS_MISMATCH
@@ -1,0 +1,1 @@
+currency_or_units_mismatch

--- a/newsroom/increment9/fixtures/increment9q7_prefunded_wallet_available/DEBIT_EXCEEDING_RESERVATION
+++ b/newsroom/increment9/fixtures/increment9q7_prefunded_wallet_available/DEBIT_EXCEEDING_RESERVATION
@@ -1,0 +1,1 @@
+debit_exceeding_reservation

--- a/newsroom/increment9/fixtures/increment9q7_prefunded_wallet_available/DEBIT_WITHOUT_RESERVATION
+++ b/newsroom/increment9/fixtures/increment9q7_prefunded_wallet_available/DEBIT_WITHOUT_RESERVATION
@@ -1,0 +1,1 @@
+debit_without_reservation

--- a/newsroom/increment9/fixtures/increment9q7_prefunded_wallet_available/MALFORMED_REQUEST
+++ b/newsroom/increment9/fixtures/increment9q7_prefunded_wallet_available/MALFORMED_REQUEST
@@ -1,0 +1,1 @@
+malformed_request

--- a/newsroom/increment9/fixtures/increment9q7_prefunded_wallet_available/OVERDRAFT_RESERVATION
+++ b/newsroom/increment9/fixtures/increment9q7_prefunded_wallet_available/OVERDRAFT_RESERVATION
@@ -1,0 +1,1 @@
+overdraft_reservation

--- a/newsroom/increment9/fixtures/increment9q7_prefunded_wallet_available/REPLENISHMENT_ATTEMPT
+++ b/newsroom/increment9/fixtures/increment9q7_prefunded_wallet_available/REPLENISHMENT_ATTEMPT
@@ -1,0 +1,1 @@
+replenishment_attempt

--- a/newsroom/increment9/fixtures/increment9q7_prefunded_wallet_available/SUBSCRIPTION_CLASS_DEBIT
+++ b/newsroom/increment9/fixtures/increment9q7_prefunded_wallet_available/SUBSCRIPTION_CLASS_DEBIT
@@ -1,0 +1,1 @@
+subscription_class_debit

--- a/newsroom/increment9/fixtures/increment9q7_prefunded_wallet_available/TRANSFER_ATTEMPT
+++ b/newsroom/increment9/fixtures/increment9q7_prefunded_wallet_available/TRANSFER_ATTEMPT
@@ -1,0 +1,1 @@
+transfer_attempt

--- a/newsroom/increment9/fixtures/increment9q7_prefunded_wallet_available/wallet.json
+++ b/newsroom/increment9/fixtures/increment9q7_prefunded_wallet_available/wallet.json
@@ -1,0 +1,1 @@
+{"budget_transfer_allowed":false,"capacity_gbp_minor_units":25000,"currency":"GBP_MINOR_UNITS"}

--- a/newsroom/increment9/prefunded_wallet.py
+++ b/newsroom/increment9/prefunded_wallet.py
@@ -1,0 +1,316 @@
+"""Prefunded Wallet for Increment 9Q-7: fixture ledger, no live provider balances.
+
+Injected capacity, reservations and debits only. Refuses overdraft, replenishment
+and transfer. AVAILABLE means sufficiency-before-spend, not mere wallet existence.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Mapping
+
+from newsroom.authority.canonical import (
+    CanonicalizationError,
+    canonical_json_bytes,
+    digest_bytes,
+    validate_sha256_digest,
+)
+from newsroom.increment9.comparator import BudgetCaps, ComparatorContractError
+from newsroom.increment9.controller import (
+    ControllerError,
+    ControllerLedgerEntry,
+    ControllerStage,
+    LedgerKind,
+)
+
+CAPACITY_GBP_MINOR_UNITS = 25_000
+CURRENCY = "GBP_MINOR_UNITS"
+SPEND_METERED = "INCREMENTAL_PAID_API"
+SPEND_SUBSCRIPTION = "SUBSCRIPTION"
+ADMITTED_SPEND_CLASSES = frozenset({SPEND_METERED, SPEND_SUBSCRIPTION})
+FIXTURE_TIMESTAMP = "2026-08-18T00:00:00.000000Z"
+FIXTURE_WALLET: dict[str, object] = {
+    "budget_transfer_allowed": False,
+    "capacity_gbp_minor_units": CAPACITY_GBP_MINOR_UNITS,
+    "currency": CURRENCY,
+}
+_WALLET_FIELDS = frozenset(FIXTURE_WALLET)
+_TOKEN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:/\-]{0,255}\Z")
+
+
+class PrefundedWalletError(ValueError):
+    """Wallet bind, reservation or debit failed closed."""
+
+
+def budget_caps_digest() -> str:
+    """Canonical digest of the frozen OD-011 BudgetCaps contract."""
+
+    return BudgetCaps().canonical_digest
+
+
+def _token(value: object, field: str) -> str:
+    if type(value) is not str or not value or value != value.strip():
+        raise PrefundedWalletError(f"{field} token is malformed")
+    encoded = value.encode("utf-8", errors="strict")
+    if len(encoded) > 256 or _TOKEN.fullmatch(value) is None:
+        raise PrefundedWalletError(f"{field} token is malformed")
+    return value
+
+
+def _digest(value: object, field: str) -> str:
+    if type(value) is not str:
+        raise PrefundedWalletError(f"{field} digest differs")
+    try:
+        return validate_sha256_digest(value, field=field)
+    except (CanonicalizationError, TypeError, ValueError) as exc:
+        raise PrefundedWalletError(f"{field} digest differs") from exc
+
+
+def _amount(value: object, field: str) -> int:
+    if type(value) is float:
+        raise PrefundedWalletError("currency or units differ")
+    if type(value) is not int:
+        raise PrefundedWalletError(f"{field} token is malformed")
+    if value <= 0:
+        raise PrefundedWalletError(f"{field} token is malformed")
+    return value
+
+
+def _spend_class(value: object) -> str:
+    token = _token(value, "spend_class")
+    if token not in ADMITTED_SPEND_CLASSES:
+        raise PrefundedWalletError("spend_class token is malformed")
+    return token
+
+
+def fixture_wallet(**changes: object) -> dict[str, object]:
+    values = dict(FIXTURE_WALLET)
+    values.update(changes)
+    return values
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetReservation:
+    reservation_id: str
+    amount_gbp_minor_units: int
+    spend_class: str
+    budget_rules_digest: str
+
+    def primitive(self) -> dict[str, object]:
+        return {
+            "amount_gbp_minor_units": self.amount_gbp_minor_units,
+            "budget_rules_digest": self.budget_rules_digest,
+            "reservation_id": self.reservation_id,
+            "spend_class": self.spend_class,
+        }
+
+    @property
+    def digest(self) -> str:
+        return digest_bytes(canonical_json_bytes(self.primitive()))
+
+
+@dataclass(frozen=True, slots=True)
+class WalletDebit:
+    reservation_digest: str
+    amount_gbp_minor_units: int
+    spend_class: str
+
+    def primitive(self) -> dict[str, object]:
+        return {
+            "amount_gbp_minor_units": self.amount_gbp_minor_units,
+            "reservation_digest": self.reservation_digest,
+            "spend_class": self.spend_class,
+        }
+
+    @property
+    def digest(self) -> str:
+        return digest_bytes(canonical_json_bytes(self.primitive()))
+
+
+@dataclass(frozen=True, slots=True)
+class WalletUsage:
+    kind: str
+    digest: str
+    amount_gbp_minor_units: int
+
+
+@dataclass
+class PrefundedWallet:
+    """Injected fixture ledger. Opening balance equals OD-011 capacity."""
+
+    capacity: int
+    budget_caps_digest: str
+    _reserved: dict[str, BudgetReservation] = field(default_factory=dict)
+    _consumed: dict[str, int] = field(default_factory=dict)
+    _ledger: list[WalletUsage] = field(default_factory=list)
+
+    @property
+    def available(self) -> int:
+        return self.capacity - sum(item.amount_gbp_minor_units for item in self._reserved.values())
+
+    @property
+    def ledger(self) -> tuple[WalletUsage, ...]:
+        return tuple(self._ledger)
+
+    def _bind_digest(self, presented: object) -> str:
+        digest = _digest(presented, "budget_rules_digest")
+        if digest != self.budget_caps_digest:
+            raise PrefundedWalletError("budget rules digest differs")
+        return digest
+
+    def reserve(
+        self,
+        *,
+        reservation_id: object,
+        amount_gbp_minor_units: object,
+        spend_class: object,
+        budget_rules_digest: object,
+    ) -> BudgetReservation:
+        token = _token(reservation_id, "reservation_id")
+        if token in self._reserved:
+            raise PrefundedWalletError("reservation_id token is malformed")
+        amount = _amount(amount_gbp_minor_units, "amount_gbp_minor_units")
+        cls = _spend_class(spend_class)
+        digest = self._bind_digest(budget_rules_digest)
+        if amount > self.available:
+            raise PrefundedWalletError("reservation exceeds remaining balance")
+        reservation = BudgetReservation(token, amount, cls, digest)
+        self._reserved[token] = reservation
+        self._consumed[token] = 0
+        self._ledger.append(
+            WalletUsage("RESERVATION", reservation.digest, amount)
+        )
+        return reservation
+
+    def debit(
+        self,
+        *,
+        reservation_id: object,
+        amount_gbp_minor_units: object,
+        spend_class: object,
+        budget_rules_digest: object,
+    ) -> WalletDebit:
+        digest = self._bind_digest(budget_rules_digest)
+        amount = _amount(amount_gbp_minor_units, "amount_gbp_minor_units")
+        cls = _spend_class(spend_class)
+        if cls == SPEND_SUBSCRIPTION:
+            self._ledger.append(
+                WalletUsage("SUBSCRIPTION", digest, amount)
+            )
+            raise PrefundedWalletError("subscription-class debit is refused")
+        token = _token(reservation_id, "reservation_id")
+        reservation = self._reserved.get(token)
+        if reservation is None:
+            raise PrefundedWalletError(
+                "debit is not bound to a ledgered Budget Reservation"
+            )
+        remaining = reservation.amount_gbp_minor_units - self._consumed[token]
+        if amount > remaining:
+            raise PrefundedWalletError("debit exceeds its reservation")
+        record = WalletDebit(reservation.digest, amount, cls)
+        self._consumed[token] += amount
+        self._ledger.append(WalletUsage("DEBIT", record.digest, amount))
+        return record
+
+    def replenish(self, amount_gbp_minor_units: object) -> None:
+        raise PrefundedWalletError("replenishment is refused")
+
+    def transfer(self, amount_gbp_minor_units: object, destination: object) -> None:
+        raise PrefundedWalletError("budget transfer is refused")
+
+
+def bind_wallet(fixture: Mapping[str, object]) -> PrefundedWallet:
+    """Refuse a fixture that is not the OD-011 prefunded, non-transferable cap."""
+
+    if not isinstance(fixture, Mapping) or not fixture:
+        raise PrefundedWalletError("wallet is required")
+    if set(fixture) != _WALLET_FIELDS:
+        raise PrefundedWalletError("wallet is required")
+    caps = BudgetCaps()
+    currency = fixture["currency"]
+    if type(currency) is not str or currency != CURRENCY:
+        raise PrefundedWalletError("currency or units differ")
+    capacity = fixture["capacity_gbp_minor_units"]
+    if type(capacity) is float:
+        raise PrefundedWalletError("currency or units differ")
+    if type(capacity) is not int:
+        raise PrefundedWalletError("wallet is required")
+    if capacity != caps.gross_monetary_gbp_minor_units:
+        raise PrefundedWalletError("wallet capacity differs from OD-011")
+    if fixture["budget_transfer_allowed"] is not False:
+        raise PrefundedWalletError("budget transfer is refused")
+    if caps.budget_transfer_allowed is not False:
+        raise PrefundedWalletError("budget transfer is refused")
+    return PrefundedWallet(
+        capacity=capacity, budget_caps_digest=caps.canonical_digest
+    )
+
+
+def bound_wallet(fixture: Mapping[str, object] | None = None) -> PrefundedWallet:
+    return bind_wallet(fixture if fixture is not None else FIXTURE_WALLET)
+
+
+def ledger_budget_reservation(reservation_digest: str) -> ControllerLedgerEntry:
+    """Controller BUDGET_RESERVATION chain entry for a wallet reservation digest."""
+
+    return ControllerLedgerEntry(
+        ordinal=1,
+        stage=ControllerStage.SOURCE,
+        kind=LedgerKind.BUDGET_RESERVATION,
+        payload_digest=reservation_digest,
+        previous_entry_digest=None,
+        persisted_at=FIXTURE_TIMESTAMP,
+    )
+
+
+def refuse_namesake_satisfaction(gates: tuple[str, ...] | list[str]) -> None:
+    """Refuse RUNTIME_GATES list membership as this First I/O Gate."""
+
+    if "PREFUNDED_WALLET_AVAILABLE" in gates:
+        raise PrefundedWalletError(
+            "RUNTIME_GATES membership cannot satisfy this First I/O Gate"
+        )
+    raise PrefundedWalletError(
+        "PREFUNDED_WALLET_AVAILABLE is absent from RUNTIME_GATES"
+    )
+
+
+def bind_campaign_prefunded_wallet() -> str:
+    """Campaign PREFUNDED_WALLET_AVAILABLE bind: the wallet, not a bare gate name.
+
+    RUNTIME_GATES list membership cannot PASS.
+    """
+
+    try:
+        caps = BudgetCaps()
+    except ComparatorContractError as exc:
+        raise PrefundedWalletError("wallet capacity differs from OD-011") from exc
+    wallet = bound_wallet()
+    if wallet.capacity != caps.gross_monetary_gbp_minor_units:
+        raise PrefundedWalletError("wallet capacity differs from OD-011")
+    if wallet.budget_caps_digest != caps.canonical_digest:
+        raise PrefundedWalletError("budget rules digest differs")
+    reservation = wallet.reserve(
+        reservation_id="campaign-bind",
+        amount_gbp_minor_units=1,
+        spend_class=SPEND_METERED,
+        budget_rules_digest=caps.canonical_digest,
+    )
+    try:
+        entry = ledger_budget_reservation(reservation.digest)
+    except ControllerError as exc:
+        raise PrefundedWalletError(
+            "debit is not bound to a ledgered Budget Reservation"
+        ) from exc
+    if entry.kind is not LedgerKind.BUDGET_RESERVATION:
+        raise PrefundedWalletError(
+            "debit is not bound to a ledgered Budget Reservation"
+        )
+    wallet.debit(
+        reservation_id="campaign-bind",
+        amount_gbp_minor_units=1,
+        spend_class=SPEND_METERED,
+        budget_rules_digest=caps.canonical_digest,
+    )
+    return caps.canonical_digest

--- a/newsroom/increment9/prefunded_wallet_available.py
+++ b/newsroom/increment9/prefunded_wallet_available.py
@@ -1,0 +1,462 @@
+"""Increment 9Q-7 PREFUNDED_WALLET_AVAILABLE qualification evidence.
+
+CI fixture digests only. Does not mint First I/O Gate Records. Loading this
+module performs no network I/O and no production writes.
+
+Qualification proves cap bind, non-replenishing prefund and
+reservation-before-spend availability on the real contracts, fail-closed.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+from newsroom.authority.canonical import canonical_json_bytes, digest_bytes
+from newsroom.increment9.comparator import (
+    BudgetCaps,
+    ComparatorContractError,
+    ResourceReservation,
+)
+from newsroom.increment9.controller import ControllerError
+from newsroom.increment9.epoch import EvaluationEpoch, EpochAuthorityError
+from newsroom.increment9.plan import INCREMENT_9_SHADOW_PLAN_DIGEST
+from newsroom.increment9.prefunded_wallet import (
+    CAPACITY_GBP_MINOR_UNITS,
+    SPEND_METERED,
+    SPEND_SUBSCRIPTION,
+    PrefundedWalletError,
+    bind_campaign_prefunded_wallet,
+    bind_wallet,
+    bound_wallet,
+    budget_caps_digest,
+    fixture_wallet,
+    ledger_budget_reservation,
+    refuse_namesake_satisfaction,
+)
+
+SCHEMA_VERSION = "newsroom.increment9.qualification-evidence.v1"
+GATE_ID = "PREFUNDED_WALLET_AVAILABLE"
+WALLET_NAME = "wallet.json"
+
+REFUSAL_CLASSES = (
+    "CAPACITY_MISMATCH",
+    "CURRENCY_OR_UNITS_MISMATCH",
+    "REPLENISHMENT_ATTEMPT",
+    "TRANSFER_ATTEMPT",
+    "OVERDRAFT_RESERVATION",
+    "DEBIT_WITHOUT_RESERVATION",
+    "DEBIT_EXCEEDING_RESERVATION",
+    "SUBSCRIPTION_CLASS_DEBIT",
+    "BUDGET_RULES_DIGEST_DRIFT",
+    "MALFORMED_REQUEST",
+    "ANTI_NAMESAKE",
+)
+PACKAGE_FIXTURES = (
+    Path(__file__).parent / "fixtures" / "increment9q7_prefunded_wallet_available"
+)
+_MARKERS = {
+    "CAPACITY_MISMATCH": b"capacity_mismatch",
+    "CURRENCY_OR_UNITS_MISMATCH": b"currency_or_units_mismatch",
+    "REPLENISHMENT_ATTEMPT": b"replenishment_attempt",
+    "TRANSFER_ATTEMPT": b"transfer_attempt",
+    "OVERDRAFT_RESERVATION": b"overdraft_reservation",
+    "DEBIT_WITHOUT_RESERVATION": b"debit_without_reservation",
+    "DEBIT_EXCEEDING_RESERVATION": b"debit_exceeding_reservation",
+    "SUBSCRIPTION_CLASS_DEBIT": b"subscription_class_debit",
+    "BUDGET_RULES_DIGEST_DRIFT": b"budget_rules_digest_drift",
+    "MALFORMED_REQUEST": b"malformed_request",
+    "ANTI_NAMESAKE": b"anti_namesake",
+}
+_DIGEST = "sha256:" + "0" * 64
+_OPENED = "2026-08-16T00:00:00.000000Z"
+_CLOSES = "2026-09-13T00:00:00.000000Z"
+
+Probe = Callable[[str, Path], bool]
+
+
+class QualificationError(ValueError):
+    """Qualification inventory, probe or digest check failed closed."""
+
+
+@dataclass(frozen=True, slots=True)
+class RefusalDigest:
+    refusal_class: str
+    before_digest: str
+    after_digest: str
+    engaged: bool
+    count: int
+
+
+@dataclass(frozen=True, slots=True)
+class QualificationEvidence:
+    gate_id: str
+    status: str
+    refusals_engaged: int
+    refusals: tuple[RefusalDigest, ...]
+    budget_caps_digest: str
+    reservation_digest: str
+    evidence_digest: str
+
+
+def _reject_forbidden(inventory: Path) -> None:
+    lowered = str(inventory).lower()
+    if "news_pool" in lowered:
+        raise QualificationError("inventory must not alias news_pool")
+
+
+def _refusal_surfaces(inventory: Path) -> tuple[tuple[str, Path], ...]:
+    if not inventory.is_dir():
+        raise QualificationError("inventory is required")
+    missing = [rc for rc in REFUSAL_CLASSES if not (inventory / rc).is_file()]
+    if missing:
+        raise QualificationError(f"missing refusal class: {missing[0]}")
+    extras = sorted(
+        path.name
+        for path in inventory.iterdir()
+        if path.name not in REFUSAL_CLASSES and path.name != WALLET_NAME
+    )
+    if extras:
+        raise QualificationError(f"unexpected refusal class: {extras[0]}")
+    return tuple((rc, inventory / rc) for rc in REFUSAL_CLASSES)
+
+
+def _load_wallet(inventory: Path) -> dict[str, object]:
+    path = inventory / WALLET_NAME
+    if not path.is_file():
+        raise QualificationError("wallet is required")
+    try:
+        raw = json.loads(path.read_bytes().decode("utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise QualificationError("wallet is required") from exc
+    if type(raw) is not dict or not raw:
+        raise QualificationError("wallet is required")
+    try:
+        bind_wallet(raw)
+    except PrefundedWalletError as exc:
+        raise QualificationError("wallet is required") from exc
+    return raw
+
+
+def _digest_file(path: Path) -> str:
+    return digest_bytes(path.read_bytes())
+
+
+def _refused(action: Callable[[], object]) -> bool:
+    try:
+        action()
+    except (
+        PrefundedWalletError,
+        ComparatorContractError,
+        ControllerError,
+        EpochAuthorityError,
+    ):
+        return True
+    return False
+
+
+def _reserve(
+    wallet=None,
+    *,
+    reservation_id: str = "reservation-1",
+    amount: int = 1,
+    spend_class: str = SPEND_METERED,
+    digest: str | None = None,
+):
+    active = wallet if wallet is not None else bound_wallet()
+    return active.reserve(
+        reservation_id=reservation_id,
+        amount_gbp_minor_units=amount,
+        spend_class=spend_class,
+        budget_rules_digest=digest if digest is not None else budget_caps_digest(),
+    )
+
+
+def default_probe(refusal_class: str, path: Path) -> bool:
+    """Verify that a prefunded-wallet refusal class engages on the real contracts.
+
+    Returns True if the refusal engaged (fail-closed). Returns False if it
+    did not engage (unexpected success).
+    """
+    if refusal_class not in REFUSAL_CLASSES:
+        raise QualificationError(f"unknown refusal class: {refusal_class}")
+    if not path.is_file():
+        raise QualificationError(f"missing refusal class: {refusal_class}")
+    if _MARKERS[refusal_class] not in path.read_bytes():
+        return False
+    probes = {
+        "CAPACITY_MISMATCH": _should_engage_capacity_mismatch,
+        "CURRENCY_OR_UNITS_MISMATCH": _should_engage_currency_or_units_mismatch,
+        "REPLENISHMENT_ATTEMPT": _should_engage_replenishment_attempt,
+        "TRANSFER_ATTEMPT": _should_engage_transfer_attempt,
+        "OVERDRAFT_RESERVATION": _should_engage_overdraft_reservation,
+        "DEBIT_WITHOUT_RESERVATION": _should_engage_debit_without_reservation,
+        "DEBIT_EXCEEDING_RESERVATION": _should_engage_debit_exceeding_reservation,
+        "SUBSCRIPTION_CLASS_DEBIT": _should_engage_subscription_class_debit,
+        "BUDGET_RULES_DIGEST_DRIFT": _should_engage_budget_rules_digest_drift,
+        "MALFORMED_REQUEST": _should_engage_malformed_request,
+        "ANTI_NAMESAKE": _should_engage_anti_namesake,
+    }
+    return bool(probes[refusal_class]())
+
+
+def _should_engage_capacity_mismatch() -> bool:
+    drifted = fixture_wallet(capacity_gbp_minor_units=24_999)
+    return _refused(lambda: BudgetCaps(gross_monetary_gbp_minor_units=24_999)) and _refused(
+        lambda: bind_wallet(drifted)
+    )
+
+
+def _should_engage_currency_or_units_mismatch() -> bool:
+    usd = fixture_wallet(currency="USD")
+    fractional = fixture_wallet(capacity_gbp_minor_units=25000.5)  # type: ignore[arg-type]
+    wallet = bound_wallet()
+    return all(
+        (
+            _refused(lambda: bind_wallet(usd)),
+            _refused(lambda: bind_wallet(fractional)),
+            _refused(lambda: _reserve(wallet, amount=1.5)),  # type: ignore[arg-type]
+        )
+    )
+
+
+def _should_engage_replenishment_attempt() -> bool:
+    return _refused(lambda: bound_wallet().replenish(1))
+
+
+def _should_engage_transfer_attempt() -> bool:
+    transferable = fixture_wallet(budget_transfer_allowed=True)
+    return all(
+        (
+            _refused(lambda: BudgetCaps(budget_transfer_allowed=True)),
+            _refused(lambda: bind_wallet(transferable)),
+            _refused(lambda: bound_wallet().transfer(1, "other-wallet")),
+        )
+    )
+
+
+def _should_engage_overdraft_reservation() -> bool:
+    caps = BudgetCaps()
+    over = ResourceReservation(
+        gross_monetary_gbp_minor_units=caps.gross_monetary_gbp_minor_units + 1
+    )
+    over_cap = over.gross_monetary_gbp_minor_units > caps.gross_monetary_gbp_minor_units
+    return over_cap and _refused(
+        lambda: _reserve(amount=CAPACITY_GBP_MINOR_UNITS + 1)
+    )
+
+
+def _should_engage_debit_without_reservation() -> bool:
+    wallet = bound_wallet()
+    return _refused(
+        lambda: wallet.debit(
+            reservation_id="absent-reservation",
+            amount_gbp_minor_units=1,
+            spend_class=SPEND_METERED,
+            budget_rules_digest=budget_caps_digest(),
+        )
+    )
+
+
+def _should_engage_debit_exceeding_reservation() -> bool:
+    wallet = bound_wallet()
+    _reserve(wallet, amount=10)
+    return _refused(
+        lambda: wallet.debit(
+            reservation_id="reservation-1",
+            amount_gbp_minor_units=11,
+            spend_class=SPEND_METERED,
+            budget_rules_digest=budget_caps_digest(),
+        )
+    )
+
+
+def _should_engage_subscription_class_debit() -> bool:
+    wallet = bound_wallet()
+    before = wallet.available
+    refused = _refused(
+        lambda: wallet.debit(
+            reservation_id="reservation-1",
+            amount_gbp_minor_units=1,
+            spend_class=SPEND_SUBSCRIPTION,
+            budget_rules_digest=budget_caps_digest(),
+        )
+    )
+    ledgered = any(item.kind == "SUBSCRIPTION" for item in wallet.ledger)
+    return refused and ledgered and wallet.available == before == CAPACITY_GBP_MINOR_UNITS
+
+
+def _fixture_epoch(digest: str) -> EvaluationEpoch:
+    return EvaluationEpoch(
+        epoch_id="epoch-9q7-fixture",
+        plan_digest=INCREMENT_9_SHADOW_PLAN_DIGEST,
+        shadow_scope_digest=_DIGEST.replace("0", "6"),
+        source_portfolio_digest=_DIGEST.replace("0", "2"),
+        prospective_universe_digest=_DIGEST.replace("0", "1"),
+        slice_rules_digest=_DIGEST.replace("0", "7"),
+        thresholds_digest=_DIGEST.replace("0", "8"),
+        comparator_rules_digest=_DIGEST.replace("0", "a"),
+        reviewer_rules_digest=_DIGEST.replace("0", "9"),
+        budget_rules_digest=digest,
+        rights_rules_digest=_DIGEST.replace("0", "3"),
+        opened_at=_OPENED,
+        cutoff_at=_OPENED,
+        closes_at=_CLOSES,
+    )
+
+
+def _should_engage_budget_rules_digest_drift() -> bool:
+    expected = budget_caps_digest()
+    drifted = "sha256:" + "0" * 64
+    epoch = _fixture_epoch(expected)
+    epoch_bound = epoch.budget_rules_digest == expected == BudgetCaps().canonical_digest
+    return (
+        drifted != expected
+        and epoch_bound
+        and _refused(lambda: _reserve(digest=drifted))
+    )
+
+
+def _should_engage_malformed_request() -> bool:
+    wallet = bound_wallet()
+    over_long = "H" * 257
+    return all(
+        (
+            _refused(lambda: _reserve(wallet, amount=-1, reservation_id="neg")),
+            _refused(lambda: _reserve(wallet, amount=0, reservation_id="zero")),
+            _refused(
+                lambda: _reserve(
+                    wallet, spend_class="NOT_A_SPEND_CLASS", reservation_id="cls"
+                )
+            ),
+            _refused(lambda: _reserve(wallet, reservation_id=over_long)),
+        )
+    )
+
+
+def _should_engage_anti_namesake() -> bool:
+    from scripts.increment9_shadow_campaign import RUNTIME_GATES
+
+    namesake_closed = _refused(lambda: refuse_namesake_satisfaction(RUNTIME_GATES))
+    listed = "PREFUNDED_WALLET_AVAILABLE" in RUNTIME_GATES
+    authorised = not _refused(lambda: bind_campaign_prefunded_wallet())
+    return namesake_closed and listed and authorised
+
+
+def _refusal_payload(
+    records: tuple[RefusalDigest, ...],
+) -> list[dict[str, str | bool | int]]:
+    return [
+        {
+            "after_digest": item.after_digest,
+            "before_digest": item.before_digest,
+            "count": item.count,
+            "engaged": item.engaged,
+            "refusal_class": item.refusal_class,
+        }
+        for item in records
+    ]
+
+
+def _demonstrate(wallet_fixture: Mapping[str, object]) -> tuple[str, str]:
+    wallet = bind_wallet(wallet_fixture)
+    if wallet.capacity != CAPACITY_GBP_MINOR_UNITS:
+        raise QualificationError("wallet is required")
+    digest = budget_caps_digest()
+    if wallet.budget_caps_digest != digest:
+        raise QualificationError("wallet is required")
+    reservation = _reserve(wallet, reservation_id="evidence-reservation", amount=1)
+    try:
+        ledger_budget_reservation(reservation.digest)
+    except (PrefundedWalletError, ControllerError) as exc:
+        raise QualificationError("wallet is required") from exc
+    wallet.debit(
+        reservation_id="evidence-reservation",
+        amount_gbp_minor_units=1,
+        spend_class=SPEND_METERED,
+        budget_rules_digest=digest,
+    )
+    return digest, reservation.digest
+
+
+def assess(
+    inventory: Path,
+    *,
+    probe: Probe | None = None,
+    wallet: Mapping[str, object] | None = None,
+) -> QualificationEvidence:
+    """Assess that all eleven prefunded-wallet refusal classes engage deterministically.
+
+    Fails closed if:
+    - Inventory missing or inaccessible
+    - Fixture wallet missing or invalid
+    - Any refusal class surface missing or unexpected
+    - Any digest changes without claimed engagement
+    - Probe mutates any surface (fail-closed invariant)
+    - Any refusal fails to engage
+    """
+    _reject_forbidden(inventory)
+    surfaces = _refusal_surfaces(inventory)
+    if wallet is None:
+        bound = _load_wallet(inventory)
+    else:
+        try:
+            bind_wallet(wallet)
+        except PrefundedWalletError as exc:
+            raise QualificationError("wallet is required") from exc
+        bound = dict(wallet)
+    writer = default_probe if probe is None else probe
+    bind_wallet(bound)
+    before = {rc: _digest_file(path) for rc, path in surfaces}
+    engaged_count = 0
+    for rc, path in surfaces:
+        if writer(rc, path):
+            engaged_count += 1
+    after = {rc: _digest_file(path) for rc, path in surfaces}
+    if any(before[rc] != after[rc] for rc in REFUSAL_CLASSES):
+        raise QualificationError("refusal surface digest mutated")
+    if engaged_count != len(REFUSAL_CLASSES):
+        raise QualificationError(
+            f"not all refusals engaged: {engaged_count}/{len(REFUSAL_CLASSES)}"
+        )
+    records = tuple(
+        RefusalDigest(rc, before[rc], after[rc], True, 1) for rc in REFUSAL_CLASSES
+    )
+    digest, reservation_digest = _demonstrate(bound)
+    payload = {
+        "budget_caps_digest": digest,
+        "capacity_gbp_minor_units": CAPACITY_GBP_MINOR_UNITS,
+        "gate_id": GATE_ID,
+        "reservation_digest": reservation_digest,
+        "refusals": _refusal_payload(records),
+        "refusals_engaged": engaged_count,
+        "schema_version": SCHEMA_VERSION,
+        "status": "PASS",
+    }
+    return QualificationEvidence(
+        gate_id=GATE_ID,
+        status="PASS",
+        refusals_engaged=engaged_count,
+        refusals=records,
+        budget_caps_digest=digest,
+        reservation_digest=reservation_digest,
+        evidence_digest=digest_bytes(canonical_json_bytes(payload)),
+    )
+
+
+def evidence_json(evidence: QualificationEvidence) -> bytes:
+    """Serialise qualification evidence to canonical JSON."""
+    payload = {
+        "budget_caps_digest": evidence.budget_caps_digest,
+        "capacity_gbp_minor_units": CAPACITY_GBP_MINOR_UNITS,
+        "evidence_digest": evidence.evidence_digest,
+        "gate_id": evidence.gate_id,
+        "reservation_digest": evidence.reservation_digest,
+        "refusals": _refusal_payload(evidence.refusals),
+        "refusals_engaged": evidence.refusals_engaged,
+        "schema_version": SCHEMA_VERSION,
+        "status": evidence.status,
+    }
+    return canonical_json_bytes(payload)

--- a/newsroom/tests/test_increment9q7_prefunded_wallet_available.py
+++ b/newsroom/tests/test_increment9q7_prefunded_wallet_available.py
@@ -1,0 +1,531 @@
+import json
+import subprocess
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+import pytest
+
+from newsroom.increment9.comparator import (
+    AdmissionDisposition,
+    ApprovedPhaseAdmissionController,
+    BudgetCaps,
+    ComparatorContractError,
+    ResourceReservation,
+    StopReason,
+)
+from newsroom.increment9.controller import ControllerError, LedgerKind
+from newsroom.increment9.epoch import EpochAuthorityError
+from newsroom.increment9.prefunded_wallet import (
+    CAPACITY_GBP_MINOR_UNITS,
+    CURRENCY,
+    FIXTURE_WALLET,
+    SPEND_METERED,
+    SPEND_SUBSCRIPTION,
+    PrefundedWalletError,
+    bind_campaign_prefunded_wallet,
+    bind_wallet,
+    bound_wallet,
+    budget_caps_digest,
+    fixture_wallet,
+    ledger_budget_reservation,
+    refuse_namesake_satisfaction,
+)
+from newsroom.increment9.prefunded_wallet_available import (
+    GATE_ID,
+    PACKAGE_FIXTURES,
+    REFUSAL_CLASSES,
+    SCHEMA_VERSION,
+    WALLET_NAME,
+    QualificationError,
+    assess,
+    default_probe,
+    evidence_json,
+)
+
+_SPEC = spec_from_file_location(
+    "increment9q7_prefunded_wallet_available",
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "increment9q7_prefunded_wallet_available.py",
+)
+assert _SPEC is not None and _SPEC.loader is not None
+_CLI = module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_CLI)
+
+from scripts.increment9_shadow_campaign import (
+    RUNTIME_GATES,
+    GateRecord,
+    GateStatus,
+    _gate_findings,
+    main as campaign_main,
+)
+
+
+def _wallet_bytes() -> bytes:
+    return PACKAGE_FIXTURES.joinpath(WALLET_NAME).read_bytes()
+
+
+def _inventory(tmp_path: Path) -> Path:
+    root = tmp_path / "fixtures"
+    root.mkdir()
+    root.joinpath(WALLET_NAME).write_bytes(_wallet_bytes())
+    for rc in REFUSAL_CLASSES:
+        (root / rc).write_bytes(f"refusal:{rc}\n".encode())
+    return root
+
+
+def _authorised_inventory(tmp_path: Path) -> Path:
+    root = tmp_path / "fixtures"
+    root.mkdir()
+    for path in PACKAGE_FIXTURES.iterdir():
+        (root / path.name).write_bytes(path.read_bytes())
+    return root
+
+
+def test_assess_fails_closed_without_inventory(tmp_path: Path) -> None:
+    with pytest.raises(QualificationError, match="inventory"):
+        assess(tmp_path / "missing")
+
+
+def test_assess_fails_closed_without_a_valid_wallet(tmp_path: Path) -> None:
+    root = tmp_path / "fixtures"
+    root.mkdir()
+    for rc in REFUSAL_CLASSES:
+        (root / rc).write_bytes(PACKAGE_FIXTURES.joinpath(rc).read_bytes())
+    with pytest.raises(QualificationError, match="wallet"):
+        assess(root)
+    with pytest.raises(QualificationError, match="wallet"):
+        assess(root, wallet={})
+    (root / WALLET_NAME).write_bytes(b"{")
+    with pytest.raises(QualificationError, match="wallet"):
+        assess(root)
+
+
+def test_assess_fails_closed_when_a_refusal_class_is_missing(tmp_path: Path) -> None:
+    root = _inventory(tmp_path)
+    (root / REFUSAL_CLASSES[0]).unlink()
+    with pytest.raises(QualificationError, match="refusal"):
+        assess(root)
+
+
+def test_assess_fails_closed_when_an_extra_refusal_class_is_present(
+    tmp_path: Path,
+) -> None:
+    root = _inventory(tmp_path)
+    (root / "EXTRA").write_bytes(b"extra")
+    with pytest.raises(QualificationError, match="refusal"):
+        assess(root)
+
+
+def test_news_pool_paths_are_rejected(tmp_path: Path) -> None:
+    with pytest.raises(QualificationError, match="news_pool"):
+        assess(tmp_path / "news_pool.sqlite3")
+
+
+def test_assess_emits_qualification_evidence_not_a_gate_record(tmp_path: Path) -> None:
+    evidence = assess(_authorised_inventory(tmp_path))
+    assert evidence.gate_id == GATE_ID
+    assert evidence.status == "PASS"
+    assert evidence.refusals_engaged == len(REFUSAL_CLASSES)
+    assert tuple(item.refusal_class for item in evidence.refusals) == REFUSAL_CLASSES
+    assert all(item.before_digest == item.after_digest for item in evidence.refusals)
+    assert all(item.count == 1 and item.engaged for item in evidence.refusals)
+    assert evidence.budget_caps_digest == budget_caps_digest()
+    assert evidence.reservation_digest.startswith("sha256:")
+    payload = evidence_json(evidence)
+    assert SCHEMA_VERSION.encode() in payload
+    assert b'"refusals_engaged":11' in payload
+    assert b'"gate_id":"PREFUNDED_WALLET_AVAILABLE"' in payload
+    assert evidence.budget_caps_digest.encode() in payload
+    assert b'"capacity_gbp_minor_units":25000' in payload
+    assert b"exact_main_sha" not in payload
+    assert b"campaign-gate" not in payload
+    assert b"qualification-evidence" in payload
+
+
+def test_assess_fails_closed_when_a_probe_mutates(tmp_path: Path) -> None:
+    root = _inventory(tmp_path)
+
+    def mutate(rc: str, path: Path) -> bool:
+        path.write_bytes(path.read_bytes() + b"mutated")
+        return True
+
+    with pytest.raises(QualificationError, match="mutated"):
+        assess(root, probe=mutate)
+
+
+def test_assess_fails_closed_when_digest_changes_without_engagement(
+    tmp_path: Path,
+) -> None:
+    root = _inventory(tmp_path)
+
+    def silent_mutate(rc: str, path: Path) -> bool:
+        if rc == "CAPACITY_MISMATCH":
+            path.write_bytes(b"changed")
+        return False
+
+    with pytest.raises(QualificationError, match="mutated"):
+        assess(root, probe=silent_mutate)
+
+
+def test_assess_fails_closed_when_not_all_refusals_engage(tmp_path: Path) -> None:
+    root = _inventory(tmp_path)
+
+    def partial_engage(rc: str, path: Path) -> bool:
+        return rc in REFUSAL_CLASSES[:4]
+
+    with pytest.raises(QualificationError, match="not all refusals"):
+        assess(root, probe=partial_engage)
+
+
+def test_authorised_package_fixtures_assess_without_mutating() -> None:
+    evidence = assess(PACKAGE_FIXTURES)
+    assert evidence.status == "PASS"
+    assert evidence.refusals_engaged == len(REFUSAL_CLASSES)
+    assert all(item.before_digest == item.after_digest for item in evidence.refusals)
+    for rc in REFUSAL_CLASSES:
+        assert default_probe(rc, PACKAGE_FIXTURES / rc) is True
+
+
+def test_cli_assess_is_fail_closed_without_inventory_and_writes_evidence(
+    tmp_path: Path,
+) -> None:
+    assert _CLI.main(["assess", "--inventory", str(tmp_path / "missing")]) == 2
+    output = tmp_path / "evidence.json"
+    assert _CLI.main(["assess", "--output", str(output)]) == 0
+    raw = output.read_bytes()
+    assert b'"status":"PASS"' in raw
+    assert b"exact_main_sha" not in raw
+    assert b'"gate_id":"PREFUNDED_WALLET_AVAILABLE"' in raw
+    assert budget_caps_digest().encode() in raw
+
+
+def test_wallet_binds_od011_capacity_and_refuses_mismatch() -> None:
+    wallet = bind_wallet(FIXTURE_WALLET)
+    assert wallet.capacity == CAPACITY_GBP_MINOR_UNITS == 25_000
+    assert wallet.available == CAPACITY_GBP_MINOR_UNITS
+    assert wallet.budget_caps_digest == BudgetCaps().canonical_digest
+    assert FIXTURE_WALLET["currency"] == CURRENCY
+    with pytest.raises(ComparatorContractError):
+        BudgetCaps(gross_monetary_gbp_minor_units=24_999)
+    with pytest.raises(PrefundedWalletError, match="capacity"):
+        bind_wallet(fixture_wallet(capacity_gbp_minor_units=24_999))
+
+
+def test_currency_replenishment_and_transfer_are_refused() -> None:
+    with pytest.raises(PrefundedWalletError, match="currency"):
+        bind_wallet(fixture_wallet(currency="USD"))
+    with pytest.raises(PrefundedWalletError, match="currency"):
+        bound_wallet().reserve(
+            reservation_id="fx",
+            amount_gbp_minor_units=1.5,
+            spend_class=SPEND_METERED,
+            budget_rules_digest=budget_caps_digest(),
+        )
+    with pytest.raises(PrefundedWalletError, match="replenishment"):
+        bound_wallet().replenish(1)
+    with pytest.raises(ComparatorContractError):
+        BudgetCaps(budget_transfer_allowed=True)
+    with pytest.raises(PrefundedWalletError, match="transfer"):
+        bind_wallet(fixture_wallet(budget_transfer_allowed=True))
+    with pytest.raises(PrefundedWalletError, match="transfer"):
+        bound_wallet().transfer(1, "other-wallet")
+
+
+def test_reservation_before_spend_and_debit_rules() -> None:
+    wallet = bound_wallet()
+    reservation = wallet.reserve(
+        reservation_id="r1",
+        amount_gbp_minor_units=10,
+        spend_class=SPEND_METERED,
+        budget_rules_digest=budget_caps_digest(),
+    )
+    entry = ledger_budget_reservation(reservation.digest)
+    assert entry.kind is LedgerKind.BUDGET_RESERVATION
+    assert entry.payload_digest == reservation.digest
+    assert wallet.available == CAPACITY_GBP_MINOR_UNITS - 10
+    debit = wallet.debit(
+        reservation_id="r1",
+        amount_gbp_minor_units=4,
+        spend_class=SPEND_METERED,
+        budget_rules_digest=budget_caps_digest(),
+    )
+    assert debit.reservation_digest == reservation.digest
+    with pytest.raises(PrefundedWalletError, match="remaining"):
+        wallet.reserve(
+            reservation_id="over",
+            amount_gbp_minor_units=CAPACITY_GBP_MINOR_UNITS,
+            spend_class=SPEND_METERED,
+            budget_rules_digest=budget_caps_digest(),
+        )
+    with pytest.raises(PrefundedWalletError, match="Budget Reservation"):
+        wallet.debit(
+            reservation_id="absent",
+            amount_gbp_minor_units=1,
+            spend_class=SPEND_METERED,
+            budget_rules_digest=budget_caps_digest(),
+        )
+    with pytest.raises(PrefundedWalletError, match="exceeds"):
+        wallet.debit(
+            reservation_id="r1",
+            amount_gbp_minor_units=7,
+            spend_class=SPEND_METERED,
+            budget_rules_digest=budget_caps_digest(),
+        )
+
+
+def test_subscription_class_is_ledgered_never_debited() -> None:
+    wallet = bound_wallet()
+    with pytest.raises(PrefundedWalletError, match="subscription"):
+        wallet.debit(
+            reservation_id="r1",
+            amount_gbp_minor_units=1,
+            spend_class=SPEND_SUBSCRIPTION,
+            budget_rules_digest=budget_caps_digest(),
+        )
+    assert wallet.available == CAPACITY_GBP_MINOR_UNITS
+    assert any(item.kind == "SUBSCRIPTION" for item in wallet.ledger)
+
+
+def test_budget_rules_digest_drift_and_malformed_requests_are_refused() -> None:
+    wallet = bound_wallet()
+    with pytest.raises(PrefundedWalletError, match="digest"):
+        wallet.reserve(
+            reservation_id="drift",
+            amount_gbp_minor_units=1,
+            spend_class=SPEND_METERED,
+            budget_rules_digest="sha256:" + "0" * 64,
+        )
+    with pytest.raises(PrefundedWalletError, match="malformed"):
+        wallet.reserve(
+            reservation_id="neg",
+            amount_gbp_minor_units=-1,
+            spend_class=SPEND_METERED,
+            budget_rules_digest=budget_caps_digest(),
+        )
+    with pytest.raises(PrefundedWalletError, match="malformed"):
+        wallet.reserve(
+            reservation_id="zero",
+            amount_gbp_minor_units=0,
+            spend_class=SPEND_METERED,
+            budget_rules_digest=budget_caps_digest(),
+        )
+    with pytest.raises(PrefundedWalletError, match="malformed"):
+        wallet.reserve(
+            reservation_id="cls",
+            amount_gbp_minor_units=1,
+            spend_class="NOT_A_SPEND_CLASS",
+            budget_rules_digest=budget_caps_digest(),
+        )
+    with pytest.raises(PrefundedWalletError, match="malformed"):
+        wallet.reserve(
+            reservation_id="H" * 257,
+            amount_gbp_minor_units=1,
+            spend_class=SPEND_METERED,
+            budget_rules_digest=budget_caps_digest(),
+        )
+
+
+def test_over_budget_reservation_is_api_budget_on_comparator() -> None:
+    from .test_increment9c1_comparator_contracts import _campaign, _request
+
+    plan, epoch, manifest, cohort, campaign = _campaign()
+    assert epoch.budget_rules_digest == plan.budgets.canonical_digest
+    controller = ApprovedPhaseAdmissionController(plan, campaign)
+    receipt = controller.admit(
+        epoch,
+        manifest,
+        cohort,
+        _request(
+            plan,
+            epoch,
+            manifest,
+            cohort,
+            campaign,
+            reservation=ResourceReservation(gross_monetary_gbp_minor_units=25_001),
+        ),
+    )
+    assert receipt.disposition is AdmissionDisposition.EARLY_STOP
+    assert receipt.stop_reason is StopReason.API_BUDGET
+
+
+def test_campaign_namesake_list_membership_cannot_pass() -> None:
+    with pytest.raises(PrefundedWalletError, match="RUNTIME_GATES"):
+        refuse_namesake_satisfaction(RUNTIME_GATES)
+    bind_campaign_prefunded_wallet()
+    import scripts.increment9_shadow_campaign as campaign_mod
+
+    assert hasattr(campaign_mod, "bind_campaign_prefunded_wallet")
+    assert "PREFUNDED_WALLET_AVAILABLE" in RUNTIME_GATES
+
+
+def _gate_record(gate_id: str = "PREFUNDED_WALLET_AVAILABLE") -> GateRecord:
+    return GateRecord(
+        gate_id=gate_id,
+        observed_at="2026-08-16T00:00:00.000000Z",
+        expires_at="2026-08-17T00:00:00.000000Z",
+        exact_main_sha="a" * 40,
+        exact_main_tree="b" * 40,
+        subject_digest="sha256:" + "c" * 64,
+        evidence_digest="sha256:" + "d" * 64,
+        issuer_id="fixture",
+        status=GateStatus.PASS,
+    )
+
+
+def test_campaign_gate_check_uses_wallet_not_a_bare_gate_name() -> None:
+    findings_ok = _gate_findings(
+        {"PREFUNDED_WALLET_AVAILABLE": _gate_record()},
+        head="a" * 40,
+        tree="b" * 40,
+        observed_at="2026-08-16T12:00:00.000000Z",
+    )
+    assert "PREFUNDED_WALLET_UNBOUND" not in findings_ok
+    assert "MISSING_GATE:PREFUNDED_WALLET_AVAILABLE" not in findings_ok
+    import inspect
+    import scripts.increment9_shadow_campaign as campaign_mod
+
+    source = inspect.getsource(campaign_mod._gate_findings)
+    assert "bind_campaign_prefunded_wallet" in source
+
+
+def test_campaign_assess_lands_at_requested_output_and_reruns(
+    tmp_path: Path,
+) -> None:
+    from newsroom.increment9.protected_storage import (
+        list_audit_entries,
+        write_protected_artefact,
+    )
+
+    root = tmp_path / "storage"
+    root.mkdir(mode=0o700)
+    output = tmp_path / "exact" / "bundle.json"
+    payload = {"gate_id": GATE_ID, "status": "PASS"}
+    write_protected_artefact(
+        root,
+        artefact_class="CAMPAIGN_EVIDENCE",
+        artefact_id="bundle.json",
+        payload=payload,
+        target_path=output,
+    )
+    assert output.is_file()
+    write_protected_artefact(
+        root,
+        artefact_class="CAMPAIGN_EVIDENCE",
+        artefact_id="bundle.json",
+        payload={"gate_id": GATE_ID, "status": "PASS", "attempt": 2},
+        target_path=output,
+    )
+    assert b'"attempt":2' in output.read_bytes()
+    writes = [e for e in list_audit_entries(root) if e.operation == "WRITE"]
+    assert len(writes) == 2
+
+
+def test_campaign_cli_writes_requested_output_and_reruns(tmp_path: Path) -> None:
+    repo = tmp_path / "repository"
+    repo.mkdir()
+    subprocess.run(
+        ["git", "init", "--initial-branch=main", str(repo)],
+        check=True,
+        capture_output=True,
+    )
+    (repo / "tracked.txt").write_text("exact\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "-C", str(repo), "add", "tracked.txt"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "-c",
+            "user.name=Newsroom Tests",
+            "-c",
+            "user.email=newsroom-tests@example.invalid",
+            "commit",
+            "-m",
+            "fixture",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    gates = tmp_path / "gates"
+    gates.mkdir(mode=0o700)
+    output_dir = tmp_path / "out"
+    output_dir.mkdir(mode=0o700)
+    output = output_dir / "bundle.json"
+    argv = [
+        "assess",
+        "--repo",
+        str(repo),
+        "--gate-directory",
+        str(gates),
+        "--campaign-id",
+        "FIXTURE_CAMPAIGN",
+        "--observed-at",
+        "2026-08-16T12:00:00.000000Z",
+        "--output",
+        str(output),
+        "--accept-blocked",
+    ]
+    assert campaign_main(argv) == 0
+    assert output.is_file()
+    first = output.read_bytes()
+    assert b"PREFUNDED_WALLET_AVAILABLE" in first
+    assert b"MISSING_GATE:PREFUNDED_WALLET_AVAILABLE" in first
+    assert b"PREFUNDED_WALLET_UNBOUND" not in first
+    assert json.loads(first)["launch_receipt"]["finding_ids"]
+    assert campaign_main(argv) == 0
+    assert output.read_bytes() == first
+
+
+def test_package_wallet_carries_od011_capacity() -> None:
+    loaded = json.loads(PACKAGE_FIXTURES.joinpath(WALLET_NAME).read_bytes())
+    assert loaded == FIXTURE_WALLET
+    assert loaded["capacity_gbp_minor_units"] == CAPACITY_GBP_MINOR_UNITS
+    assert loaded["budget_transfer_allowed"] is False
+
+
+def test_epoch_budget_rules_digest_binds_budget_caps() -> None:
+    from newsroom.increment9.epoch import EvaluationEpoch
+    from newsroom.increment9.plan import INCREMENT_9_SHADOW_PLAN_DIGEST
+
+    digest = budget_caps_digest()
+    epoch = EvaluationEpoch(
+        epoch_id="epoch-9q7-test",
+        plan_digest=INCREMENT_9_SHADOW_PLAN_DIGEST,
+        shadow_scope_digest="sha256:" + "6" * 64,
+        source_portfolio_digest="sha256:" + "2" * 64,
+        prospective_universe_digest="sha256:" + "1" * 64,
+        slice_rules_digest="sha256:" + "7" * 64,
+        thresholds_digest="sha256:" + "8" * 64,
+        comparator_rules_digest="sha256:" + "a" * 64,
+        reviewer_rules_digest="sha256:" + "9" * 64,
+        budget_rules_digest=digest,
+        rights_rules_digest="sha256:" + "3" * 64,
+        opened_at="2026-08-16T00:00:00.000000Z",
+        cutoff_at="2026-08-16T00:00:00.000000Z",
+        closes_at="2026-09-13T00:00:00.000000Z",
+    )
+    assert epoch.budget_rules_digest == digest == BudgetCaps().canonical_digest
+    with pytest.raises(EpochAuthorityError):
+        EvaluationEpoch(
+            epoch_id="epoch-9q7-bad",
+            plan_digest=INCREMENT_9_SHADOW_PLAN_DIGEST,
+            shadow_scope_digest="sha256:" + "6" * 64,
+            source_portfolio_digest="sha256:" + "2" * 64,
+            prospective_universe_digest="sha256:" + "1" * 64,
+            slice_rules_digest="sha256:" + "7" * 64,
+            thresholds_digest="sha256:" + "8" * 64,
+            comparator_rules_digest="sha256:" + "a" * 64,
+            reviewer_rules_digest="sha256:" + "9" * 64,
+            budget_rules_digest="not-a-digest",
+            rights_rules_digest="sha256:" + "3" * 64,
+            opened_at="2026-08-16T00:00:00.000000Z",
+            cutoff_at="2026-08-16T00:00:00.000000Z",
+            closes_at="2026-09-13T00:00:00.000000Z",
+        )
+    with pytest.raises(ControllerError):
+        ledger_budget_reservation("not-a-digest")

--- a/scripts/increment9_shadow_campaign.py
+++ b/scripts/increment9_shadow_campaign.py
@@ -41,6 +41,10 @@ from newsroom.increment9.plan import (
     INCREMENT_9_SHADOW_PLAN,
     INCREMENT_9_SHADOW_PLAN_DIGEST,
 )
+from newsroom.increment9.prefunded_wallet import (
+    PrefundedWalletError,
+    bind_campaign_prefunded_wallet,
+)
 from newsroom.increment9.protected_storage import write_protected_artefact
 
 GATE_RECORD_SCHEMA = "newsroom.increment9.campaign-gate.v1"
@@ -360,6 +364,11 @@ def _gate_findings(
                 bind_campaign_egress_allowlist()
             except EgressAllowlistError:
                 findings.append("EGRESS_ALLOWLIST_UNBOUND")
+        if gate_id == "PREFUNDED_WALLET_AVAILABLE":
+            try:
+                bind_campaign_prefunded_wallet()
+            except PrefundedWalletError:
+                findings.append("PREFUNDED_WALLET_UNBOUND")
     return sorted(set(findings))
 
 

--- a/scripts/increment9q7_prefunded_wallet_available.py
+++ b/scripts/increment9q7_prefunded_wallet_available.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Increment 9Q-7 Prefunded Wallet Available assess CLI. No network I/O."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from newsroom.increment9.prefunded_wallet_available import (
+    PACKAGE_FIXTURES,
+    QualificationError,
+    assess,
+    evidence_json,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="PREFUNDED_WALLET_AVAILABLE qualification evidence."
+    )
+    parser.add_argument("command", choices=("assess",))
+    parser.add_argument("--inventory", default=str(PACKAGE_FIXTURES))
+    parser.add_argument("--output")
+    args = parser.parse_args(argv)
+    if not args.inventory:
+        print("inventory is required", file=sys.stderr)
+        return 2
+    try:
+        evidence = assess(Path(args.inventory))
+    except QualificationError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    payload = evidence_json(evidence)
+    sys.stdout.buffer.write(payload)
+    sys.stdout.write("\n")
+    if args.output:
+        Path(args.output).write_bytes(payload + b"\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: increment-9q7-prefunded-wallet-available
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: delete-after-merge

Closes #649

Authorised by #647. Qualification evidence for First I/O Gate `PREFUNDED_WALLET_AVAILABLE` only. Does not mint a Gate Record. Does not launch the shadow campaign.

## Scope

Prove that the OD-011 £250 cap bind, non-replenishing prefund and reservation-before-spend hold on the real contracts, fail-closed.

## Deliverables

- Mechanism `newsroom/increment9/prefunded_wallet.py` — injected fixture ledger of capacity, reservations and debits; refuses overdraft, replenishment and transfer. No live provider balances.
- Qualification module, CLI, fixtures and tests following the as-merged 9Q-6 layout
- Campaign `scripts/increment9_shadow_campaign.py` gates `PREFUNDED_WALLET_AVAILABLE` through `bind_campaign_prefunded_wallet()`, not a `RUNTIME_GATES` list membership check. `--output` path, reruns and missing-gate finding IDs unchanged.

## Eleven refusal classes (all fail-closed)

CAPACITY_MISMATCH, CURRENCY_OR_UNITS_MISMATCH, REPLENISHMENT_ATTEMPT, TRANSFER_ATTEMPT, OVERDRAFT_RESERVATION, DEBIT_WITHOUT_RESERVATION, DEBIT_EXCEEDING_RESERVATION, SUBSCRIPTION_CLASS_DEBIT, BUDGET_RULES_DIGEST_DRIFT, MALFORMED_REQUEST, ANTI_NAMESAKE

## Exact state

```text
base: 6b028cdd8046e6f8a6b810facde8dd84cc278c74
head: 85adcba3b55e641bfc77630ad822c33ae39df224
tree: 3d1fe0faf292c4e7798f63c9aa2f0b4a85c8cdbb
commits over base: 1
changed files: 17
```

## Verification

Targeted 9Q-7 tests: 23 passed. Full suite `uv run pytest newsroom/tests/ -q`: 3812 passed, 42 skipped, 22 known pre-existing failures on main (increment5a 16, increment6r 1, sdlc_github_transport 3, sdlc_watchdog 1, increment6f2 flaky 1). No new failures.

## Non-effects

No First I/O Gate Record. No campaign launch. No production mutation. No network, spend or live provider balances. CONTEXT.md untouched.


Made with [Cursor](https://cursor.com)