### PR TITLE
Reject Grok planning titles without blocking real 核實 copy

### DIFF
--- a/newsroom/control_plane/writer.py
+++ b/newsroom/control_plane/writer.py
@@ -30,12 +30,15 @@ _PROMPT = (
     "你係 Newsroom 嘅 CONT 原創記者，唔係 Graphiti。"
     "用香港繁體中文寫一篇已經完成嘅未出版新聞稿。"
     "JSON 嘅 title 同 body 必須係完稿正文，唔係計劃、核對清單、任務說明或工作備註。"
-    "禁止輸出含有「計劃」「核對」「任務」「先查」嘅標題或正文。"
+    "標題唔可以「正在」「搜集」「查核」「先查」開頭，亦唔可以係「新聞稿任務」。"
+    "正文唔可以「先查」「先核」「正在核」開頭。"
     "必須原創改寫，唔好複製來源標題或 dateline 模板。"
     "唔准 AUTO_PUBLISH，唔准當公開發行。"
     "只輸出 JSON 物件，欄位 title 同 body。"
 )
-_RESIDUE_MARKERS = ("計劃", "核對", "任務", "先查")
+_TITLE_RESIDUE_PREFIXES = ("正在", "搜集", "查核", "先查")
+_TITLE_RESIDUE_EXACT = frozenset({"新聞稿任務", "Newsroom 原創稿"})
+_BODY_RESIDUE_PREFIXES = ("先查", "先核", "正在核")
 
 
 @dataclass(frozen=True, slots=True)
@@ -101,8 +104,9 @@ def _copy_fields(payload: object) -> tuple[str, str] | None:
 def _finished_copy(title: str, body: str) -> tuple[str, str]:
     if not title or not body:
         raise RuntimeError("writer JSON missing title or body")
-    haystack = f"{title}\n{body}"
-    if any(marker in haystack for marker in _RESIDUE_MARKERS):
+    if title.startswith(_TITLE_RESIDUE_PREFIXES) or title in _TITLE_RESIDUE_EXACT:
+        raise RuntimeError("writer returned planning residue, not unpublished copy")
+    if body.startswith(_BODY_RESIDUE_PREFIXES):
         raise RuntimeError("writer returned planning residue, not unpublished copy")
     return title, body
 

--- a/newsroom/tests/test_control_plane_private_beta.py
+++ b/newsroom/tests/test_control_plane_private_beta.py
@@ -448,7 +448,7 @@ def test_cli_writer_prefers_grok_build_cli() -> None:
 def test_cli_writer_rejects_planning_residue_and_falls_back() -> None:
     def grok(_prompt: str) -> str:
         return json.dumps(
-            {"title": "新聞稿任務", "body": "先查 CONT 記者稿例，再核對官方數據。"}
+            {"title": "正在核實幼稚園收生與家長智Net來源", "body": "先查 CONT 記者稿例。"}
         )
 
     def cursor(_prompt: str) -> str:
@@ -463,9 +463,26 @@ def test_cli_writer_rejects_planning_residue_and_falls_back() -> None:
     copy = CliChainWriter(primary=grok, fallback=cursor).write(*_sample_candidate_package())
     assert copy.writer_id == "cursor-agent-cli-cont-writer"
     assert copy.title == "【未出版】立法會教育議案"
-    assert "任務" not in copy.title
-    assert "先查" not in copy.body
-    assert "核對" not in copy.body
+    assert not copy.title.startswith("正在")
+    assert not copy.body.startswith("先查")
+
+
+def test_cli_writer_accepts_finished_copy_that_mentions_verification() -> None:
+    def grok(_prompt: str) -> str:
+        return json.dumps(
+            {
+                "title": "英國入境規則公開更新",
+                "body": "申請人須按現行版本核實資格，本報根據證據包改寫。",
+            },
+            ensure_ascii=False,
+        )
+
+    def cursor(_prompt: str) -> str:
+        raise AssertionError("fallback must not run")
+
+    copy = CliChainWriter(primary=grok, fallback=cursor).write(*_sample_candidate_package())
+    assert copy.writer_id == "grok-build-cli-cont-writer"
+    assert "核實資格" in copy.body
 
 
 def test_grok_cli_uses_empty_cwd_and_three_turns(monkeypatch) -> None:


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: private-unpublished-writer-title-residue
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: delete-after-merge

## Summary
- Reject unpublished copy when the title starts with 正在 / 搜集 / 查核 / 先查, or is an exact planning stub.
- Keep finished reports that mention 核實資格 in the body.

## Exact state

```text
base: origin/main 5408014
head: feat/writer-title-residue c6ce10e
tree: 1375f97a060a0d954cabcfb2dab9008c8f3ce6b1
commits over base: 1
changed files: 2
```

## Test plan
- [x] `uv run pytest newsroom/tests/test_control_plane_private_beta.py -q` (17 passed)

## Non-effects
Does not flip `REAL_GRAPHITI_RUNTIME_ENABLED` or AUTO_PUBLISH.


Made with [Cursor](https://cursor.com)