### PR TITLE
Parse Grok CLI envelopes for unpublished CONT copy

### DIFF
--- a/newsroom/control_plane/writer.py
+++ b/newsroom/control_plane/writer.py
@@ -84,25 +84,46 @@ def _extract_json(raw: str) -> str:
     return raw[start : end + 1]
 
 
-def _parse_copy(raw: str) -> tuple[str, str]:
-    payload = json.loads(_extract_json(raw))
+def _copy_fields(payload: object) -> tuple[str, str] | None:
+    if not isinstance(payload, dict):
+        return None
     title = payload.get("title")
     body = payload.get("body")
-    if not isinstance(title, str) or not isinstance(body, str):
-        raise RuntimeError("writer JSON missing title or body")
-    return title.strip(), body.strip()
+    if isinstance(title, str) and isinstance(body, str):
+        return title.strip(), body.strip()
+    return None
+
+
+def _parse_copy(raw: str) -> tuple[str, str]:
+    payload = json.loads(_extract_json(raw))
+    found = _copy_fields(payload)
+    if found:
+        return found
+    for key in ("structured_output", "structuredOutput"):
+        found = _copy_fields(payload.get(key))
+        if found:
+            return found
+    text = payload.get("text")
+    if isinstance(text, str) and text.strip():
+        found = _copy_fields(json.loads(_extract_json(text)))
+        if found:
+            return found
+    raise RuntimeError("writer JSON missing title or body")
 
 
 def _run(command: tuple[str, ...], *, timeout: int) -> str:
-    result = subprocess.run(
-        command,
-        check=False,
-        capture_output=True,
-        text=True,
-        timeout=timeout,
-    )
+    name = os.path.basename(command[0])
+    try:
+        result = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        raise RuntimeError(f"{name} writer timed out") from None
     if result.returncode != 0:
-        name = os.path.basename(command[0])
         raise RuntimeError(f"{name} writer failed")
     if not result.stdout.strip():
         raise RuntimeError("writer returned empty stdout")
@@ -127,8 +148,7 @@ def run_grok_cli(prompt: str) -> str:
                 "--json-schema",
                 schema,
                 "--disable-web-search",
-                "--permission-mode",
-                "plan",
+                "--no-plan",
                 "--max-turns",
                 "1",
                 "--no-subagents",

--- a/newsroom/tests/test_control_plane_private_beta.py
+++ b/newsroom/tests/test_control_plane_private_beta.py
@@ -395,7 +395,13 @@ def test_cli_writer_uses_grok_then_falls_back_to_cursor_agent() -> None:
 def test_cli_writer_prefers_grok_build_cli() -> None:
     def grok(_prompt: str) -> str:
         return json.dumps(
-            {"title": "【未出版】Grok稿", "body": "【未出版原創】Grok Build CLI 正文。"}
+            {
+                "text": "",
+                "structured_output": {
+                    "title": "【未出版】Grok稿",
+                    "body": "【未出版原創】Grok Build CLI 正文。",
+                },
+            }
         )
 
     def cursor(_prompt: str) -> str:
@@ -404,6 +410,24 @@ def test_cli_writer_prefers_grok_build_cli() -> None:
     copy = CliChainWriter(primary=grok, fallback=cursor).write(*_sample_candidate_package())
     assert copy.writer_id == "grok-build-cli-cont-writer"
     assert "Grok" in copy.title
+
+
+def test_cli_writer_reads_title_from_grok_text_envelope() -> None:
+    def grok(_prompt: str) -> str:
+        return json.dumps(
+            {
+                "text": json.dumps(
+                    {"title": "【未出版】信封稿", "body": "【未出版原創】text 欄。"},
+                    ensure_ascii=False,
+                )
+            }
+        )
+
+    def cursor(_prompt: str) -> str:
+        raise AssertionError("fallback must not run")
+
+    copy = CliChainWriter(primary=grok, fallback=cursor).write(*_sample_candidate_package())
+    assert copy.title == "【未出版】信封稿"
 
 
 def test_broker_error_does_not_include_secret(monkeypatch) -> None:


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: private-unpublished-cli-writer-envelope
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: delete-after-merge

## Summary
- Parse Grok Build CLI headless JSON (`structured_output` / `text`) instead of requiring a bare `title`/`body` object.
- Drop `--permission-mode plan` in favour of `--no-plan` so the writer emits copy, not a plan.
- Timeouts raise a short RuntimeError so prompts do not land in the LaunchAgent error log.

## Exact state

```text
base: origin/main 86d78ac
head: feat/cli-writer-envelope 7ecfe36
tree: 1a4d7e46a94b4366484f0e8322b5b203eee1b91a
commits over base: 1
changed files: 2
```

## Test plan
- [x] `uv run pytest newsroom/tests/test_control_plane_private_beta.py newsroom/tests/test_control_plane_keychain.py -q` (17 passed)
- [ ] Fast CI skip path on Linux

## Non-effects
Does not flip `REAL_GRAPHITI_RUNTIME_ENABLED`, call OpenRouter from 9P proving, or use cursor-agent `--force`/`--yolo`.


Made with [Cursor](https://cursor.com)