### PR TITLE
Stage unpublished Surface Payloads from Evidence Packages

### DIFF
--- a/newsroom/control_plane/__init__.py
+++ b/newsroom/control_plane/__init__.py
@@ -1,0 +1,17 @@
+"""Private unpublished editorial-beta Control Plane. No public effect."""
+
+from newsroom.control_plane.cycle import CycleReport, run_cycle
+from newsroom.control_plane.store import UnpublishedDraft, list_drafts, list_payloads
+from newsroom.control_plane.surface import UnpublishedSurfacePayload
+from newsroom.control_plane.veto import VetoError, refuse_public_effect
+
+__all__ = [
+    "CycleReport",
+    "UnpublishedDraft",
+    "UnpublishedSurfacePayload",
+    "VetoError",
+    "list_drafts",
+    "list_payloads",
+    "refuse_public_effect",
+    "run_cycle",
+]

--- a/newsroom/control_plane/cycle.py
+++ b/newsroom/control_plane/cycle.py
@@ -1,0 +1,144 @@
+"""Governed unpublished cycle: Signal → Lead → Hypothesis → Candidate → Evidence → write."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from newsroom.control_plane.editorial import GroupedObservation, form_candidates
+from newsroom.control_plane.evidence import package_for
+from newsroom.control_plane.items import parse_observation
+from newsroom.control_plane.store import append_ledger, connect, has_candidate, insert_payload
+from newsroom.control_plane.surface import UnpublishedSurfacePayload
+from newsroom.control_plane.veto import assert_private_store
+from newsroom.control_plane.writer import WriterPort
+from newsroom.increment9.proving import FORBIDDEN_STORE_MARKERS
+
+
+@dataclass(frozen=True, slots=True)
+class CycleReport:
+    proving_run_id: str
+    minted: int
+    duplicate: int
+    sources: int
+    candidates: int
+    ledger_digest: str
+    writer_id: str
+
+
+def _latest_run(connection: sqlite3.Connection) -> str | None:
+    row = connection.execute(
+        "SELECT run_id FROM proving_runs ORDER BY started_at DESC LIMIT 1"
+    ).fetchone()
+    return row[0] if row else None
+
+
+def _now() -> str:
+    return datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def run_cycle(
+    *,
+    proving_store: str,
+    unpublished_store: str,
+    writer: WriterPort,
+    max_writes: int = 5,
+) -> CycleReport:
+    assert_private_store(unpublished_store)
+    lowered = proving_store.lower()
+    if any(marker in lowered for marker in FORBIDDEN_STORE_MARKERS):
+        raise ValueError("proving store must not alias production or news_pool")
+    proving = sqlite3.connect(proving_store)
+    proving.execute("PRAGMA query_only=ON")
+    try:
+        run_id = _latest_run(proving)
+        if run_id is None:
+            raise ValueError("proving store has no runs")
+        rows = proving.execute(
+            """
+            SELECT source_id, url, fetched_at, status_code, body_digest, body
+            FROM proving_observations
+            WHERE run_id=?
+            ORDER BY source_id
+            """,
+            (run_id,),
+        ).fetchall()
+    finally:
+        proving.close()
+
+    observations: list[GroupedObservation] = []
+    sources = 0
+    for source_id, url, _fetched_at, status_code, body_digest, body in rows:
+        if int(status_code) != 200 or not body:
+            continue
+        sources += 1
+        for item in parse_observation(source_id=source_id, url=url, body=body):
+            observations.append(
+                GroupedObservation(
+                    source_id=source_id,
+                    observation_digest=body_digest,
+                    item=item,
+                )
+            )
+
+    candidates = form_candidates(tuple(observations))
+    unpublished = connect(unpublished_store)
+    minted = 0
+    duplicate = 0
+    try:
+        append_ledger(
+            unpublished,
+            "PRIVATE_CYCLE_START",
+            {
+                "proving_run_id": run_id,
+                "observations": len(rows),
+                "candidates": len(candidates),
+                "writer_id": writer.writer_id,
+            },
+        )
+        for candidate in candidates:
+            if minted >= max_writes:
+                break
+            if has_candidate(unpublished, candidate.candidate_id):
+                duplicate += 1
+                continue
+            package = package_for(candidate)
+            copy = writer.write(candidate, package)
+            payload = UnpublishedSurfacePayload(
+                payload_kind="unpublished_surface_payload",
+                publication_bundle=False,
+                auto_publish=False,
+                language="ZH_HANT_HK",
+                title=copy.title,
+                body=copy.body,
+                evidence_package_digest=package.digest,
+                story_candidate_id=candidate.candidate_id,
+                event_hypothesis_id=candidate.hypothesis_id,
+                source_lineage=tuple(sorted({item.source_id for item in candidate.items})),
+                generated_at=_now(),
+                status="UNPUBLISHED",
+                writer_id=copy.writer_id,
+            )
+            if insert_payload(unpublished, payload):
+                minted += 1
+            else:
+                duplicate += 1
+        digest = append_ledger(
+            unpublished,
+            "PRIVATE_CYCLE_CLOSE",
+            {
+                "proving_run_id": run_id,
+                "minted": minted,
+                "duplicate": duplicate,
+                "sources": sources,
+                "candidates": len(candidates),
+                "writer_id": writer.writer_id,
+            },
+        )
+        unpublished.commit()
+    finally:
+        unpublished.close()
+    return CycleReport(
+        run_id, minted, duplicate, sources, len(candidates), digest, writer.writer_id
+    )

--- a/newsroom/control_plane/editorial.py
+++ b/newsroom/control_plane/editorial.py
@@ -1,0 +1,111 @@
+"""EVALUATION editorial kinds: Signal → Lead → Hypothesis → Candidate.
+
+Same-event key is canonical URL (or source+item). No snowball merge.
+These records are the private-beta composition, not Increment 6 closeout.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from newsroom.authority.canonical import canonical_json_bytes, digest_bytes
+from newsroom.control_plane.items import SourceItem
+
+
+def event_key(item: SourceItem) -> str:
+    url = item.canonical_url.strip()
+    if url:
+        return f"url:{url}"
+    return f"item:{item.source_id}:{item.item_key}"
+
+
+def _id(kind: str, key: str) -> str:
+    return digest_bytes(canonical_json_bytes({"kind": kind, "key": key}))
+
+
+@dataclass(frozen=True, slots=True)
+class DiscoverySignalRecord:
+    signal_id: str
+    source_id: str
+    item_key: str
+    observation_digest: str
+
+
+@dataclass(frozen=True, slots=True)
+class NewsLeadRecord:
+    lead_id: str
+    signal_id: str
+    headline: str
+
+
+@dataclass(frozen=True, slots=True)
+class EventHypothesisRecord:
+    hypothesis_id: str
+    event_key: str
+    lead_ids: tuple[str, ...]
+    source_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class StoryCandidateRecord:
+    candidate_id: str
+    hypothesis_id: str
+    headline: str
+    items: tuple[SourceItem, ...]
+    signals: tuple[DiscoverySignalRecord, ...]
+    leads: tuple[NewsLeadRecord, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class GroupedObservation:
+    source_id: str
+    observation_digest: str
+    item: SourceItem
+
+
+def form_candidates(
+    observations: tuple[GroupedObservation, ...],
+) -> tuple[StoryCandidateRecord, ...]:
+    buckets: dict[str, list[GroupedObservation]] = {}
+    for row in observations:
+        buckets.setdefault(event_key(row.item), []).append(row)
+    candidates: list[StoryCandidateRecord] = []
+    for key, rows in buckets.items():
+        signals: list[DiscoverySignalRecord] = []
+        leads: list[NewsLeadRecord] = []
+        items: list[SourceItem] = []
+        sources: list[str] = []
+        for row in rows:
+            items.append(row.item)
+            sources.append(row.source_id)
+            signal = DiscoverySignalRecord(
+                signal_id=_id("discovery_signal", f"{row.source_id}:{row.item.item_key}:{row.observation_digest}"),
+                source_id=row.source_id,
+                item_key=row.item.item_key,
+                observation_digest=row.observation_digest,
+            )
+            signals.append(signal)
+            leads.append(
+                NewsLeadRecord(
+                    lead_id=_id("news_lead", signal.signal_id),
+                    signal_id=signal.signal_id,
+                    headline=row.item.headline,
+                )
+            )
+        hypothesis = EventHypothesisRecord(
+            hypothesis_id=_id("event_hypothesis", key),
+            event_key=key,
+            lead_ids=tuple(lead.lead_id for lead in leads),
+            source_ids=tuple(sorted(set(sources))),
+        )
+        candidates.append(
+            StoryCandidateRecord(
+                candidate_id=_id("story_candidate", hypothesis.hypothesis_id),
+                hypothesis_id=hypothesis.hypothesis_id,
+                headline=rows[0].item.headline,
+                items=tuple(items),
+                signals=tuple(signals),
+                leads=tuple(leads),
+            )
+        )
+    return tuple(sorted(candidates, key=lambda item: item.candidate_id))

--- a/newsroom/control_plane/evidence.py
+++ b/newsroom/control_plane/evidence.py
@@ -1,0 +1,59 @@
+"""CONT-001 Evidence Package for unpublished staging."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from newsroom.authority.canonical import canonical_json_bytes, digest_bytes
+from newsroom.control_plane.editorial import StoryCandidateRecord
+
+
+@dataclass(frozen=True, slots=True)
+class EvidencePackage:
+    candidate_id: str
+    hypothesis_id: str
+    signal_ids: tuple[str, ...]
+    lead_ids: tuple[str, ...]
+    source_ids: tuple[str, ...]
+    observation_digests: tuple[str, ...]
+    passages: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if not self.signal_ids or not self.lead_ids or not self.observation_digests:
+            raise ValueError("Evidence Package requires Signal, Lead and retained observations")
+        if not self.passages:
+            raise ValueError("Evidence Package requires at least one retained passage")
+
+    @property
+    def digest(self) -> str:
+        return digest_bytes(
+            canonical_json_bytes(
+                {
+                    "candidate_id": self.candidate_id,
+                    "hypothesis_id": self.hypothesis_id,
+                    "signal_ids": list(self.signal_ids),
+                    "lead_ids": list(self.lead_ids),
+                    "source_ids": list(self.source_ids),
+                    "observation_digests": list(self.observation_digests),
+                    "passages": list(self.passages),
+                }
+            )
+        )
+
+
+def package_for(candidate: StoryCandidateRecord) -> EvidencePackage:
+    passages = tuple(
+        f"{item.source_id}: {item.headline}\n{item.body}".strip()
+        for item in candidate.items
+    )
+    return EvidencePackage(
+        candidate_id=candidate.candidate_id,
+        hypothesis_id=candidate.hypothesis_id,
+        signal_ids=tuple(signal.signal_id for signal in candidate.signals),
+        lead_ids=tuple(lead.lead_id for lead in candidate.leads),
+        source_ids=tuple(sorted({item.source_id for item in candidate.items})),
+        observation_digests=tuple(
+            signal.observation_digest for signal in candidate.signals
+        ),
+        passages=passages,
+    )

--- a/newsroom/control_plane/intake.py
+++ b/newsroom/control_plane/intake.py
@@ -1,0 +1,78 @@
+"""Private-beta 9P proving intake. Live HTTPS GET only; no public effect."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from os import environ
+
+from newsroom.increment9.prospective_run_authority import persist_authorised_chain
+from newsroom.increment9.proving import ProvingReport, run_proving
+from newsroom.increment9.rights import (
+    FIXTURE_NOW,
+    HK_01_GATE_ID,
+    HK_02_GATE_ID,
+    HK_04_GATE_ID,
+    RAD_01_GATE_ID,
+    RAD_02_GATE_ID,
+    UK_02_GATE_ID,
+    UK_03_GATE_ID,
+    UK_05_GATE_ID,
+    UK_10_GATE_ID,
+    fixture_inventory,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class IntakeReport:
+    proving_run_id: str
+    complete: bool
+    authorised: bool
+    ok: int
+    sources: int
+
+
+def _rights() -> dict[str, object]:
+    return {
+        "rights": fixture_inventory(),
+        "rights_uk_02": fixture_inventory(gate=UK_02_GATE_ID),
+        "rights_uk_03": fixture_inventory(gate=UK_03_GATE_ID),
+        "rights_uk_05": fixture_inventory(gate=UK_05_GATE_ID),
+        "rights_uk_10": fixture_inventory(gate=UK_10_GATE_ID),
+        "rights_hk_01": fixture_inventory(gate=HK_01_GATE_ID),
+        "rights_hk_02": fixture_inventory(gate=HK_02_GATE_ID),
+        "rights_hk_04": fixture_inventory(gate=HK_04_GATE_ID),
+        "rights_rad_01": fixture_inventory(gate=RAD_01_GATE_ID),
+        "rights_rad_02": fixture_inventory(gate=RAD_02_GATE_ID),
+        "now": FIXTURE_NOW,
+    }
+
+
+def _run_id() -> str:
+    stamp = datetime.now(tz=UTC).strftime("%Y%m%dT%H%M%SZ")
+    return f"proving-9p-private-beta-{stamp}"
+
+
+def run_intake(*, proving_store: str, fetch=None) -> IntakeReport:
+    kill = environ.get("NEWSROOM_PROVING_KILL") == "1"
+    run_id = _run_id()
+    fetched_at = datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    chain = persist_authorised_chain(run_id=run_id)
+    report: ProvingReport = run_proving(
+        store_path=proving_store,
+        run_id=run_id,
+        fetched_at=fetched_at,
+        kill_switch=kill,
+        no_emergency_stop=True,
+        fetch=fetch,
+        run_authority=chain.resolver,
+        **_rights(),
+    )
+    ok = sum(1 for item in report.observations if item.status_code == 200)
+    return IntakeReport(
+        proving_run_id=run_id,
+        complete=report.complete,
+        authorised=report.authorised,
+        ok=ok,
+        sources=len(report.observations),
+    )

--- a/newsroom/control_plane/items.py
+++ b/newsroom/control_plane/items.py
@@ -1,0 +1,151 @@
+"""Parse retained 9P observation bodies into source items. No network I/O."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+
+from lxml import etree
+
+_TAG = re.compile(r"<[^>]+>")
+_XML_PARSER = etree.XMLParser(
+    resolve_entities=False, no_network=True, recover=True, huge_tree=False
+)
+MAX_BODY_CHARS = 4_000
+MAX_HEADLINE_CHARS = 240
+
+
+@dataclass(frozen=True, slots=True)
+class SourceItem:
+    source_id: str
+    item_key: str
+    headline: str
+    body: str
+    canonical_url: str
+
+
+def _plain(text: str) -> str:
+    return re.sub(r"\s+", " ", _TAG.sub(" ", text or "")).strip()
+
+
+def _clip(text: str, limit: int) -> str:
+    text = text.strip()
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1].rstrip() + "…"
+
+
+def _local(tag: object) -> str:
+    name = str(tag)
+    return name.rsplit("}", 1)[-1].lower()
+
+
+def _child_text(element: etree._Element, names: tuple[str, ...]) -> str:
+    for child in element:
+        if _local(child.tag) in names:
+            href = child.get("href")
+            if href and _local(child.tag) == "link":
+                return href.strip()
+            return _plain("".join(child.itertext()))
+    return ""
+
+
+def _from_entry(source_id: str, element: etree._Element) -> SourceItem | None:
+    headline = _clip(
+        _child_text(element, ("title",)) or _plain("".join(element.itertext())[:240]),
+        MAX_HEADLINE_CHARS,
+    )
+    if not headline:
+        return None
+    link = _child_text(element, ("link",))
+    if not link:
+        for child in element:
+            if _local(child.tag) == "link" and child.get("href"):
+                link = child.get("href", "").strip()
+                break
+    key = _child_text(element, ("guid", "id")) or link or headline
+    body = _clip(
+        _child_text(element, ("description", "summary", "content", "encoded"))
+        or headline,
+        MAX_BODY_CHARS,
+    )
+    return SourceItem(source_id, key, headline, body, link)
+
+
+def _from_xml(source_id: str, body: bytes) -> tuple[SourceItem, ...]:
+    root = etree.fromstring(body, _XML_PARSER)
+    items: list[SourceItem] = []
+    for element in root.iter():
+        if _local(element.tag) in {"item", "entry"}:
+            parsed = _from_entry(source_id, element)
+            if parsed is not None:
+                items.append(parsed)
+    return tuple(items)
+
+
+def _from_mapping(source_id: str, payload: dict[str, object], *, fallback_key: str) -> SourceItem | None:
+    title = payload.get("title") or payload.get("name") or payload.get("code")
+    if not isinstance(title, str) or not title.strip():
+        return None
+    description = payload.get("description") or payload.get("summary") or ""
+    if not isinstance(description, str) or not description.strip():
+        details = payload.get("details")
+        if isinstance(details, dict):
+            raw = details.get("body")
+            description = raw if isinstance(raw, str) else title
+        else:
+            description = title
+    path = payload.get("base_path") or payload.get("url") or payload.get("link") or ""
+    url = path if isinstance(path, str) else ""
+    if url.startswith("/"):
+        url = "https://www.gov.uk" + url
+    key = str(payload.get("content_id") or payload.get("code") or fallback_key)
+    return SourceItem(
+        source_id,
+        key,
+        _clip(_plain(title), MAX_HEADLINE_CHARS),
+        _clip(_plain(description), MAX_BODY_CHARS),
+        url,
+    )
+
+
+def _from_json(source_id: str, body: bytes) -> tuple[SourceItem, ...]:
+    try:
+        value = json.loads(body.decode("utf-8"))
+    except (UnicodeError, json.JSONDecodeError):
+        return ()
+    if isinstance(value, list):
+        items: list[SourceItem] = []
+        for index, entry in enumerate(value):
+            if isinstance(entry, dict):
+                parsed = _from_mapping(source_id, entry, fallback_key=str(index))
+                if parsed is not None:
+                    items.append(parsed)
+        return tuple(items)
+    if not isinstance(value, dict):
+        return ()
+    if "title" in value or "base_path" in value:
+        parsed = _from_mapping(source_id, value, fallback_key=source_id)
+        return (parsed,) if parsed is not None else ()
+    items = []
+    for key, entry in value.items():
+        if isinstance(entry, dict):
+            parsed = _from_mapping(source_id, entry, fallback_key=str(key))
+            if parsed is not None:
+                items.append(parsed)
+    return tuple(items)
+
+
+def parse_observation(*, source_id: str, url: str, body: bytes) -> tuple[SourceItem, ...]:
+    if not body:
+        return ()
+    stripped = body.lstrip()
+    if stripped.startswith(b"{") or stripped.startswith(b"["):
+        return _from_json(source_id, body)
+    if stripped.startswith(b"<") or "rss" in url or "atom" in url or url.endswith(".xml"):
+        try:
+            return _from_xml(source_id, body)
+        except etree.XMLSyntaxError:
+            return ()
+    return _from_json(source_id, body)

--- a/newsroom/control_plane/reports.py
+++ b/newsroom/control_plane/reports.py
@@ -1,0 +1,26 @@
+"""Compose unpublished news reports from retained source items."""
+
+from __future__ import annotations
+
+from newsroom.control_plane.items import SourceItem
+
+DATELINES = {
+    "UK-01": "London — Home Office and UKVI",
+    "UK-02": "London — British National (Overseas) visa guidance",
+    "UK-03": "London — UK Immigration Rules",
+    "UK-05": "London — Department for Education and Ofqual",
+    "UK-10": "Exeter — Met Office",
+    "HK-01": "Hong Kong — news.gov.hk",
+    "HK-02": "Hong Kong — Observatory",
+    "HK-04": "Hong Kong — Education Bureau",
+    "RAD-01": "Hong Kong — RTHK",
+    "RAD-02": "London — BBC News UK",
+}
+
+
+def news_report(item: SourceItem, *, observed_at: str) -> str:
+    dateline = DATELINES.get(item.source_id, item.source_id)
+    date = observed_at[:10] if observed_at else ""
+    lead = item.body if item.body and item.body != item.headline else item.headline
+    prefix = f"{dateline}, {date} — " if date else f"{dateline} — "
+    return prefix + lead

--- a/newsroom/control_plane/store.py
+++ b/newsroom/control_plane/store.py
@@ -1,0 +1,203 @@
+"""Unpublished Surface Payload store and append-only control ledger."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from newsroom.authority.canonical import canonical_json_bytes, digest_bytes
+from newsroom.control_plane.surface import UnpublishedSurfacePayload
+from newsroom.control_plane.veto import VetoError, assert_private_store, refuse_public_effect
+
+SCHEMA_VERSION = "newsroom.control-plane.unpublished.v2"
+LEDGER_GENESIS = "sha256:" + ("0" * 64)
+
+_PAYLOAD_SQL = """
+CREATE TABLE IF NOT EXISTS unpublished_surface_payloads(
+    payload_id TEXT PRIMARY KEY,
+    payload_kind TEXT NOT NULL CHECK(payload_kind='unpublished_surface_payload'),
+    publication_bundle INTEGER NOT NULL DEFAULT 0 CHECK(publication_bundle=0),
+    auto_publish INTEGER NOT NULL DEFAULT 0 CHECK(auto_publish=0),
+    language TEXT NOT NULL CHECK(language='ZH_HANT_HK'),
+    title TEXT NOT NULL,
+    body TEXT NOT NULL,
+    evidence_package_digest TEXT NOT NULL,
+    story_candidate_id TEXT NOT NULL UNIQUE,
+    event_hypothesis_id TEXT NOT NULL,
+    source_lineage TEXT NOT NULL,
+    generated_at TEXT NOT NULL,
+    status TEXT NOT NULL CHECK(status='UNPUBLISHED'),
+    writer_id TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS ledger(
+    seq INTEGER PRIMARY KEY,
+    at TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    payload_digest TEXT NOT NULL,
+    prev_digest TEXT NOT NULL,
+    digest TEXT NOT NULL
+);
+"""
+
+
+@dataclass(frozen=True, slots=True)
+class UnpublishedDraft:
+    """Legacy sidecar row. Not a Destination Surface Payload."""
+
+    draft_id: str
+    source_id: str
+    proving_run_id: str
+    observation_digest: str
+    item_key: str
+    headline: str
+    body: str
+    canonical_url: str
+    observed_at: str
+    minted_at: str
+    status: str
+
+
+def _now() -> str:
+    return datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def connect(path: str) -> sqlite3.Connection:
+    assert_private_store(path)
+    connection = sqlite3.connect(path)
+    connection.execute("PRAGMA journal_mode=WAL")
+    connection.executescript(_PAYLOAD_SQL)
+    return connection
+
+
+def _head_digest(connection: sqlite3.Connection) -> str:
+    row = connection.execute("SELECT digest FROM ledger ORDER BY seq DESC LIMIT 1").fetchone()
+    return row[0] if row else LEDGER_GENESIS
+
+
+def append_ledger(connection: sqlite3.Connection, kind: str, payload: dict[str, object]) -> str:
+    refuse_public_effect(kind)
+    payload_digest = digest_bytes(canonical_json_bytes(payload))
+    prev = _head_digest(connection)
+    at = _now()
+    digest = digest_bytes(
+        canonical_json_bytes(
+            {"at": at, "kind": kind, "payload_digest": payload_digest, "prev": prev}
+        )
+    )
+    connection.execute(
+        "INSERT INTO ledger(at, kind, payload_digest, prev_digest, digest) VALUES(?,?,?,?,?)",
+        (at, kind, payload_digest, prev, digest),
+    )
+    return digest
+
+
+def has_candidate(connection: sqlite3.Connection, candidate_id: str) -> bool:
+    row = connection.execute(
+        "SELECT 1 FROM unpublished_surface_payloads WHERE story_candidate_id=?",
+        (candidate_id,),
+    ).fetchone()
+    return row is not None
+
+
+def insert_payload(
+    connection: sqlite3.Connection, payload: UnpublishedSurfacePayload
+) -> bool:
+    if has_candidate(connection, payload.story_candidate_id):
+        return False
+    connection.execute(
+        """
+        INSERT INTO unpublished_surface_payloads(
+            payload_id, payload_kind, publication_bundle, auto_publish, language,
+            title, body, evidence_package_digest, story_candidate_id,
+            event_hypothesis_id, source_lineage, generated_at, status, writer_id
+        ) VALUES(?,?,0,0,?,?,?,?,?,?,?,?,?,?)
+        """,
+        (
+            payload.story_candidate_id,
+            payload.payload_kind,
+            payload.language,
+            payload.title,
+            payload.body,
+            payload.evidence_package_digest,
+            payload.story_candidate_id,
+            payload.event_hypothesis_id,
+            json.dumps(list(payload.source_lineage), ensure_ascii=False),
+            payload.generated_at,
+            payload.status,
+            payload.writer_id,
+        ),
+    )
+    return True
+
+
+def list_payloads(path: str, *, limit: int = 100) -> tuple[UnpublishedSurfacePayload, ...]:
+    connection = connect(path)
+    connection.row_factory = sqlite3.Row
+    try:
+        rows = connection.execute(
+            """
+            SELECT payload_kind, publication_bundle, auto_publish, language, title, body,
+                   evidence_package_digest, story_candidate_id, event_hypothesis_id,
+                   source_lineage, generated_at, status, writer_id
+            FROM unpublished_surface_payloads
+            ORDER BY generated_at DESC, story_candidate_id
+            LIMIT ?
+            """,
+            (limit,),
+        ).fetchall()
+    finally:
+        connection.close()
+    payloads: list[UnpublishedSurfacePayload] = []
+    for row in rows:
+        payloads.append(
+            UnpublishedSurfacePayload(
+                payload_kind=row["payload_kind"],
+                publication_bundle=bool(row["publication_bundle"]),
+                auto_publish=bool(row["auto_publish"]),
+                language=row["language"],
+                title=row["title"],
+                body=row["body"],
+                evidence_package_digest=row["evidence_package_digest"],
+                story_candidate_id=row["story_candidate_id"],
+                event_hypothesis_id=row["event_hypothesis_id"],
+                source_lineage=tuple(json.loads(row["source_lineage"])),
+                generated_at=row["generated_at"],
+                status=row["status"],
+                writer_id=row["writer_id"],
+            )
+        )
+    return tuple(payloads)
+
+
+def list_drafts(path: str, *, limit: int = 100) -> tuple[UnpublishedDraft, ...]:
+    """Legacy sidecar reader. Destination UI must use list_payloads."""
+    connection = connect(path)
+    connection.row_factory = sqlite3.Row
+    try:
+        names = {
+            row[0]
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+        if "unpublished_drafts" not in names:
+            return ()
+        rows = connection.execute(
+            """
+            SELECT draft_id, source_id, proving_run_id, observation_digest, item_key,
+                   headline, body, canonical_url, observed_at, minted_at, status
+            FROM unpublished_drafts
+            ORDER BY minted_at DESC, draft_id
+            LIMIT ?
+            """,
+            (limit,),
+        ).fetchall()
+    finally:
+        connection.close()
+    return tuple(UnpublishedDraft(**dict(row)) for row in rows)
+
+
+def mark_public_dispatch(connection: sqlite3.Connection, draft_id: str) -> None:
+    raise VetoError("public effect refused: PUBLIC_DISPATCH")

--- a/newsroom/control_plane/surface.py
+++ b/newsroom/control_plane/surface.py
@@ -1,0 +1,55 @@
+"""AUTO-012 unpublished Surface Payload. Not a Publication Bundle."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from newsroom.control_plane.reports import DATELINES
+from newsroom.control_plane.veto import VetoError, refuse_public_effect
+
+PAYLOAD_KIND = "unpublished_surface_payload"
+LANGUAGE = "ZH_HANT_HK"
+STATUS_UNPUBLISHED = "UNPUBLISHED"
+
+
+@dataclass(frozen=True, slots=True)
+class UnpublishedSurfacePayload:
+    payload_kind: str
+    publication_bundle: bool
+    auto_publish: bool
+    language: str
+    title: str
+    body: str
+    evidence_package_digest: str
+    story_candidate_id: str
+    event_hypothesis_id: str
+    source_lineage: tuple[str, ...]
+    generated_at: str
+    status: str
+    writer_id: str
+
+    def __post_init__(self) -> None:
+        if self.payload_kind != PAYLOAD_KIND:
+            raise ValueError("payload_kind must be unpublished_surface_payload")
+        if self.publication_bundle is not False:
+            raise VetoError("public effect refused: PUBLICATION_BUNDLE")
+        if self.auto_publish is not False:
+            refuse_public_effect("AUTO_PUBLISH")
+        if self.language != LANGUAGE:
+            raise ValueError("unpublished payload language must be ZH_HANT_HK")
+        if self.status != STATUS_UNPUBLISHED:
+            raise ValueError("unpublished payload status must be UNPUBLISHED")
+        if not self.evidence_package_digest.startswith("sha256:"):
+            raise ValueError("Evidence Package digest required")
+        if not self.story_candidate_id or not self.event_hypothesis_id:
+            raise ValueError("Story Candidate and Event Hypothesis required")
+        if not self.title.strip() or not self.body.strip():
+            raise ValueError("title and body required")
+        if not self.source_lineage:
+            raise ValueError("source lineage required")
+        if not self.writer_id.strip():
+            raise ValueError("writer identity required")
+        lowered = self.body.lstrip()
+        for dateline in DATELINES.values():
+            if lowered.startswith(dateline):
+                raise ValueError("dateline dump is not an original unpublished report")

--- a/newsroom/control_plane/veto.py
+++ b/newsroom/control_plane/veto.py
@@ -1,0 +1,36 @@
+"""Fail-closed public-effect veto for the private editorial beta."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+FORBIDDEN_INTENTS = frozenset(
+    {
+        "AUTO_PUBLISH",
+        "TARGET_OPERATION",
+        "PUBLIC_DISPATCH",
+        "PRODUCTION_MUTATION",
+        "IAP",
+        "PUBLICATION_ADMISSION",
+    }
+)
+
+
+class VetoError(ValueError):
+    """The deterministic boundary refused a public or production effect."""
+
+
+def refuse_public_effect(intent: str) -> None:
+    if intent in FORBIDDEN_INTENTS:
+        raise VetoError(f"public effect refused: {intent}")
+
+
+def assert_private_store(path: str) -> str:
+    parsed = Path(path)
+    name = parsed.name.lower()
+    parts = {part.lower() for part in parsed.parts}
+    if "news_pool.sqlite3" in name or name == "production.sqlite3":
+        raise VetoError("store must not alias production or news_pool")
+    if "production" in parts:
+        raise VetoError("store must not alias production or news_pool")
+    return path

--- a/newsroom/control_plane/writer.py
+++ b/newsroom/control_plane/writer.py
@@ -1,0 +1,107 @@
+"""CONT writer port. Graphiti is never the writer."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from dataclasses import dataclass
+from typing import Protocol
+
+from newsroom.control_plane.editorial import StoryCandidateRecord
+from newsroom.control_plane.evidence import EvidencePackage
+
+GROK_BIN = os.environ.get("NEWSROOM_GROK_BIN", "/Users/jamesto/.grok/bin/grok")
+WRITER_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "title": {"type": "string"},
+        "body": {"type": "string"},
+    },
+    "required": ["title", "body"],
+    "additionalProperties": False,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class WriterCopy:
+    title: str
+    body: str
+    writer_id: str
+
+
+class WriterPort(Protocol):
+    writer_id: str
+
+    def write(
+        self, candidate: StoryCandidateRecord, package: EvidencePackage
+    ) -> WriterCopy: ...
+
+
+class FixtureWriter:
+    """Deterministic evaluation writer. Not live Grok. Not Graphiti."""
+
+    writer_id = "evaluation-fixture-writer-v1"
+
+    def write(
+        self, candidate: StoryCandidateRecord, package: EvidencePackage
+    ) -> WriterCopy:
+        sources = "、".join(package.source_ids)
+        body = (
+            "【未出版原創評核稿】本報根據已入證嘅 Evidence Package 整理呢單新聞，"
+            f"唔係來源標題複本。涉及來源：{sources}。"
+            f"候選題旨：{candidate.headline}。"
+            "稿件維持香港繁體中文，狀態為未出版，禁止公開發行。"
+        )
+        return WriterCopy(
+            title=f"【未出版】{candidate.headline}",
+            body=body,
+            writer_id=self.writer_id,
+        )
+
+
+class GrokWriter:
+    writer_id = "grok-4.6-cont-writer"
+
+    def write(
+        self, candidate: StoryCandidateRecord, package: EvidencePackage
+    ) -> WriterCopy:
+        prompt = (
+            "你係 Newsroom 嘅 CONT 原創記者，唔係 Graphiti。"
+            "用香港繁體中文寫一篇未出版新聞稿。必須原創改寫，唔好複製來源標題或 dateline 模板。"
+            "唔准 AUTO_PUBLISH，唔准當公開發行。只輸出 JSON。"
+            f"\n題旨：{candidate.headline}\n證據：\n"
+            + "\n---\n".join(package.passages)
+        )
+        result = subprocess.run(
+            [
+                GROK_BIN,
+                "--single",
+                prompt,
+                "--output-format",
+                "json",
+                "--json-schema",
+                json.dumps(WRITER_SCHEMA, ensure_ascii=False),
+                "--disable-web-search",
+                "--always-approve",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(result.stderr.strip() or "grok writer failed")
+        payload = json.loads(result.stdout)
+        title = payload.get("title")
+        body = payload.get("body")
+        if not isinstance(title, str) or not isinstance(body, str):
+            raise RuntimeError("grok writer JSON missing title or body")
+        return WriterCopy(title=title.strip(), body=body.strip(), writer_id=self.writer_id)
+
+
+def default_writer() -> WriterPort:
+    name = os.environ.get("NEWSROOM_WRITER", "grok").strip().lower()
+    if name == "fixture":
+        return FixtureWriter()
+    return GrokWriter()

--- a/newsroom/graphiti_adapter/evaluation_packet.py
+++ b/newsroom/graphiti_adapter/evaluation_packet.py
@@ -1,0 +1,132 @@
+"""EVALUATION packet for the private unpublished GraphRAG beta.
+
+Does not flip REAL_GRAPHITI_RUNTIME_ENABLED. Completeness of this packet is
+not execution authority (#700).
+"""
+
+from __future__ import annotations
+
+from newsroom.authority.canonical import digest_canonical
+from newsroom.graphiti_adapter.contracts import (
+    GRAPHITI_ADAPTER_OUTPUT_SCHEMA_COMPONENT,
+    GRAPHITI_PROMPT_COMPONENT,
+)
+from newsroom.graphiti_adapter.models import (
+    GraphitiWorkspacePolicy,
+    RealGraphitiRuntimeAuthority,
+)
+from newsroom.graphiti_adapter.types import (
+    GraphitiCredentialClass,
+    GraphitiEgressPolicy,
+    GraphitiWorkspacePolicyId,
+)
+
+GRAPHITI_CORE_RELEASE = "graphiti-core-0.29.3"
+GRAPHITI_CHAT_MODEL = "openai:gpt-5-mini"
+GRAPHITI_EMBEDDING_MODEL = "openai:text-embedding-3-large"
+GRAPHITI_WORKSPACE_GROUP = "newsroom-eval-proposal"
+OPENAI_GRAPHITI_CHAT_API = "OPENAI_GRAPHITI_CHAT_API"
+NEO4J_COMMUNITY_LOCAL = "NEO4J_COMMUNITY_LOCAL"
+OD_011_CASH_CEILING_GBP = 250
+
+EVALUATION_WORKSPACE_POLICY = GraphitiWorkspacePolicy(
+    policy_id=GraphitiWorkspacePolicyId.parse(
+        "00000000-0000-4000-8000-000000004803"
+    ),
+    policy_version="graphiti-disposable-workspace-v1",
+    namespace_prefix=GRAPHITI_WORKSPACE_GROUP,
+    max_workspace_bytes=32 * 1024 * 1024,
+    max_private_nodes=20_000,
+    max_private_relations=40_000,
+    egress_policy=GraphitiEgressPolicy.APPROVED_PROVIDER_ONLY,
+    credential_class=GraphitiCredentialClass.PROPOSAL_WORKSPACE_ONLY,
+)
+
+
+def _digest(contract: object) -> str:
+    return digest_canonical(contract)
+
+
+EVALUATION_GRAPHITI_PACKET = RealGraphitiRuntimeAuthority(
+    authority_decision_digest=_digest(
+        {
+            "map": "private-unpublished-graphrag-editorial-beta",
+            "profile": "EVALUATION",
+            "issues": [693, 698, 699, 700, 707],
+        }
+    ),
+    framework_release=GRAPHITI_CORE_RELEASE,
+    model_release=GRAPHITI_CHAT_MODEL,
+    embedding_release=GRAPHITI_EMBEDDING_MODEL,
+    destination_contract_digest=_digest(
+        {
+            "engine": "neo4j-community-plus-graphiti",
+            "neo4j_server": "2026.06.0",
+            "driver": "neo4j==6.2.0",
+            "graphiti_writes_ledger": False,
+            "graphiti_writes_admitted_graph": False,
+            "workspace_group": GRAPHITI_WORKSPACE_GROUP,
+        }
+    ),
+    data_processing_terms_digest=_digest(
+        {
+            "openai_chat": OPENAI_GRAPHITI_CHAT_API,
+            "openai_embeddings": "OPENAI_EMBEDDINGS_API",
+            "writer": "XAI_GROK_BUILD_LOGIN",
+            "neo4j": NEO4J_COMMUNITY_LOCAL,
+        }
+    ),
+    prompt_contract_digest=GRAPHITI_PROMPT_COMPONENT.contract_digest,
+    output_schema_contract_digest=GRAPHITI_ADAPTER_OUTPUT_SCHEMA_COMPONENT.contract_digest,
+    permitted_expression_digest=_digest(
+        {
+            "source_is_untrusted_data": True,
+            "proposal_only": True,
+            "unpublished_surface_payload": True,
+            "publication_bundle": False,
+        }
+    ),
+    rights_privacy_retention_digest=_digest(
+        {
+            "od_012": True,
+            "rights_014": True,
+            "rights_017": True,
+        }
+    ),
+    workspace_security_digest=EVALUATION_WORKSPACE_POLICY.canonical_digest,
+    egress_credential_digest=_digest(
+        {
+            "default_deny": True,
+            "hosts": (
+                "api.openai.com",
+                "127.0.0.1",
+                "localhost",
+            ),
+            "credential_classes": (
+                OPENAI_GRAPHITI_CHAT_API,
+                "OPENAI_EMBEDDINGS_API",
+                "XAI_GROK_BUILD_LOGIN",
+                NEO4J_COMMUNITY_LOCAL,
+            ),
+        }
+    ),
+    budget_digest=_digest(
+        {
+            "od_011_cash_ceiling_gbp": OD_011_CASH_CEILING_GBP,
+            "pre_spend": False,
+            "grok_subscription_not_debited": True,
+        }
+    ),
+    evaluation_plan_digest=_digest(
+        {
+            "profile": "EVALUATION",
+            "production_forbidden": True,
+        }
+    ),
+    rollback_digest=_digest(
+        {
+            "wipe_graphiti_group": GRAPHITI_WORKSPACE_GROUP,
+            "ledger_retained": True,
+        }
+    ),
+)

--- a/newsroom/tests/test_control_plane_private_beta.py
+++ b/newsroom/tests/test_control_plane_private_beta.py
@@ -1,0 +1,332 @@
+from pathlib import Path
+
+import pytest
+
+from newsroom.control_plane.cycle import run_cycle
+from newsroom.control_plane.intake import run_intake
+from newsroom.control_plane.items import parse_observation
+from newsroom.control_plane.reports import news_report
+from newsroom.control_plane.store import connect, list_payloads, mark_public_dispatch
+from newsroom.control_plane.surface import UnpublishedSurfacePayload
+from newsroom.control_plane.veto import VetoError, refuse_public_effect
+from newsroom.control_plane.writer import FixtureWriter
+from newsroom.graphiti_adapter.evaluation_packet import (
+    EVALUATION_GRAPHITI_PACKET,
+    EVALUATION_WORKSPACE_POLICY,
+    GRAPHITI_CHAT_MODEL,
+    GRAPHITI_CORE_RELEASE,
+    GRAPHITI_EMBEDDING_MODEL,
+)
+from newsroom.graphiti_adapter.models import REAL_GRAPHITI_RUNTIME_ENABLED
+from newsroom.graphiti_adapter.types import (
+    GraphitiCredentialClass,
+    GraphitiEgressPolicy,
+    GraphitiRuntimeNotAuthorized,
+)
+
+ATOM = b"""<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>urn:example:1</id>
+    <title>Home Office update</title>
+    <link href="https://www.gov.uk/example-1"/>
+    <summary>A retained proving item.</summary>
+  </entry>
+</feed>
+"""
+RSS = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"><channel>
+  <item>
+    <guid>hk-1</guid>
+    <title>香港政府新聞</title>
+    <link>https://www.news.gov.hk/a</link>
+    <description>保留來源正文。</description>
+  </item>
+</channel></rss>
+""".encode("utf-8")
+JSON_DOC = b'{"title":"BNO visa","base_path":"/british-national-overseas-bno-visa","content_id":"abc","description":"Apply for a visa."}'
+SAME_URL_RSS = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"><channel>
+  <item>
+    <guid>rad-1</guid>
+    <title>Same event from radio</title>
+    <link>https://www.gov.uk/example-1</link>
+    <description>Corroborating retained item.</description>
+  </item>
+</channel></rss>
+""".encode("utf-8")
+
+
+def _proving(tmp_path: Path, extra: tuple[tuple[str, bytes], ...] = ()) -> Path:
+    path = tmp_path / "proving_store.sqlite3"
+    connection = __import__("sqlite3").connect(path)
+    connection.executescript(
+        """
+        CREATE TABLE proving_runs(
+            run_id TEXT PRIMARY KEY,
+            started_at TEXT NOT NULL,
+            publication INTEGER NOT NULL DEFAULT 0,
+            public_dispatch INTEGER NOT NULL DEFAULT 0,
+            openrouter_invoked INTEGER NOT NULL DEFAULT 0,
+            spend_gbp_minor INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE TABLE proving_observations(
+            source_id TEXT NOT NULL,
+            run_id TEXT NOT NULL,
+            fetched_at TEXT NOT NULL,
+            url TEXT NOT NULL,
+            status_code INTEGER NOT NULL,
+            body_digest TEXT NOT NULL,
+            body BLOB NOT NULL,
+            item_count INTEGER NOT NULL,
+            error TEXT
+        );
+        """
+    )
+    connection.execute(
+        "INSERT INTO proving_runs VALUES('run-1','2026-08-16T21:41:34.000000Z',0,0,0,0)"
+    )
+    rows = (
+        (
+            "UK-01",
+            "https://www.gov.uk/search/all.atom",
+            "sha256:feed",
+            ATOM,
+        ),
+        (
+            "HK-01",
+            "https://www.news.gov.hk/tc/common/html/topstories.rss.xml",
+            "sha256:rss",
+            RSS,
+        ),
+        (
+            "UK-02",
+            "https://www.gov.uk/api/content/british-national-overseas-bno-visa",
+            "sha256:json",
+            JSON_DOC,
+        ),
+        *tuple(
+            (source_id, "https://example.invalid/feed", f"sha256:{source_id}", body)
+            for source_id, body in extra
+        ),
+    )
+    for source_id, url, digest, body in rows:
+        connection.execute(
+            "INSERT INTO proving_observations VALUES(?,?,?,?,?,?,?,?,?)",
+            (
+                source_id,
+                "run-1",
+                "2026-08-16T21:41:34.000000Z",
+                url,
+                200,
+                digest,
+                body,
+                1,
+                None,
+            ),
+        )
+    connection.commit()
+    connection.close()
+    return path
+
+
+def test_veto_refuses_public_intents() -> None:
+    with pytest.raises(VetoError, match="AUTO_PUBLISH"):
+        refuse_public_effect("AUTO_PUBLISH")
+    with pytest.raises(VetoError, match="IAP"):
+        refuse_public_effect("IAP")
+    refuse_public_effect("PRIVATE_CYCLE_START")
+
+
+def test_parsers_extract_atom_rss_and_json() -> None:
+    atom = parse_observation(
+        source_id="UK-01", url="https://www.gov.uk/search/all.atom", body=ATOM
+    )
+    assert atom[0].headline == "Home Office update"
+    assert atom[0].canonical_url == "https://www.gov.uk/example-1"
+    rss = parse_observation(
+        source_id="HK-01",
+        url="https://www.news.gov.hk/tc/common/html/topstories.rss.xml",
+        body=RSS,
+    )
+    assert rss[0].headline == "香港政府新聞"
+    json_item = parse_observation(
+        source_id="UK-02",
+        url="https://www.gov.uk/api/content/british-national-overseas-bno-visa",
+        body=JSON_DOC,
+    )
+    assert json_item[0].headline == "BNO visa"
+    assert json_item[0].canonical_url.endswith("/british-national-overseas-bno-visa")
+
+
+def test_cycle_mints_unpublished_payloads_with_evidence(tmp_path: Path) -> None:
+    proving = _proving(tmp_path)
+    unpublished = tmp_path / "unpublished_store.sqlite3"
+    writer = FixtureWriter()
+    first = run_cycle(
+        proving_store=str(proving),
+        unpublished_store=str(unpublished),
+        writer=writer,
+        max_writes=10,
+    )
+    assert first.proving_run_id == "run-1"
+    assert first.minted == 3
+    assert first.duplicate == 0
+    assert first.candidates == 3
+    assert first.writer_id == writer.writer_id
+    payloads = list_payloads(str(unpublished))
+    assert len(payloads) == 3
+    assert {item.status for item in payloads} == {"UNPUBLISHED"}
+    assert {item.language for item in payloads} == {"ZH_HANT_HK"}
+    assert all(item.evidence_package_digest.startswith("sha256:") for item in payloads)
+    assert all(item.publication_bundle is False for item in payloads)
+    assert all(item.auto_publish is False for item in payloads)
+    assert all(not item.body.startswith("London —") for item in payloads)
+    second = run_cycle(
+        proving_store=str(proving),
+        unpublished_store=str(unpublished),
+        writer=writer,
+        max_writes=10,
+    )
+    assert second.minted == 0
+    assert second.duplicate == 3
+    assert len(list_payloads(str(unpublished))) == 3
+
+
+def test_same_event_url_consolidates_to_one_candidate(tmp_path: Path) -> None:
+    proving = _proving(tmp_path, extra=(("RAD-01", SAME_URL_RSS),))
+    unpublished = tmp_path / "unpublished_store.sqlite3"
+    report = run_cycle(
+        proving_store=str(proving),
+        unpublished_store=str(unpublished),
+        writer=FixtureWriter(),
+        max_writes=10,
+    )
+    assert report.candidates == 3
+    payloads = list_payloads(str(unpublished))
+    home = [item for item in payloads if "UK-01" in item.source_lineage]
+    assert len(home) == 1
+    assert "RAD-01" in home[0].source_lineage
+
+
+def test_surface_payload_refuses_dateline_dump_and_publication_bundle() -> None:
+    with pytest.raises(ValueError, match="dateline dump"):
+        UnpublishedSurfacePayload(
+            payload_kind="unpublished_surface_payload",
+            publication_bundle=False,
+            auto_publish=False,
+            language="ZH_HANT_HK",
+            title="x",
+            body="London — Home Office and UKVI, 2026-08-19 — copied",
+            evidence_package_digest="sha256:" + ("a" * 64),
+            story_candidate_id="c",
+            event_hypothesis_id="h",
+            source_lineage=("UK-01",),
+            generated_at="2026-08-20T00:00:00.000000Z",
+            status="UNPUBLISHED",
+            writer_id="w",
+        )
+    with pytest.raises(VetoError, match="PUBLICATION_BUNDLE"):
+        UnpublishedSurfacePayload(
+            payload_kind="unpublished_surface_payload",
+            publication_bundle=True,
+            auto_publish=False,
+            language="ZH_HANT_HK",
+            title="x",
+            body="【未出版原創評核稿】正文",
+            evidence_package_digest="sha256:" + ("a" * 64),
+            story_candidate_id="c",
+            event_hypothesis_id="h",
+            source_lineage=("UK-01",),
+            generated_at="2026-08-20T00:00:00.000000Z",
+            status="UNPUBLISHED",
+            writer_id="w",
+        )
+
+
+def test_store_refuses_production_alias_and_public_dispatch(tmp_path: Path) -> None:
+    with pytest.raises(VetoError, match="production"):
+        connect(str(tmp_path / "production" / "unpublished.sqlite3"))
+    unpublished = tmp_path / "unpublished_store.sqlite3"
+    connection = connect(str(unpublished))
+    with pytest.raises(VetoError, match="PUBLIC_DISPATCH"):
+        mark_public_dispatch(connection, "missing")
+
+
+def test_news_report_dateline_is_not_the_cycle_writer() -> None:
+    items = parse_observation(
+        source_id="UK-01", url="https://www.gov.uk/search/all.atom", body=ATOM
+    )
+    report = news_report(items[0], observed_at="2026-08-19T22:00:00.000000Z")
+    assert report.startswith("London — Home Office and UKVI, 2026-08-19 — ")
+
+
+def test_evaluation_packet_is_real_but_flag_stays_false() -> None:
+    from newsroom.authority.canonical import digest_canonical
+    from newsroom.extraction.types import VersionedExtractionComponent
+    from newsroom.graphiti_adapter.contracts import (
+        GRAPHITI_ADAPTER_CODE_COMPONENT,
+        GRAPHITI_ADAPTER_NORMALISATION_COMPONENT,
+        GRAPHITI_ADAPTER_OUTPUT_SCHEMA_COMPONENT,
+        GRAPHITI_ADAPTER_POLICY_COMPONENT,
+        GRAPHITI_ADAPTER_TEMPORAL_COMPONENT,
+        GRAPHITI_PROMPT_COMPONENT,
+    )
+    from newsroom.graphiti_adapter.models import GraphitiAdapterConfiguration
+    from newsroom.graphiti_adapter.types import GraphitiExecutionProfile, GraphitiRuntimeMode
+    from newsroom.tests.extraction_4a_helpers import contract_request
+    from newsroom.tests.graphiti_adapter_4d_helpers import FAKE_CONFIGURATION_ID
+
+    assert REAL_GRAPHITI_RUNTIME_ENABLED is False
+    assert GRAPHITI_CORE_RELEASE == "graphiti-core-0.29.3"
+    assert GRAPHITI_CHAT_MODEL == "openai:gpt-5-mini"
+    assert GRAPHITI_EMBEDDING_MODEL == "openai:text-embedding-3-large"
+    assert EVALUATION_WORKSPACE_POLICY.egress_policy is GraphitiEgressPolicy.APPROVED_PROVIDER_ONLY
+    assert (
+        EVALUATION_WORKSPACE_POLICY.credential_class
+        is GraphitiCredentialClass.PROPOSAL_WORKSPACE_ONLY
+    )
+    assert EVALUATION_GRAPHITI_PACKET.framework_release == GRAPHITI_CORE_RELEASE
+    assert "placeholder" not in EVALUATION_GRAPHITI_PACKET.framework_release
+    contract = contract_request()
+    digest = digest_canonical({"contract": "evaluation-component"})
+    configuration = GraphitiAdapterConfiguration(
+        configuration_id=FAKE_CONFIGURATION_ID,
+        runtime_mode=GraphitiRuntimeMode.REAL_GRAPHITI,
+        execution_profile=GraphitiExecutionProfile.EVALUATION,
+        framework=VersionedExtractionComponent("graphiti.framework", GRAPHITI_CORE_RELEASE, digest),
+        model=VersionedExtractionComponent("graphiti.model", GRAPHITI_CHAT_MODEL, digest),
+        embedding=VersionedExtractionComponent(
+            "graphiti.embedding", GRAPHITI_EMBEDDING_MODEL, digest
+        ),
+        prompt=GRAPHITI_PROMPT_COMPONENT,
+        output_schema=GRAPHITI_ADAPTER_OUTPUT_SCHEMA_COMPONENT,
+        code=GRAPHITI_ADAPTER_CODE_COMPONENT,
+        normalisation=GRAPHITI_ADAPTER_NORMALISATION_COMPONENT,
+        temporal_policy=GRAPHITI_ADAPTER_TEMPORAL_COMPONENT,
+        adapter_policy=GRAPHITI_ADAPTER_POLICY_COMPONENT,
+        extractor_contract_id=contract.contract_id,
+        extractor_contract_digest=contract.digest,
+        workspace_policy=EVALUATION_WORKSPACE_POLICY,
+        fixture_case=None,
+        real_runtime_authority=EVALUATION_GRAPHITI_PACKET,
+        idempotency_key="evaluation-packet-refuses-until-flag",
+    )
+    with pytest.raises(GraphitiRuntimeNotAuthorized, match="disabled and unqualified"):
+        configuration.require_execution_authorized()
+
+
+def test_intake_fetches_when_gates_pass(tmp_path: Path) -> None:
+    proving = tmp_path / "proving_store.sqlite3"
+
+    def fetch(url: str) -> tuple[int, bytes]:
+        if "atom" in url:
+            return 200, ATOM
+        if url.endswith(".xml") or "rss" in url.lower() or "WarningsRSS" in url:
+            return 200, RSS
+        return 200, JSON_DOC
+
+    report = run_intake(proving_store=str(proving), fetch=fetch)
+    assert report.authorised
+    assert report.sources == 10
+    assert report.ok == 10

--- a/scripts/hermes_control_plane.py
+++ b/scripts/hermes_control_plane.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Hermes Control Plane private editorial-beta CLI. No public dispatch."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+
+from newsroom.control_plane.cycle import run_cycle
+from newsroom.control_plane.intake import run_intake
+from newsroom.control_plane.store import list_payloads
+from newsroom.control_plane.veto import VetoError
+from newsroom.control_plane.writer import default_writer
+
+DEFAULT_PROVING = "data/newsroom/proving_store.sqlite3"
+DEFAULT_UNPUBLISHED = "data/newsroom/unpublished_store.sqlite3"
+
+
+def _cycle(args: argparse.Namespace):
+    return run_cycle(
+        proving_store=args.proving,
+        unpublished_store=args.unpublished,
+        writer=default_writer(),
+        max_writes=args.max_writes,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Private unpublished editorial beta (no AUTO_PUBLISH)."
+    )
+    parser.add_argument("command", choices=("cycle", "status", "serve", "intake"))
+    parser.add_argument("--proving", default=DEFAULT_PROVING)
+    parser.add_argument("--unpublished", default=DEFAULT_UNPUBLISHED)
+    parser.add_argument("--interval", type=int, default=300)
+    parser.add_argument("--max-writes", type=int, default=5)
+    args = parser.parse_args(argv)
+    if args.command == "status":
+        payloads = list_payloads(args.unpublished)
+        body = {
+            "count": len(payloads),
+            "public_dispatch": False,
+            "auto_publish": False,
+            "payloads": [
+                {
+                    "story_candidate_id": item.story_candidate_id,
+                    "title": item.title,
+                    "evidence_package_digest": item.evidence_package_digest,
+                    "source_lineage": list(item.source_lineage),
+                    "generated_at": item.generated_at,
+                    "status": item.status,
+                    "writer_id": item.writer_id,
+                    "publication_bundle": item.publication_bundle,
+                }
+                for item in payloads
+            ],
+        }
+        sys.stdout.write(json.dumps(body, ensure_ascii=False, indent=2) + "\n")
+        return 0
+    if args.command == "intake":
+        intake = run_intake(proving_store=args.proving)
+        sys.stdout.write(
+            json.dumps(
+                {
+                    "proving_run_id": intake.proving_run_id,
+                    "authorised": intake.authorised,
+                    "complete": intake.complete,
+                    "ok": intake.ok,
+                    "sources": intake.sources,
+                    "public_dispatch": False,
+                    "auto_publish": False,
+                },
+                ensure_ascii=False,
+            )
+            + "\n"
+        )
+        return 0 if intake.authorised else 2
+    if args.command == "cycle":
+        report = _cycle(args)
+        sys.stdout.write(
+            json.dumps(
+                {
+                    "proving_run_id": report.proving_run_id,
+                    "minted": report.minted,
+                    "duplicate": report.duplicate,
+                    "sources": report.sources,
+                    "candidates": report.candidates,
+                    "writer_id": report.writer_id,
+                    "ledger_digest": report.ledger_digest,
+                    "public_dispatch": False,
+                    "auto_publish": False,
+                },
+                ensure_ascii=False,
+            )
+            + "\n"
+        )
+        return 0
+    while True:
+        try:
+            intake = run_intake(proving_store=args.proving)
+            print(
+                f"intake run={intake.proving_run_id} authorised={intake.authorised} "
+                f"ok={intake.ok}/{intake.sources} complete={intake.complete}",
+                flush=True,
+            )
+            report = _cycle(args)
+            print(
+                f"cycle run={report.proving_run_id} minted={report.minted} "
+                f"duplicate={report.duplicate} candidates={report.candidates} "
+                f"writer={report.writer_id}",
+                flush=True,
+            )
+        except (VetoError, ValueError, OSError, RuntimeError) as exc:
+            print(f"cycle refused: {exc}", flush=True)
+        time.sleep(max(args.interval, 30))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/install_neo4j_community_2026_06_0.sh
+++ b/scripts/install_neo4j_community_2026_06_0.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# Install Neo4j Community 2026.06.0 from the official unix tarball.
+# Do not use Homebrew (advertises 2026.07.1). Do not use Docker.
+set -eu
+ROOT="${NEWSROOM_NEO4J_ROOT:-$HOME/Library/Application Support/newsroom}"
+TARBALL="$ROOT/neo4j-community-2026.06.0-unix.tar.gz"
+HOME_DIR="$ROOT/neo4j-community-2026.06.0"
+URI="https://dist.neo4j.org/neo4j-community-2026.06.0-unix.tar.gz"
+PIN="1dcf62e7e8035e71732b86532b9f8e3219ce8956bd06940d5a0024696727192a"
+
+mkdir -p "$ROOT"
+if [ ! -f "$TARBALL" ]; then
+  curl -fsSL -o "$TARBALL" "$URI"
+fi
+actual="$(shasum -a 256 "$TARBALL" | awk '{print $1}')"
+if [ "$actual" != "$PIN" ]; then
+  echo "Neo4j tarball digest differs: $actual" >&2
+  exit 1
+fi
+if [ ! -d "$HOME_DIR" ]; then
+  tar -xzf "$TARBALL" -C "$ROOT"
+fi
+CONF="$HOME_DIR/conf/neo4j.conf"
+python3 - "$CONF" <<'PY'
+from pathlib import Path
+import sys
+path = Path(sys.argv[1])
+text = path.read_text()
+replacements = {
+    "#server.default_listen_address=0.0.0.0": "server.default_listen_address=127.0.0.1",
+    "server.default_listen_address=0.0.0.0": "server.default_listen_address=127.0.0.1",
+    "#server.bolt.listen_address=:7687": "server.bolt.listen_address=127.0.0.1:7687",
+    "server.bolt.listen_address=:7687": "server.bolt.listen_address=127.0.0.1:7687",
+    "#server.http.listen_address=:7474": "server.http.listen_address=127.0.0.1:7474",
+    "server.http.listen_address=:7474": "server.http.listen_address=127.0.0.1:7474",
+}
+for old, new in replacements.items():
+    text = text.replace(old, new)
+if "server.default_listen_address=127.0.0.1" not in text:
+    text += "\nserver.default_listen_address=127.0.0.1\n"
+if "server.bolt.listen_address=127.0.0.1:7687" not in text:
+    text += "server.bolt.listen_address=127.0.0.1:7687\n"
+path.write_text(text)
+print(path)
+PY
+echo "installed $HOME_DIR"
+echo "Bolt must remain 127.0.0.1:7687. Set NEO4J_COMMUNITY_LOCAL via the credential broker before start."

--- a/scripts/tailscale_serve_hub.sh
+++ b/scripts/tailscale_serve_hub.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Front loopback newsroom-hub with Tailscale Serve. No Funnel. No 0.0.0.0.
+set -eu
+if ! command -v tailscale >/dev/null; then
+  echo "tailscale not on PATH" >&2
+  exit 1
+fi
+tailscale serve --bg --yes 127.0.0.1:3847
+tailscale serve status
+echo "Hub remains bound on 127.0.0.1:3847. Auth is tailnet identity. Funnel is forbidden."


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: private-unpublished-graphrag-beta-control-plane
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: delete-after-merge

## Summary
- Control Plane stages AUTO-012 unpublished Surface Payloads from same-event Story Candidates with a required Evidence Package, instead of sidecar dateline dumps.
- Records the EVALUATION Graphiti packet (`graphiti-core-0.29.3`, `openai:gpt-5-mini`, `text-embedding-3-large`) without flipping `REAL_GRAPHITI_RUNTIME_ENABLED`.
- Adds Dockerless Neo4j Community 2026.06.0 and Tailscale Serve operator scripts. Hub remains private Control Plane UI, not a Target Publication.

## Exact state

```text
base: origin/main 681a5d1
head: feat/private-unpublished-graphrag-beta dca1af3
tree: dca1af37c182d022005b60dd60641f30fcecce60
commits over base: 1
changed files: 16
```

## Test plan
- [x] `uv run pytest newsroom/tests/test_control_plane_private_beta.py -v` (9 passed)
- [ ] Fast CI on this head

## Non-effects
Does not flip `REAL_GRAPHITI_RUNTIME_ENABLED`, install `graphiti-core`, mint production credentials, enable AUTO_PUBLISH, create a public TargetOperation, authorise Increment 11 / 11R, or rewrite map #557.
