### PR TITLE
Route unpublished Graphiti and CONT writer calls through OpenRouter

### DIFF
--- a/newsroom/control_plane/broker.py
+++ b/newsroom/control_plane/broker.py
@@ -1,0 +1,40 @@
+"""Keychain broker for private-beta credentials. Never returns secret bytes to logs."""
+
+from __future__ import annotations
+
+import subprocess
+
+OPENROUTER_ACCOUNT = "OPENROUTER_API"
+OPENROUTER_SERVICE = "newsroom.shadow.v1"
+
+
+class BrokerError(RuntimeError):
+    """Credential injection failed closed."""
+
+
+def _keychain_password(*, account: str, service: str) -> str:
+    result = subprocess.run(
+        [
+            "security",
+            "find-generic-password",
+            "-a",
+            account,
+            "-s",
+            service,
+            "-w",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if result.returncode != 0:
+        raise BrokerError(f"Keychain class {account} is absent")
+    secret = result.stdout.strip()
+    if not secret:
+        raise BrokerError(f"Keychain class {account} is empty")
+    return secret
+
+
+def openrouter_api_key() -> str:
+    return _keychain_password(account=OPENROUTER_ACCOUNT, service=OPENROUTER_SERVICE)

--- a/newsroom/control_plane/writer.py
+++ b/newsroom/control_plane/writer.py
@@ -1,17 +1,22 @@
-"""CONT writer port. Graphiti is never the writer."""
+"""CONT writer port. Graphiti is never the writer. Live copy uses OpenRouter."""
 
 from __future__ import annotations
 
 import json
 import os
-import subprocess
+import urllib.error
+import urllib.request
 from dataclasses import dataclass
 from typing import Protocol
 
+from newsroom.control_plane.broker import openrouter_api_key
 from newsroom.control_plane.editorial import StoryCandidateRecord
 from newsroom.control_plane.evidence import EvidencePackage
+from newsroom.graphiti_adapter.evaluation_packet import (
+    OPENROUTER_BASE_URL,
+    OPENROUTER_WRITER_SLUG,
+)
 
-GROK_BIN = os.environ.get("NEWSROOM_GROK_BIN", "/Users/jamesto/.grok/bin/grok")
 WRITER_SCHEMA = {
     "type": "object",
     "properties": {
@@ -39,7 +44,7 @@ class WriterPort(Protocol):
 
 
 class FixtureWriter:
-    """Deterministic evaluation writer. Not live Grok. Not Graphiti."""
+    """Deterministic evaluation writer. Not live OpenRouter. Not Graphiti."""
 
     writer_id = "evaluation-fixture-writer-v1"
 
@@ -60,8 +65,23 @@ class FixtureWriter:
         )
 
 
-class GrokWriter:
-    writer_id = "grok-4.6-cont-writer"
+def _parse_copy(raw: str) -> tuple[str, str]:
+    payload = json.loads(raw)
+    title = payload.get("title")
+    body = payload.get("body")
+    if not isinstance(title, str) or not isinstance(body, str):
+        raise RuntimeError("writer JSON missing title or body")
+    return title.strip(), body.strip()
+
+
+class OpenRouterWriter:
+    """CONT writer via OpenRouter `x-ai/grok-4.6`. Injects OPENROUTER_API only."""
+
+    writer_id = "openrouter-x-ai.grok-4.6-cont-writer"
+
+    def __init__(self, *, post=None, api_key=None) -> None:
+        self._post = post or _openrouter_chat
+        self._api_key = api_key
 
     def write(
         self, candidate: StoryCandidateRecord, package: EvidencePackage
@@ -69,39 +89,53 @@ class GrokWriter:
         prompt = (
             "你係 Newsroom 嘅 CONT 原創記者，唔係 Graphiti。"
             "用香港繁體中文寫一篇未出版新聞稿。必須原創改寫，唔好複製來源標題或 dateline 模板。"
-            "唔准 AUTO_PUBLISH，唔准當公開發行。只輸出 JSON。"
+            "唔准 AUTO_PUBLISH，唔准當公開發行。"
+            "只輸出 JSON 物件，欄位 title 同 body。"
             f"\n題旨：{candidate.headline}\n證據：\n"
             + "\n---\n".join(package.passages)
         )
-        result = subprocess.run(
-            [
-                GROK_BIN,
-                "--single",
-                prompt,
-                "--output-format",
-                "json",
-                "--json-schema",
-                json.dumps(WRITER_SCHEMA, ensure_ascii=False),
-                "--disable-web-search",
-                "--always-approve",
-            ],
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=180,
-        )
-        if result.returncode != 0:
-            raise RuntimeError(result.stderr.strip() or "grok writer failed")
-        payload = json.loads(result.stdout)
-        title = payload.get("title")
-        body = payload.get("body")
-        if not isinstance(title, str) or not isinstance(body, str):
-            raise RuntimeError("grok writer JSON missing title or body")
-        return WriterCopy(title=title.strip(), body=body.strip(), writer_id=self.writer_id)
+        secret = self._api_key() if self._api_key else openrouter_api_key()
+        raw = self._post(prompt=prompt, api_key=secret)
+        title, body = _parse_copy(raw)
+        return WriterCopy(title=title, body=body, writer_id=self.writer_id)
+
+
+def _openrouter_chat(*, prompt: str, api_key: str) -> str:
+    payload = json.dumps(
+        {
+            "model": OPENROUTER_WRITER_SLUG,
+            "messages": [{"role": "user", "content": prompt}],
+            "response_format": {"type": "json_object"},
+        }
+    ).encode("utf-8")
+    request = urllib.request.Request(
+        f"{OPENROUTER_BASE_URL}/chat/completions",
+        data=payload,
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "HTTP-Referer": "https://github.com/fol2/newsroom",
+            "X-Title": "newsroom-unpublished-beta",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=120) as response:
+            body = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"OpenRouter writer HTTP {exc.code}") from exc
+    choices = body.get("choices")
+    if not isinstance(choices, list) or not choices:
+        raise RuntimeError("OpenRouter writer returned no choices")
+    message = choices[0].get("message") if isinstance(choices[0], dict) else None
+    content = message.get("content") if isinstance(message, dict) else None
+    if not isinstance(content, str) or not content.strip():
+        raise RuntimeError("OpenRouter writer returned empty content")
+    return content
 
 
 def default_writer() -> WriterPort:
-    name = os.environ.get("NEWSROOM_WRITER", "grok").strip().lower()
+    name = os.environ.get("NEWSROOM_WRITER", "openrouter").strip().lower()
     if name == "fixture":
         return FixtureWriter()
-    return GrokWriter()
+    return OpenRouterWriter()

--- a/newsroom/graphiti_adapter/evaluation_packet.py
+++ b/newsroom/graphiti_adapter/evaluation_packet.py
@@ -1,7 +1,9 @@
 """EVALUATION packet for the private unpublished GraphRAG beta.
 
+Metered model and embedding calls use OpenRouter (`OPENROUTER_API`).
 Does not flip REAL_GRAPHITI_RUNTIME_ENABLED. Completeness of this packet is
-not execution authority (#700).
+not execution authority (#700). Increment 9P proving still must not call
+OpenRouter (`OPENROUTER_UNUSED`).
 """
 
 from __future__ import annotations
@@ -22,10 +24,16 @@ from newsroom.graphiti_adapter.types import (
 )
 
 GRAPHITI_CORE_RELEASE = "graphiti-core-0.29.3"
-GRAPHITI_CHAT_MODEL = "openai:gpt-5-mini"
-GRAPHITI_EMBEDDING_MODEL = "openai:text-embedding-3-large"
+GRAPHITI_CHAT_MODEL = "openrouter:openai.gpt-5-mini"
+GRAPHITI_EMBEDDING_MODEL = "openrouter:openai.text-embedding-3-large"
+WRITER_MODEL = "openrouter:x-ai.grok-4.6"
+OPENROUTER_CHAT_SLUG = "openai/gpt-5-mini"
+OPENROUTER_EMBEDDING_SLUG = "openai/text-embedding-3-large"
+OPENROUTER_WRITER_SLUG = "x-ai/grok-4.6"
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 GRAPHITI_WORKSPACE_GROUP = "newsroom-eval-proposal"
-OPENAI_GRAPHITI_CHAT_API = "OPENAI_GRAPHITI_CHAT_API"
+OPENROUTER_API = "OPENROUTER_API"
+OPENROUTER_KEYCHAIN_SERVICE = "newsroom.shadow.v1"
 NEO4J_COMMUNITY_LOCAL = "NEO4J_COMMUNITY_LOCAL"
 OD_011_CASH_CEILING_GBP = 250
 
@@ -53,6 +61,7 @@ EVALUATION_GRAPHITI_PACKET = RealGraphitiRuntimeAuthority(
             "map": "private-unpublished-graphrag-editorial-beta",
             "profile": "EVALUATION",
             "issues": [693, 698, 699, 700, 707],
+            "provider": OPENROUTER_API,
         }
     ),
     framework_release=GRAPHITI_CORE_RELEASE,
@@ -70,9 +79,9 @@ EVALUATION_GRAPHITI_PACKET = RealGraphitiRuntimeAuthority(
     ),
     data_processing_terms_digest=_digest(
         {
-            "openai_chat": OPENAI_GRAPHITI_CHAT_API,
-            "openai_embeddings": "OPENAI_EMBEDDINGS_API",
-            "writer": "XAI_GROK_BUILD_LOGIN",
+            "metered_api": OPENROUTER_API,
+            "keychain_service": OPENROUTER_KEYCHAIN_SERVICE,
+            "writer": WRITER_MODEL,
             "neo4j": NEO4J_COMMUNITY_LOCAL,
         }
     ),
@@ -98,14 +107,12 @@ EVALUATION_GRAPHITI_PACKET = RealGraphitiRuntimeAuthority(
         {
             "default_deny": True,
             "hosts": (
-                "api.openai.com",
+                "openrouter.ai",
                 "127.0.0.1",
                 "localhost",
             ),
             "credential_classes": (
-                OPENAI_GRAPHITI_CHAT_API,
-                "OPENAI_EMBEDDINGS_API",
-                "XAI_GROK_BUILD_LOGIN",
+                OPENROUTER_API,
                 NEO4J_COMMUNITY_LOCAL,
             ),
         }
@@ -114,13 +121,14 @@ EVALUATION_GRAPHITI_PACKET = RealGraphitiRuntimeAuthority(
         {
             "od_011_cash_ceiling_gbp": OD_011_CASH_CEILING_GBP,
             "pre_spend": False,
-            "grok_subscription_not_debited": True,
+            "provider": OPENROUTER_API,
         }
     ),
     evaluation_plan_digest=_digest(
         {
             "profile": "EVALUATION",
             "production_forbidden": True,
+            "proving_openrouter_unused": True,
         }
     ),
     rollback_digest=_digest(

--- a/newsroom/tests/test_control_plane_private_beta.py
+++ b/newsroom/tests/test_control_plane_private_beta.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import json
 
 import pytest
 
@@ -9,13 +10,15 @@ from newsroom.control_plane.reports import news_report
 from newsroom.control_plane.store import connect, list_payloads, mark_public_dispatch
 from newsroom.control_plane.surface import UnpublishedSurfacePayload
 from newsroom.control_plane.veto import VetoError, refuse_public_effect
-from newsroom.control_plane.writer import FixtureWriter
+from newsroom.control_plane.writer import FixtureWriter, OpenRouterWriter
 from newsroom.graphiti_adapter.evaluation_packet import (
     EVALUATION_GRAPHITI_PACKET,
     EVALUATION_WORKSPACE_POLICY,
     GRAPHITI_CHAT_MODEL,
     GRAPHITI_CORE_RELEASE,
     GRAPHITI_EMBEDDING_MODEL,
+    OPENROUTER_API,
+    WRITER_MODEL,
 )
 from newsroom.graphiti_adapter.models import REAL_GRAPHITI_RUNTIME_ENABLED
 from newsroom.graphiti_adapter.types import (
@@ -279,8 +282,12 @@ def test_evaluation_packet_is_real_but_flag_stays_false() -> None:
 
     assert REAL_GRAPHITI_RUNTIME_ENABLED is False
     assert GRAPHITI_CORE_RELEASE == "graphiti-core-0.29.3"
-    assert GRAPHITI_CHAT_MODEL == "openai:gpt-5-mini"
-    assert GRAPHITI_EMBEDDING_MODEL == "openai:text-embedding-3-large"
+    assert OPENROUTER_API == "OPENROUTER_API"
+    assert GRAPHITI_CHAT_MODEL == "openrouter:openai.gpt-5-mini"
+    assert GRAPHITI_EMBEDDING_MODEL == "openrouter:openai.text-embedding-3-large"
+    assert WRITER_MODEL == "openrouter:x-ai.grok-4.6"
+    assert EVALUATION_GRAPHITI_PACKET.model_release == GRAPHITI_CHAT_MODEL
+    assert "placeholder" not in EVALUATION_GRAPHITI_PACKET.framework_release
     assert EVALUATION_WORKSPACE_POLICY.egress_policy is GraphitiEgressPolicy.APPROVED_PROVIDER_ONLY
     assert (
         EVALUATION_WORKSPACE_POLICY.credential_class
@@ -330,3 +337,74 @@ def test_intake_fetches_when_gates_pass(tmp_path: Path) -> None:
     assert report.authorised
     assert report.sources == 10
     assert report.ok == 10
+
+
+def test_openrouter_writer_does_not_call_graphiti() -> None:
+    from newsroom.control_plane.editorial import (
+        DiscoverySignalRecord,
+        NewsLeadRecord,
+        StoryCandidateRecord,
+    )
+    from newsroom.control_plane.evidence import EvidencePackage
+
+    seen: dict[str, str] = {}
+
+    def post(*, prompt: str, api_key: str) -> str:
+        seen["prompt"] = prompt
+        seen["api_key"] = api_key
+        return json.dumps(
+                {"title": "【未出版】測試稿", "body": "【未出版原創】根據證據包改寫，唔係來源標題複本。"}
+        )
+
+    writer = OpenRouterWriter(post=post, api_key=lambda: "test-openrouter-token")
+    candidate = StoryCandidateRecord(
+        candidate_id="c1",
+        hypothesis_id="h1",
+        headline="Home Office update",
+        items=parse_observation(
+            source_id="UK-01", url="https://www.gov.uk/search/all.atom", body=ATOM
+        ),
+        signals=(
+            DiscoverySignalRecord(
+                signal_id="s1",
+                source_id="UK-01",
+                item_key="k",
+                observation_digest="sha256:" + ("b" * 64),
+            ),
+        ),
+        leads=(NewsLeadRecord(lead_id="l1", signal_id="s1", headline="Home Office update"),),
+    )
+    package = EvidencePackage(
+        candidate_id="c1",
+        hypothesis_id="h1",
+        signal_ids=("s1",),
+        lead_ids=("l1",),
+        source_ids=("UK-01",),
+        observation_digests=("sha256:" + ("b" * 64),),
+        passages=("UK-01: retained",),
+    )
+    copy = writer.write(candidate, package)
+    assert copy.writer_id.startswith("openrouter-")
+    assert copy.title.startswith("【未出版】")
+    assert "來源標題複本" in copy.body
+    assert seen["api_key"] == "test-openrouter-token"
+    assert "Graphiti" in seen["prompt"]
+
+
+def test_broker_error_does_not_include_secret(monkeypatch) -> None:
+    from newsroom.control_plane import broker
+
+    class Result:
+        returncode = 1
+        stdout = "super-secret-openrouter-key\n"
+        stderr = "not found"
+
+    monkeypatch.setattr(
+        broker.subprocess,
+        "run",
+        lambda *args, **kwargs: Result(),
+    )
+    with pytest.raises(broker.BrokerError, match="OPENROUTER_API is absent") as caught:
+        broker.openrouter_api_key()
+    assert "super-secret-openrouter-key" not in str(caught.value)
+


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: private-unpublished-openrouter-route
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: delete-after-merge

## Summary
- Metered Graphiti chat/embeddings and the CONT writer use OpenRouter (`OPENROUTER_API` in Keychain service `newsroom.shadow.v1`).
- Writer model is `x-ai/grok-4.6` via `https://openrouter.ai/api/v1`. Graphiti chat/embeddings remain `openai/gpt-5-mini` and `openai/text-embedding-3-large` through the same host.
- Direct OpenAI hosts and the Grok Build TUI are not this beta’s live route. 9P proving still must not call OpenRouter. The Graphiti real-runtime flag stays false.

## Exact state

```text
base: origin/main 3821298
head: feat/openrouter-evaluation-route bdb8903
tree: bdb8903228397f93f7fdfa43ea882274cbf194f1
commits over base: 1
changed files: 4
```

## Test plan
- [x] `uv run pytest newsroom/tests/test_control_plane_private_beta.py -v` (11 passed)
- [ ] Fast CI on this head

## Non-effects
Does not flip `REAL_GRAPHITI_RUNTIME_ENABLED`, install `graphiti-core`, call OpenRouter from 9P proving, enable AUTO_PUBLISH, or mint a public TargetOperation.
