### PR TITLE
Let Graphiti extract via OpenRouter json_object instead of failing closed

### DIFF
--- a/newsroom/control_plane/cycle.py
+++ b/newsroom/control_plane/cycle.py
@@ -175,27 +175,28 @@ def run_cycle(
                     raise
                 except (RuntimeError, ValueError, OSError, json.JSONDecodeError):
                     continue
-                if insert_graphiti_attempt(
+                append_ledger(
                     unpublished,
-                    candidate_id=candidate.candidate_id,
-                    outcome=result.outcome,
-                    proposal_count=result.proposal_count,
-                    failure_code=result.failure_code,
-                ):
-                    append_ledger(
+                    "GRAPHITI_EVALUATION_ATTEMPT",
+                    {
+                        "story_candidate_id": candidate.candidate_id,
+                        "evidence_package_digest": package.digest,
+                        "outcome": result.outcome,
+                        "proposal_count": result.proposal_count,
+                        "failure_code": result.failure_code,
+                        "workspace_group": GRAPHITI_WORKSPACE_GROUP,
+                        "profile": "EVALUATION",
+                    },
+                )
+                if result.outcome in {"COMPLETE", "PARTIAL"}:
+                    insert_graphiti_attempt(
                         unpublished,
-                        "GRAPHITI_EVALUATION_ATTEMPT",
-                        {
-                            "story_candidate_id": candidate.candidate_id,
-                            "evidence_package_digest": package.digest,
-                            "outcome": result.outcome,
-                            "proposal_count": result.proposal_count,
-                            "failure_code": result.failure_code,
-                            "workspace_group": GRAPHITI_WORKSPACE_GROUP,
-                            "profile": "EVALUATION",
-                        },
+                        candidate_id=candidate.candidate_id,
+                        outcome=result.outcome,
+                        proposal_count=result.proposal_count,
+                        failure_code=result.failure_code,
                     )
-                    graphiti_ok += 1
+                graphiti_ok += 1
         digest = append_ledger(
             unpublished,
             "PRIVATE_CYCLE_CLOSE",

--- a/newsroom/graphiti_adapter/real.py
+++ b/newsroom/graphiti_adapter/real.py
@@ -228,11 +228,16 @@ async def _add_episode(
         small_model=OPENROUTER_CHAT_SLUG,
         base_url=OPENROUTER_BASE_URL,
     )
+    # OpenRouter's gpt-5-mini rejects Graphiti's native json_schema (additionalProperties).
+    llm_client = runtime.OpenAIGenericClient(
+        config=llm_config,
+        structured_output_mode="json_object",
+    )
     graphiti = runtime.Graphiti(
         f"bolt://{NEO4J_BOLT_HOST}:{NEO4J_BOLT_PORT}",
         _NEO4J_USER,
         password,
-        llm_client=runtime.OpenAIGenericClient(config=llm_config),
+        llm_client=llm_client,
         embedder=runtime.OpenAIEmbedder(
             config=runtime.OpenAIEmbedderConfig(
                 api_key=api_key,
@@ -385,13 +390,13 @@ class RealGraphitiAdapter:
             )
         except (BrokerError, GraphitiAdapterContractError):
             raise
-        except Exception:
+        except Exception as exc:
             return _produced(
                 attempt,
                 outcome=ExtractionOutcome.RETRYABLE_FAILURE,
                 failure_code=ExtractionFailureCode.PRODUCER_INTERNAL_ERROR,
                 validation=None,
-                raw=None,
+                raw={"error_type": type(exc).__name__},
                 proposals=(),
             )
 

--- a/newsroom/tests/test_control_plane_private_beta.py
+++ b/newsroom/tests/test_control_plane_private_beta.py
@@ -297,6 +297,63 @@ def test_cycle_reserves_graphiti_spend_before_stub_extract(tmp_path: Path) -> No
     assert kinds.count("GRAPHITI_EVALUATION_ATTEMPT") == 2
 
 
+def test_cycle_retries_failed_graphiti_extract(tmp_path: Path) -> None:
+    from newsroom.control_plane.graphiti import GraphitiCycleResult
+
+    proving = _proving(tmp_path)
+    unpublished = tmp_path / "unpublished_store.sqlite3"
+    calls: list[str] = []
+
+    class FlakyGraphiti:
+        def extract(self, package):
+            calls.append(package.candidate_id)
+            if len(calls) == 1:
+                return GraphitiCycleResult(
+                    candidate_id=package.candidate_id,
+                    outcome="FAILED",
+                    proposal_count=0,
+                    failure_code="PRODUCER_INTERNAL_ERROR",
+                )
+            return GraphitiCycleResult(
+                candidate_id=package.candidate_id,
+                outcome="COMPLETE",
+                proposal_count=1,
+                failure_code="NONE",
+            )
+
+    first = run_cycle(
+        proving_store=str(proving),
+        unpublished_store=str(unpublished),
+        writer=FixtureWriter(),
+        max_writes=10,
+        graphiti=FlakyGraphiti(),
+        max_graphiti=1,
+    )
+    assert first.graphiti == 1
+    connection = __import__("sqlite3").connect(unpublished)
+    stored = connection.execute(
+        "SELECT COUNT(*) FROM unpublished_graphiti_attempts"
+    ).fetchone()[0]
+    connection.close()
+    assert stored == 0
+    second = run_cycle(
+        proving_store=str(proving),
+        unpublished_store=str(unpublished),
+        writer=FixtureWriter(),
+        max_writes=10,
+        graphiti=FlakyGraphiti(),
+        max_graphiti=1,
+    )
+    assert second.graphiti == 1
+    assert calls[0] == calls[1]
+    connection = __import__("sqlite3").connect(unpublished)
+    stored = connection.execute(
+        "SELECT outcome, proposal_count FROM unpublished_graphiti_attempts"
+    ).fetchone()
+    connection.close()
+    assert stored == ("COMPLETE", 1)
+
+
 def test_surface_payload_refuses_dateline_dump_and_publication_bundle() -> None:
     with pytest.raises(ValueError, match="dateline dump"):
         UnpublishedSurfacePayload(

--- a/newsroom/tests/test_graphiti_adapter_real_executor.py
+++ b/newsroom/tests/test_graphiti_adapter_real_executor.py
@@ -176,6 +176,14 @@ def test_flag_is_true_for_evaluation_and_graphiti_core_is_an_optional_extra() ->
     assert 'version = "0.29.3"' in lock
 
 
+def test_openrouter_generic_client_uses_json_object_mode() -> None:
+    from newsroom.graphiti_adapter.real import _add_episode
+
+    source = inspect.getsource(_add_episode)
+    assert 'structured_output_mode="json_object"' in source
+    assert "OpenAIGenericClient" in source
+
+
 def test_else_branch_constructs_real_adapter_instead_of_unreachable_assertion() -> None:
     source = inspect.getsource(_GraphitiAdapterBoundary._execute_attempt_locked)
     assert "unreachable real Graphiti execution path" not in source


### PR DESCRIPTION
Lifecycle: canonical
Delivery-Atom: private-unpublished-graphiti-json-object
Canonical-PR: self
Checkpoint-Ref: NONE
Close-When: merged
Branch-Retention: delete-after-merge

## Summary
- OpenRouter `gpt-5-mini` rejected Graphiti's native `json_schema` (`additionalProperties` required false). Use `json_object`.
- FAILED EVALUATION attempts stay retryable; only COMPLETE/PARTIAL occupy the unique attempt row.
- Host probe after the change: 2 nodes (`香港天文台`, `強烈季候風信號`) and 1 edge.

## Exact state

```text
base: origin/main 35c1b44
head: feat/graphiti-openrouter-json-object b46868b
tree: b85e2c83d4716082fd4b10c7f864c57e496c9128
commits over base: 1
changed files: 4
```

## Test plan
- [x] `uv run pytest newsroom/tests/test_control_plane_private_beta.py newsroom/tests/test_graphiti_adapter_real_executor.py newsroom/tests/test_graphiti_adapter_admission.py -q` (34 passed)
- [x] live `add_episode` probe completed with nodes/edges

## Non-effects
Does not enable PRODUCTION or AUTO_PUBLISH. Increment 9P proving still must not call OpenRouter.


Made with [Cursor](https://cursor.com)