### PR TITLE
Route unpublished CONT writer through Grok Build CLI

### DIFF
--- a/newsroom/control_plane/writer.py
+++ b/newsroom/control_plane/writer.py
@@ -1,22 +1,22 @@
-"""CONT writer port. Graphiti is never the writer. Live copy uses OpenRouter."""
+"""CONT writer: Grok Build CLI, then cursor-agent CLI. Graphiti is never the writer."""
 
 from __future__ import annotations
 
 import json
 import os
-import urllib.error
-import urllib.request
+import shutil
+import subprocess
+import tempfile
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Callable, Protocol
 
-from newsroom.control_plane.broker import openrouter_api_key
 from newsroom.control_plane.editorial import StoryCandidateRecord
 from newsroom.control_plane.evidence import EvidencePackage
-from newsroom.graphiti_adapter.evaluation_packet import (
-    OPENROUTER_BASE_URL,
-    OPENROUTER_WRITER_SLUG,
-)
 
+GROK_BIN = os.environ.get("NEWSROOM_GROK_BIN", "/Users/jamesto/.grok/bin/grok")
+CURSOR_AGENT_BIN = os.environ.get(
+    "NEWSROOM_CURSOR_AGENT_BIN", "/Users/jamesto/.local/bin/cursor-agent"
+)
 WRITER_SCHEMA = {
     "type": "object",
     "properties": {
@@ -26,6 +26,12 @@ WRITER_SCHEMA = {
     "required": ["title", "body"],
     "additionalProperties": False,
 }
+_PROMPT = (
+    "你係 Newsroom 嘅 CONT 原創記者，唔係 Graphiti。"
+    "用香港繁體中文寫一篇未出版新聞稿。必須原創改寫，唔好複製來源標題或 dateline 模板。"
+    "唔准 AUTO_PUBLISH，唔准當公開發行。"
+    "只輸出 JSON 物件，欄位 title 同 body。"
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -44,8 +50,6 @@ class WriterPort(Protocol):
 
 
 class FixtureWriter:
-    """Deterministic evaluation writer. Not live OpenRouter. Not Graphiti."""
-
     writer_id = "evaluation-fixture-writer-v1"
 
     def write(
@@ -65,8 +69,23 @@ class FixtureWriter:
         )
 
 
+def _prompt(candidate: StoryCandidateRecord, package: EvidencePackage) -> str:
+    return (
+        f"{_PROMPT}\n題旨：{candidate.headline}\n證據：\n"
+        + "\n---\n".join(package.passages)
+    )
+
+
+def _extract_json(raw: str) -> str:
+    start = raw.find("{")
+    end = raw.rfind("}")
+    if start < 0 or end <= start:
+        raise RuntimeError("writer returned no JSON object")
+    return raw[start : end + 1]
+
+
 def _parse_copy(raw: str) -> tuple[str, str]:
-    payload = json.loads(raw)
+    payload = json.loads(_extract_json(raw))
     title = payload.get("title")
     body = payload.get("body")
     if not isinstance(title, str) or not isinstance(body, str):
@@ -74,68 +93,134 @@ def _parse_copy(raw: str) -> tuple[str, str]:
     return title.strip(), body.strip()
 
 
-class OpenRouterWriter:
-    """CONT writer via OpenRouter `x-ai/grok-4.6`. Injects OPENROUTER_API only."""
+def _run(command: tuple[str, ...], *, timeout: int) -> str:
+    result = subprocess.run(
+        command,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if result.returncode != 0:
+        name = os.path.basename(command[0])
+        raise RuntimeError(f"{name} writer failed")
+    if not result.stdout.strip():
+        raise RuntimeError("writer returned empty stdout")
+    return result.stdout
 
-    writer_id = "openrouter-x-ai.grok-4.6-cont-writer"
 
-    def __init__(self, *, post=None, api_key=None) -> None:
-        self._post = post or _openrouter_chat
-        self._api_key = api_key
+def run_grok_cli(prompt: str) -> str:
+    schema = json.dumps(WRITER_SCHEMA, ensure_ascii=False)
+    with tempfile.NamedTemporaryFile(
+        "w", encoding="utf-8", suffix=".txt", delete=False
+    ) as handle:
+        handle.write(prompt)
+        path = handle.name
+    try:
+        return _run(
+            (
+                GROK_BIN,
+                "--prompt-file",
+                path,
+                "-m",
+                "grok-4.6",
+                "--json-schema",
+                schema,
+                "--disable-web-search",
+                "--permission-mode",
+                "plan",
+                "--max-turns",
+                "1",
+                "--no-subagents",
+            ),
+            timeout=180,
+        )
+    finally:
+        os.unlink(path)
+
+
+def run_cursor_agent_cli(prompt: str) -> str:
+    return _run(
+        (
+            CURSOR_AGENT_BIN,
+            "--print",
+            "--mode",
+            "ask",
+            "--output-format",
+            "text",
+            "--sandbox",
+            "enabled",
+            "--trust",
+            prompt,
+        ),
+        timeout=180,
+    )
+
+
+class CliChainWriter:
+    """Primary: Grok Build CLI. Fallback: cursor-agent CLI."""
+
+    writer_id = "grok-build-cli-cont-writer"
+
+    def __init__(
+        self,
+        *,
+        primary: Callable[[str], str] | None = None,
+        fallback: Callable[[str], str] | None = None,
+    ) -> None:
+        self._primary = primary or run_grok_cli
+        self._fallback = fallback or run_cursor_agent_cli
 
     def write(
         self, candidate: StoryCandidateRecord, package: EvidencePackage
     ) -> WriterCopy:
-        prompt = (
-            "你係 Newsroom 嘅 CONT 原創記者，唔係 Graphiti。"
-            "用香港繁體中文寫一篇未出版新聞稿。必須原創改寫，唔好複製來源標題或 dateline 模板。"
-            "唔准 AUTO_PUBLISH，唔准當公開發行。"
-            "只輸出 JSON 物件，欄位 title 同 body。"
-            f"\n題旨：{candidate.headline}\n證據：\n"
-            + "\n---\n".join(package.passages)
-        )
-        secret = self._api_key() if self._api_key else openrouter_api_key()
-        raw = self._post(prompt=prompt, api_key=secret)
-        title, body = _parse_copy(raw)
-        return WriterCopy(title=title, body=body, writer_id=self.writer_id)
+        prompt = _prompt(candidate, package)
+        try:
+            title, body = _parse_copy(self._primary(prompt))
+            return WriterCopy(title=title, body=body, writer_id=self.writer_id)
+        except (RuntimeError, json.JSONDecodeError, OSError, subprocess.TimeoutExpired):
+            title, body = _parse_copy(self._fallback(prompt))
+            return WriterCopy(
+                title=title,
+                body=body,
+                writer_id="cursor-agent-cli-cont-writer",
+            )
 
 
-def _openrouter_chat(*, prompt: str, api_key: str) -> str:
-    payload = json.dumps(
-        {
-            "model": OPENROUTER_WRITER_SLUG,
-            "messages": [{"role": "user", "content": prompt}],
-            "response_format": {"type": "json_object"},
-        }
-    ).encode("utf-8")
-    request = urllib.request.Request(
-        f"{OPENROUTER_BASE_URL}/chat/completions",
-        data=payload,
-        method="POST",
-        headers={
-            "Authorization": f"Bearer {api_key}",
-            "Content-Type": "application/json",
-            "HTTP-Referer": "https://github.com/fol2/newsroom",
-            "X-Title": "newsroom-unpublished-beta",
-        },
+def grok_cli_ready() -> bool:
+    return shutil.which(GROK_BIN) is not None or os.path.isfile(GROK_BIN)
+
+
+def cursor_agent_cli_ready() -> bool:
+    return shutil.which(CURSOR_AGENT_BIN) is not None or os.path.isfile(CURSOR_AGENT_BIN)
+
+
+def prove_grok_cli() -> None:
+    result = subprocess.run(
+        (GROK_BIN, "version"),
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=20,
     )
-    try:
-        with urllib.request.urlopen(request, timeout=120) as response:
-            body = json.loads(response.read().decode("utf-8"))
-    except urllib.error.HTTPError as exc:
-        raise RuntimeError(f"OpenRouter writer HTTP {exc.code}") from exc
-    choices = body.get("choices")
-    if not isinstance(choices, list) or not choices:
-        raise RuntimeError("OpenRouter writer returned no choices")
-    message = choices[0].get("message") if isinstance(choices[0], dict) else None
-    content = message.get("content") if isinstance(message, dict) else None
-    if not isinstance(content, str) or not content.strip():
-        raise RuntimeError("OpenRouter writer returned empty content")
-    return content
+    if result.returncode != 0 or "grok" not in result.stdout.lower():
+        raise RuntimeError("Grok Build CLI is not logged in or not runnable")
+
+
+def prove_cursor_agent_cli() -> None:
+    result = subprocess.run(
+        (CURSOR_AGENT_BIN, "--list-models"),
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    if result.returncode != 0 or "Available models" not in result.stdout:
+        raise RuntimeError("cursor-agent CLI is not logged in or not runnable")
 
 
 def default_writer() -> WriterPort:
-    name = os.environ.get("NEWSROOM_WRITER", "openrouter").strip().lower()
+    name = os.environ.get("NEWSROOM_WRITER", "grok").strip().lower()
     if name == "fixture":
         return FixtureWriter()
-    return OpenRouterWriter()
+    return CliChainWriter()

--- a/newsroom/graphiti_adapter/evaluation_packet.py
+++ b/newsroom/graphiti_adapter/evaluation_packet.py
@@ -1,9 +1,9 @@
 """EVALUATION packet for the private unpublished GraphRAG beta.
 
-Metered model and embedding calls use OpenRouter (`OPENROUTER_API`).
-Does not flip REAL_GRAPHITI_RUNTIME_ENABLED. Completeness of this packet is
-not execution authority (#700). Increment 9P proving still must not call
-OpenRouter (`OPENROUTER_UNUSED`).
+Metered Graphiti chat and embedding calls use OpenRouter (`OPENROUTER_API`).
+The CONT writer is Grok Build CLI (`grok-4.6`), with cursor-agent CLI fallback.
+Does not flip REAL_GRAPHITI_RUNTIME_ENABLED. Increment 9P proving still must not
+call OpenRouter (`OPENROUTER_UNUSED`).
 """
 
 from __future__ import annotations
@@ -26,10 +26,10 @@ from newsroom.graphiti_adapter.types import (
 GRAPHITI_CORE_RELEASE = "graphiti-core-0.29.3"
 GRAPHITI_CHAT_MODEL = "openrouter:openai.gpt-5-mini"
 GRAPHITI_EMBEDDING_MODEL = "openrouter:openai.text-embedding-3-large"
-WRITER_MODEL = "openrouter:x-ai.grok-4.6"
+WRITER_MODEL = "grok-build-cli:grok-4.6"
+WRITER_FALLBACK = "cursor-agent-cli"
 OPENROUTER_CHAT_SLUG = "openai/gpt-5-mini"
 OPENROUTER_EMBEDDING_SLUG = "openai/text-embedding-3-large"
-OPENROUTER_WRITER_SLUG = "x-ai/grok-4.6"
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 GRAPHITI_WORKSPACE_GROUP = "newsroom-eval-proposal"
 OPENROUTER_API = "OPENROUTER_API"
@@ -82,6 +82,7 @@ EVALUATION_GRAPHITI_PACKET = RealGraphitiRuntimeAuthority(
             "metered_api": OPENROUTER_API,
             "keychain_service": OPENROUTER_KEYCHAIN_SERVICE,
             "writer": WRITER_MODEL,
+            "writer_fallback": WRITER_FALLBACK,
             "neo4j": NEO4J_COMMUNITY_LOCAL,
         }
     ),
@@ -122,6 +123,7 @@ EVALUATION_GRAPHITI_PACKET = RealGraphitiRuntimeAuthority(
             "od_011_cash_ceiling_gbp": OD_011_CASH_CEILING_GBP,
             "pre_spend": False,
             "provider": OPENROUTER_API,
+            "writer_subscription_not_debited": True,
         }
     ),
     evaluation_plan_digest=_digest(

--- a/newsroom/tests/test_control_plane_keychain.py
+++ b/newsroom/tests/test_control_plane_keychain.py
@@ -12,6 +12,22 @@ from newsroom.control_plane.broker import (
     prove_neo4j_keychain,
     prove_openrouter_keychain,
 )
+from newsroom.control_plane.writer import (
+    cursor_agent_cli_ready,
+    grok_cli_ready,
+    prove_cursor_agent_cli,
+    prove_grok_cli,
+)
+
+
+@pytest.mark.skipif(not grok_cli_ready(), reason="Grok Build CLI not on this host")
+def test_grok_build_cli_is_logged_in() -> None:
+    prove_grok_cli()
+
+
+@pytest.mark.skipif(not cursor_agent_cli_ready(), reason="cursor-agent CLI not on this host")
+def test_cursor_agent_cli_is_logged_in() -> None:
+    prove_cursor_agent_cli()
 
 
 @pytest.mark.skipif(not openrouter_keychain_ready(), reason=OPENROUTER_KEYCHAIN_SKIP)

--- a/newsroom/tests/test_control_plane_private_beta.py
+++ b/newsroom/tests/test_control_plane_private_beta.py
@@ -10,7 +10,7 @@ from newsroom.control_plane.reports import news_report
 from newsroom.control_plane.store import connect, list_payloads, mark_public_dispatch
 from newsroom.control_plane.surface import UnpublishedSurfacePayload
 from newsroom.control_plane.veto import VetoError, refuse_public_effect
-from newsroom.control_plane.writer import FixtureWriter, OpenRouterWriter
+from newsroom.control_plane.writer import CliChainWriter, FixtureWriter
 from newsroom.graphiti_adapter.evaluation_packet import (
     EVALUATION_GRAPHITI_PACKET,
     EVALUATION_WORKSPACE_POLICY,
@@ -18,6 +18,7 @@ from newsroom.graphiti_adapter.evaluation_packet import (
     GRAPHITI_CORE_RELEASE,
     GRAPHITI_EMBEDDING_MODEL,
     OPENROUTER_API,
+    WRITER_FALLBACK,
     WRITER_MODEL,
 )
 from newsroom.graphiti_adapter.models import REAL_GRAPHITI_RUNTIME_ENABLED
@@ -285,7 +286,8 @@ def test_evaluation_packet_is_real_but_flag_stays_false() -> None:
     assert OPENROUTER_API == "OPENROUTER_API"
     assert GRAPHITI_CHAT_MODEL == "openrouter:openai.gpt-5-mini"
     assert GRAPHITI_EMBEDDING_MODEL == "openrouter:openai.text-embedding-3-large"
-    assert WRITER_MODEL == "openrouter:x-ai.grok-4.6"
+    assert WRITER_MODEL == "grok-build-cli:grok-4.6"
+    assert WRITER_FALLBACK == "cursor-agent-cli"
     assert EVALUATION_GRAPHITI_PACKET.model_release == GRAPHITI_CHAT_MODEL
     assert "placeholder" not in EVALUATION_GRAPHITI_PACKET.framework_release
     assert EVALUATION_WORKSPACE_POLICY.egress_policy is GraphitiEgressPolicy.APPROVED_PROVIDER_ONLY
@@ -339,7 +341,7 @@ def test_intake_fetches_when_gates_pass(tmp_path: Path) -> None:
     assert report.ok == 10
 
 
-def test_openrouter_writer_does_not_call_graphiti() -> None:
+def _sample_candidate_package():
     from newsroom.control_plane.editorial import (
         DiscoverySignalRecord,
         NewsLeadRecord,
@@ -347,16 +349,6 @@ def test_openrouter_writer_does_not_call_graphiti() -> None:
     )
     from newsroom.control_plane.evidence import EvidencePackage
 
-    seen: dict[str, str] = {}
-
-    def post(*, prompt: str, api_key: str) -> str:
-        seen["prompt"] = prompt
-        seen["api_key"] = api_key
-        return json.dumps(
-                {"title": "【未出版】測試稿", "body": "【未出版原創】根據證據包改寫，唔係來源標題複本。"}
-        )
-
-    writer = OpenRouterWriter(post=post, api_key=lambda: "test-openrouter-token")
     candidate = StoryCandidateRecord(
         candidate_id="c1",
         hypothesis_id="h1",
@@ -383,12 +375,35 @@ def test_openrouter_writer_does_not_call_graphiti() -> None:
         observation_digests=("sha256:" + ("b" * 64),),
         passages=("UK-01: retained",),
     )
-    copy = writer.write(candidate, package)
-    assert copy.writer_id.startswith("openrouter-")
+    return candidate, package
+
+
+def test_cli_writer_uses_grok_then_falls_back_to_cursor_agent() -> None:
+    def grok(_prompt: str) -> str:
+        raise RuntimeError("grok writer failed")
+
+    def cursor(_prompt: str) -> str:
+        return json.dumps(
+            {"title": "【未出版】測試稿", "body": "【未出版原創】根據證據包改寫，唔係來源標題複本。"}
+        )
+
+    copy = CliChainWriter(primary=grok, fallback=cursor).write(*_sample_candidate_package())
+    assert copy.writer_id == "cursor-agent-cli-cont-writer"
     assert copy.title.startswith("【未出版】")
-    assert "來源標題複本" in copy.body
-    assert seen["api_key"] == "test-openrouter-token"
-    assert "Graphiti" in seen["prompt"]
+
+
+def test_cli_writer_prefers_grok_build_cli() -> None:
+    def grok(_prompt: str) -> str:
+        return json.dumps(
+            {"title": "【未出版】Grok稿", "body": "【未出版原創】Grok Build CLI 正文。"}
+        )
+
+    def cursor(_prompt: str) -> str:
+        raise AssertionError("fallback must not run")
+
+    copy = CliChainWriter(primary=grok, fallback=cursor).write(*_sample_candidate_package())
+    assert copy.writer_id == "grok-build-cli-cont-writer"
+    assert "Grok" in copy.title
 
 
 def test_broker_error_does_not_include_secret(monkeypatch) -> None:


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: private-unpublished-cli-cont-writer
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: delete-after-merge

## Summary
- Replace the OpenRouter CONT writer with Grok Build CLI (`grok-4.6`), falling back to cursor-agent CLI in ask/sandbox mode.
- OpenRouter remains the metered Graphiti chat/embedding path only. Writer spend stays on the logged-in CLIs.
- Host probes skip on CI without the CLIs; they never print secrets.

## Exact state

```text
base: origin/main aadf73b
head: feat/cli-cont-writer 6a6998f
tree: a85da61b7ed1f02699d91b05fcd47c04f1689c78
commits over base: 1
changed files: 4
```

## Test plan
- [x] `uv run pytest newsroom/tests/test_control_plane_private_beta.py newsroom/tests/test_control_plane_keychain.py -v` (16 passed on macm4, including grok/cursor-agent login probes)
- [ ] Fast CI skip path on Linux

## Non-effects
Does not flip `REAL_GRAPHITI_RUNTIME_ENABLED`, call OpenRouter from 9P proving, use cursor-agent `--force`/`--yolo`, or mint a public TargetOperation.


Made with [Cursor](https://cursor.com)