### PR TITLE
Admit Graphiti proposals into Neo4j projectors without ledger writes

### DIFF
--- a/newsroom/graphiti_adapter/__init__.py
+++ b/newsroom/graphiti_adapter/__init__.py
@@ -4,6 +4,19 @@ Real Graphiti/model execution is deliberately disabled.  The public package
 exports deterministic fake and approved replay implementations only.
 """
 
+from .admission import (
+    ADMITTED_NEO4J_LABELS,
+    ADMITTED_OD006_VECTOR_DIMENSIONS,
+    AdmittedGraphitiProjectorWrite,
+    GRAPHITI_ADMITTED_PROJECTOR_FAMILY_ID,
+    GraphitiProposalAdmissionAction,
+    GraphitiProposalAdmissionDecision,
+    GraphitiProposalAdmissionDecisionId,
+    GraphitiProposalAdmissionError,
+    admit_graphiti_proposals_for_projectors,
+    increment4_batches_for_admitted_graphiti,
+    require_admitted_projector_write,
+)
 from .contracts import (
     GRAPHITI_ADAPTER_CONTRACT_VERSION,
     GRAPHITI_ADAPTER_POLICY_VERSION,
@@ -73,9 +86,13 @@ from .types import (
 from .workspace import DisposableProposalWorkspace
 
 __all__ = [
+    "ADMITTED_NEO4J_LABELS",
+    "ADMITTED_OD006_VECTOR_DIMENSIONS",
+    "AdmittedGraphitiProjectorWrite",
     "ApprovedReplayBundle",
     "ApprovedReplayGraphitiAdapter",
     "DeterministicFakeGraphitiAdapter",
+    "GRAPHITI_ADMITTED_PROJECTOR_FAMILY_ID",
     "DisposableProposalWorkspace",
     "GRAPHITI_ADAPTER_CONTRACT_VERSION",
     "GRAPHITI_ADAPTER_POLICY_VERSION",
@@ -120,6 +137,10 @@ __all__ = [
     "GraphitiCleanupReceipt",
     "GraphitiInputManifest",
     "GraphitiManifestPassage",
+    "GraphitiProposalAdmissionAction",
+    "GraphitiProposalAdmissionDecision",
+    "GraphitiProposalAdmissionDecisionId",
+    "GraphitiProposalAdmissionError",
     "GraphitiProposalProducerBridge",
     "GraphitiReplayApprovalRequest",
     "GraphitiReplaySource",
@@ -130,6 +151,9 @@ __all__ = [
     "REAL_GRAPHITI_RUNTIME_ENABLED",
     "REPLAY_WORKSPACE_POLICY",
     "RealGraphitiRuntimeAuthority",
+    "admit_graphiti_proposals_for_projectors",
+    "increment4_batches_for_admitted_graphiti",
     "qualification_configuration",
     "replay_configuration",
+    "require_admitted_projector_write",
 ]

--- a/newsroom/graphiti_adapter/admission.py
+++ b/newsroom/graphiti_adapter/admission.py
@@ -1,0 +1,309 @@
+"""Explicit Graphiti proposal admission before admitted Neo4j projector writes.
+
+Graphiti remains proposal-only (GRAG-020). Entity and relation proposals need a
+typed admit, reject, or hold decision before any Increment 4 admitted projector
+write (GRAG-023). Graphiti vectors stay out of the admitted OD-006 1,024-d index.
+EVALUATION only; the adapter never writes the ledger or admitted labels.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from newsroom.authority.types import UUIDv4Id
+from newsroom.entities.types import EntityResolutionDecisionAction
+from newsroom.extraction.models import ProposalDraft
+from newsroom.extraction.types import ExtractionProposalKind
+from .evaluation_packet import GRAPHITI_WORKSPACE_GROUP
+from .types import (
+    GraphitiAdapterContractError,
+    GraphitiExecutionProfile,
+    digest,
+    token,
+)
+from newsroom.relations.models import RelationDecisionAction
+
+
+ADMITTED_OD006_VECTOR_DIMENSIONS = 1024
+GRAPHITI_ADMITTED_PROJECTOR_FAMILY_ID = "graph.increment4.admitted"
+ADMITTED_NEO4J_LABELS = (
+    "NewsroomAdmittedRelationEndpoint",
+    "NewsroomAdmittedRelationIdentity",
+)
+_PROJECTABLE_KINDS = frozenset(
+    {
+        ExtractionProposalKind.ENTITY_MENTION,
+        ExtractionProposalKind.ENTITY_EQUIVALENCE,
+        ExtractionProposalKind.RELATION,
+    }
+)
+
+
+class GraphitiProposalAdmissionError(GraphitiAdapterContractError):
+    """Graphiti proposals cannot enter admitted projectors without a typed decision."""
+
+
+class GraphitiProposalAdmissionDecisionId(UUIDv4Id):
+    pass
+
+
+class GraphitiProposalAdmissionAction(StrEnum):
+    ADMIT = "ADMIT"
+    REJECT = "REJECT"
+    HOLD = "HOLD"
+
+    @property
+    def may_write_admitted_projector(self) -> bool:
+        return self is GraphitiProposalAdmissionAction.ADMIT
+
+
+@dataclass(frozen=True, slots=True)
+class GraphitiProposalAdmissionDecision:
+    decision_id: GraphitiProposalAdmissionDecisionId
+    proposal_digest: str
+    proposal_kind: ExtractionProposalKind
+    proposal_local_id: str
+    action: GraphitiProposalAdmissionAction
+    reason_code: str
+    workspace_group: str = GRAPHITI_WORKSPACE_GROUP
+    execution_profile: GraphitiExecutionProfile = GraphitiExecutionProfile.EVALUATION
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.decision_id, GraphitiProposalAdmissionDecisionId):
+            raise GraphitiProposalAdmissionError("admission decision identity must be typed")
+        digest(self.proposal_digest, field="graphiti_admission_proposal_digest")
+        if not isinstance(self.proposal_kind, ExtractionProposalKind):
+            raise GraphitiProposalAdmissionError("admission proposal kind must be typed")
+        if self.proposal_kind not in _PROJECTABLE_KINDS:
+            raise GraphitiProposalAdmissionError(
+                "only Graphiti entity and relation proposals may be admitted"
+            )
+        token(self.proposal_local_id, field="graphiti_admission_proposal_local_id")
+        if not isinstance(self.action, GraphitiProposalAdmissionAction):
+            raise GraphitiProposalAdmissionError("admission action must be typed")
+        token(self.reason_code, field="graphiti_admission_reason_code")
+        token(self.workspace_group, field="graphiti_admission_workspace_group")
+        if self.workspace_group != GRAPHITI_WORKSPACE_GROUP:
+            raise GraphitiProposalAdmissionError(
+                "Graphiti admission is bound to disposable group newsroom-eval-proposal"
+            )
+        if not isinstance(self.execution_profile, GraphitiExecutionProfile):
+            raise GraphitiProposalAdmissionError("admission execution profile must be typed")
+        if self.execution_profile is not GraphitiExecutionProfile.EVALUATION:
+            raise GraphitiProposalAdmissionError(
+                "Graphiti admission is authorised only under EVALUATION"
+            )
+
+    @property
+    def may_write_admitted_projector(self) -> bool:
+        return self.action.may_write_admitted_projector
+
+    def entity_resolution_action(self) -> EntityResolutionDecisionAction:
+        if self.proposal_kind is ExtractionProposalKind.RELATION:
+            raise GraphitiProposalAdmissionError(
+                "relation proposals use the relation admission seam"
+            )
+        return {
+            GraphitiProposalAdmissionAction.ADMIT: EntityResolutionDecisionAction.ACCEPT,
+            GraphitiProposalAdmissionAction.REJECT: EntityResolutionDecisionAction.REJECT,
+            GraphitiProposalAdmissionAction.HOLD: EntityResolutionDecisionAction.HOLD,
+        }[self.action]
+
+    def relation_admission_action(self) -> RelationDecisionAction:
+        if self.proposal_kind is not ExtractionProposalKind.RELATION:
+            raise GraphitiProposalAdmissionError(
+                "entity proposals use the entity resolution seam"
+            )
+        return {
+            GraphitiProposalAdmissionAction.ADMIT: RelationDecisionAction.ADMIT,
+            GraphitiProposalAdmissionAction.REJECT: RelationDecisionAction.REJECT,
+            GraphitiProposalAdmissionAction.HOLD: RelationDecisionAction.HOLD,
+        }[self.action]
+
+
+@dataclass(frozen=True, slots=True)
+class AdmittedGraphitiProjectorWrite:
+    """Proposal artifacts eligible for the existing Increment 4 admitted projector."""
+
+    proposals: tuple[ProposalDraft, ...]
+    decisions: tuple[GraphitiProposalAdmissionDecision, ...]
+    workspace_group: str = GRAPHITI_WORKSPACE_GROUP
+    projector_family_id: str = GRAPHITI_ADMITTED_PROJECTOR_FAMILY_ID
+    admitted_vector_dimensions_excluded: int = ADMITTED_OD006_VECTOR_DIMENSIONS
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.proposals, tuple) or any(
+            not isinstance(item, ProposalDraft) for item in self.proposals
+        ):
+            raise GraphitiProposalAdmissionError(
+                "admitted projector write needs typed proposal drafts"
+            )
+        if not isinstance(self.decisions, tuple) or any(
+            not isinstance(item, GraphitiProposalAdmissionDecision)
+            for item in self.decisions
+        ):
+            raise GraphitiProposalAdmissionError(
+                "admitted projector write needs typed admission decisions"
+            )
+        if len(self.proposals) != len(self.decisions):
+            raise GraphitiProposalAdmissionError(
+                "admitted projector write must pair each proposal with its ADMIT decision"
+            )
+        if self.workspace_group != GRAPHITI_WORKSPACE_GROUP:
+            raise GraphitiProposalAdmissionError(
+                "admitted projector write is bound to disposable group newsroom-eval-proposal"
+            )
+        if self.projector_family_id != GRAPHITI_ADMITTED_PROJECTOR_FAMILY_ID:
+            raise GraphitiProposalAdmissionError(
+                "Graphiti admission binds only the Increment 4 admitted projector family"
+            )
+        if self.admitted_vector_dimensions_excluded != ADMITTED_OD006_VECTOR_DIMENSIONS:
+            raise GraphitiProposalAdmissionError(
+                "Graphiti vectors must stay out of the admitted OD-006 1,024-d index"
+            )
+        expected = tuple(sorted(self.proposals, key=lambda item: item.local_id))
+        if self.proposals != expected:
+            raise GraphitiProposalAdmissionError(
+                "admitted projector proposals must be sorted by local identity"
+            )
+        for proposal, decision in zip(self.proposals, self.decisions, strict=True):
+            if decision.proposal_digest != proposal.digest:
+                raise GraphitiProposalAdmissionError(
+                    "admitted projector write decision does not bind its proposal"
+                )
+            if not decision.may_write_admitted_projector:
+                raise GraphitiProposalAdmissionError(
+                    "admitted projector write cannot carry reject or hold decisions"
+                )
+
+    @property
+    def may_write_admitted_projector(self) -> bool:
+        return bool(self.proposals)
+
+
+def admit_graphiti_proposals_for_projectors(
+    *,
+    proposals: tuple[ProposalDraft, ...],
+    decisions: tuple[GraphitiProposalAdmissionDecision, ...],
+) -> AdmittedGraphitiProjectorWrite:
+    """Return ADMIT-only artifacts for existing projector seams. Fail closed otherwise."""
+
+    if not isinstance(proposals, tuple) or not proposals:
+        raise GraphitiProposalAdmissionError("Graphiti admission needs typed proposals")
+    if any(not isinstance(item, ProposalDraft) for item in proposals):
+        raise GraphitiProposalAdmissionError("Graphiti admission needs typed proposal drafts")
+    if not isinstance(decisions, tuple) or any(
+        not isinstance(item, GraphitiProposalAdmissionDecision) for item in decisions
+    ):
+        raise GraphitiProposalAdmissionError("Graphiti admission needs typed decisions")
+    if len(decisions) != len(proposals):
+        raise GraphitiProposalAdmissionError(
+            "each Graphiti proposal needs exactly one admission decision"
+        )
+    by_digest = {item.digest: item for item in proposals}
+    if len(by_digest) != len(proposals):
+        raise GraphitiProposalAdmissionError("Graphiti proposal digests must be unique")
+    seen_ids: set[str] = set()
+    seen_digests: set[str] = set()
+    admitted: list[tuple[ProposalDraft, GraphitiProposalAdmissionDecision]] = []
+    for decision in decisions:
+        identity = str(decision.decision_id)
+        if identity in seen_ids:
+            raise GraphitiProposalAdmissionError("admission decision identities must be unique")
+        seen_ids.add(identity)
+        if decision.proposal_digest in seen_digests:
+            raise GraphitiProposalAdmissionError(
+                "each proposal may have only one admission decision"
+            )
+        seen_digests.add(decision.proposal_digest)
+        proposal = by_digest.get(decision.proposal_digest)
+        if proposal is None:
+            raise GraphitiProposalAdmissionError("admission decision names an unknown proposal")
+        if (
+            proposal.local_id != decision.proposal_local_id
+            or proposal.kind is not decision.proposal_kind
+        ):
+            raise GraphitiProposalAdmissionError(
+                "admission decision does not bind the exact proposal identity"
+            )
+        if decision.may_write_admitted_projector:
+            admitted.append((proposal, decision))
+    if seen_digests != set(by_digest):
+        raise GraphitiProposalAdmissionError(
+            "each Graphiti proposal needs exactly one admission decision"
+        )
+    admitted.sort(key=lambda item: item[0].local_id)
+    return AdmittedGraphitiProjectorWrite(
+        proposals=tuple(item[0] for item in admitted),
+        decisions=tuple(item[1] for item in admitted),
+    )
+
+
+def require_admitted_projector_write(
+    admission: AdmittedGraphitiProjectorWrite,
+) -> AdmittedGraphitiProjectorWrite:
+    if not isinstance(admission, AdmittedGraphitiProjectorWrite):
+        raise GraphitiProposalAdmissionError("admitted projector write must be typed")
+    if not admission.may_write_admitted_projector:
+        raise GraphitiProposalAdmissionError(
+            "admitted projector write requires an ADMIT decision"
+        )
+    return admission
+
+
+def increment4_batches_for_admitted_graphiti(
+    *,
+    admission: AdmittedGraphitiProjectorWrite,
+    snapshot: object,
+    generation_id: object,
+    family: object,
+) -> tuple[object, ...]:
+    """Gate existing Increment 4 projector mapping behind an ADMIT decision."""
+
+    require_admitted_projector_write(admission)
+    from newsroom.increment4.contracts import INCREMENT4_ADMITTED_FAMILY_ID
+    from newsroom.increment4.models import Increment4AdmittedProjectionSnapshot
+    from newsroom.increment4.projection import build_increment4_admitted_batches
+    from newsroom.projection.models import ProjectionFamilyDefinition, ProjectionGenerationId
+
+    if INCREMENT4_ADMITTED_FAMILY_ID != GRAPHITI_ADMITTED_PROJECTOR_FAMILY_ID:
+        raise GraphitiProposalAdmissionError(
+            "Graphiti admission projector family drifted from Increment 4"
+        )
+    if not isinstance(snapshot, Increment4AdmittedProjectionSnapshot):
+        raise GraphitiProposalAdmissionError(
+            "admitted projector write requires a typed Increment 4 snapshot"
+        )
+    if not isinstance(generation_id, ProjectionGenerationId):
+        raise GraphitiProposalAdmissionError(
+            "admitted projector write requires a typed projection generation"
+        )
+    if not isinstance(family, ProjectionFamilyDefinition):
+        raise GraphitiProposalAdmissionError(
+            "admitted projector write requires a typed projection family"
+        )
+    if family.family_id != INCREMENT4_ADMITTED_FAMILY_ID:
+        raise GraphitiProposalAdmissionError(
+            "Graphiti admission binds only the Increment 4 admitted projector family"
+        )
+    return build_increment4_admitted_batches(
+        snapshot,
+        generation_id=generation_id,
+        family=family,
+    )
+
+
+__all__ = [
+    "ADMITTED_NEO4J_LABELS",
+    "ADMITTED_OD006_VECTOR_DIMENSIONS",
+    "AdmittedGraphitiProjectorWrite",
+    "GRAPHITI_ADMITTED_PROJECTOR_FAMILY_ID",
+    "GraphitiProposalAdmissionAction",
+    "GraphitiProposalAdmissionDecision",
+    "GraphitiProposalAdmissionDecisionId",
+    "GraphitiProposalAdmissionError",
+    "admit_graphiti_proposals_for_projectors",
+    "increment4_batches_for_admitted_graphiti",
+    "require_admitted_projector_write",
+]

--- a/newsroom/graphiti_adapter/traceability.py
+++ b/newsroom/graphiti_adapter/traceability.py
@@ -123,9 +123,9 @@ _ROWS = (
     ),
     (
         "GRAG-023",
-        "newsroom.authority._graphiti_adapter_facade:GovernedGraphitiProposalAdapter",
-        "newsroom/tests/test_projection_b1_graphiti_adapter.py",
-        "IMPLEMENTED_NO_ADMISSION_COMMAND_OR_CREDENTIAL_ON_ADAPTER_FACADE",
+        "newsroom.graphiti_adapter.admission:GraphitiProposalAdmissionDecision",
+        "newsroom/tests/test_graphiti_adapter_admission.py",
+        "IMPLEMENTED_EXPLICIT_ADMIT_REJECT_HOLD_BEFORE_ADMITTED_PROJECTOR_WRITE",
     ),
     (
         "GRAG-024",

--- a/newsroom/tests/test_graphiti_adapter_admission.py
+++ b/newsroom/tests/test_graphiti_adapter_admission.py
@@ -1,0 +1,338 @@
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+
+import pytest
+
+from newsroom.authority.canonical import digest_bytes
+from newsroom.entities.types import EntityResolutionDecisionAction
+from newsroom.extraction.models import ProposalDraft
+from newsroom.extraction.types import (
+    EvidenceRange,
+    ExtractionPassageId,
+    ExtractionProposalKind,
+    ProposalPredicateHint,
+)
+from newsroom.graphiti_adapter import REAL_GRAPHITI_RUNTIME_ENABLED
+from newsroom.graphiti_adapter.admission import (
+    ADMITTED_NEO4J_LABELS,
+    ADMITTED_OD006_VECTOR_DIMENSIONS,
+    GRAPHITI_ADMITTED_PROJECTOR_FAMILY_ID,
+    GraphitiProposalAdmissionAction,
+    GraphitiProposalAdmissionDecision,
+    GraphitiProposalAdmissionDecisionId,
+    GraphitiProposalAdmissionError,
+    admit_graphiti_proposals_for_projectors,
+    increment4_batches_for_admitted_graphiti,
+    require_admitted_projector_write,
+)
+from newsroom.graphiti_adapter.evaluation_packet import (
+    EVALUATION_GRAPHITI_PACKET,
+    GRAPHITI_WORKSPACE_GROUP,
+    WRITER_FALLBACK,
+    WRITER_MODEL,
+)
+from newsroom.graphiti_adapter.real import RealGraphitiAdapter
+from newsroom.graphiti_adapter.types import GraphitiExecutionProfile
+from newsroom.increment4.contracts import INCREMENT4_ADMITTED_FAMILY_ID
+from newsroom.relations.models import RelationDecisionAction
+
+
+_ADAPTER_ROOT = Path(__file__).resolve().parents[2] / "newsroom" / "graphiti_adapter"
+_DECISION_A = GraphitiProposalAdmissionDecisionId.parse(
+    "00000000-0000-4000-8000-000000004941"
+)
+_DECISION_B = GraphitiProposalAdmissionDecisionId.parse(
+    "00000000-0000-4000-8000-000000004942"
+)
+
+
+def _evidence() -> EvidenceRange:
+    return EvidenceRange(
+        passage_id=ExtractionPassageId.parse("00000000-0000-4000-8000-000000004940"),
+        start_byte=0,
+        end_byte=4,
+        evidence_text_digest=digest_bytes(b"test"),
+    )
+
+
+def _entity(*, local_id: str = "entity.one") -> ProposalDraft:
+    return ProposalDraft(
+        local_id=local_id,
+        kind=ExtractionProposalKind.ENTITY_MENTION,
+        subject_placeholder="Hong Kong",
+        object_placeholder=None,
+        predicate_hint=None,
+        confidence_basis_points=None,
+        uncertainty_codes=(),
+        rationale_codes=("GRAPHITI_EVALUATION_SPAN",),
+        evidence=(_evidence(),),
+    )
+
+
+def _relation(*, local_id: str = "relation.one") -> ProposalDraft:
+    return ProposalDraft(
+        local_id=local_id,
+        kind=ExtractionProposalKind.RELATION,
+        subject_placeholder="Hong Kong",
+        object_placeholder="Transport Department",
+        predicate_hint=ProposalPredicateHint.ABOUT_EVENT,
+        confidence_basis_points=None,
+        uncertainty_codes=(),
+        rationale_codes=("GRAPHITI_EVALUATION_SPAN",),
+        evidence=(_evidence(),),
+    )
+
+
+def _decision(
+    proposal: ProposalDraft,
+    *,
+    decision_id: GraphitiProposalAdmissionDecisionId,
+    action: GraphitiProposalAdmissionAction,
+    reason_code: str = "EVALUATION_ADMIT",
+    workspace_group: str = GRAPHITI_WORKSPACE_GROUP,
+    execution_profile: GraphitiExecutionProfile = GraphitiExecutionProfile.EVALUATION,
+) -> GraphitiProposalAdmissionDecision:
+    return GraphitiProposalAdmissionDecision(
+        decision_id=decision_id,
+        proposal_digest=proposal.digest,
+        proposal_kind=proposal.kind,
+        proposal_local_id=proposal.local_id,
+        action=action,
+        reason_code=reason_code,
+        workspace_group=workspace_group,
+        execution_profile=execution_profile,
+    )
+
+
+def test_admit_is_required_before_increment4_projector_write() -> None:
+    entity = _entity()
+    relation = _relation()
+    write = admit_graphiti_proposals_for_projectors(
+        proposals=(entity, relation),
+        decisions=(
+            _decision(entity, decision_id=_DECISION_A, action=GraphitiProposalAdmissionAction.ADMIT),
+            _decision(
+                relation,
+                decision_id=_DECISION_B,
+                action=GraphitiProposalAdmissionAction.ADMIT,
+                reason_code="EVALUATION_ADMIT_RELATION",
+            ),
+        ),
+    )
+    gated = require_admitted_projector_write(write)
+    assert gated.may_write_admitted_projector is True
+    assert gated.proposals == (entity, relation)
+    assert gated.workspace_group == "newsroom-eval-proposal"
+    assert gated.projector_family_id == INCREMENT4_ADMITTED_FAMILY_ID
+    assert gated.projector_family_id == GRAPHITI_ADMITTED_PROJECTOR_FAMILY_ID
+    assert gated.admitted_vector_dimensions_excluded == 1024
+    assert gated.admitted_vector_dimensions_excluded == ADMITTED_OD006_VECTOR_DIMENSIONS
+    assert write.decisions[0].entity_resolution_action() is (
+        EntityResolutionDecisionAction.ACCEPT
+    )
+    assert write.decisions[1].relation_admission_action() is RelationDecisionAction.ADMIT
+    with pytest.raises(
+        GraphitiProposalAdmissionError,
+        match="typed Increment 4 snapshot",
+    ):
+        increment4_batches_for_admitted_graphiti(
+            admission=write,
+            snapshot=None,
+            generation_id=None,
+            family=None,
+        )
+
+
+@pytest.mark.parametrize(
+    "action",
+    (
+        GraphitiProposalAdmissionAction.REJECT,
+        GraphitiProposalAdmissionAction.HOLD,
+    ),
+)
+def test_reject_and_hold_cannot_produce_admitted_projector_writes(
+    action: GraphitiProposalAdmissionAction,
+) -> None:
+    entity = _entity()
+    write = admit_graphiti_proposals_for_projectors(
+        proposals=(entity,),
+        decisions=(
+            _decision(
+                entity,
+                decision_id=_DECISION_A,
+                action=action,
+                reason_code="EVALUATION_HOLD",
+            ),
+        ),
+    )
+    assert write.proposals == ()
+    assert write.may_write_admitted_projector is False
+    with pytest.raises(GraphitiProposalAdmissionError, match="ADMIT decision"):
+        require_admitted_projector_write(write)
+    with pytest.raises(GraphitiProposalAdmissionError, match="ADMIT decision"):
+        increment4_batches_for_admitted_graphiti(
+            admission=write,
+            snapshot=None,
+            generation_id=None,
+            family=None,
+        )
+
+
+def test_hold_leaves_admitted_sibling_eligible_for_existing_projector_seam() -> None:
+    entity = _entity()
+    relation = _relation()
+    write = admit_graphiti_proposals_for_projectors(
+        proposals=(entity, relation),
+        decisions=(
+            _decision(entity, decision_id=_DECISION_A, action=GraphitiProposalAdmissionAction.ADMIT),
+            _decision(
+                relation,
+                decision_id=_DECISION_B,
+                action=GraphitiProposalAdmissionAction.HOLD,
+                reason_code="EVALUATION_HOLD",
+            ),
+        ),
+    )
+    assert write.proposals == (entity,)
+    assert write.decisions[0].action is GraphitiProposalAdmissionAction.ADMIT
+    require_admitted_projector_write(write)
+
+
+def test_missing_decision_fails_closed() -> None:
+    entity = _entity()
+    relation = _relation()
+    with pytest.raises(GraphitiProposalAdmissionError, match="exactly one"):
+        admit_graphiti_proposals_for_projectors(
+            proposals=(entity, relation),
+            decisions=(
+                _decision(
+                    entity,
+                    decision_id=_DECISION_A,
+                    action=GraphitiProposalAdmissionAction.ADMIT,
+                ),
+            ),
+        )
+
+
+def test_production_profile_and_foreign_group_are_refused() -> None:
+    entity = _entity()
+    with pytest.raises(GraphitiProposalAdmissionError, match="EVALUATION"):
+        _decision(
+            entity,
+            decision_id=_DECISION_A,
+            action=GraphitiProposalAdmissionAction.ADMIT,
+            execution_profile=GraphitiExecutionProfile.PRODUCTION,
+        )
+    with pytest.raises(GraphitiProposalAdmissionError, match="newsroom-eval-proposal"):
+        _decision(
+            entity,
+            decision_id=_DECISION_A,
+            action=GraphitiProposalAdmissionAction.ADMIT,
+            workspace_group="graphiti-qualification",
+        )
+
+
+def test_claim_proposals_are_outside_this_admission_slice() -> None:
+    claim = ProposalDraft(
+        local_id="claim.one",
+        kind=ExtractionProposalKind.CLAIM,
+        subject_placeholder="Hong Kong",
+        object_placeholder=None,
+        predicate_hint=None,
+        confidence_basis_points=None,
+        uncertainty_codes=(),
+        rationale_codes=("GRAPHITI_EVALUATION_SPAN",),
+        evidence=(_evidence(),),
+    )
+    with pytest.raises(GraphitiProposalAdmissionError, match="entity and relation"):
+        GraphitiProposalAdmissionDecision(
+            decision_id=_DECISION_A,
+            proposal_digest=claim.digest,
+            proposal_kind=claim.kind,
+            proposal_local_id=claim.local_id,
+            action=GraphitiProposalAdmissionAction.ADMIT,
+            reason_code="EVALUATION_ADMIT",
+        )
+
+
+def test_real_adapter_cannot_mutate_ledger_or_admitted_labels() -> None:
+    assert REAL_GRAPHITI_RUNTIME_ENABLED is False
+    assert GRAPHITI_WORKSPACE_GROUP == "newsroom-eval-proposal"
+    assert inspect.signature(RealGraphitiAdapter.execute).parameters.keys() == {
+        "self",
+        "attempt",
+        "workspace_root",
+    }
+    source = (_ADAPTER_ROOT / "real.py").read_text(encoding="utf-8")
+    assert "group_id=GRAPHITI_WORKSPACE_GROUP" in source
+    assert "update_communities=False" in source
+    for label in ADMITTED_NEO4J_LABELS:
+        assert label not in source
+    assert "VECTOR_GENERATION_1024" not in source
+    assert "ledger_events" not in source
+    tree = ast.parse(source, filename="real.py")
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module)
+    forbidden = {
+        "sqlite3",
+        "neo4j",
+        "newsroom.authority._entity_store_commit",
+        "newsroom.increment4.projection",
+        "newsroom.projection.neo4j",
+    }
+    assert not imported & forbidden
+    assert not any(
+        name.startswith("newsroom.projection.neo4j")
+        or name.startswith("newsroom.authority._entity")
+        or name.startswith("newsroom.authority._relation")
+        for name in imported
+    )
+
+
+def test_graphiti_adapter_sources_stay_on_private_workspace_and_group_id() -> None:
+    files = (
+        "fake.py",
+        "replay.py",
+        "producer.py",
+        "workspace.py",
+        "real.py",
+    )
+    for name in files:
+        text = (_ADAPTER_ROOT / name).read_text(encoding="utf-8")
+        for label in ADMITTED_NEO4J_LABELS:
+            assert label not in text
+        assert "VECTOR_GENERATION_1024" not in text
+        assert "AUTO_PUBLISH" not in text
+        assert "TargetOperation" not in text
+        tree = ast.parse(text, filename=name)
+        imported: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.update(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.add(node.module)
+        assert "sqlite3" not in imported
+        assert "newsroom.authority.persistence" not in imported
+    packet = EVALUATION_GRAPHITI_PACKET.canonical_value()
+    assert packet["framework_release"] == "graphiti-core-0.29.3"
+    destination = {
+        "engine": "neo4j-community-plus-graphiti",
+        "neo4j_server": "2026.06.0",
+        "driver": "neo4j==6.2.0",
+        "graphiti_writes_ledger": False,
+        "graphiti_writes_admitted_graph": False,
+        "workspace_group": GRAPHITI_WORKSPACE_GROUP,
+    }
+    from newsroom.authority.canonical import digest_canonical
+
+    assert packet["destination_contract_digest"] == digest_canonical(destination)
+    assert WRITER_MODEL == "grok-build-cli:grok-4.6"
+    assert WRITER_FALLBACK == "cursor-agent-cli"
+    assert ADMITTED_OD006_VECTOR_DIMENSIONS == 1024


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: private-unpublished-graphiti-admission
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: delete-after-merge

## Scope

Closes #715. Graphiti entity and relation proposals become eligible for the existing Increment 4 admitted projector (`graph.increment4.admitted`) only after a typed admit / reject / hold decision. Graphiti remains proposal-only on disposable group `newsroom-eval-proposal` (GRAG-020 / GRAG-021 / GRAG-023). Graphiti vectors stay out of the admitted OD-006 1,024-d index.

## Exact state

```text
base: 4b01bb97c04d34e7ebc564d088f8de51d89f1f48
head: b52747fa79127b0eaa56e083895b957559208dca
tree: d16c8fd72c059300031582bc90a9d590f76cc990
commits over base: 1
changed files: 4
```

## Verification

- `uv lock --check`
- `uv run pytest` on the new admission tests, 4D fake/replay/contracts/security/traceability/workspace/lifecycle and related Graphiti adapter files, Increment 4E flag pin, and Increment 9Q-8 `OPENROUTER_UNUSED`: 121 passed. Admission lane: 9 passed. `REAL_GRAPHITI_RUNTIME_ENABLED is False`.

## Non-effects

- Does not flip `REAL_GRAPHITI_RUNTIME_ENABLED`.
- Does not add PRODUCTION, a fifth Graphiti profile, Increment 11, AUTO_PUBLISH, or public TargetOperation.
- Does not change the CONT writer (Grok Build CLI / cursor-agent fallback).
- Does not write the ledger or admitted Neo4j labels from `graphiti_adapter` / `real.py`.
- Does not mix Graphiti embeddings into the admitted OD-006 1,024-d index.
- 9P proving remains `OPENROUTER_UNUSED`.

Made with [Cursor](https://cursor.com)