### PR TITLE
Prove OpenRouter and Neo4j Keychain injection on this host

### DIFF
--- a/newsroom/control_plane/broker.py
+++ b/newsroom/control_plane/broker.py
@@ -2,14 +2,42 @@
 
 from __future__ import annotations
 
+import json
+import shutil
+import socket
 import subprocess
+import urllib.error
+import urllib.request
+from typing import Final
+
+from newsroom.graphiti_adapter.evaluation_packet import OPENROUTER_BASE_URL
 
 OPENROUTER_ACCOUNT = "OPENROUTER_API"
 OPENROUTER_SERVICE = "newsroom.shadow.v1"
+NEO4J_ACCOUNT = "newsroom"
+NEO4J_SERVICE = "NEO4J_COMMUNITY_LOCAL"
+NEO4J_BOLT_HOST = "127.0.0.1"
+NEO4J_BOLT_PORT = 7687
+_MIN_SECRET_CHARS = 20
+OPENROUTER_KEYCHAIN_SKIP: Final[str] = "OPENROUTER_API Keychain class not on this host"
+NEO4J_KEYCHAIN_SKIP: Final[str] = "NEO4J_COMMUNITY_LOCAL Keychain class not on this host"
 
 
 class BrokerError(RuntimeError):
     """Credential injection failed closed."""
+
+
+def keychain_present(*, account: str, service: str) -> bool:
+    if shutil.which("security") is None:
+        return False
+    result = subprocess.run(
+        ["security", "find-generic-password", "-a", account, "-s", service],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    return result.returncode == 0
 
 
 def _keychain_password(*, account: str, service: str) -> str:
@@ -31,10 +59,80 @@ def _keychain_password(*, account: str, service: str) -> str:
     if result.returncode != 0:
         raise BrokerError(f"Keychain class {account} is absent")
     secret = result.stdout.strip()
-    if not secret:
+    if len(secret) < _MIN_SECRET_CHARS:
         raise BrokerError(f"Keychain class {account} is empty")
     return secret
 
 
+def _secret_shape(secret: str) -> str:
+    if len(secret) < _MIN_SECRET_CHARS:
+        return "too_short"
+    if secret.startswith("sk-"):
+        return "ok"
+    return "bad_prefix"
+
+
 def openrouter_api_key() -> str:
     return _keychain_password(account=OPENROUTER_ACCOUNT, service=OPENROUTER_SERVICE)
+
+
+def neo4j_community_password() -> str:
+    return _keychain_password(account=NEO4J_ACCOUNT, service=NEO4J_SERVICE)
+
+
+def openrouter_keychain_ready() -> bool:
+    return keychain_present(account=OPENROUTER_ACCOUNT, service=OPENROUTER_SERVICE)
+
+
+def neo4j_keychain_ready() -> bool:
+    return keychain_present(account=NEO4J_ACCOUNT, service=NEO4J_SERVICE)
+
+
+def prove_openrouter_keychain() -> None:
+    """Inject OPENROUTER_API and confirm OpenRouter accepts it. Never logs the secret."""
+    secret = openrouter_api_key()
+    if _secret_shape(secret) != "ok":
+        raise BrokerError("OPENROUTER_API Keychain secret has an invalid shape")
+    request = urllib.request.Request(
+        f"{OPENROUTER_BASE_URL}/key",
+        method="GET",
+        headers={"Authorization": f"Bearer {secret}"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:
+            status = response.status
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        raise BrokerError(
+            f"OpenRouter rejected Keychain OPENROUTER_API HTTP {exc.code}"
+        ) from None
+    except urllib.error.URLError as exc:
+        raise BrokerError("OpenRouter Keychain probe could not reach openrouter.ai") from exc
+    if status != 200 or not isinstance(payload, dict):
+        raise BrokerError("OpenRouter Keychain probe returned a malformed body")
+
+
+def prove_neo4j_keychain() -> None:
+    """Inject NEO4J_COMMUNITY_LOCAL and confirm Bolt accepts it. Never logs the secret."""
+    password = neo4j_community_password()
+    try:
+        socket.create_connection((NEO4J_BOLT_HOST, NEO4J_BOLT_PORT), timeout=3).close()
+    except OSError as exc:
+        raise BrokerError("Neo4j Bolt is not listening on 127.0.0.1:7687") from exc
+    from neo4j import GraphDatabase
+
+    driver = GraphDatabase.driver(
+        f"bolt://{NEO4J_BOLT_HOST}:{NEO4J_BOLT_PORT}",
+        auth=("neo4j", password),
+    )
+    try:
+        with driver.session() as session:
+            value = session.run("RETURN 1 AS n").single()
+            if value is None or int(value["n"]) != 1:
+                raise BrokerError("Neo4j Keychain probe query failed")
+    except Exception as exc:
+        if isinstance(exc, BrokerError):
+            raise
+        raise BrokerError("Neo4j rejected Keychain NEO4J_COMMUNITY_LOCAL") from None
+    finally:
+        driver.close()

--- a/newsroom/tests/test_control_plane_keychain.py
+++ b/newsroom/tests/test_control_plane_keychain.py
@@ -1,0 +1,24 @@
+"""Host Keychain probes. Skip on CI hosts without the classes. Never print secrets."""
+
+from __future__ import annotations
+
+import pytest
+
+from newsroom.control_plane.broker import (
+    NEO4J_KEYCHAIN_SKIP,
+    OPENROUTER_KEYCHAIN_SKIP,
+    neo4j_keychain_ready,
+    openrouter_keychain_ready,
+    prove_neo4j_keychain,
+    prove_openrouter_keychain,
+)
+
+
+@pytest.mark.skipif(not openrouter_keychain_ready(), reason=OPENROUTER_KEYCHAIN_SKIP)
+def test_openrouter_keychain_injects_and_is_accepted() -> None:
+    prove_openrouter_keychain()
+
+
+@pytest.mark.skipif(not neo4j_keychain_ready(), reason=NEO4J_KEYCHAIN_SKIP)
+def test_neo4j_keychain_injects_and_bolt_accepts() -> None:
+    prove_neo4j_keychain()


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: private-unpublished-keychain-probe
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: delete-after-merge

## Summary
- Adds host probes that inject `OPENROUTER_API` and `NEO4J_COMMUNITY_LOCAL` from Keychain and confirm OpenRouter / Bolt accept them.
- Failures report HTTP/Bolt status only. Secret bytes never enter assertions or exception text.
- CI without macOS `security` skips.

## Exact state

```text
base: origin/main 211cea3
head: feat/openrouter-keychain-probe c2945e5
tree: c2945e548bab694f8dca1a424e5fc60ce62ba6e4
commits over base: 1
changed files: 2
```

## Test plan
- [x] `uv run pytest newsroom/tests/test_control_plane_keychain.py -v` (2 passed on macm4)
- [ ] Fast CI skip path on Linux

## Non-effects
Does not flip `REAL_GRAPHITI_RUNTIME_ENABLED`, print Keychain secrets, or call OpenRouter from 9P proving.
