### PR TITLE
Keep minting unpublished copy and reject Grok planning residue

### DIFF
--- a/newsroom/control_plane/cycle.py
+++ b/newsroom/control_plane/cycle.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -11,7 +12,7 @@ from newsroom.control_plane.evidence import package_for
 from newsroom.control_plane.items import parse_observation
 from newsroom.control_plane.store import append_ledger, connect, has_candidate, insert_payload
 from newsroom.control_plane.surface import UnpublishedSurfacePayload
-from newsroom.control_plane.veto import assert_private_store
+from newsroom.control_plane.veto import VetoError, assert_private_store
 from newsroom.control_plane.writer import WriterPort
 from newsroom.increment9.proving import FORBIDDEN_STORE_MARKERS
 
@@ -104,22 +105,29 @@ def run_cycle(
                 duplicate += 1
                 continue
             package = package_for(candidate)
-            copy = writer.write(candidate, package)
-            payload = UnpublishedSurfacePayload(
-                payload_kind="unpublished_surface_payload",
-                publication_bundle=False,
-                auto_publish=False,
-                language="ZH_HANT_HK",
-                title=copy.title,
-                body=copy.body,
-                evidence_package_digest=package.digest,
-                story_candidate_id=candidate.candidate_id,
-                event_hypothesis_id=candidate.hypothesis_id,
-                source_lineage=tuple(sorted({item.source_id for item in candidate.items})),
-                generated_at=_now(),
-                status="UNPUBLISHED",
-                writer_id=copy.writer_id,
-            )
+            try:
+                copy = writer.write(candidate, package)
+                payload = UnpublishedSurfacePayload(
+                    payload_kind="unpublished_surface_payload",
+                    publication_bundle=False,
+                    auto_publish=False,
+                    language="ZH_HANT_HK",
+                    title=copy.title,
+                    body=copy.body,
+                    evidence_package_digest=package.digest,
+                    story_candidate_id=candidate.candidate_id,
+                    event_hypothesis_id=candidate.hypothesis_id,
+                    source_lineage=tuple(
+                        sorted({item.source_id for item in candidate.items})
+                    ),
+                    generated_at=_now(),
+                    status="UNPUBLISHED",
+                    writer_id=copy.writer_id,
+                )
+            except VetoError:
+                raise
+            except (RuntimeError, ValueError, OSError, json.JSONDecodeError):
+                continue
             if insert_payload(unpublished, payload):
                 minted += 1
             else:

--- a/newsroom/control_plane/writer.py
+++ b/newsroom/control_plane/writer.py
@@ -28,10 +28,14 @@ WRITER_SCHEMA = {
 }
 _PROMPT = (
     "你係 Newsroom 嘅 CONT 原創記者，唔係 Graphiti。"
-    "用香港繁體中文寫一篇未出版新聞稿。必須原創改寫，唔好複製來源標題或 dateline 模板。"
+    "用香港繁體中文寫一篇已經完成嘅未出版新聞稿。"
+    "JSON 嘅 title 同 body 必須係完稿正文，唔係計劃、核對清單、任務說明或工作備註。"
+    "禁止輸出含有「計劃」「核對」「任務」「先查」嘅標題或正文。"
+    "必須原創改寫，唔好複製來源標題或 dateline 模板。"
     "唔准 AUTO_PUBLISH，唔准當公開發行。"
     "只輸出 JSON 物件，欄位 title 同 body。"
 )
+_RESIDUE_MARKERS = ("計劃", "核對", "任務", "先查")
 
 
 @dataclass(frozen=True, slots=True)
@@ -94,24 +98,33 @@ def _copy_fields(payload: object) -> tuple[str, str] | None:
     return None
 
 
+def _finished_copy(title: str, body: str) -> tuple[str, str]:
+    if not title or not body:
+        raise RuntimeError("writer JSON missing title or body")
+    haystack = f"{title}\n{body}"
+    if any(marker in haystack for marker in _RESIDUE_MARKERS):
+        raise RuntimeError("writer returned planning residue, not unpublished copy")
+    return title, body
+
+
 def _parse_copy(raw: str) -> tuple[str, str]:
     payload = json.loads(_extract_json(raw))
     found = _copy_fields(payload)
     if found:
-        return found
+        return _finished_copy(*found)
     for key in ("structured_output", "structuredOutput"):
         found = _copy_fields(payload.get(key))
         if found:
-            return found
+            return _finished_copy(*found)
     text = payload.get("text")
     if isinstance(text, str) and text.strip():
         found = _copy_fields(json.loads(_extract_json(text)))
         if found:
-            return found
+            return _finished_copy(*found)
     raise RuntimeError("writer JSON missing title or body")
 
 
-def _run(command: tuple[str, ...], *, timeout: int) -> str:
+def _run(command: tuple[str, ...], *, timeout: int, cwd: str | None = None) -> str:
     name = os.path.basename(command[0])
     try:
         result = subprocess.run(
@@ -120,6 +133,7 @@ def _run(command: tuple[str, ...], *, timeout: int) -> str:
             capture_output=True,
             text=True,
             timeout=timeout,
+            cwd=cwd,
         )
     except subprocess.TimeoutExpired:
         raise RuntimeError(f"{name} writer timed out") from None
@@ -132,12 +146,10 @@ def _run(command: tuple[str, ...], *, timeout: int) -> str:
 
 def run_grok_cli(prompt: str) -> str:
     schema = json.dumps(WRITER_SCHEMA, ensure_ascii=False)
-    with tempfile.NamedTemporaryFile(
-        "w", encoding="utf-8", suffix=".txt", delete=False
-    ) as handle:
-        handle.write(prompt)
-        path = handle.name
-    try:
+    with tempfile.TemporaryDirectory(prefix="newsroom-grok-writer-") as cwd:
+        path = os.path.join(cwd, "prompt.txt")
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(prompt)
         return _run(
             (
                 GROK_BIN,
@@ -150,13 +162,14 @@ def run_grok_cli(prompt: str) -> str:
                 "--disable-web-search",
                 "--no-plan",
                 "--max-turns",
-                "1",
+                "3",
                 "--no-subagents",
+                "--reasoning-effort",
+                "low",
             ),
-            timeout=180,
+            timeout=300,
+            cwd=cwd,
         )
-    finally:
-        os.unlink(path)
 
 
 def run_cursor_agent_cli(prompt: str) -> str:

--- a/newsroom/tests/test_control_plane_private_beta.py
+++ b/newsroom/tests/test_control_plane_private_beta.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import json
+import os
 
 import pytest
 
@@ -10,7 +11,7 @@ from newsroom.control_plane.reports import news_report
 from newsroom.control_plane.store import connect, list_payloads, mark_public_dispatch
 from newsroom.control_plane.surface import UnpublishedSurfacePayload
 from newsroom.control_plane.veto import VetoError, refuse_public_effect
-from newsroom.control_plane.writer import CliChainWriter, FixtureWriter
+from newsroom.control_plane.writer import CliChainWriter, FixtureWriter, run_grok_cli
 from newsroom.graphiti_adapter.evaluation_packet import (
     EVALUATION_GRAPHITI_PACKET,
     EVALUATION_WORKSPACE_POLICY,
@@ -195,6 +196,38 @@ def test_cycle_mints_unpublished_payloads_with_evidence(tmp_path: Path) -> None:
     assert second.minted == 0
     assert second.duplicate == 3
     assert len(list_payloads(str(unpublished))) == 3
+
+
+def test_cycle_continues_after_one_writer_failure(tmp_path: Path) -> None:
+    proving = _proving(tmp_path)
+    unpublished = tmp_path / "unpublished_store.sqlite3"
+
+    class FlakyWriter:
+        writer_id = "test-flaky-writer"
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def write(self, candidate, package):
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError("grok writer timed out")
+            return FixtureWriter().write(candidate, package)
+
+    writer = FlakyWriter()
+    report = run_cycle(
+        proving_store=str(proving),
+        unpublished_store=str(unpublished),
+        writer=writer,
+        max_writes=10,
+    )
+    assert writer.calls >= 2
+    assert report.minted == 2
+    assert report.candidates == 3
+    payloads = list_payloads(str(unpublished))
+    assert len(payloads) == 2
+    assert all(item.auto_publish is False for item in payloads)
+    assert all(item.status == "UNPUBLISHED" for item in payloads)
 
 
 def test_same_event_url_consolidates_to_one_candidate(tmp_path: Path) -> None:
@@ -410,6 +443,64 @@ def test_cli_writer_prefers_grok_build_cli() -> None:
     copy = CliChainWriter(primary=grok, fallback=cursor).write(*_sample_candidate_package())
     assert copy.writer_id == "grok-build-cli-cont-writer"
     assert "Grok" in copy.title
+
+
+def test_cli_writer_rejects_planning_residue_and_falls_back() -> None:
+    def grok(_prompt: str) -> str:
+        return json.dumps(
+            {"title": "新聞稿任務", "body": "先查 CONT 記者稿例，再核對官方數據。"}
+        )
+
+    def cursor(_prompt: str) -> str:
+        return json.dumps(
+            {
+                "title": "【未出版】立法會教育議案",
+                "body": "【未出版原創】立法會通過教育議案，本報根據證據包改寫。",
+            },
+            ensure_ascii=False,
+        )
+
+    copy = CliChainWriter(primary=grok, fallback=cursor).write(*_sample_candidate_package())
+    assert copy.writer_id == "cursor-agent-cli-cont-writer"
+    assert copy.title == "【未出版】立法會教育議案"
+    assert "任務" not in copy.title
+    assert "先查" not in copy.body
+    assert "核對" not in copy.body
+
+
+def test_grok_cli_uses_empty_cwd_and_three_turns(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class Result:
+        returncode = 0
+        stdout = json.dumps({"title": "t", "body": "b"})
+        stderr = ""
+
+    def fake_run(command, **kwargs):
+        captured["command"] = command
+        captured["timeout"] = kwargs.get("timeout")
+        captured["cwd"] = kwargs.get("cwd")
+        captured["entries"] = os.listdir(kwargs["cwd"]) if kwargs.get("cwd") else []
+        return Result()
+
+    monkeypatch.setattr("newsroom.control_plane.writer.subprocess.run", fake_run)
+    run_grok_cli("prompt")
+    command = captured["command"]
+    assert isinstance(command, tuple)
+    assert captured["timeout"] == 300
+    assert command[command.index("--max-turns") + 1] == "3"
+    assert command[command.index("--reasoning-effort") + 1] == "low"
+    assert "--json-schema" in command
+    assert "--no-plan" in command
+    assert "--disable-web-search" in command
+    assert "--no-subagents" in command
+    assert "--always-approve" not in command
+    assert "--force" not in command
+    assert "--yolo" not in command
+    assert captured["entries"] == ["prompt.txt"]
+    cwd = captured["cwd"]
+    assert isinstance(cwd, str)
+    assert cwd != os.getcwd()
 
 
 def test_cli_writer_reads_title_from_grok_text_envelope() -> None:


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: private-unpublished-writer-loop
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: delete-after-merge

Closes #713.

## Scope

Keep the Hermes Control Plane cycle minting original unpublished Surface Payloads when one writer call fails, and refuse Grok planning residue so newsroom-hub shows finished Hong Kong Traditional Chinese copy rather than plan stubs.

## Exact state

```text
base: 60acba666909662a2ed7e6f617bf6eaa386bac9c
head: 15a18dbb18e50adaa70b504f9b6bdf086b29d65f
tree: f21473ecc203df137bae81992e9d4b0e22de8817
commits over base: 1
changed files:
  newsroom/control_plane/cycle.py
  newsroom/control_plane/writer.py
  newsroom/tests/test_control_plane_private_beta.py
```

## Verification

- `uv run pytest newsroom/tests/test_control_plane_private_beta.py -v` — 16 passed
- Fast CI on this head is a compatibility signal only; no signed exact-main closeout is claimed.

## Non-effects

- Does not flip `REAL_GRAPHITI_RUNTIME_ENABLED`.
- Does not AUTO_PUBLISH. Hub is not a Target Publication.
- Does not treat OpenRouter as a writer. Graphiti is never the writer.
- Does not use `--always-approve`, `--force`, or `--yolo`.
- Envelope parse for Grok `structured_output` / `text` is unchanged.

Made with [Cursor](https://cursor.com)